### PR TITLE
Fix null check

### DIFF
--- a/app/uiauto/lib/mechanic.js
+++ b/app/uiauto/lib/mechanic.js
@@ -264,7 +264,12 @@ var mechanic = (function() {
         valueInKey: function(key, val) {
           var result = this.map(function(idx, el) {
             if (key in el) {
-              if (el[key]().indexOf(val) !== -1) {
+              var elKey = el[key]();
+              if (elKey === null) {
+                return null;
+              }
+
+              if (elKey.indexOf(val) !== -1) {
                 return el;
               }
             }


### PR DESCRIPTION
`Selenium::WebDriver::Error::JavascriptError: 'null' is not an object (evaluating 'el[key]().indexOf')`

This happens when an element exists that doesn't have the proper value.

> execute_script "[$('text')[0].name()]"
> => [nil]
