### PR TITLE
Fix source on real device

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -476,8 +476,8 @@ Android.prototype.getPageSource = function(cb) {
   async.series(
         [
           function(cb) {
-            var cmd = me.adb.adbCmd + ' shell uiautomator dump /cache/dump.xml;';
-            cmd += me.adb.adbCmd + ' pull /cache/dump.xml ' + xmlFile;
+            var cmd = me.adb.adbCmd + ' shell uiautomator dump /data/local/tmp/dump.xml;';
+            cmd += me.adb.adbCmd + ' pull /data/local/tmp/dump.xml ' + xmlFile;
             logger.debug('getPageSource command: ' + cmd);
             exec(cmd, {}, function(err, stdout, stderr) {
               if (err) {
@@ -519,8 +519,8 @@ Android.prototype.getPageSourceXML = function(cb) {
   async.series(
         [
           function(cb) {
-            var cmd = me.adb.adbCmd + ' shell uiautomator dump /cache/dump.xml;';
-            cmd += me.adb.adbCmd + ' pull /cache/dump.xml ' + xmlFile;
+            var cmd = me.adb.adbCmd + ' shell uiautomator dump /data/local/tmp/dump.xml;';
+            cmd += me.adb.adbCmd + ' pull /data/local/tmp/dump.xml ' + xmlFile;
             logger.debug('getPageSourceXML command: ' + cmd);
             exec(cmd, {}, function(err, stdout, stderr) {
               if (err) {


### PR DESCRIPTION
/cache works on the simulator and fails on device.
/data/local/tmp is [used by Android's uiautomatorviewer](https://android.googlesource.com/platform/tools/swt/+/master/uiautomatorviewer/src/main/java/com/android/uiautomator/UiAutomatorHelper.java) so appium should use that
as well.

Fix #457
