### PR TITLE
Sendkeys fix

### DIFF
--- a/app/uiauto/appium/element.js
+++ b/app/uiauto/appium/element.js
@@ -62,7 +62,7 @@ UIAElement.prototype.setValueByType = function(newValue) {
       type === "UIATextView" || type === "UIASearchBar") {
     // do the full-on clear,keyboard typing operation
     this.setValue("");
-    if (!this.hasKeyboardFocus()) {
+    if (this.hasKeyboardFocus() === 0) {
     	this.tap();
     }
     au.sendKeysToActiveElement(newValue);

--- a/app/uiauto/appium/element.js
+++ b/app/uiauto/appium/element.js
@@ -59,7 +59,7 @@ UIAElement.prototype.setValueByType = function(newValue) {
   var type = this.type();
 
   if (type === "UIATextField" || type === "UIASecureTextField" ||
-      type === "UIATextView") {
+      type === "UIATextView" || type === "UIASearchBar") {
     // do the full-on clear,keyboard typing operation
     this.setValue("");
     if (!this.hasKeyboardFocus()) {

--- a/app/uiauto/appium/element.js
+++ b/app/uiauto/appium/element.js
@@ -62,7 +62,9 @@ UIAElement.prototype.setValueByType = function(newValue) {
       type === "UIATextView") {
     // do the full-on clear,keyboard typing operation
     this.setValue("");
-    this.tap();
+    if (!this.hasKeyboardFocus()) {
+    	this.tap();
+    }
     au.sendKeysToActiveElement(newValue);
   } else if (type === "UIAPickerWheel") {
     this.selectValue(newValue);


### PR DESCRIPTION
We were having trouble testing some views that had search bars. Specifically, sending text to a search bar simply just set the text property of the search bar, as opposed to typing in the text. Sending "\n" would obviously not submit the search in this case.
