### PR TITLE
Async javascript + some refactoring

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -34,6 +34,7 @@ var Android = function(opts) {
   this.shuttingDown = false;
   this.adb = null;
   this.swipeStepsPerSec = 200;
+  this.asyncWaitMs = 0;
   this.capabilities = {
     platform: 'LINUX'
     , browserName: 'Android'
@@ -405,6 +406,10 @@ Android.prototype.implicitWait = function(ms, cb) {
     status: status.codes.Success.code
     , value: null
   });
+};
+
+Android.prototype.asyncTimeoutMs = function(ms, cb) {
+    cb(new NotYetImplementError(), null);
 };
 
 Android.prototype.elementDisplayed = function(elementId, cb) {

--- a/app/android.js
+++ b/app/android.js
@@ -408,8 +408,12 @@ Android.prototype.implicitWait = function(ms, cb) {
   });
 };
 
-Android.prototype.asyncTimeoutMs = function(ms, cb) {
-    cb(new NotYetImplementError(), null);
+Android.prototype.asyncScriptTimeout = function(ms, cb) {
+    cb(new NotYetImplementedError(), null);
+};
+
+Android.prototype.executeAsync = function(script, args, responseUrl, cb) {
+    cb(new NotYetImplementedError(), null);
 };
 
 Android.prototype.elementDisplayed = function(elementId, cb) {

--- a/app/controller.js
+++ b/app/controller.js
@@ -623,7 +623,7 @@ exports.getCommandTimeout = function(req, res) {
 
 exports.receiveAsyncResponse = function(req, res) {
   var asyncResponse = req.body;
-  req.device.receiveAsyncResponse(asyncResponse, getResponseHandler(req, res));
+  req.device.receiveAsyncResponse(asyncResponse);
 };
 
 exports.setValueImmediate = function(req, res) {

--- a/app/controller.js
+++ b/app/controller.js
@@ -446,6 +446,11 @@ exports.implicitWait = function(req, res) {
   req.device.implicitWait(ms, getResponseHandler(req, res));
 };
 
+exports.asyncScriptTimeout = function(req, res) {
+  var ms = req.body.ms;
+  req.device.asyncScriptTimeout(ms, getResponseHandler(req, res));
+};
+
 exports.setOrientation = function(req, res) {
   var orientation = req.body.orientation;
   req.device.setOrientation(orientation, getResponseHandler(req, res));

--- a/app/controller.js
+++ b/app/controller.js
@@ -534,7 +534,10 @@ exports.execute = function(req, res) {
 exports.executeAsync = function(req, res) {
   var script = req.body.script
     , args = req.body.args
-    , responseUrl = ('http://' + req.appium.args.address + ':' + req.appium.args.port + '/wd/hub/session/' + req.appium.sessionId + '/receive_async_response');
+    , responseUrl = '';
+
+    responseUrl += 'http://' + req.appium.args.address + ':' + req.appium.args.port;
+    responseUrl += '/wd/hub/session/' + req.appium.sessionId + '/receive_async_response';
 
   if(checkMissingParams(res, {script: script, args: args})) {
     req.device.executeAsync(script, args, responseUrl, getResponseHandler(req, res));

--- a/app/controller.js
+++ b/app/controller.js
@@ -531,6 +531,16 @@ exports.execute = function(req, res) {
   }
 };
 
+exports.executeAsync = function(req, res) {
+  var script = req.body.script
+    , args = req.body.args
+    , responseUrl = ('http://' + req.appium.args.address + ':' + req.appium.args.port + '/wd/hub/session/' + req.appium.sessionId + '/receive_async_response');
+
+  if(checkMissingParams(res, {script: script, args: args})) {
+    req.device.executeAsync(script, args, responseUrl, getResponseHandler(req, res));
+    }
+};
+
 exports.executeMobileMethod = function(req, res, cmd) {
   var args = req.body.args
     , params = {};
@@ -609,6 +619,11 @@ exports.setCommandTimeout = function(req, res) {
 
 exports.getCommandTimeout = function(req, res) {
   req.device.getCommandTimeout(getResponseHandler(req, res));
+};
+
+exports.receiveAsyncResponse = function(req, res) {
+  var asyncResponse = req.body;
+  req.device.receiveAsyncResponse(asyncResponse, getResponseHandler(req, res));
 };
 
 exports.setValueImmediate = function(req, res) {

--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -270,7 +270,7 @@ RemoteDebugger.prototype.executeAtomAsync = function(atom, args, frames, respons
     for (var i = 0; i < frames.length; i++) {
       script = this.wrapScriptForFrame(script, frames[i]);
     }
-    script += "(" + args.join(',') + ")";
+    script += "(" + args.join(',') + ", " + asyncCallBack + ", true )";
   } else {
     logger.info("Executing atom in default context");
     script += "(" + atomSrc + ")(" + args.join(',') + ", " + asyncCallBack + ", true )";

--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -258,10 +258,9 @@ RemoteDebugger.prototype.executeAtom = function(atom, args, frames, cb) {
 
 RemoteDebugger.prototype.executeAtomAsync = function(atom, args, frames, responseUrl, cb) {
   var atomSrc, script = ""
-    , me = this
     , asyncCallBack = "";
 
-  asyncCallBack += "function(res) { xmlHttp = new XMLHttpRequest(); xmlHttp.open('POST', '" + responseUrl + "', true);"
+  asyncCallBack += "function(res) { xmlHttp = new XMLHttpRequest(); xmlHttp.open('POST', '" + responseUrl + "');"
   asyncCallBack += "xmlHttp.setRequestHeader('Content-type','application/json'); xmlHttp.send(res); }"
 
   atomSrc = atoms.get(atom);

--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -274,7 +274,6 @@ RemoteDebugger.prototype.executeAtomAsync = function(atom, args, frames, respons
   } else {
     logger.info("Executing atom in default context");
     script += "(" + atomSrc + ")(" + args.join(',') + ", " + asyncCallBack + ", true )";
-    console.log(script)
   }
   this.execute(script, function(err, res) {
     if (err) {

--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -260,7 +260,7 @@ RemoteDebugger.prototype.executeAtomAsync = function(atom, args, frames, respons
   var atomSrc, script = ""
     , asyncCallBack = "";
 
-  asyncCallBack += "function(res) { xmlHttp = new XMLHttpRequest(); xmlHttp.open('POST', '" + responseUrl + "');"
+  asyncCallBack += "function(res) { xmlHttp = new XMLHttpRequest(); xmlHttp.open('POST', '" + responseUrl + "', true);"
   asyncCallBack += "xmlHttp.setRequestHeader('Content-type','application/json'); xmlHttp.send(res); }"
 
   atomSrc = atoms.get(atom);
@@ -280,11 +280,6 @@ RemoteDebugger.prototype.executeAtomAsync = function(atom, args, frames, respons
     if (err) {
       cb(err, {
         status: status.codes.UnknownError.code
-        , value: res
-      });
-    } else {
-      cb(null, {
-        status: status.codes.Success.code
         , value: res
       });
     }

--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -256,6 +256,42 @@ RemoteDebugger.prototype.executeAtom = function(atom, args, frames, cb) {
   });
 };
 
+RemoteDebugger.prototype.executeAtomAsync = function(atom, args, frames, responseUrl, cb) {
+  var atomSrc, script = ""
+    , me = this
+    , asyncCallBack = "";
+
+  asyncCallBack += "function(res) { xmlHttp = new XMLHttpRequest(); xmlHttp.open('POST', '" + responseUrl + "', true);"
+  asyncCallBack += "xmlHttp.setRequestHeader('Content-type','application/json'); xmlHttp.send(res); }"
+
+  atomSrc = atoms.get(atom);
+  args = _.map(args, JSON.stringify);
+  if (frames.length > 0) {
+    script = atomSrc;
+    for (var i = 0; i < frames.length; i++) {
+      script = this.wrapScriptForFrame(script, frames[i]);
+    }
+    script += "(" + args.join(',') + ")";
+  } else {
+    logger.info("Executing atom in default context");
+    script += "(" + atomSrc + ")(" + args.join(',') + ", " + asyncCallBack + ", true )";
+    console.log(script)
+  }
+  this.execute(script, function(err, res) {
+    if (err) {
+      cb(err, {
+        status: status.codes.UnknownError.code
+        , value: res
+      });
+    } else {
+      cb(null, {
+        status: status.codes.Success.code
+        , value: res
+      });
+    }
+  });
+};
+
 RemoteDebugger.prototype.execute = function(command, cb) {
   var me = this;
   if (this.pageLoading) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -849,9 +849,45 @@ IOS.prototype.executeAtomAsync = function(atom, args, responseUrl, cb) {
 };
 
 IOS.prototype.receiveAsyncResponse = function(asyncResponse) {
-  var asyncCb = this.asyncResponseCb;
-  console.log(asyncResponse);
+  var asyncCb = this.asyncResponseCb
+    , me = this;
+
+  var parseElementResponse = function(element) {
+    var objId = element.ELEMENT
+    , clientId = (5000 + me.webElementIds.length).toString();
+    me.webElementIds.push(objId);
+    return {ELEMENT: clientId};
+  };
+
   if (asyncCb !== null) {
+    var args = asyncResponse
+    if (typeof args.value.length === "undefined") {
+      if (typeof args.value.ELEMENT !== "undefined") {
+        var wdElement = parseElementResponse(args.value);
+        if (wdElement === null) {
+          cb(null, {
+            status: status.codes.UnknownError.code
+            , value: "Error converting element ID atom for using in WD: " + args.value.ELEMENT
+          });
+        }
+      }
+      args.value = wdElement;
+    } else {
+      var args = asyncResponse.value;
+      for (var i=0; i < args.length; i++) {
+        if (typeof args[i].ELEMENT !== "undefined") {
+          var wdElement = parseElementResponse(args[i]);
+          if (wdElement === null) {
+            cb(null, {
+              status: status.codes.UnknownError.code
+              , value: "Error converting element ID atom for using in WD: " + args[i].ELEMENT
+            });
+          return;
+          }
+          args[i] = wdElement;
+        }
+      }
+    }
     asyncCb(null, asyncResponse);
   this.asyncResponseCb = null;
   }

--- a/app/ios.js
+++ b/app/ios.js
@@ -1593,8 +1593,14 @@ IOS.prototype.execute = function(script, args, cb) {
   if (this.curWindowHandle === null) {
     this.proxy(script, cb);
   } else {
-    this.convertElementForAtoms(args, cb);
-    this.executeAtom('execute_script', [script, args], cb);
+    var me = this;
+    this.convertElementForAtoms(args, function(err, res) {
+      if (err) {
+        cb(null, res);
+      } else {
+        me.executeAtom('execute_script', [script, res], cb);
+      }
+    });
   }
 };
 
@@ -1602,8 +1608,14 @@ IOS.prototype.executeAsync = function(script, args, responseUrl, cb) {
   if (this.curWindowHandle === null) {
     this.proxy(script, cb);
   } else {
-    this.convertElementForAtoms(args, cb);
-    this.executeAtomAsync('execute_async_script', [script, args, this.asyncWaitMs], responseUrl, cb);
+    var me = this;
+    this.convertElementForAtoms(args, function(err, res) {
+      if (err) {
+        cb(null, res);
+      } else {
+        me.executeAtomAsync('execute_async_script', [script, args, me.asyncWaitMs], responseUrl, cb);
+      }
+    });
   }
 };
 
@@ -1612,7 +1624,7 @@ IOS.prototype.convertElementForAtoms = function(args, cb) {
     if (typeof args[i].ELEMENT !== "undefined") {
       var atomsElement = this.getAtomsElement(args[i].ELEMENT);
       if (atomsElement === null) {
-        cb(null, {
+        cb(true, {
           status: status.codes.UnknownError.code
           , value: "Error converting element ID for using in WD atoms: " + args[i].ELEMENT
         });
@@ -1621,6 +1633,7 @@ IOS.prototype.convertElementForAtoms = function(args, cb) {
       args[i] = atomsElement;
     }
   }
+  cb(false, args);
 };
 
 IOS.prototype.title = function(cb) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -861,35 +861,39 @@ IOS.prototype.receiveAsyncResponse = function(asyncResponse) {
 
   if (asyncCb !== null) {
     var args = asyncResponse
-    if (typeof args.value.length === "undefined") {
-      if (typeof args.value.ELEMENT !== "undefined") {
-        var wdElement = parseElementResponse(args.value);
-        if (wdElement === null) {
-          cb(null, {
-            status: status.codes.UnknownError.code
-            , value: "Error converting element ID atom for using in WD: " + args.value.ELEMENT
-          });
-        }
-      }
-      args.value = wdElement;
-    } else {
-      var args = asyncResponse.value;
-      for (var i=0; i < args.length; i++) {
-        if (typeof args[i].ELEMENT !== "undefined") {
-          var wdElement = parseElementResponse(args[i]);
+    if (args.value !== null) {
+      if (typeof args.value.length === "undefined") {
+        if (typeof args.value.ELEMENT !== "undefined") {
+          var wdElement = parseElementResponse(args.value);
           if (wdElement === null) {
             cb(null, {
               status: status.codes.UnknownError.code
-              , value: "Error converting element ID atom for using in WD: " + args[i].ELEMENT
+              , value: "Error converting element ID atom for using in WD: " + args.value.ELEMENT
             });
-          return;
           }
-          args[i] = wdElement;
+          args.value = wdElement;
+        }
+      } else {
+        var args = asyncResponse.value;
+        for (var i=0; i < args.length; i++) {
+          if (args[i] !== null) {
+            if (typeof args[i].ELEMENT !== "undefined") {
+              var wdElement = parseElementResponse(args[i]);
+              if (wdElement === null) {
+                cb(null, {
+                  status: status.codes.UnknownError.code
+                  , value: "Error converting element ID atom for using in WD: " + args[i].ELEMENT
+                });
+              return;
+              }
+              args[i] = wdElement;
+            }
+          }
         }
       }
     }
     asyncCb(null, asyncResponse);
-  this.asyncResponseCb = null;
+    this.asyncResponseCb = null;
   }
 };
 

--- a/app/ios.js
+++ b/app/ios.js
@@ -785,6 +785,9 @@ IOS.prototype.receiveAsyncResponse = function(asyncResponse) {
     this.parseExecuteResponse(asyncResponse, asyncCb);
     asyncCb(null, asyncResponse);
     this.asyncResponseCb = null;
+  } else {
+    logger.warn("Received async response when we weren't expecting one! " +
+                    "Response was: " + JSON.stringify(asyncResponse));
   }
 };
 

--- a/app/ios.js
+++ b/app/ios.js
@@ -857,7 +857,6 @@ IOS.prototype.lookForAlert = function(cb, looks) {
           } else {
             // say we're processing remote cmd again
             me.processingRemoteCmd = true;
-            console.log('calling setTimeout again');
             setTimeout(_.bind(me.lookForAlert, me, [cb, looks]), 1000);
           }
         }

--- a/app/ios.js
+++ b/app/ios.js
@@ -817,18 +817,16 @@ IOS.prototype.parseExecuteResponse = function(response, cb) {
       var args = response.value;
       for (var i=0; i < args.length; i++) {
         wdElement = args[i];
-        if (args[i] !== null) {
-          if (typeof args[i].ELEMENT !== "undefined") {
-            wdElement = this.parseElementResponse(args[i]);
-            if (wdElement === null) {
-              cb(null, {
-                status: status.codes.UnknownError.code
-                , value: "Error converting element ID atom for using in WD: " + args[i].ELEMENT
-              });
-              return;
-            }
-          args[i] = wdElement;
+        if ((args[i] !== null) && (typeof args[i].ELEMENT !== "undefined")) {
+          wdElement = this.parseElementResponse(args[i]);
+          if (wdElement === null) {
+            cb(null, {
+              status: status.codes.UnknownError.code
+              , value: "Error converting element ID atom for using in WD: " + args[i].ELEMENT
+            });
+            return;
           }
+        args[i] = wdElement;
         }
       }
       response.value = args;

--- a/app/ios.js
+++ b/app/ios.js
@@ -43,6 +43,7 @@ var IOS = function(args) {
   this.windowHandleCache = [];
   this.webElementIds = [];
   this.implicitWaitMs = 0;
+  this.asyncWaitMs = 0;
   this.curCoords = null;
   this.curWebCoords = null;
   this.onPageChangeCb = null;
@@ -1160,6 +1161,15 @@ IOS.prototype.frame = function(frame, cb) {
 IOS.prototype.implicitWait = function(ms, cb) {
   this.implicitWaitMs = parseInt(ms, 10);
   logger.info("Set iOS implicit wait to " + ms + "ms");
+  cb(null, {
+    status: status.codes.Success.code
+    , value: null
+  });
+};
+
+IOS.prototype.asyncScriptTimeout = function(ms, cb) {
+  this.asyncTimeout = parseInt(ms, 10);
+  logger.info("Set iOS async script timeout to " + ms + "ms");
   cb(null, {
     status: status.codes.Success.code
     , value: null

--- a/app/ios.js
+++ b/app/ios.js
@@ -857,10 +857,10 @@ IOS.prototype.lookForAlert = function(cb, looks) {
           } else {
             // say we're processing remote cmd again
             me.processingRemoteCmd = true;
+            looks ++;
             setTimeout(_.bind(me.lookForAlert, me, [cb, looks]), 1000);
           }
         }
-        looks++;
       });
     }
   }
@@ -1634,7 +1634,7 @@ IOS.prototype.convertElementForAtoms = function(args, cb) {
       args[i] = atomsElement;
     }
   }
-  cb(false, args);
+  cb(null, args);
 };
 
 IOS.prototype.title = function(cb) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -752,6 +752,7 @@ IOS.prototype.executeAtom = function(atom, args, cb, alwaysDefaultFrame) {
     this.processingRemoteCmd = false;
     if (!this.returned) {
       this.returned = true;
+      res = this.parseExecuteResponse(res);
       cb(err, res);
     }
   }, this));

--- a/app/ios.js
+++ b/app/ios.js
@@ -1168,7 +1168,7 @@ IOS.prototype.implicitWait = function(ms, cb) {
 };
 
 IOS.prototype.asyncScriptTimeout = function(ms, cb) {
-  this.asyncTimeout = parseInt(ms, 10);
+  this.asyncWaitMs = parseInt(ms, 10);
   logger.info("Set iOS async script timeout to " + ms + "ms");
   cb(null, {
     status: status.codes.Success.code

--- a/app/ios.js
+++ b/app/ios.js
@@ -827,15 +827,18 @@ IOS.prototype.executeAtomAsync = function(atom, args, responseUrl, cb) {
       logger.info("atom '" + atom + " did not return yet, checking to see if " +
                   "we are blocked by an alert");
       this.proxy("au.alertIsPresent()", function(err, res) {
-        if (res.value === true) {
-          logger.info("Found an alert, returning control to client");
-          returned = true;
-          cb(null, {
-            status: status.codes.Success.code
-            , value: ''
-          });
-        } else {
-          setTimeout(lookForAlert, 1000);
+        if (res !== null) {
+          if (res.value === true) {
+            logger.info("Found an alert, returning control to client");
+            returned = true;
+            cb(null, {
+              status: status.codes.Success.code
+              , value: ''
+            });
+          } else {
+            console.log('queueing lookForAlert');
+            setTimeout(lookForAlert, 1000);
+          }
         }
       });
     }

--- a/app/routing.js
+++ b/app/routing.js
@@ -48,6 +48,7 @@ module.exports = function(appium) {
   rest.post('/wd/hub/session/:sessionId?/accept_alert', controller.postAcceptAlert);
   rest.post('/wd/hub/session/:sessionId?/dismiss_alert', controller.postDismissAlert);
   rest.post('/wd/hub/session/:sessionId?/timeouts/implicit_wait', controller.implicitWait);
+  rest.post('/wd/hub/session/:sessionId?/timeouts/async_script', controller.asyncScriptTimeout);
   rest.get('/wd/hub/session/:sessionId/orientation', controller.getOrientation);
   rest.post('/wd/hub/session/:sessionId/orientation', controller.setOrientation);
   rest.get('/wd/hub/session/:sessionId/screenshot', controller.getScreenshot);
@@ -99,7 +100,6 @@ var routeNotYetImplemented = function(rest) {
   // The rest of the API:
   rest.post('/wd/hub/session/:sessionId?/timeouts', controller.notYetImplemented);
   rest.post('/wd/hub/session/:sessionId?/execute_async', controller.notYetImplemented);
-  rest.post('/wd/hub/session/:sessionId?/timeouts/async_script', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/ime/available_engines', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/ime/active_engine', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/ime/activated', controller.notYetImplemented);

--- a/app/routing.js
+++ b/app/routing.js
@@ -64,6 +64,7 @@ module.exports = function(appium) {
   rest.delete('/wd/hub/session/:sessionId?/window', controller.closeWindow);
   rest.get('/wd/hub/session/:sessionId?/window/:windowhandle?/size', controller.getWindowSize);
   rest.post('/wd/hub/session/:sessionId?/execute', controller.execute);
+  rest.post('/wd/hub/session/:sessionId?/execute_async', controller.executeAsync);
   rest.get('/wd/hub/session/:sessionId?/title', controller.title);
   rest.post('/wd/hub/session/:sessionId?/element/:elementId?/submit', controller.submit);
   rest.post('/wd/hub/session/:sessionId?/moveto', controller.moveTo);
@@ -71,6 +72,9 @@ module.exports = function(appium) {
   rest.post('/wd/hub/session/:sessionId?/back', controller.back);
   rest.post('/wd/hub/session/:sessionId?/forward', controller.forward);
   rest.post('/wd/hub/session/:sessionId?/refresh', controller.refresh);
+
+  // allow appium to receive async response
+  rest.post('/wd/hub/session/:sessionId?/receive_async_response', controller.receiveAsyncResponse);
 
   // these are for testing purposes only
   rest.post('/wd/hub/produce_error', controller.produceError);
@@ -99,7 +103,6 @@ var routeNotYetImplemented = function(rest) {
   rest.get('/wd/hub/session/:sessionId?/local_storage/size', controller.notYetImplemented);
   // The rest of the API:
   rest.post('/wd/hub/session/:sessionId?/timeouts', controller.notYetImplemented);
-  rest.post('/wd/hub/session/:sessionId?/execute_async', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/ime/available_engines', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/ime/active_engine', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/ime/activated', controller.notYetImplemented);

--- a/server.js
+++ b/server.js
@@ -18,9 +18,24 @@ var main = function(args, readyCb, doneCb) {
   // in case we'll support blackberry at some point
   args.device = 'iOS';
 
+  var allowCrossDomain = function(req, res, next) {
+    res.header('Access-Control-Allow-Origin', '*');
+    res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS,DELETE');
+    res.header('Access-Control-Allow-Headers', 'origin, content-type, accept');
+
+    // need to respond 200 to OPTIONS
+
+    if ('OPTIONS' == req.method) {
+      res.send(200);
+    } else {
+      next();
+    }
+  }
+
   rest.configure(function() {
     rest.use(express.favicon());
     rest.use(express.static(path.join(__dirname, '/app/static')));
+    rest.use(allowCrossDomain);
     if (args.verbose) {
       rest.use(express.logger('dev'));
     }

--- a/server.js
+++ b/server.js
@@ -30,7 +30,7 @@ var main = function(args, readyCb, doneCb) {
     } else {
       next();
     }
-  }
+  };
 
   rest.configure(function() {
     rest.use(express.favicon());

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -619,7 +619,7 @@ module.exports.buildTests = function(webviewType) {
       loadWebView(h.driver, function() {
         h.driver.frame("first", function(err) {
           should.not.exist(err);
-          h.driver.execute("return document.title;", function(err, res) {
+          h.driver.execute("return document.getElementsByTagName('h1')[0].innerHTML;", function(err, res) {
             res.should.equal("Sub frame 1");
             done();
           });
@@ -660,11 +660,11 @@ module.exports.buildTests = function(webviewType) {
         });
       });
     });
-    it.only('should execute async javascript in frame', function(done) {
+    it('should execute async javascript in frame', function(done) {
       loadWebView(h.driver, function() {
         h.driver.frame("first", function(err) {
           should.not.exist(err);
-          h.driver.executeAsync("arguments[arguments.length - 1](document.title);", function(err, res) {
+          h.driver.executeAsync("arguments[arguments.length - 1](document.getElementsByTagName('h1')[0].innerHTML);", function(err, res) {
             res.should.equal("Sub frame 1");
             done();
           });

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -606,6 +606,15 @@ module.exports.buildTests = function(webviewType) {
         });
       });
     });
+    it('should be able to return multiple elements from javascript', function(done) {
+      loadWebView(h.driver, function() {
+        h.driver.execute('return document.getElementsByTagName("a")', function(err, res) {
+          should.not.exist(err);
+          res[0].ELEMENT.should.equal('5000');
+          done();
+        });
+      });
+    });
   });
 
   desc("executeAsync", function(h) {
@@ -635,7 +644,7 @@ module.exports.buildTests = function(webviewType) {
           h.driver.executeAsync("return 1 + 2", function(err, res) {
             should.exist(err);
             err.status.should.equal(28);
-            done()
+            done();
           });
         });
       });

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -632,7 +632,7 @@ module.exports.buildTests = function(webviewType) {
     it("should bubble up javascript errors", function(done) {
       loadWebView(h.driver, function() {
         h.driver.executeAsync("'nan'--", function(err, val) {
-          err.message.should.equal("Error response status: 13.");
+          err.status.should.equal(13);
           should.not.exist(val);
           done();
         });
@@ -651,7 +651,7 @@ module.exports.buildTests = function(webviewType) {
     });
     it("should timeout when callback isn't invoked", function(done) {
       loadWebView(h.driver, function() {
-        h.driver.setAsyncScriptTimeout('10000', function(err, res) {
+        h.driver.setAsyncScriptTimeout('2000', function(err, res) {
           h.driver.executeAsync("return 1 + 2", function(err, res) {
             should.exist(err);
             err.status.should.equal(28);

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -608,6 +608,40 @@ module.exports.buildTests = function(webviewType) {
     });
   });
 
+  desc("executeAsync", function(h) {
+    it("should bubble up javascript errors", function(done) {
+      loadWebView(h.driver, function() {
+        h.driver.executeAsync("'nan'--", function(err, val) {
+          err.message.should.equal("Error response status: 13.");
+          should.not.exist(val);
+          done();
+        });
+      });
+    });
+    it("should execute async javascript", function(done) {
+      loadWebView(h.driver, function() {
+        h.driver.setAsyncScriptTimeout('10000', function(err, res) {
+          h.driver.executeAsync("arguments[arguments.length - 1](123);", function(err, val) {
+            should.not.exist(err);
+            val.should.equal(123);
+            done();
+          });
+        });
+      });
+    });
+    it("should timeout when callback isn't invoked", function(done) {
+      loadWebView(h.driver, function() {
+        h.driver.setAsyncScriptTimeout('10000', function(err, res) {
+          h.driver.executeAsync("return 1 + 2", function(err, res) {
+            should.exist(err);
+            err.status.should.equal(28);
+            done()
+          });
+        });
+      });
+    });
+  });
+
   desc('alerts', function(h) {
     it('should accept alert', function(done) {
       loadWebView(h.driver, function() {

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -621,7 +621,7 @@ module.exports.buildTests = function(webviewType) {
           should.not.exist(err);
           h.driver.execute("return document.title;", function(err, res) {
             res.should.equal("Sub frame 1");
-            done()
+            done();
           });
         });
       }, testEndpoint + 'frameset.html', "Frameset guinea pig");
@@ -666,7 +666,7 @@ module.exports.buildTests = function(webviewType) {
           should.not.exist(err);
           h.driver.executeAsync("arguments[arguments.length - 1](document.title);", function(err, res) {
             res.should.equal("Sub frame 1");
-            done()
+            done();
           });
         });
       }, testEndpoint + 'frameset.html', "Frameset guinea pig");

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -608,12 +608,23 @@ module.exports.buildTests = function(webviewType) {
     });
     it('should be able to return multiple elements from javascript', function(done) {
       loadWebView(h.driver, function() {
-        h.driver.execute('return document.getElementsByTagName("a")', function(err, res) {
+        h.driver.execute('return document.getElementsByTagName("a");', function(err, res) {
           should.not.exist(err);
           res[0].ELEMENT.should.equal('5000');
           done();
         });
       });
+    });
+    it('should execute javascript in frame', function(done) {
+      loadWebView(h.driver, function() {
+        h.driver.frame("first", function(err) {
+          should.not.exist(err);
+          h.driver.execute("return document.title;", function(err, res) {
+            res.should.equal("Sub frame 1");
+            done()
+          });
+        });
+      }, testEndpoint + 'frameset.html', "Frameset guinea pig");
     });
   });
 
@@ -648,6 +659,17 @@ module.exports.buildTests = function(webviewType) {
           });
         });
       });
+    });
+    it.only('should execute async javascript in frame', function(done) {
+      loadWebView(h.driver, function() {
+        h.driver.frame("first", function(err) {
+          should.not.exist(err);
+          h.driver.executeAsync("arguments[arguments.length - 1](document.title);", function(err, res) {
+            res.should.equal("Sub frame 1");
+            done()
+          });
+        });
+      }, testEndpoint + 'frameset.html', "Frameset guinea pig");
     });
   });
 


### PR DESCRIPTION
This adds almost all the support for async js. All that's left is handling page navigation during execution, since the strategy we're using here (XmlHTTPRequests) doesn't work well when stuck in unload like the callback is.

**This shouldn't be merged until jlipps has a chance to do some code review, since a LOT has been moved around.**
