### PR TITLE
Fix status

### DIFF
--- a/app/controller.js
+++ b/app/controller.js
@@ -6,6 +6,7 @@ var status = require('./uiauto/lib/status')
   , _s = require("underscore.string")
   , swig = require('swig')
   , path = require('path')
+  , version = require('../package.json').version
   , _ = require('underscore');
 
 function getResponseHandler(req, res) {
@@ -143,7 +144,7 @@ exports.sessionBeforeFilter = function(req, res, next) {
 exports.getStatus = function(req, res) {
   // Return a static JSON object to the client
   respondSuccess(req, res, {
-    build: {version: 'Appium 1.0'}
+    build: {version: version}
   });
 };
 


### PR DESCRIPTION
#612

``` ruby
> driver.send(:bridge).status
get 
=> #<Selenium::WebDriver::Remote::Response:0x007fbaccaf4ab8
 @code=200,
 @payload=
  {"status"=>0,
   "value"=>{"build"=>{"version"=>"0.5.2"}},
   "sessionId"=>"eeb61d13-40c0-48a2-ba9e-7a9f527aed36"}>
```

There's a different issue where the Ruby bindings can't call status. I'm preparing a patch for upstream.
