### PR TITLE
Fix result handling

### DIFF
--- a/instruments/instruments.js
+++ b/instruments/instruments.js
@@ -80,6 +80,16 @@ Instruments.prototype.startSocketServer = function(sock) {
       this.bufferedData = "";
       try {
         data = JSON.parse(data);
+        
+        // Handle {"event":"cmd","result":{"0":{},"1":{}}}
+        if (typeof data.result !== "undefined" &&
+            typeof data.result.status === "undefined" &&
+            typeof data.result.value === "undefined") {
+              var result = data.result;
+              data.result = {};
+              data.result.status = 0;
+              data.result.value = result;
+        }
       } catch (e) {
         logger.error("Couldn't parse JSON data from socket, maybe buffer issue?");
         logger.error(data);


### PR DESCRIPTION
>  > @driver.execute_script 'UIATarget.localTarget().frontMostApp().mainWindow().buttons()'
> => {"0"=>{}, "1"=>{}}

The above no longer triggers Selenium::WebDriver::Error::IndexOutOfBoundsError:
