### PR TITLE
Add a configuration scheme so we fail gracefully on config errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ app/android/AndroidManifest.xml
 android/bootstrap/target/
 org.eclipse.ltk.core.refactoring.prefs
 /selendroid
+.appiumconfig

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,6 +15,7 @@ var path = require('path')
   , installAndroidApp = gruntHelpers.installAndroidApp
   , generateServerDocs = gruntHelpers.generateServerDocs
   , generateAppiumIo = gruntHelpers.generateAppiumIo
+  , setDeviceConfigVer = gruntHelpers.setDeviceConfigVer
   , runTestsWithServer = gruntHelpers.runTestsWithServer;
 
 module.exports = function(grunt) {
@@ -154,5 +155,8 @@ module.exports = function(grunt) {
   });
   grunt.registerTask('generateAppiumIo', function() {
     generateAppiumIo(grunt, this.async());
+  });
+  grunt.registerTask('setConfigVer', function(device) {
+    setDeviceConfigVer(grunt, device, this.async());
   });
 };

--- a/app/appium.js
+++ b/app/appium.js
@@ -70,6 +70,10 @@ Appium.prototype.attachTo = function(rest, cb) {
   }
 };
 
+Appium.prototype.registerConfig = function(configObj) {
+  this.serverConfig = configObj;
+};
+
 Appium.prototype.preLaunch = function(cb) {
   logger.info("Pre-launching app");
   if (!this.args.app && !this.args.safari) {
@@ -174,6 +178,11 @@ Appium.prototype.configure = function(desiredCaps, cb) {
   this.deviceType = this.getDeviceType(desiredCaps);
   if (this.isIos()) {
     this.iosDeviceType = this.getIosDeviceType(desiredCaps);
+  }
+  if (!_.has(this.serverConfig, this.deviceType)) {
+    logger.error("Trying to run a session for device " + this.deviceType + " " +
+                 "but that device hasn't been configured. Run config");
+    return cb(new Error("Device " + this.deviceType + " not configured yet"));
   }
   this.args.androidPackage = desiredCaps["app-package"] || this.args.androidPackage;
   this.args.androidActivity = desiredCaps["app-activity"] || this.args.androidActivity;

--- a/app/test/unit/queue.js
+++ b/app/test/unit/queue.js
@@ -46,6 +46,8 @@ describe('Appium', function() {
     , logPath = path.resolve(__dirname, "../../../appium.log")
     , inst = appium({app: "/path/to/fake.app", log: logPath});
 
+  inst.registerConfig({ios: true});
+
   var start = function(cb) {
         cb(null, {});
       }

--- a/grunt-helpers.js
+++ b/grunt-helpers.js
@@ -12,6 +12,7 @@ var _ = require("underscore")
   , spawn = require('child_process').spawn
   , parser = require('./app/parser')
   , namp = require('namp')
+  , appiumVer = require('./package.json').version
   , fs = require('fs');
 
 module.exports.startAppium = function(appName, verbose, readyCb, doneCb) {
@@ -124,6 +125,29 @@ module.exports.tail = function(grunt, filename, cb) {
   });
   proc.on('exit', function(code) {
     cb(code);
+  });
+};
+
+module.exports.setDeviceConfigVer = function(grunt, device, cb) {
+  var configPath = path.resolve(__dirname, '.appiumconfig');
+  fs.readFile(configPath, function(err, data) {
+    var writeVer = function(config) {
+      if (typeof config[device] === "undefined") {
+        config[device] = {};
+      }
+      config[device].version = appiumVer;
+      grunt.log.write("\n");
+      grunt.log.write(JSON.stringify(config));
+      fs.writeFile(configPath, JSON.stringify(config), cb);
+    };
+    if (err) {
+      grunt.log.write("Config file doesn't exist, creating it");
+      var config = {};
+      writeVer(config);
+    } else {
+      grunt.log.write("Config file exists, updating it");
+      writeVer(JSON.parse(data.toString('utf8')));
+    }
   });
 };
 

--- a/reset.sh
+++ b/reset.sh
@@ -9,7 +9,6 @@ should_reset_android=0
 should_reset_ios=0
 should_reset_selendroid=0
 appium_home=$(pwd)
-selendroid_ver="0.3"
 
 while test $# != 0
 do
@@ -56,6 +55,7 @@ reset_ios() {
     grunt buildApp:TestApp
     grunt buildApp:UICatalog
     grunt buildApp:WebViewApp
+    grunt setConfigVer:ios
 }
 
 get_apidemos() {
@@ -74,6 +74,7 @@ reset_android() {
     echo "Configuring and rebuilding Android test apps"
     grunt configAndroidApp:ApiDemos
     grunt buildAndroidApp:ApiDemos
+    grunt setConfigVer:android
 }
 
 reset_selendroid() {
@@ -90,6 +91,7 @@ reset_selendroid() {
     mvn install
     popd
     grunt buildSelendroidAndroidApp:WebViewDemo
+    grunt setConfigVer:selendroid
 }
 
 cleanup() {

--- a/server.js
+++ b/server.js
@@ -2,35 +2,52 @@
 var http = require('http')
   , express = require('express')
   , path = require('path')
+  , fs = require('fs')
   , logger = require('./logger').get('appium')
   , appium = require('./app/appium')
   , bodyParser = require('./middleware').parserWrap
   , status = require('./app/uiauto/lib/status')
+  , appiumVer = require('./package.json').version
+  , async = require('async')
+  , _ = require("underscore")
   , parser = require('./app/parser');
 
+var allowCrossDomain = function(req, res, next) {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS,DELETE');
+  res.header('Access-Control-Allow-Headers', 'origin, content-type, accept');
+
+  // need to respond 200 to OPTIONS
+
+  if ('OPTIONS' == req.method) {
+    res.send(200);
+  } else {
+    next();
+  }
+};
+
+var winstonStream = {
+  write: function(msg) {
+    msg = msg.replace(/$\s*$/m, "");
+    msg = msg.replace(/\[[^\]]+\] /, "");
+    logger.log('debug', msg);
+  }
+};
+
+var catchAllHandler = function(e, req, res, next) {
+  res.send(500, {
+    status: status.codes.UnknownError.code
+    , value: "ERROR running Appium command: " + e.message
+  });
+  next(e);
+};
+
 var main = function(args, readyCb, doneCb) {
-  var rest = express()
-    , server = http.createServer(rest);
   if (typeof doneCb === "undefined") {
     doneCb = function() {};
   }
-
-  // in case we'll support blackberry at some point
-  args.device = 'iOS';
-
-  var allowCrossDomain = function(req, res, next) {
-    res.header('Access-Control-Allow-Origin', '*');
-    res.header('Access-Control-Allow-Methods', 'GET,POST,PUT,OPTIONS,DELETE');
-    res.header('Access-Control-Allow-Headers', 'origin, content-type, accept');
-
-    // need to respond 200 to OPTIONS
-
-    if ('OPTIONS' == req.method) {
-      res.send(200);
-    } else {
-      next();
-    }
-  };
+  var rest = express()
+    , server = http.createServer(rest);
 
   rest.configure(function() {
     rest.use(express.favicon());
@@ -40,26 +57,12 @@ var main = function(args, readyCb, doneCb) {
       rest.use(express.logger('dev'));
     }
     if (args.log || args.webhook) {
-      var winstonStream = {
-        write: function(msg) {
-          msg = msg.replace(/$\s*$/m, "");
-          msg = msg.replace(/\[[^\]]+\] /, "");
-          logger.log('debug', msg);
-        }
-      };
       rest.use(express.logger({stream: winstonStream}));
     }
     rest.use(bodyParser);
     rest.use(express.methodOverride());
     rest.use(rest.router);
-    // catch all error handler
-    rest.use(function(e, req, res, next) {
-      res.send(500, {
-        status: status.codes.UnknownError.code
-        , value: "ERROR running Appium command: " + e.message
-      });
-      next(e);
-    });
+    rest.use(catchAllHandler);
   });
 
   // Instantiate the appium instance
@@ -68,33 +71,91 @@ var main = function(args, readyCb, doneCb) {
   // Hook up REST http interface
   appiumServer.attachTo(rest);
 
-  // Start the server either now or after pre-launching device
-  var next = function(appiumServer) {
+  var checkSetup = function(cb) {
+    var configFile = path.resolve(__dirname, ".appiumconfig");
+    fs.readFile(configFile, function(err, data) {
+      if (err) {
+        logger.error("Could not find config file; looks like config hasn't " +
+                     "been run! Please run reset.sh or appium configure.");
+        return cb(err);
+      }
+      var rawConfig;
+      try {
+        rawConfig = JSON.parse(data.toString('utf8'));
+      } catch (e) {
+        logger.error("Error parsing configuration json, please re-run config");
+        return cb(e);
+      }
+      var versionMismatches = {};
+      _.each(rawConfig, function(deviceConfig, key) {
+        if (deviceConfig.version !== appiumVer) {
+          versionMismatches[key] = deviceConfig.version;
+        }
+      });
+      if (_.keys(versionMismatches).length) {
+        logger.error("Got some configuration version mismatches. Appium is " +
+                     "at " + appiumVer + ".");
+        _.each(versionMismatches, function(mismatchedVer, key) {
+          logger.error(key + " configured at " + mismatchedVer);
+        });
+        logger.error("Please re-run reset.sh or config");
+        return cb(new Error("Appium / config version mismatch"));
+      } else {
+        appiumServer.registerConfig(rawConfig);
+        cb(null);
+      }
+    });
+  };
+
+  var conditionallyPreLaunch = function(cb) {
+    if (args.launch) {
+      logger.info("Starting Appium in pre-launch mode".cyan);
+      appiumServer.preLaunch(function(err) {
+        if (err) {
+          logger.error("Could not pre-launch appium: " + err);
+          cb(err);
+        } else {
+          cb(null);
+        }
+      });
+    } else {
+      cb(null);
+    }
+  };
+
+  var startListening = function(cb) {
+    var alreadyReturned = false;
     server.listen(args.port, args.address, function() {
-      var logMessage = "Appium REST http interface listener started on "+args.address+":"+args.port;
+      var logMessage = "Appium REST http interface listener started on " +
+                       args.address + ":" + args.port;
       logger.info(logMessage.cyan);
     });
     server.on('error', function(err) {
       logger.error("Couldn't start Appium REST http interface listener. Requested port is already in use. Please make sure there's no other instance of Appium running already.");
-    });
-    if (readyCb) {
-      readyCb(appiumServer);
-    }
-  };
-
-  if (args.launch) {
-    logger.info("Starting Appium in pre-launch mode".cyan);
-    appiumServer.preLaunch(function(err, appiumServer) {
-      if (err) {
-        logger.error("Could not pre-launch appium: " + err);
-        process.exit(1);
-      } else {
-        next(appiumServer);
+      if (!alreadyReturned) {
+        alreadyReturned = true;
+        cb(err);
       }
     });
-  } else {
-    next(appiumServer);
-  }
+    setTimeout(function() {
+      if (!alreadyReturned) {
+        alreadyReturned = true;
+        cb(null);
+      }
+    }, 1000);
+  };
+
+  async.series([
+    checkSetup
+    , conditionallyPreLaunch
+    , startListening
+  ], function(err) {
+    if (err) {
+      process.exit(1);
+    } else if (typeof readyCb === "function") {
+      readyCb(appiumServer);
+    }
+  });
 
   server.on('close', doneCb);
   return server;


### PR DESCRIPTION
Server.js now checks before launching if reset.sh has been run on the same version of appium that it belongs to.

Appium.js now checks before launching a specific device that `./reset.sh --[device]` has been run.

This should keep people from being able to launch appium sessions and have it fail for weird reasons like they haven't yet built selendroid or instruments-without-delay.

@penguinho this could be a breaking change for Appium.app so heads up!
