### PR TITLE
Fix #148 leaving domain sockets open

### DIFF
--- a/instruments/instruments.js
+++ b/instruments/instruments.js
@@ -29,6 +29,7 @@ var Instruments = function(app, udid, bootstrap, template, sock, cb, exitCb) {
   this.eventRouter = {
     'cmd': this.commandHandler
   };
+  this.socketServer = null;
   if (typeof sock === "undefined") {
     sock = '/tmp/instruments_sock';
   }

--- a/instruments/instruments.js
+++ b/instruments/instruments.js
@@ -60,7 +60,7 @@ Instruments.prototype.startSocketServer = function(sock) {
 
   var socketConnectTimeout = setTimeout(_.bind(onSocketNeverConnect, this), 300000);
 
-  var server = net.createServer({allowHalfOpen: true}, _.bind(function(conn) {
+  this.socketServer = net.createServer({allowHalfOpen: true}, _.bind(function(conn) {
     if (!this.hasConnected) {
       this.hasConnected = true;
       this.debug("Instruments is ready to receive commands");
@@ -114,8 +114,12 @@ Instruments.prototype.startSocketServer = function(sock) {
     }, this));
 
   }, this));
-
-  server.listen(sock, _.bind(function() {
+ 
+  this.socketServer.on('close', _.bind(function() {
+    this.debug("Instruments socket server closed");
+  }, this));
+  
+  this.socketServer.listen(sock, _.bind(function() {
     this.debug("Instruments socket server started at " + sock);
     this.launch();
   }, this));
@@ -145,10 +149,11 @@ Instruments.prototype.launch = function() {
         self.resultHandler = self.defaultResultHandler;
         self.onReceiveCommand = null;
         if (self.currentSocket) {
-			    self.debug("Socket closed forcibly due to exit");
-			    self.currentSocket.end();
-			    self.currentSocket.destroy();	// close this
-		    }
+          self.debug("Socket closed forcibly due to exit");
+          self.currentSocket.end();
+          self.currentSocket.destroy();	// close this
+          self.socketServer.close();
+        }
       });
     } else {
       throw e;


### PR DESCRIPTION
In order to make sure the domain socket closes, we need to close() the
socket server itself, which requires paying attention to its creation
and subsequently closing the listener when Instruments quits from under us.
