### PR TITLE
removed the "Note"

### DIFF
--- a/docs/hybrid.md
+++ b/docs/hybrid.md
@@ -41,11 +41,7 @@ Once installed you can start the proxy with the following command:
 > ios_webkit_debug_proxy -c 0e4b2f612b65e98c1d07d22ee08678130d345429:27753 -d
 ``` 
 
-<b>NOTE:</b> the proxy requires the <b>"web inspector"</b> to be turned on to allow a connection to be established.
-
-Turn it on by going to <b> settings > safari > advanced </b>. Please be aware that the web inspector was <b>added as part of iOS 6</b> and was not available previously.
-
-<b>NOTE</b>: Please use the manual installation process for now untill the latest version of the proxy has been tagged and added to brew.
+<b>NOTE:</b> the proxy requires the <b>"web inspector"</b> to be turned on to allow a connection to be established. Turn it on by going to <b> settings > safari > advanced </b>. Please be aware that the web inspector was <b>added as part of iOS 6</b> and was not available previously.
 
 ## Wd.js Code example
 


### PR DESCRIPTION
the proxy has been fixed and tagged and can now be installed through brew. So note was not valid anymore.
