### PR TITLE
Timing fix for proxying through selenium

### DIFF
--- a/app/uiauto/appium/app.js
+++ b/app/uiauto/appium/app.js
@@ -55,6 +55,12 @@ $.extend(au, {
           value: 'Unsupported orientation: ' + orientation
         };
       }
+      // Need to wait a moment for the animation to complete.
+      // This might be better done with a callback
+      var now = Date.now()
+      while (Date.now() - now < 500) {
+        var i = 0
+      }
       var newOrientation = au.getScreenOrientation().value;
       if (newOrientation == orientation) {
         return {

--- a/app/uiauto/appium/app.js
+++ b/app/uiauto/appium/app.js
@@ -57,9 +57,9 @@ $.extend(au, {
       }
       // Need to wait a moment for the animation to complete.
       // This might be better done with a callback
-      var now = Date.now()
+      var now = Date.now();
       while (Date.now() - now < 500) {
-        var i = 0
+        var i = 0;
       }
       var newOrientation = au.getScreenOrientation().value;
       if (newOrientation == orientation) {


### PR DESCRIPTION
Some bindings (and selenium) have strict expectations about what is returned here, and due to the time it takes for the animation to happen, we're returning 'false' when the orientation really did change. This fixes it. Might need to figure out a pattern to deal with animation waits.
