### PR TITLE
Flick element - make flick work with sliders

### DIFF
--- a/app/controller.js
+++ b/app/controller.js
@@ -212,9 +212,23 @@ exports.getScreenshot = function(req, res) {
 exports.flick = function(req, res) {
   var swipe = req.body.swipe
     , xSpeed = req.body.xSpeed
-    , ySpeed = req.body.ySpeed;
+    , ySpeed = req.body.ySpeed
+    , element = req.body.element;
 
-  req.device.flick(xSpeed, ySpeed, swipe, getResponseHandler(req, res));
+  if (element) {
+    exports.flickElement(req, res);
+  } else {
+    req.device.flick(xSpeed, ySpeed, swipe, getResponseHandler(req, res));
+  }
+};
+
+exports.flickElement = function(req, res) {
+  var element = req.body.element
+    , xoffset = req.body.xoffset
+    , yoffset = req.body.yoffset
+    , speed = req.body.speed;
+
+  req.device.flickElement(element, xoffset, yoffset, speed, getResponseHandler(req, res));
 };
 
 exports.postUrl = function(req, res) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -372,6 +372,14 @@ IOS.prototype.flick = function(xSpeed, ySpeed, swipe, cb) {
   });
 };
 
+IOS.prototype.flickElement = function(elementId, xoffset, yoffset, speed, cb) {
+  var command = ["elements['", elementId, "'].touchFlick(", xoffset, ",", yoffset, ",", speed, ")"].join('');
+
+  this.proxy(command, function(err, json) {
+    cb(err, json);
+  });
+};
+
 IOS.prototype.url = function(cb) {
   // in the future, detect whether we have a UIWebView that we can use to
   // make sense of this command. For now, and otherwise, it's a no-op

--- a/app/uiauto/lib/appiumutils.js
+++ b/app/uiauto/lib/appiumutils.js
@@ -518,6 +518,26 @@ touchSwipeFromSpeed = function(xSpeed, ySpeed) {
     };
 }
 
+// does a flick from a center of a specified element (use case: sliders)
+UIAElement.prototype.touchFlick = function(xoffset, yoffset) {
+  var options = {
+        startOffset : {
+            x : 0.5,
+            y : 0.5
+        },
+        endOffset : {
+            x : 0.5 + xoffset,
+            y : 0.5 + yoffset
+        }
+    };
+
+  this.flickInsideWithOptions(options);
+  return {
+    status: codes.Success.code,
+    value: null
+  };
+}
+
 // alerts
 
 getAlertText = function() {

--- a/sample-code/examples/python/uicatalog.py
+++ b/sample-code/examples/python/uicatalog.py
@@ -151,6 +151,17 @@ class TestSequenceFunctions(unittest.TestCase):
         self.assertEqual(location1['x'], location2['x'])
         self.assertNotEqual(location1['y'], location2['y'])
 
+    def test_slider(self):
+        # go to controls
+        self._open_menu_position(1)
+        # get the slider
+        slider = self.driver.find_element_by_tag_name("slider")
+        self.assertEqual(slider.get_attribute("value"), "50%")
+        drag = TouchActions(self.driver)
+        drag.flick_element(slider, -0.5, 0, 0)
+        drag.perform()
+        self.assertEqual(slider.get_attribute("value"), "0%")
+
     def test_sessions(self):
         data = json.loads(urllib2.urlopen("http://localhost:4723/wd/hub/sessions").read())
         self.assertEqual(self.driver.session_id, data[0]['id'])

--- a/test/uicatalog/flick.js
+++ b/test/uicatalog/flick.js
@@ -19,3 +19,23 @@ describeWd('flick gesture', function(h) {
     });
   });
 });
+
+describeWd("flick element", function(h) {
+  return it("slider value should change", function(done) {
+    h.driver.elementsByTagName("tableCell", function(err, elements) {
+      elements[1].click(function(){
+        h.driver.elementByTagName("slider", function(err, element) {
+          element.getAttribute("value", function(err, valueBefore) {
+            element.flick(-0.5, 0, 1, function() {
+              element.getAttribute("value", function(err, valueAfter) {
+                assert.equal(valueBefore, "50%");
+                assert.equal(valueAfter, "0%");
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
DISCUSSION: @admc @jlipps @sourishkrout

As UI elements in the iOS are pretty standard it might be a good idea to make standard bindings for them 

For example:
- UIStepper - increment ('tap +'), decrement ('tap -')
- UIASlider - 'set to 10%', 'set to 90%'  - in docs this object has method 'dragToValue' which we could use - http://developer.apple.com/library/ios/#documentation/ToolsLanguages/Reference/UIASliderClassReference/UIASlider/UIASlider.html 

![Screen Shot 2013-01-24 at 13 02 03](https://f.cloud.github.com/assets/778717/93353/ee82a978-661d-11e2-8798-5c157e3ad6ae.png)

If we won't do this on our side, devs will have to produce some workarounds. I'm not sure how to accomodate that inside JSON Wire protocol..
