### PR TITLE
Fix reset selendroid

### DIFF
--- a/app/routing.js
+++ b/app/routing.js
@@ -2,6 +2,7 @@
 var controller = require('./controller')
   , request = require('./device').request
   , _ = require('underscore')
+  , _s = require("underscore.string")
   , logger = require('../logger').get('appium');
 
 var shouldProxy = function(req) {
@@ -15,6 +16,14 @@ var shouldProxy = function(req) {
   var method = req.route.method.toUpperCase();
   var path = req.originalUrl;
   var shouldAvoid = false;
+
+  // check for POST /execute mobile:
+  if (method === 'POST' &&
+      new RegExp('^/wd/hub/session/.+/execute$').test(path) &&
+      _s.startsWith(req.body.script, "mobile: ")) {
+    shouldAvoid = true;
+  }
+
   _.each(avoid, function(pathToAvoid) {
     if (method === pathToAvoid[0] && pathToAvoid[1].exec(path)) {
       shouldAvoid = true;


### PR DESCRIPTION
Fixes #513

I can't test Android properly without the ability to reset. This passes all execute commands to Appium. I'm not sure how to tell if we're in a webview or not because of #511. Ideally, this proxy would only occur if we're not in a webview.
