### PR TITLE
Add wait for activity.

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -21,6 +21,7 @@ var Android = function(opts) {
   this.apkPath = opts.apkPath;
   this.appPackage = opts.appPackage;
   this.appActivity = opts.appActivity;
+  this.appWaitActivity = opts.appWaitActivity;
   this.verbose = opts.verbose;
   this.queue = [];
   this.progress = 0;

--- a/app/appium.js
+++ b/app/appium.js
@@ -164,6 +164,7 @@ Appium.prototype.configure = function(desiredCaps, cb) {
   }
   this.args.androidPackage = desiredCaps["app-package"] || this.args.androidPackage;
   this.args.androidActivity = desiredCaps["app-activity"] || this.args.androidActivity;
+  this.args.androidWaitActivity = desiredCaps["app-wait-activity"] || this.args.androidActivity;
   if (hasAppInCaps || this.args.app) {
     var appPath = (hasAppInCaps ? desiredCaps.app : this.args.app)
       , origin = (hasAppInCaps ? "desiredCaps" : "command line")
@@ -309,6 +310,7 @@ Appium.prototype.invoke = function() {
           , verbose: this.args.verbose
           , appPackage: this.args.androidPackage
           , appActivity: this.args.androidActivity
+          , appWaitActivity: this.args.androidWaitActivity
           , reset: !this.args.noReset
           , fastReset: this.args.fastReset
         };

--- a/app/parser.js
+++ b/app/parser.js
@@ -134,6 +134,15 @@ var args = [
             "to launch from your package (e.g., MainActivity)"
   }],
 
+  [['--app-wait-activity'], {
+    dest: 'androidWaitActivity'
+    , defaultValue: false
+    , required: false
+    , example: "SplashActivity"
+    , help: "(Android-only) Activity name for the Android activity you want " +
+            "to wait for (e.g., SplashActivity)"
+  }],
+
   [['--safari'], {
     defaultValue: false
     , action: 'storeTrue'

--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -23,6 +23,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--without-delay`|false|(IOS-only) IOS has a weird built-in unavoidable delay. One way around this is to run instruments with a library loaded to patch it so that it skips the delay. Use this flag to speed up  test execution.||
 |`--app-pkg`|null|(Android-only) Java package of the Android app you want to run (e.g., com.example.android.myApp)|`--app-pkg com.example.android.myApp`|
 |`--app-activity`|MainActivity|(Android-only) Activity name for the Android activity you want to launch from your package (e.g., MainActivity)|`--app-activity MainActivity`|
+|`--app-wait-activity`|false|(Android-only) Activity name for the Android activity you want to wait for (e.g., SplashActivity)|`--app-wait-activity SplashActivity`|
 |`--safari`|false|(IOS-Only) Use the safari app||
 |`--force-iphone`|false|(IOS-only) Use the iPhone Simulator no matter what the app wants||
 |`--force-ipad`|false|(IOS-only) Use the iPad Simulator no matter what the app wants||

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -30,6 +30,7 @@ var ADB = function(opts) {
   this.avdName = opts.avdName;
   this.appPackage = opts.appPackage;
   this.appActivity = opts.appActivity;
+  this.appWaitActivity = opts.appWaitActivity;
   this.apkPath = opts.apkPath;
   this.adb = "adb";
   this.adbCmd = this.adb;
@@ -629,7 +630,8 @@ ADB.prototype.waitForActivity = function(cb) {
     , match = null
     , foundActivity = false
     , found = null
-    , searchRe = new RegExp(/mFocusedApp.+ ([a-zA-Z0-9\.]+)\/\.([^\}]+)\}/);
+    , searchRe = new RegExp(/mFocusedApp.+ ([a-zA-Z0-9\.]+)\/\.([^\}]+)\}/)
+    , targetActivity = this.appWaitActivity || this.appActivity;
 
   var getFocusedApp = _.bind(function() {
     exec(cmd, _.bind(function(err, stdout) {
@@ -642,7 +644,7 @@ ADB.prototype.waitForActivity = function(cb) {
           match = searchRe.exec(line);
           if (match) {
             found = match;
-            if (match[1] === this.appPackage && match[2] === this.appActivity) {
+            if (match[1] === this.appPackage && match[2] === targetActivity) {
               foundActivity = true;
             }
           }


### PR DESCRIPTION
Fix #332

This fixes the problem where the starting activity is not the activity that Appium should be waiting for.
