### PR TITLE
Added initial pom file for boostrap project

### DIFF
--- a/uiautomator/bootstrap/README.md
+++ b/uiautomator/bootstrap/README.md
@@ -1,0 +1,12 @@
+Bootstrap Android
+===
+
+To install the Android Maven dependencies in your local environment, run the following:
+
+* Clone https://github.com/mosabua/maven-android-sdk-deployer into your workstation
+* Set the ANDROID_HOME environment to the location of the Android SDK, eg. `export ANDROID_HOME=/Developer/adt-bundle-mac-x86_64-20130219/sdk/`
+* Run `mvn install` from the `maven-android-sdk-deployer` directory
+
+You can then compile the bootstrap project by running
+
+    mvn package

--- a/uiautomator/bootstrap/pom.xml
+++ b/uiautomator/bootstrap/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.appium.android</groupId>
+    <artifactId>bootstrap</artifactId>
+    <description>Maven project for the Appium Android Bootstrap</description>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <build>
+        <sourceDirectory>${basedir}/src</sourceDirectory>
+        <plugins>
+
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.5</source>
+                    <target>1.5</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20080701</version>
+        </dependency>
+
+        <dependency>
+          <groupId>android</groupId>
+          <artifactId>android</artifactId>
+          <version>4.2.2_r2</version>
+        </dependency>
+
+        <dependency>
+          <groupId>android.test.uiautomator</groupId>
+          <artifactId>uiautomator</artifactId>
+          <version>4.2.2_r2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+        </dependency>
+
+    </dependencies>
+
+</project>


### PR DESCRIPTION
In response to appium/appium#353, I've added an initial version of a pom.xml file that can be used to build the bootstrap project.  The pom file relies on the [Maven Android SDK Deployer](https://github.com/mosabua/maven-android-sdk-deployer) project, which will deploy the Android SDK jars to a local Maven repository.  

To install the Android 4.2 dependencies within your local Maven repository, run `mvn -P4.2 install` from the maven-android-sdk-deployer directory.

Let me know what you think:)
