### PR TITLE
Reconnect after bootstrap disconnect

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -68,7 +68,8 @@ Android.prototype.start = function(cb, onDie) {
   var onLaunch = _.bind(function(err) {
     if (err) {
       logger.error("Relaunching adb....");
-      this.adb.waitForDevice(function(){ didLaunch = true; cb(null); });
+      var me = this;
+      this.adb.waitForDevice(function(){ didLaunch = true; me.push(null, true); cb(null); });
     } else {
       logger.info("ADB launched! Ready for commands (will time out in " +
                   (this.commandTimeoutMs / 1000) + "secs)");

--- a/app/android.js
+++ b/app/android.js
@@ -67,10 +67,8 @@ Android.prototype.start = function(cb, onDie) {
 
   var onLaunch = _.bind(function(err) {
     if (err) {
-      logger.error("ADB failed to launch!");
-      this.adb = null;
-      this.onStop = null;
-      cb(err);
+      logger.error("Relaunching adb....");
+      this.adb.waitForDevice(function(){ didLaunch = true; cb(null); });
     } else {
       logger.info("ADB launched! Ready for commands (will time out in " +
                   (this.commandTimeoutMs / 1000) + "secs)");

--- a/app/android.js
+++ b/app/android.js
@@ -159,8 +159,6 @@ Android.prototype.push = function(elem, resendLast) {
     this.queue.push(this.lastCmd);
   } else {
     this.queue.push(elem);
-    // Store the last command in case the bootstrap jar disconnects.
-    this.lastCmd = elem;
   }
 
   var next = _.bind(function() {
@@ -177,6 +175,11 @@ Android.prototype.push = function(elem, resendLast) {
       , action = target[0][0]
       , params = typeof target[0][1] === "undefined" ? {} : target[0][1]
       , cb = target[1];
+
+    if (!resendLast) {
+      // Store the last command in case the bootstrap jar disconnects.
+      this.lastCmd = target;
+    }
 
     this.cbForCurrentCmd = cb;
 

--- a/app/appium.js
+++ b/app/appium.js
@@ -341,6 +341,12 @@ Appium.prototype.invoke = function() {
 
     this.device.start(function(err) {
       me.progress++;
+      // Ensure we don't use an undefined session.
+      if (typeof me.sessions[me.progress] === 'undefined') {
+        me.progress--;
+        return;
+      }
+
       me.sessions[me.progress].sessionId = me.sessionId;
       me.sessions[me.progress].callback(err, me.device);
       if (err) {


### PR DESCRIPTION
We don't know if the bootstrap has disconnected until a command is issued and
the `uiautomator runtest` command crashes. The crash is detected, uiautomator is
restarted, and the command that detected the crash is resent.
## 

Sometimes there's this error `ADB failed to launch!` so I think there's a timing issue.
