### PR TITLE
Make appium accept selenium's args for execute script

### DIFF
--- a/app/ios.js
+++ b/app/ios.js
@@ -884,6 +884,18 @@ IOS.prototype.execute = function(script, args, cb) {
   if (this.curWindowHandle === null) {
     this.proxy(script, cb);
   } else {
+    for (var i=0; i < args.length; i++) {
+      if (typeof args[i].ELEMENT !== "undefined") {
+        var atomsElement = this.getAtomsElement(args[i].ELEMENT);
+        if (atomsElement === undefined || null) {
+          cb(null, {
+            status: status.codes.UnknownError.code
+            , value: "Error converting element ID for using in WD atoms: " + args[i].ELEMENT
+          });
+        }
+        args[i] = atomsElement;
+      }
+    }
     this.remote.executeAtom('execute_script', [script, args], cb);
   }
 };

--- a/app/ios.js
+++ b/app/ios.js
@@ -289,6 +289,9 @@ IOS.prototype.getAtomsElement = function(wdId) {
   } catch(e) {
     return null;
   }
+  if (typeof atomsId === "undefined") {
+    return null;
+  }
   return {'ELEMENT': atomsId};
 };
 
@@ -887,11 +890,12 @@ IOS.prototype.execute = function(script, args, cb) {
     for (var i=0; i < args.length; i++) {
       if (typeof args[i].ELEMENT !== "undefined") {
         var atomsElement = this.getAtomsElement(args[i].ELEMENT);
-        if (atomsElement === undefined || null) {
+        if (atomsElement === null) {
           cb(null, {
             status: status.codes.UnknownError.code
             , value: "Error converting element ID for using in WD atoms: " + args[i].ELEMENT
           });
+        return;
         }
         args[i] = atomsElement;
       }

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -301,6 +301,28 @@ module.exports.buildTests = function(webviewType) {
         });
       });
     });
+    it('should convert selenium element arg to webview element', function(done) {
+      loadWebView(h.driver, function() {
+        h.driver.elementById('useragent', function(err, el) {
+          should.not.exist(err);
+          h.driver.execute('return arguments[0].scrollIntoView(true);', [{'ELEMENT': '5000'}], function(err) {
+            should.not.exist(err);
+            done();
+          });
+        });
+      });
+    });
+    it('should catch stale or undefined element as arg', function(done) {
+      loadWebView(h.driver, function() {
+        h.driver.elementById('useragent', function(err, el) {
+          should.not.exist(err);
+          h.driver.execute('return arguments[0].scrollIntoView(true);', [{'ELEMENT': '5002'}], function(err) {
+            should.exist(err);
+            done();
+          });
+        });
+      });
+    });
   });
 };
 

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -312,7 +312,7 @@ module.exports.buildTests = function(webviewType) {
         });
       });
     });
-    it.only('should catch stale or undefined element as arg', function(done) {
+    it('should catch stale or undefined element as arg', function(done) {
       loadWebView(h.driver, function() {
         h.driver.elementById('useragent', function(err, el) {
           should.not.exist(err);

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -305,18 +305,18 @@ module.exports.buildTests = function(webviewType) {
       loadWebView(h.driver, function() {
         h.driver.elementById('useragent', function(err, el) {
           should.not.exist(err);
-          h.driver.execute('return arguments[0].scrollIntoView(true);', [{'ELEMENT': '5000'}], function(err) {
+          h.driver.execute('return arguments[0].scrollIntoView(true);', [{'ELEMENT': el.value}], function(err) {
             should.not.exist(err);
             done();
           });
         });
       });
     });
-    it('should catch stale or undefined element as arg', function(done) {
+    it.only('should catch stale or undefined element as arg', function(done) {
       loadWebView(h.driver, function() {
         h.driver.elementById('useragent', function(err, el) {
           should.not.exist(err);
-          h.driver.execute('return arguments[0].scrollIntoView(true);', [{'ELEMENT': '5002'}], function(err) {
+          h.driver.execute('return arguments[0].scrollIntoView(true);', [{'ELEMENT': (el.value + 1)}], function(err) {
             should.exist(err);
             done();
           });


### PR DESCRIPTION
If you make a call something like:

```
web_element = driver.find_element_by_something('element')
execute_script('arguments[0].scrollIntoView(true);', web_element)
```

Selenium will proxy the 'web_element' as [{'ELEMENT': elementId}].

Appium cannot handle this response, as it needs to convert the elementId into a wde value for the remote webdriver. This change does that.

Please review:

ios.js:891 and following. Not sure how to handle a callback in a loop.
webview.js:320 - what's a better way to check for an error here (more specifically)? I noticed that it's not raising the error in the callback in ios.js:891.

I leave making appium handle the response with a web element to someone else (probably future Jason, who's already pissed that I'm not doing it).
