### PR TITLE
HTTPS for REST API

### DIFF
--- a/sample-code/examples/ruby/sauce_example.rb
+++ b/sample-code/examples/ruby/sauce_example.rb
@@ -61,7 +61,7 @@ def server_url
 end
 
 def rest_jobs_url
-  "http://#{AUTH_DETAILS}@saucelabs.com/rest/v1/#{SAUCE_USERNAME}/jobs"
+  "https://#{AUTH_DETAILS}@saucelabs.com/rest/v1/#{SAUCE_USERNAME}/jobs"
 end
 
 # Because WebDriver doesn't have the concept of test failure, use the Sauce


### PR DESCRIPTION
Let's at least try to use SSL where it's supported. #212
