### PR TITLE
[Android] Steps must be int or Java will crash

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -419,7 +419,7 @@ Android.prototype.swipe = function(startX, startY, endX, endY, duration, touchCo
     , startY: startY
     , endX: endX
     , endY: endY
-    , steps: (duration * 1000) / 5
+    , steps: Math.round((duration * 1000) / 5)
   };
   if (elId !== null) {
     swipeOpts.elementId = elId;


### PR DESCRIPTION
Fix #291

I didn't test this however it should work. Java will crash if steps is not an int.
