### PR TITLE
fix grunt functional test crashes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,24 +34,24 @@ module.exports = function(grunt) {
     }
     , mochaTestWithServer: {
       TestApp: ['ios', {
-        functional: ['test/functional/testapp/*.js']
+        functional: ['test/functional/testapp']
         , server: ['test/functional/appium/appium.js'
                    , 'test/functional/appium/jsonwp.js']
       }]
       , UICatalog: ['ios', {
-        functional: ['test/functional/uicatalog/*.js']
+        functional: ['test/functional/uicatalog']
       }]
       , WebViewApp: ['ios', {
-        functional: ['test/functional/webview/*.js']
+        functional: ['test/functional/webview']
       }]
       , ApiDemos: ['android', {
-        functional: ['test/functional/apidemos/*.js']
+        functional: ['test/functional/apidemos']
       }]
       , Safari: ['ios', {
-        functional: ['test/functional/safari/*.js']
+        functional: ['test/functional/safari']
       }]
       , Preferences: ['ios', {
-        functional: ['test/functional/prefs/*.js']
+        functional: ['test/functional/prefs']
       }]
     }
     , mochaTestConfig: {


### PR DESCRIPTION
Apparently when you run mocha tests (a) as a subprocess and (b) with multiple arguments, it crashes on first failure. If either of those is not the case, it will run all tests as expected.

We have to run as a subprocess, but we don't have to run with all test arguments on one line. Instead, let's loop through them one-by-one so we get nice output and test continuation even if some tests fail.
