### PR TITLE
Add mobile 'source' getPageSourceXML

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -453,6 +453,34 @@ Android.prototype.getPageSource = function(cb) {
         });
 };
 
+Android.prototype.getPageSourceXML = function(cb) {
+  var me = this;
+  var xmlFile = '/tmp/dump.xml';
+  async.series(
+        [
+          function(cb) {
+            var cmd = me.adb.adbCmd + ' shell uiautomator dump /cache/dump.xml;';
+            cmd += me.adb.adbCmd + ' pull /cache/dump.xml ' + xmlFile;
+            logger.debug('getPageSourceXML command: ' + cmd);
+            exec(cmd, {}, function(err, stdout, stderr) {
+              if (err) {
+                logger.warn(stderr);
+                return cb(err);
+              }
+              cb(null);
+            });
+          }
+        ],
+        // Top level cb
+        function(){
+          var xml = fs.readFileSync(xmlFile, 'utf8');
+          cb(null, {
+               status: status.codes.Success.code
+               , value: xml
+             });
+        });
+};
+
 Android.prototype.getAlertText = function(cb) {
     cb(new NotYetImplementedError(), null);
 };

--- a/app/controller.js
+++ b/app/controller.js
@@ -281,6 +281,18 @@ exports.mobileFlick = function(req, res) {
   }
 };
 
+exports.mobileSource = function(req, res) {
+  var type = req.body.type;
+
+  if(checkMissingParams(res, {type: type})) {
+    if (type.toLowerCase() === "xml") {
+      req.device.getPageSourceXML(getResponseHandler(req, res));
+    } else {
+      req.device.getPageSource(getResponseHandler(req, res));
+    }
+  }
+};
+
 exports.mobileSwipe = function(req, res) {
   var onElement = typeof req.body.element !== "undefined";
   req.body = _.defaults(req.body, {
@@ -674,6 +686,7 @@ var mobileCmdMap = {
   , 'keyevent' : exports.keyevent
   , 'leaveWebView': exports.leaveWebView
   , 'fireEvent': exports.fireEvent
+  , 'source': exports.mobileSource
 };
 
 exports.produceError = function(req, res) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -1169,6 +1169,8 @@ IOS.prototype.getPageSource = function(cb) {
   }
 };
 
+IOS.prototype.getPageSourceXML = IOS.prototype.getPageSource;
+
 IOS.prototype.getAlertText = function(cb) {
   this.proxy("au.getAlertText()", cb);
 };


### PR DESCRIPTION
There's no XPath for JSON. The XML is much easier to deal with. This adds a `mobile 'source'` method which returns XML on Android and the regular source on iOS.

``` ruby
> mobile 'source'
post
session/1227006c-1b72-4215-bfbe-8c79064fb053/execute
{"script":"mobile: source","args":[]}
=> "<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>...
```
