### PR TITLE
Selendroid support and adb.js rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ app/android/AndroidManifest.xml
 *~
 uiautomator/bootstrap/target/
 org.eclipse.ltk.core.refactoring.prefs
-selendroid
+/selendroid

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ app/android/AndroidManifest.xml
 *~
 uiautomator/bootstrap/target/
 org.eclipse.ltk.core.refactoring.prefs
+selendroid

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "submodules/appium.io"]
 	path = submodules/appium.io
 	url = https://github.com/appium/appium.io.git
+[submodule "submodules/selendroid"]
+	path = submodules/selendroid
+	url = https://github.com/DominikDary/selendroid.git

--- a/app/android.js
+++ b/app/android.js
@@ -72,6 +72,7 @@ Android.prototype.start = function(cb, onDie) {
     var skipRelaunchOn = [
       'App never showed up'
       , 'Could not sign one or more apks'
+      , 'Could not find a connected Android device'
     ];
     var checkShouldSkipRelaunch = function(msg) {
       var skip = false;

--- a/app/android.js
+++ b/app/android.js
@@ -127,7 +127,7 @@ Android.prototype.start = function(cb, onDie) {
   if (this.adb === null) {
     // Pass Android opts and Android ref to adb.
     this.adb = adb(this.opts, this);
-    this.adb.start(onLaunch, onExit);
+    this.adb.startAppium(onLaunch, onExit);
   } else {
     logger.error("Tried to start ADB when we already have one running!");
   }

--- a/app/appium.js
+++ b/app/appium.js
@@ -364,6 +364,7 @@ Appium.prototype.invoke = function() {
       } else if (this.isSelendroid()) {
         var selendroidOpts = {
           apkPath: this.args.app
+          , desiredCaps: this.desiredCapabilities
           , verbose: this.args.verbose
           , udid: this.args.udid
           , appPackage: this.args.androidPackage

--- a/app/appium.js
+++ b/app/appium.js
@@ -369,6 +369,7 @@ Appium.prototype.invoke = function() {
           , udid: this.args.udid
           , appPackage: this.args.androidPackage
           , appActivity: this.args.androidActivity
+          , appDeviceReadyTimeout: this.args.androidDeviceReadyTimeout
         };
         this.devices[this.deviceType] = selendroid(selendroidOpts);
       } else {

--- a/app/appium.js
+++ b/app/appium.js
@@ -379,12 +379,16 @@ Appium.prototype.invoke = function() {
     }
     this.device = this.devices[this.deviceType];
 
-    this.device.start(function(err) {
+    this.device.start(function(err, sessionIdOverride) {
       me.progress++;
       // Ensure we don't use an undefined session.
       if (typeof me.sessions[me.progress] === 'undefined') {
         me.progress--;
         return;
+      }
+      if (sessionIdOverride) {
+        me.sessionId = sessionIdOverride;
+        logger.info("Overriding session id with " + sessionIdOverride);
       }
 
       me.sessions[me.progress].sessionId = me.sessionId;

--- a/app/appium.js
+++ b/app/appium.js
@@ -15,6 +15,7 @@ var routing = require('./routing')
   , _ = require('underscore')
   , ios = require('./ios')
   , android = require('./android')
+  , selendroid = require('./selendroid')
   , status = require("./uiauto/lib/status");
 
 var Appium = function(args) {
@@ -108,6 +109,8 @@ Appium.prototype.getDeviceType = function(desiredCaps) {
       return "ios";
     } else if (desiredCaps.device.toLowerCase().indexOf('ipad') !== -1) {
       return "ios";
+    } else if (desiredCaps.device.toLowerCase().indexOf('selendroid') !== -1) {
+      return "selendroid";
     } else {
       return "android";
     }
@@ -116,6 +119,8 @@ Appium.prototype.getDeviceType = function(desiredCaps) {
       return "ios";
     } else if (desiredCaps.browserName.toLowerCase() === "safari") {
       return "ios";
+    } else if (desiredCaps.browserName.toLowerCase().indexOf('selendroid') !== -1) {
+      return "selendroid";
     } else {
       return "android";
     }
@@ -145,6 +150,10 @@ Appium.prototype.isIos = function() {
 
 Appium.prototype.isAndroid = function() {
   return this.deviceType === "android";
+};
+
+Appium.prototype.isSelendroid = function() {
+  return this.deviceType === "selendroid";
 };
 
 Appium.prototype.getAppExt = function() {
@@ -352,6 +361,15 @@ Appium.prototype.invoke = function() {
           , fastReset: this.args.fastReset
         };
         this.devices[this.deviceType] = android(androidOpts);
+      } else if (this.isSelendroid()) {
+        var selendroidOpts = {
+          apkPath: this.args.app
+          , verbose: this.args.verbose
+          , udid: this.args.udid
+          , appPackage: this.args.androidPackage
+          , appActivity: this.args.androidActivity
+        };
+        this.devices[this.deviceType] = selendroid(selendroidOpts);
       } else {
         throw new Error("Tried to start a device that doesn't exist: " +
                         this.deviceType);

--- a/app/device.js
+++ b/app/device.js
@@ -2,6 +2,7 @@
 
 var errors = require('./errors')
   , request = require('request')
+  , _ = require('underscore')
   , logger = require('../logger').get('appium');
 
 var UnknownError = errors.UnknownError
@@ -59,7 +60,7 @@ exports.waitForCondition = function(waitMs, condFn, cb, intervalMs) {
   spin();
 };
 
-exports.bypass = function(url, method, body, contentType, cb) {
+exports.request = function(url, method, body, contentType, cb) {
   if (typeof cb === "undefined" && typeof contentType === "function") {
     cb = contentType;
     contentType = null;
@@ -74,7 +75,13 @@ exports.bypass = function(url, method, body, contentType, cb) {
     url: url
     , method: method
     , headers: {'Content-Type': contentType}
-    , body: body
   };
+  if (_.contains(['put', 'post', 'patch'], method.toLowerCase())) {
+    if (typeof body !== "string") {
+      opts.json = body;
+    } else {
+      opts.body = body;
+    }
+  }
   request(opts, cb);
 };

--- a/app/device.js
+++ b/app/device.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var errors = require('./errors')
+  , request = require('request')
   , logger = require('../logger').get('appium');
 
 var UnknownError = errors.UnknownError
@@ -56,4 +57,24 @@ exports.waitForCondition = function(waitMs, condFn, cb, intervalMs) {
     });
   };
   spin();
+};
+
+exports.bypass = function(url, method, body, contentType, cb) {
+  if (typeof cb === "undefined" && typeof contentType === "function") {
+    cb = contentType;
+    contentType = null;
+  }
+  if (typeof contentType === "undefined" || contentType === null) {
+    contentType = "application/json";
+  }
+  if (!(/^https?:\/\//.exec(url))) {
+    url = 'http://' + url;
+  }
+  var opts = {
+    url: url
+    , method: method
+    , headers: {'Content-Type': contentType}
+    , body: body
+  };
+  request(opts, cb);
 };

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -8,6 +8,7 @@ var logger = require('../logger').get('appium')
   , path = require('path')
   , rimraf = require('rimraf')
   , exec = require('child_process').exec
+  , util = require('util')
   , temp = require('temp');
 
 exports.downloadFile = function(fileUrl, cb) {
@@ -276,5 +277,19 @@ exports.rotateImage = function(imgPath, deg, cb) {
     if (err) return cb(err);
     console.log(stdout);
     cb(null);
+  });
+};
+
+exports.copyFile = function (src, dst, cb) {
+  var is
+    , os;
+
+  fs.stat(src, function (err) {
+    if (err) {
+      return cb(err);
+    }
+    is = fs.createReadStream(src);
+    os = fs.createWriteStream(dst);
+    util.pump(is, os, cb);
   });
 };

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -279,17 +279,3 @@ exports.rotateImage = function(imgPath, deg, cb) {
     cb(null);
   });
 };
-
-exports.copyFile = function (src, dst, cb) {
-  var is
-    , os;
-
-  fs.stat(src, function (err) {
-    if (err) {
-      return cb(err);
-    }
-    is = fs.createReadStream(src);
-    os = fs.createWriteStream(dst);
-    util.pump(is, os, cb);
-  });
-};

--- a/app/routing.js
+++ b/app/routing.js
@@ -41,7 +41,8 @@ module.exports = function(appium) {
               req.headers['content-type'], function(err, response, body) {
         if (err) return next(err);
         logger.debug("Proxied response received with status " +
-                     response.statusCode + ": " + body);
+                     response.statusCode + ": " +
+                     JSON.stringify(body).slice(0, 1000));
         res.headers = response.headers;
         res.send(response.statusCode, body);
       });

--- a/app/routing.js
+++ b/app/routing.js
@@ -1,18 +1,54 @@
 "use strict";
 var controller = require('./controller')
+  , request = require('./device').request
+  , _ = require('underscore')
   , logger = require('../logger').get('appium');
 
+var shouldProxy = function(req) {
+  if (req.device === null) return false;
+
+  var avoid = [
+    ['POST', '/wd/hub/session']
+    , ['DELETE', '/wd/hub/session/:sessionId?']
+  ];
+  var method = req.route.method.toUpperCase();
+  var path = req.route.path;
+  var shouldAvoid = false;
+  _.each(avoid, function(pathToAvoid) {
+    if (method === pathToAvoid[0] && path === pathToAvoid[1]) {
+      shouldAvoid = true;
+    }
+  });
+  return !shouldAvoid;
+};
+
+
 module.exports = function(appium) {
-  var rest = appium.rest
-    , inject = function(req, res, next) {
-        req.appium = appium;
-        req.device = appium.device;
-        logger.debug("Appium request initiated at " + req.url);
-        if (typeof req.body === "object") {
-          logger.debug("Request received with params: " + JSON.stringify(req.body));
-        }
-        next();
-      };
+  var rest = appium.rest;
+  var inject = function(req, res, next) {
+    req.appium = appium;
+    req.device = appium.device;
+    logger.debug("Appium request initiated at " + req.url);
+    if (typeof req.body === "object") {
+      logger.debug("Request received with params: " + JSON.stringify(req.body));
+    }
+    if (shouldProxy(req)) {
+      logger.debug("Proxying command to " + req.device.proxyHost + ":" +
+                   req.device.proxyPort);
+      var url = 'http://' + req.device.proxyHost + ':' + req.device.proxyPort +
+                req.originalUrl;
+      request(url, req.route.method.toUpperCase(), req.body,
+              req.headers['content-type'], function(err, response, body) {
+        if (err) return next(err);
+        logger.debug("Proxied response received with status " +
+                     response.statusCode + ": " + body);
+        res.headers = response.headers;
+        res.send(response.statusCode, body);
+      });
+    } else {
+      next();
+    }
+  };
 
   // Make appium available to all REST http requests.
   rest.all('/wd/*', inject);

--- a/app/routing.js
+++ b/app/routing.js
@@ -8,14 +8,14 @@ var shouldProxy = function(req) {
   if (req.device === null) return false;
 
   var avoid = [
-    ['POST', '/wd/hub/session']
-    , ['DELETE', '/wd/hub/session/:sessionId?']
+    ['POST', new RegExp('^/wd/hub/session$')]
+    , ['DELETE', new RegExp('^/wd/hub/session/[^/]+$')]
   ];
   var method = req.route.method.toUpperCase();
-  var path = req.route.path;
+  var path = req.originalUrl;
   var shouldAvoid = false;
   _.each(avoid, function(pathToAvoid) {
-    if (method === pathToAvoid[0] && path === pathToAvoid[1]) {
+    if (method === pathToAvoid[0] && pathToAvoid[1].exec(path)) {
       shouldAvoid = true;
     }
   });

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -30,8 +30,8 @@ Selendroid.prototype.start = function(cb) {
   var opts = _.clone(this.opts);
   opts.port = this.proxyPort;
   opts.devicePort = 8080;
-  opts.fastReset = false;
-  opts.cleanApp = false;
+  //opts.fastReset = false;
+  //opts.cleanApp = false;
   this.adb = new adb(opts);
   this.ensureServerExists(_.bind(function(err) {
     if (err) return cb(err);

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -22,7 +22,9 @@ var Selendroid = function(opts) {
   this.isProxy = true;
 };
 
-Selendroid.prototype.getProxiedSession = function(cb) {
+Selendroid.prototype.start = function(cb) {
+  console.log("starting selendroid");
+  cb(null);
 };
 
 module.exports = function(opts) {

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -3,10 +3,12 @@
 var errors = require('./errors')
   , adb = require('../uiautomator/adb')
   , _ = require('underscore')
+  , bypass = require('./device').bypass
   , logger = require('../logger').get('appium')
   , status = require("./uiauto/lib/status")
   , exec = require('child_process').exec
   , fs = require('fs')
+  , copyFile = require('./helpers').copyFile
   , async = require('async')
   , path = require('path')
   , UnknownError = errors.UnknownError;
@@ -16,15 +18,78 @@ var Selendroid = function(opts) {
   this.udid = opts.udid;
   this.appPackage = opts.appPackage;
   this.appActivity = opts.appActivity;
+  this.desiredCaps = opts.desiredCaps;
   this.verbose = opts.verbose;
   this.onStop = function() {};
   this.adb = null;
   this.isProxy = true;
+  this.proxyHost = 'localhost';
+  this.proxyPort = 8080;
 };
 
 Selendroid.prototype.start = function(cb) {
-  console.log("starting selendroid");
-  cb(null);
+  logger.info("Starting selendroid server");
+  this.ensureServerExists(_.bind(function(err) {
+    if (err) return cb(err);
+    // modify desired caps
+    var desiredCaps = _.clone(this.desiredCaps);
+    //this.bypass('/wd/hub/session', 'POST', desiredCaps, function(err, res, body) {
+      //console.log(err);
+      //console.log(res);
+      //console.log(body);
+      //cb(null);
+    //});
+    cb(null);
+  }, this));
+};
+
+Selendroid.prototype.ensureServerExists = function(cb) {
+  logger.info("Checking whether selendroid is built for package yet");
+  var fileName = 'selendroid-' + this.appPackage + '.apk';
+  var filePath = path.resolve(__dirname, "../selendroid/selendroid-server",
+                              "target", fileName);
+  fs.stat(filePath, _.bind(function(err) {
+    if (err) {
+      logger.info("Selendroid needs to be built");
+      return this.buildServer(cb);
+    }
+    logger.info("Selendroid server already exists, not rebuilding");
+    cb(null);
+  }, this));
+};
+
+Selendroid.prototype.buildServer = function(cb) {
+  logger.info("Building selendroid server for package " + this.appPackage);
+  var buildDir = path.resolve(__dirname, "../selendroid/selendroid-server");
+  var src = buildDir + "/target/selendroid-server-0.3.apk";
+  var dest = buildDir + "/target/selendroid- " + this.appPackage + '.apk';
+  var cmd = "mvn install -Dandroid.renameInstrumentationTargetPackage=" +
+            this.appPackage;
+  exec(cmd, {cwd: buildDir}, function(err, stdout, stderr) {
+    if (err) {
+      logger.error("Unable to build selendroid server");
+      console.log(stdout);
+      console.log(stderr);
+      return cb(err);
+    }
+    logger.info("Copying selendroid server to correct destination");
+    copyFile(src, dest, function(err) {
+      if (err) {
+        logger.error("Error copying selendroid to destination");
+        return cb(err);
+      }
+      logger.info("Selendroid server copied successfully");
+      cb(null);
+    });
+  });
+};
+
+Selendroid.prototype.bypass = function(endpoint, method, data, cb) {
+  if (endpoint[0] !== '/') {
+    endpoint = '/' + endpoint;
+  }
+  var url = 'http://' + this.proxyHost + ':' + this.proxyPort + endpoint;
+  bypass(url, method, data ? data : null, cb);
 };
 
 module.exports = function(opts) {

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -8,7 +8,7 @@ var errors = require('./errors')
   , status = require("./uiauto/lib/status")
   , exec = require('child_process').exec
   , fs = require('fs')
-  , copyFile = require('./helpers').copyFile
+  , ncp = require('ncp')
   , async = require('async')
   , path = require('path')
   , UnknownError = errors.UnknownError;
@@ -80,7 +80,7 @@ Selendroid.prototype.buildServer = function(cb) {
       return cb(err);
     }
     logger.info("Copying selendroid server to correct destination");
-    copyFile(src, dest, _.bind(function(err) {
+    ncp(src, dest, _.bind(function(err) {
       if (err) {
         logger.error("Error copying selendroid to destination");
         return cb(err);

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -1,0 +1,31 @@
+"use strict";
+
+var errors = require('./errors')
+  , adb = require('../uiautomator/adb')
+  , _ = require('underscore')
+  , logger = require('../logger').get('appium')
+  , status = require("./uiauto/lib/status")
+  , exec = require('child_process').exec
+  , fs = require('fs')
+  , async = require('async')
+  , path = require('path')
+  , UnknownError = errors.UnknownError;
+
+var Selendroid = function(opts) {
+  this.apkPath = opts.apkPath;
+  this.udid = opts.udid;
+  this.appPackage = opts.appPackage;
+  this.appActivity = opts.appActivity;
+  this.verbose = opts.verbose;
+  this.onStop = function() {};
+  this.adb = null;
+  this.isProxy = true;
+};
+
+Selendroid.prototype.getProxiedSession = function(cb) {
+};
+
+module.exports = function(opts) {
+  return new Selendroid(opts);
+};
+

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ncp": "~0.4.2",
     "swig": "~0.13.5",
     "async": "~0.2.6",
+    "mkdirp": "~0.3.5",
     "binary-cookies": "~0.1.1"
   },
   "scripts": {

--- a/reset.sh
+++ b/reset.sh
@@ -89,6 +89,7 @@ reset_android() {
 reset_selendroid() {
     echo "---- RESETTING SELENDROID ----"
     echo "Downloading/updating selendroid"
+    rm -rf submodules/selendroid/selendroid-server/target
     git submodule update --init submodules/selendroid
     rm -rf selendroid
     ln -s $appium_home/submodules/selendroid $appium_home/selendroid

--- a/reset.sh
+++ b/reset.sh
@@ -92,12 +92,6 @@ reset_selendroid() {
     git submodule update --init submodules/selendroid
     rm -rf selendroid
     ln -s $appium_home/submodules/selendroid $appium_home/selendroid
-    echo "Building selendroid server for ApiDemos"
-    pushd selendroid/selendroid-server
-    mvn install -Dandroid.renameInstrumentationTargetPackage=com.example.android.apis
-    echo "Copying ApiDemos selendroid server to a good home"
-    cp target/selendroid-server-$selendroid_ver.apk $appium_home/selendroid/selendroid-apidemos.apk
-    popd
 }
 
 cleanup() {

--- a/reset.sh
+++ b/reset.sh
@@ -7,20 +7,29 @@
 set -e
 should_reset_android=0
 should_reset_ios=0
+should_reset_selendroid=0
+appium_home=$(pwd)
+selendroid_ver="0.3"
 
 while test $# != 0
 do
-    echo $1
     case "$1" in
         "--android") should_reset_android=1;;
         "--ios") should_reset_ios=1;;
+        "--selendroid") should_reset_selendroid=1;;
     esac
     shift
 done
 
-if [[ $should_reset_android -eq 0 ]] && [[ $should_reset_ios -eq 0 ]]; then
+if [[ $should_reset_android -eq 0 ]] && [[ $should_reset_ios -eq 0 ]] && [[ $should_reset_selendroid -eq 0 ]]; then
     should_reset_android=1
     should_reset_ios=1
+    should_reset_selendroid=1
+fi
+
+# if selendroid is selected, we need all the android stuff too
+if [ $should_reset_selendroid -eq 1 ]; then
+    should_reset_android=1
 fi
 
 reset_general() {
@@ -68,13 +77,27 @@ reset_android() {
     echo "Downloading/updating AndroidApiDemos"
     git submodule update --init submodules/ApiDemos
     rm -rf sample-code/apps/ApiDemos
-    ln -s $(pwd)/submodules/ApiDemos $(pwd)/sample-code/apps/ApiDemos
+    ln -s $appium_home/submodules/ApiDemos $appium_home/sample-code/apps/ApiDemos
     echo "Building Android bootstrap"
     grunt configAndroidBootstrap
     grunt buildAndroidBootstrap
     echo "Configuring and rebuilding Android test apps"
     grunt configAndroidApp:ApiDemos
     grunt buildAndroidApp:ApiDemos
+}
+
+reset_selendroid() {
+    echo "---- RESETTING SELENDROID ----"
+    echo "Downloading/updating selendroid"
+    git submodule update --init submodules/selendroid
+    rm -rf selendroid
+    ln -s $appium_home/submodules/selendroid $appium_home/selendroid
+    echo "Building selendroid server for ApiDemos"
+    pushd selendroid/selendroid-server
+    mvn install -Dandroid.renameInstrumentationTargetPackage=com.example.android.apis
+    echo "Copying ApiDemos selendroid server to a good home"
+    cp target/selendroid-server-$selendroid_ver.apk $appium_home/selendroid/selendroid-apidemos.apk
+    popd
 }
 
 cleanup() {
@@ -91,5 +114,8 @@ if [ $should_reset_ios -eq 1 ]; then
 fi
 if [ $should_reset_android -eq 1 ]; then
     reset_android
+fi
+if [ $should_reset_selendroid -eq 1 ]; then
+    reset_selendroid
 fi
 cleanup

--- a/reset.sh
+++ b/reset.sh
@@ -27,11 +27,6 @@ if [[ $should_reset_android -eq 0 ]] && [[ $should_reset_ios -eq 0 ]] && [[ $sho
     should_reset_selendroid=1
 fi
 
-# if selendroid is selected, we need all the android stuff too
-if [ $should_reset_selendroid -eq 1 ]; then
-    should_reset_android=1
-fi
-
 reset_general() {
     echo "---- RESETTING NPM ----"
     echo "Clearing dev version of wd.js"
@@ -72,12 +67,16 @@ reset_ios() {
     grunt buildApp:WebViewApp
 }
 
-reset_android() {
-    echo "---- RESETTING ANDROID ----"
+get_apidemos() {
     echo "Downloading/updating AndroidApiDemos"
     git submodule update --init submodules/ApiDemos
     rm -rf sample-code/apps/ApiDemos
     ln -s $appium_home/submodules/ApiDemos $appium_home/sample-code/apps/ApiDemos
+}
+
+reset_android() {
+    echo "---- RESETTING ANDROID ----"
+    get_apidemos
     echo "Building Android bootstrap"
     grunt configAndroidBootstrap
     grunt buildAndroidBootstrap
@@ -88,6 +87,7 @@ reset_android() {
 
 reset_selendroid() {
     echo "---- RESETTING SELENDROID ----"
+    get_apidemos
     echo "Downloading/updating selendroid"
     rm -rf submodules/selendroid/selendroid-server/target
     git submodule update --init submodules/selendroid

--- a/test/functional/selendroid/basic.js
+++ b/test/functional/selendroid/basic.js
@@ -1,0 +1,28 @@
+/*global it:true */
+"use strict";
+
+var path = require('path')
+  , appPath = path.resolve(__dirname, "../../../sample-code/apps/ApiDemos/bin/ApiDemos-debug.apk")
+  , appPkg = "com.example.android.apis"
+  , appAct = "ApiDemos"
+  , driverBlock = require("../../helpers/driverblock.js")
+  , describeWd = driverBlock.describeForApp(appPath, "selendroid", appPkg, appAct)
+  , should = require('should');
+
+  describeWd('basic', function(h) {
+    it('should find and click an element', function(done) {
+      h.driver.elementByName('Accessibility', function(err, el) {
+        should.not.exist(err);
+        should.exist(el);
+        el.click(function(err) {
+          should.not.exist(err);
+          h.driver.elementByLinkText("Accessibility Node Provider", function(err, el) {
+            should.not.exist(err);
+            should.exist(el);
+            done();
+          });
+        });
+      });
+    });
+  });
+

--- a/test/functional/selendroid/basic.js
+++ b/test/functional/selendroid/basic.js
@@ -11,18 +11,24 @@ var path = require('path')
 
   describeWd('basic', function(h) {
     it('should find and click an element', function(done) {
-      h.driver.elementByName('Accessibility', function(err, el) {
-        should.not.exist(err);
-        should.exist(el);
-        el.click(function(err) {
+      // selendroid appears to have some issues with implicit waits
+      // hence the timeouts
+      setTimeout(function() {
+        h.driver.elementByName('Accessibility', function(err, el) {
           should.not.exist(err);
-          h.driver.elementByLinkText("Accessibility Node Provider", function(err, el) {
+          should.exist(el);
+          el.click(function(err) {
             should.not.exist(err);
-            should.exist(el);
-            done();
+            setTimeout(function() {
+              h.driver.elementByLinkText("Accessibility Node Provider", function(err, el) {
+                should.not.exist(err);
+                should.exist(el);
+                done();
+              });
+            }, 1000);
           });
         });
-      });
+      }, 1000);
     });
   });
 

--- a/test/functional/selendroid/basic.js
+++ b/test/functional/selendroid/basic.js
@@ -14,13 +14,13 @@ var path = require('path')
       // selendroid appears to have some issues with implicit waits
       // hence the timeouts
       setTimeout(function() {
-        h.driver.elementByName('Accessibility', function(err, el) {
+        h.driver.elementByName('App', function(err, el) {
           should.not.exist(err);
           should.exist(el);
           el.click(function(err) {
             should.not.exist(err);
             setTimeout(function() {
-              h.driver.elementByLinkText("Accessibility Node Provider", function(err, el) {
+              h.driver.elementByLinkText("Action Bar", function(err, el) {
                 should.not.exist(err);
                 should.exist(el);
                 done();

--- a/test/helpers/driverblock.js
+++ b/test/helpers/driverblock.js
@@ -108,22 +108,24 @@ var describeForApp = function(app, device, appPackage, appActivity) {
   if (typeof device === "undefined") {
     device = "ios";
   }
-  var browserName, appPath;
+  var browserName, appPath, realDevice;
   if (device === "ios") {
+    realDevice = "iPhone Simulator";
     browserName = "iOS";
   } else if (device === "android") {
-    browserName = "Android";
+    browserName = realDevice = "Android";
+  } else if (device === "selendroid") {
+    browserName = realDevice = "Selendroid";
   }
   if (/\//.exec(app) || /\./.exec(app)) {
     appPath = app;
   } else {
     if (device === "ios") {
       appPath = path.resolve(__dirname, "../../sample-code/apps/" + app + "/build/Release-iphonesimulator/" + app + ".app");
-    } else if (device === "android") {
+    } else if (device === "android" || device === "selendroid") {
       appPath = path.resolve(__dirname, "../../sample-code/apps/" + app + "/bin/" + app + "-debug.apk");
     }
   }
-  var realDevice = device == "ios" ? "iPhone Simulator" : "Android";
 
   return function(desc, tests, host, port, caps, extraCaps) {
     if (typeof extraCaps === "undefined") {

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -79,6 +79,7 @@ ADB.prototype.checkAdbPresent = function(cb) {
   this.checkSdkBinaryPresent("adb", _.bind(function(err, binaryLoc) {
     if (err) return cb(err);
     this.adb = binaryLoc;
+    cb(null);
   }, this));
 };
 

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -364,10 +364,12 @@ ADB.prototype.startSelendroid = function(serverPath, onReady) {
 
   var conditionalInsertManifest = function(cb) {
     if (!modServerExists) {
-      logger.info("Rebuilt selendroid server does not exist");
+      logger.info("Rebuilt selendroid server does not exist, inserting " +
+                  "modified manifest");
       me.insertSelendroidManifest(serverPath, cb);
     } else {
-      logger.info("Rebuilt selendroid server already exists");
+      logger.info("Rebuilt selendroid server already exists, no need to " +
+                  "rebuild it with a new manifest");
       cb();
     }
   };
@@ -383,7 +385,8 @@ ADB.prototype.startSelendroid = function(serverPath, onReady) {
     function(cb) { me.installApk(me.selendroidServerPath, cb); },
     function(cb) { me.installApp(cb); },
     function(cb) { me.forwardPort(cb); },
-    function(cb) { me.pushSelendroid(cb); }
+    function(cb) { me.pushSelendroid(cb); },
+    function(cb) { logger.info("Selendroid server is launching"); cb(); }
   ], onReady);
 };
 

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -339,28 +339,20 @@ ADB.prototype.startAppium = function(onReady, onExit) {
   var me = this;
   async.series(
     [
+      function(cb) { me.prepareDevice(cb); },
+      function(cb) { me.pushAppium(cb); },
       function(cb) {
-        me.prepareDevice(function(err) { if (err) return onReady(err); cb(null); });
+        if (!me.appPackage) return cb(new Error("appPackage must be set."));
+        me.checkFastReset(cb);
       },
-      function(cb) {
-        me.pushAppium(function(err) { if (err) return onReady(err); cb(null); });
-      },
-      function(cb) {
-        if (!me.appPackage) return onReady("appPackage must be set.");
-        me.checkFastReset(function(err) {
-          if (err) return onReady(err); cb(null);
-        });
-      },
-      function(cb) {
-        me.installApp(function(err) { if (err) return onReady(err); cb(null); });
-      },
+      function(cb) { me.installApp(cb); },
       function(cb) {
         me.startApp(function(err) {
-          if (err) return onReady(err);
+          if (err) return cb(err);
           doRun(function(){ cb(null); });
         });
       }
-    ]
+    ], onReady
   );
 };
 

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -153,11 +153,11 @@ ADB.prototype.compileManifest = function(cb, manifest) {
         }
 
         // Compile manifest into manifest.xml.apk
-        var compile_manifest = ['aapt package -M "', manifest,
+        var compileManifest = ['aapt package -M "', manifest,
                                 '" -I "', platforms + platform + '/android.jar" -F "',
                                 manifest, '.apk" -f'].join('');
-        logger.debug(compile_manifest);
-        exec(compile_manifest, {}, function(err, stdout, stderr) {
+        logger.debug(compileManifest);
+        exec(compileManifest, {}, function(err, stdout, stderr) {
           if (err) {
             logger.debug(stderr);
             return cb("error compiling manifest");

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -27,7 +27,8 @@ var ADB = function(opts, android) {
   // Don't uninstall if using fast reset.
   // Uninstall if reset is set and fast reset isn't.
   this.skipUninstall = opts.fastReset || !(opts.reset || false);
-  this.port = opts.port || 4724;
+  this.systemPort = opts.port || 4724;
+  this.devicePort = opts.devicePort || 4724;
   this.avdName = opts.avdName;
   this.appPackage = opts.appPackage;
   this.appActivity = opts.appActivity;
@@ -374,9 +375,9 @@ ADB.prototype.getConnectedDevices = function(cb) {
 
 ADB.prototype.forwardPort = function(cb) {
   this.requireDeviceId();
-  var devicePort = 4724;
-  this.debug("Forwarding system:" + this.port + " to device:" + devicePort);
-  var arg = "tcp:" + this.port + " tcp:" + devicePort;
+  this.debug("Forwarding system:" + this.systemPort + " to device:" +
+             this.devicePort);
+  var arg = "tcp:" + this.systemPort + " tcp:" + this.devicePort;
   exec(this.adbCmd + " forward " + arg, _.bind(function(err) {
     if (err) {
       logger.error(err);
@@ -436,7 +437,7 @@ ADB.prototype.checkForSocketReady = function(output) {
   if (/Appium Socket Server Ready/.exec(output)) {
     this.requirePortForwarded();
     this.debug("Connecting to server on device...");
-    this.socketClient = net.connect(this.port, _.bind(function() {
+    this.socketClient = net.connect(this.systemPort, _.bind(function() {
       this.debug("Connected!");
       this.onSocketReady(null);
     }, this));

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -278,6 +278,8 @@ ADB.prototype.checkFastReset = function(cb) {
     return cb(null);
   }
 
+  if (!this.appPackage) return cb(new Error("appPackage must be set."));
+
   var me = this;
   me.checkApkCert(me.cleanAPK, function(cleanSigned){
     me.checkApkCert(me.apkPath, function(appSigned){
@@ -297,59 +299,55 @@ ADB.prototype.checkFastReset = function(cb) {
   });
 };
 
+ADB.prototype.getDeviceWithRetry = function(cb) {
+  var me = this;
+  var getDevices = function(innerCb) {
+    me.getConnectedDevices(function(err, devices) {
+      if (devices.length === 0 || err) {
+        return innerCb(new Error("Could not find a connected Android device."));
+      }
+      innerCb(null);
+    });
+  };
+  getDevices(function(err) {
+    if (err) {
+      logger.info("Could not find devices, restarting adb server...");
+      me.restartAdb(function() {
+        getDevices(cb);
+      });
+    } else {
+      cb(null);
+    }
+  });
+};
+
 ADB.prototype.prepareDevice = function(onReady) {
   var me = this;
   async.series([
     function(cb) { me.checkAdbPresent(cb); },
-    function(cb) {
-      var getDevices = function(innerCb) {
-        me.getConnectedDevices(function(err, devices) {
-          if (devices.length === 0 || err) {
-            return innerCb(new Error("Could not find a connected Android device."));
-          }
-          innerCb(null);
-        });
-      };
-      getDevices(function(err) {
-        if (err) {
-          logger.info("Restarting adb...");
-          me.restartAdb(function() {
-            getDevices(cb);
-          });
-        } else {
-          cb(null);
-        }
-      });
-    },
+    function(cb) { me.getDeviceWithRetry(cb);},
     function(cb) { me.waitForDevice(cb); },
     function(cb) { me.forwardPort(cb); }
   ], onReady);
 };
 
 ADB.prototype.startAppium = function(onReady, onExit) {
+  var me = this
+    , doRun = function(err) {
+        if (err) return onReady(err);
+        me.runBootstrap(onReady, onExit);
+      };
   this.onExit = onExit;
-  var doRun = _.bind(function() {
-    this.runBootstrap(onReady, onExit);
-  }, this);
 
   logger.debug("Using fast reset? " + this.fastReset);
 
-  var me = this;
-  async.series( [
+  async.series([
     function(cb) { me.prepareDevice(cb); },
     function(cb) { me.pushAppium(cb); },
-    function(cb) {
-      if (!me.appPackage) return cb(new Error("appPackage must be set."));
-      me.checkFastReset(cb);
-    },
+    function(cb) { me.checkFastReset(cb); },
     function(cb) { me.installApp(cb); },
-    function(cb) {
-      me.startApp(function(err) {
-        if (err) return cb(err);
-        doRun(function(){ cb(null); });
-      });
-    }
-  ], onReady);
+    function(cb) { me.startApp(cb); }
+  ], doRun);
 };
 
 ADB.prototype.getConnectedDevices = function(cb) {

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -110,21 +110,10 @@ ADB.prototype.buildFastReset = function(skipAppSign, cb) {
   fs.writeFileSync(manifest, newContent, utf8);
   logger.debug("Created manifest");
 
-  async.series(
-    [
-      function(cb) {
-        me.compileManifest(function(err) { if (err) return cb(err); cb(null); }, manifest);
-      },
-      function(cb) {
-        me.insertManifest(manifest, skipAppSign, function(err) {
-          if (err) return cb(err);
-          cb(null);
-        });
-      },
-    ],
-    // Invoke top level function cb
-    function(err) { cb(err); }
-  );
+  async.series([
+    function(cb) { me.compileManifest(cb, manifest); },
+    function(cb) { me.insertManifest(manifest, skipAppSign, cb); },
+  ], cb);
 };
 
 ADB.prototype.compileManifest = function(cb, manifest) {

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -325,10 +325,10 @@ ADB.prototype.getDeviceWithRetry = function(cb) {
 ADB.prototype.prepareDevice = function(onReady) {
   var me = this;
   async.series([
-    me.checkAdbPresent
-    , me.getDeviceWithRetry
-    , me.waitForDevice
-    , me.forwardPort
+    function(cb) { me.checkAdbPresent(cb); },
+    function(cb) { me.getDeviceWithRetry(cb);},
+    function(cb) { me.waitForDevice(cb); },
+    function(cb) { me.forwardPort(cb); }
   ], onReady);
 };
 
@@ -343,11 +343,11 @@ ADB.prototype.startAppium = function(onReady, onExit) {
   logger.debug("Using fast reset? " + this.fastReset);
 
   async.series([
-    me.prepareDevice
-    , me.pushAppium
-    , me.checkFastReset
-    , me.installApp
-    , me.startApp
+    function(cb) { me.prepareDevice(cb); },
+    function(cb) { me.pushAppium(cb); },
+    function(cb) { me.checkFastReset(cb); },
+    function(cb) { me.installApp(cb); },
+    function(cb) { me.startApp(cb); }
   ], doRun);
 };
 
@@ -884,10 +884,10 @@ ADB.prototype.installApp = function(cb) {
   };
 
   async.series([
-    determineInstallAndCleanStatus,
-    doInstall,
-    doClean,
-    doFastReset
+    function(cb) { determineInstallAndCleanStatus(cb); },
+    function(cb) { doInstall(cb); },
+    function(cb) { doClean(cb); },
+    function(cb) { doFastReset(cb); }
   ], cb);
 };
 

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -123,12 +123,12 @@ ADB.prototype.buildFastReset = function(skipAppSign, cb) {
 
   async.series([
     function(cb) { me.checkSdkBinaryPresent("aapt", cb); },
-    function(cb) { me.compileManifest(cb, manifest); },
+    function(cb) { me.compileManifest(manifest, cb); },
     function(cb) { me.insertManifest(manifest, skipAppSign, cb); },
   ], cb);
 };
 
-ADB.prototype.compileManifest = function(cb, manifest) {
+ADB.prototype.compileManifest = function(manifest, cb) {
   var androidHome = process.env.ANDROID_HOME
     , platforms = androidHome + '/platforms/'
     , platform = 'android-17';
@@ -342,6 +342,7 @@ ADB.prototype.startSelendroid = function(serverPath, onReady) {
                 cmd);
     exec(cmd, function(err, stdout) {
       if (stdout.indexOf("Exception") !== -1) {
+        logger.error(stdout);
         var msg = stdout.split("\n")[0] || "Unknown exception starting selendroid";
         return cb(new Error(msg));
       }

--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -297,7 +297,7 @@ ADB.prototype.checkFastReset = function(cb) {
   });
 };
 
-ADB.prototype.start = function(onReady, onExit) {
+ADB.prototype.startAppium = function(onReady, onExit) {
   this.onExit = onExit;
   var doRun = _.bind(function() {
     this.runBootstrap(onReady, onExit);


### PR DESCRIPTION
[Selendroid](http://github.com/DominikDary/selendroid) is a selenium server that runs via Android's [Instrumentation](http://developer.android.com/reference/android/app/Instrumentation.html) framework. This pull request incorporates it into Appium and makes it as easy to run as Appium's own UiAutomator-based framework. Simply pull this code, run `./reset.sh --selendroid`, and put 'selendroid' as the `device` in your desiredCapabilities.

The main reasons to use Selendroid instead of regular Appium technology are if:
1. You need to automate devices with Android < 4.1
2. You need webview automation (say for hybrid apps)

Selendroid requires building a special server specifically for your app and installing it on the device. This process is handled invisibly by the code in this pull request.

I also cleaned up, refactored, and organized adb.js to handle Selendroid and to make it prettier all around.
