### PR TITLE
Cleanup of some python examples.

### DIFF
--- a/docs/android-hax-emulator.md
+++ b/docs/android-hax-emulator.md
@@ -1,0 +1,9 @@
+# Intel® Hardware Accelerated Execution Manager
+
+If you find the android emultor a slow and your system runs on an Intel® cpu, you can check out HAXM. HAXM let's you leverage your hardware for virtualization accelerating the emulator.
+
+* You can find all relevent documentation on [Intel's website][1]
+* This will require an x86 emulator image
+
+[1]: http://software.intel.com/en-us/articles/intel-hardware-accelerated-execution-manager/ "Hax" 
+[2]: http://software.intel.com/en-us/search/site/language/en?query=Intel%20Hardware%20Accelerated%20Execution%20Manager%20%28HAXM%29 "Hax all"

--- a/sample-code/examples/python/android.py
+++ b/sample-code/examples/python/android.py
@@ -3,11 +3,18 @@ from time import sleep
 
 from selenium import webdriver
 
+# Returns abs path relative to this file and not cwd
+PATH = lambda p: os.path.abspath(
+    os.path.join(os.path.dirname(__file__), p)
+)
+
 desired_caps = {}
 desired_caps['device'] = 'Android'
 desired_caps['browserName'] = ''
 desired_caps['version'] = '4.2'
-desired_caps['app'] = os.path.abspath('../../../sample-code/apps/ApiDemos/bin/ApiDemos-debug.apk')
+desired_caps['app'] = PATH(
+    '../../../sample-code/apps/ApiDemos/bin/ApiDemos-debug.apk'
+)
 desired_caps['app-package'] = 'com.example.android.apis'
 desired_caps['app-activity'] = 'ApiDemos'
 

--- a/sample-code/examples/python/android2.py
+++ b/sample-code/examples/python/android2.py
@@ -1,11 +1,16 @@
 import os
 from selenium import webdriver
 
+# Returns abs path relative to this file and not cwd
+PATH = lambda p: os.path.abspath(
+    os.path.join(os.path.dirname(__file__), p)
+)
+
 desired_caps = {}
 desired_caps['device'] = 'Android'
 desired_caps['browserName'] = ''
 desired_caps['version'] = '4.2'
-desired_caps['app'] = os.path.abspath('../../../sample-code/apps/ApiDemos/bin/ApiDemos-debug.apk')
+desired_caps['app'] = PATH('../../../sample-code/apps/ApiDemos/bin/ApiDemos-debug.apk')
 desired_caps['app-package'] = 'com.example.android.apis'
 desired_caps['app-activity'] = 'ApiDemos'
 

--- a/sample-code/examples/python/android_contacts.py
+++ b/sample-code/examples/python/android_contacts.py
@@ -1,11 +1,16 @@
 import os
 from selenium import webdriver
 
+# Returns abs path relative to this file and not cwd
+PATH = lambda p: os.path.abspath(
+    os.path.join(os.path.dirname(__file__), p)
+)
+
 desired_caps = {}
 desired_caps['device'] = 'Android'
 desired_caps['browserName'] = ''
 desired_caps['version'] = '4.2'
-desired_caps['app'] = os.path.abspath('../../../sample-code/apps/ContactManager/ContactManager.apk')
+desired_caps['app'] = PATH('../../../sample-code/apps/ContactManager/ContactManager.apk')
 desired_caps['app-package'] = 'com.example.android.contactmanager'
 desired_caps['app-activity'] = 'ContactManager'
 

--- a/sample-code/examples/python/android_web_view.py
+++ b/sample-code/examples/python/android_web_view.py
@@ -4,21 +4,24 @@ import unittest
 from time import sleep
 from selenium import webdriver
 
+
 class TestAndroidWebView(unittest.TestCase):
 
     def setUp(self):
         app = os.path.abspath(
-            glob.glob(os.path.join(os.path.dirname(__file__), 
-                                   '../../apps/WebViewDemo/target') + '/*.apk')[0])
+            glob.glob(os.path.join(
+                os.path.dirname(__file__), '../../apps/WebViewDemo/target')
+                      + '/*.apk')[0])
         desired_caps = {
             'device': 'selendroid',
             'app': app,
-            'browserName':"native-android-driver",
+            'browserName': "native-android-driver",
             'app-package': 'org.openqa.selendroid.testapp',
             'app-activity': 'HomeScreenActivity'
         }
-        
-        self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
+
+        self.driver = webdriver.Remote('http://localhost:4723/wd/hub',
+                                       desired_caps)
 
     def test(self):
         button = self.driver.find_element_by_name('buttonStartWebviewCD')


### PR DESCRIPTION
PEP8 treatment on android_web_view
for android, android2 and android_contact -> Make apk path absolute and not depend on cwd.
