### PR TITLE
Newline in `which` output

### DIFF
--- a/uiautomator/adb.js
+++ b/uiautomator/adb.js
@@ -80,7 +80,7 @@ ADB.prototype.checkSdkBinaryPresent = function(binary, cb) {
 ADB.prototype.checkAdbPresent = function(cb) {
   this.checkSdkBinaryPresent("adb", _.bind(function(err, binaryLoc) {
     if (err) return cb(err);
-    this.adb = binaryLoc;
+    this.adb = binaryLoc.trim();
     cb(null);
   }, this));
 };


### PR DESCRIPTION
Which command sometimes appends a newline ('\n') at the end of it's output. Trim output to get rid of newline if present.
