### PR TITLE
Updating reset.sh to fix #417

### DIFF
--- a/reset.sh
+++ b/reset.sh
@@ -9,6 +9,8 @@ echo "Building instruments-without-delay"
 pushd submodules/instruments-without-delay
 ./build.sh
 popd
+echo "Appending the ANDROID_HOME path variable location"
+export ANDROID_HOME="/usr/local/adt/sdk":$ANDROID_HOME
 echo "Downloading/updating AndroidApiDemos"
 git submodule update --init submodules/ApiDemos
 rm -rf sample-code/apps/ApiDemos


### PR DESCRIPTION
Added the shell command to export the ANDROID_HOME path variable in reset.sh
Fix for https://github.com/appium/appium/issues/417

*Will not break anything, if Android Home is set correctly.
