### PR TITLE
[Android] Remove skipInstall

### DIFF
--- a/app/appium.js
+++ b/app/appium.js
@@ -317,7 +317,6 @@ Appium.prototype.invoke = function() {
           , appActivity: this.args.androidActivity
           , reset: !this.args.noReset
           , fastReset: this.args.fastReset
-          , skipInstall: this.args.skipAndroidInstall
         };
         this.devices[this.deviceType] = android(androidOpts);
       } else {

--- a/app/parser.js
+++ b/app/parser.js
@@ -134,17 +134,6 @@ var args = [
             "to launch from your package (e.g., MainActivity)"
   }],
 
-  [['--skip-install'], {
-    dest: 'skipAndroidInstall'
-    , defaultValue: false
-    , action: 'storeTrue'
-    , required: false
-    , help: "(Android-only) Don't install the app; assume it's already on the " +
-            'device with a recent version. Useful for test development ' +
-            'against an unchanging app.'
-    , nargs: 0
-  }],
-
   [['--safari'], {
     defaultValue: false
     , action: 'storeTrue'

--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -23,7 +23,6 @@ All flags are optional, but some are required in conjunction with certain others
 |`--without-delay`|false|(IOS-only) IOS has a weird built-in unavoidable delay. One way around this is to run instruments with a library loaded to patch it so that it skips the delay. Use this flag to speed up  test execution.||
 |`--app-pkg`|null|(Android-only) Java package of the Android app you want to run (e.g., com.example.android.myApp)|`--app-pkg com.example.android.myApp`|
 |`--app-activity`|MainActivity|(Android-only) Activity name for the Android activity you want to launch from your package (e.g., MainActivity)|`--app-activity MainActivity`|
-|`--skip-install`|false|(Android-only) Don't install the app; assume it's already on the device with a recent version. Useful for test development against an unchanging app.||
 |`--safari`|false|(IOS-Only) Use the safari app||
 |`--force-iphone`|false|(IOS-only) Use the iPhone Simulator no matter what the app wants||
 |`--force-ipad`|false|(IOS-only) Use the iPad Simulator no matter what the app wants||

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -23,7 +23,6 @@ var ADB = function(opts) {
     opts.sdkRoot = process.env.ANDROID_HOME || '';
   }
   this.sdkRoot = opts.sdkRoot;
-  this.skipInstall = opts.skipInstall || false;
   // Don't uninstall if using fast reset.
   // Uninstall if reset is set and fast reset isn't.
   this.skipUninstall = opts.fastReset || !(opts.reset || false);
@@ -795,12 +794,7 @@ ADB.prototype.installApp = function(cb) {
           function() { cb(null); });
   };
 
-  if (this.skipInstall) {
-    this.debug("Not installing app because server started with --skip-install");
-    cb();
-  } else {
-    next();
-  }
+  next();
 };
 
 ADB.prototype.back = function(cb) {


### PR DESCRIPTION
Install is now able to detect if the APK exists on device or not.
This removes the need for a skipInstall flag.

Fix #313
