### PR TITLE
Added configurable timeout for device ready state

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -22,6 +22,7 @@ var Android = function(opts) {
   this.appPackage = opts.appPackage;
   this.appActivity = opts.appActivity;
   this.appWaitActivity = opts.appWaitActivity;
+  this.appDeviceReadyTimeout = opts.appDeviceReadyTimeout;
   this.verbose = opts.verbose;
   this.queue = [];
   this.progress = 0;

--- a/app/appium.js
+++ b/app/appium.js
@@ -165,6 +165,7 @@ Appium.prototype.configure = function(desiredCaps, cb) {
   this.args.androidPackage = desiredCaps["app-package"] || this.args.androidPackage;
   this.args.androidActivity = desiredCaps["app-activity"] || this.args.androidActivity;
   this.args.androidWaitActivity = desiredCaps["app-wait-activity"] || this.args.androidActivity;
+  this.args.androidDeviceReadyTimeout = desiredCaps["device-ready-timeout"] || this.args.androidDeviceReadyTimeout;
   if (hasAppInCaps || this.args.app) {
     var appPath = (hasAppInCaps ? desiredCaps.app : this.args.app)
       , origin = (hasAppInCaps ? "desiredCaps" : "command line")
@@ -329,6 +330,7 @@ Appium.prototype.invoke = function() {
           , appPackage: this.args.androidPackage
           , appActivity: this.args.androidActivity
           , appWaitActivity: this.args.androidWaitActivity
+          , appDeviceReadyTimeout: this.args.androidDeviceReadyTimeout
           , reset: !this.args.noReset
           , fastReset: this.args.fastReset
         };

--- a/app/parser.js
+++ b/app/parser.js
@@ -143,6 +143,14 @@ var args = [
             "to wait for (e.g., SplashActivity)"
   }],
 
+ [['--device-ready-timeout'], {
+    dest: 'androidDeviceReadyTimeout'
+    , defaultValue: '5'
+    , required: false
+    , example: "5"
+    , help: "(Android-only) Timeout in seconds while waiting for device to become ready"
+  }],
+
   [['--safari'], {
     defaultValue: false
     , action: 'storeTrue'

--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -24,6 +24,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--app-pkg`|null|(Android-only) Java package of the Android app you want to run (e.g., com.example.android.myApp)|`--app-pkg com.example.android.myApp`|
 |`--app-activity`|MainActivity|(Android-only) Activity name for the Android activity you want to launch from your package (e.g., MainActivity)|`--app-activity MainActivity`|
 |`--app-wait-activity`|false|(Android-only) Activity name for the Android activity you want to wait for (e.g., SplashActivity)|`--app-wait-activity SplashActivity`|
+|`--device-ready-timeout`|5|(Android-only) Timeout in seconds while waiting for device to become ready|`--device-ready-timeout 5`|
 |`--safari`|false|(IOS-Only) Use the safari app||
 |`--force-iphone`|false|(IOS-only) Use the iPhone Simulator no matter what the app wants||
 |`--force-ipad`|false|(IOS-only) Use the iPad Simulator no matter what the app wants||

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -512,7 +512,7 @@ ADB.prototype.waitForDevice = function(cb) {
                this.appDeviceReadyTimeout + ")");
     var movedOn = false
       , cmd = this.adbCmd + " wait-for-device"
-      , timeoutSecs = parseInt(this.appDeviceReadyTimeout);
+      , timeoutSecs = parseInt(this.appDeviceReadyTimeout, 10);
 
     setTimeout(_.bind(function() {
       if (!movedOn) {

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -31,6 +31,7 @@ var ADB = function(opts) {
   this.appPackage = opts.appPackage;
   this.appActivity = opts.appActivity;
   this.appWaitActivity = opts.appWaitActivity;
+  this.appDeviceReadyTimeout = opts.appDeviceReadyTimeout;
   this.apkPath = opts.apkPath;
   this.adb = "adb";
   this.adbCmd = this.adb;
@@ -507,10 +508,11 @@ ADB.prototype.waitForDevice = function(cb) {
   this.requireDeviceId();
   var doWait = _.bind(function(innerCb) {
     this.debug("Waiting for device " + this.curDeviceId + " to be ready " +
-               "and to respond to shell commands");
+               "and to respond to shell commands (timeout = " +
+               this.appDeviceReadyTimeout + ")");
     var movedOn = false
       , cmd = this.adbCmd + " wait-for-device"
-      , timeoutSecs = 5;
+      , timeoutSecs = parseInt(this.appDeviceReadyTimeout);
 
     setTimeout(_.bind(function() {
       if (!movedOn) {


### PR DESCRIPTION
I found that 5 seconds was too short for our app, and so I made it
configurable with the option:  device-ready-timeout in seconds.
