### PR TITLE
Change which allows multiple selendroid servers to run on one MAC/PC

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,32 @@
 -------------------------------------
+CHANGES IN VERSION 0.7.0 (from 0.6.1)
+-------------------------------------
+[GENERAL]
+- allow new session requests to override current session; this can be disabled
+  with the --no-session-override flag
+- make sure reset.sh fails if android bootstrap can't build
+- make --no-reset do what it's supposed to do, and fix description in docs
+- check to make sure conflicting arguments aren't passed to the server before
+  launching
+- removed deprecated flags completely (hence the minor version bump)
+- bringing some error messages into line across platforms
+- fix some issues with grunt building functions
+
+[ANDROID]
+- add find element by ID (parses strings.xml)
+- remove a sleep in bootstrap server that caused delays
+- make sure app is uninstalled when not using fast reset
+- make sure AndroidManifest.xml.apk is writable (for npm installed appium)
+- make sure device wakes up / unlocks before running test
+- add set geo location support
+- clean up and fix issues relating to mid-session bootstrap.jar restart
+- app-wait-activity now takes comma-separated list of valid activities
+
+[IOS]
+- fix some tests
+- fix mobile: reset
+
+-------------------------------------
 CHANGES IN VERSION 0.6.1 (from 0.6.0)
 -------------------------------------
 [GENERAL]

--- a/android/adb.js
+++ b/android/adb.js
@@ -510,7 +510,7 @@ ADB.prototype.startSelendroid = function(serverPath, onReady) {
 };
 
 ADB.prototype.pushSelendroid = function(cb) {
-  var cmd = "adb -s " + this.curDeviceId + " shell am instrument -e main_activity '" + this.appPackage +
+  var cmd = this.adbCmd + " shell am instrument -e main_activity '" + this.appPackage +
             "." + this.appActivity + "' " + this.appPackage +
             ".selendroid/org.openqa.selendroid.ServerInstrumentation";
   logger.info("Starting instrumentation process for selendroid with cmd: " +

--- a/android/adb.js
+++ b/android/adb.js
@@ -510,7 +510,7 @@ ADB.prototype.startSelendroid = function(serverPath, onReady) {
 };
 
 ADB.prototype.pushSelendroid = function(cb) {
-  var cmd = "adb shell am instrument -e main_activity '" + this.appPackage +
+  var cmd = "adb -s " + this.curDeviceId + " shell am instrument -e main_activity '" + this.appPackage +
             "." + this.appActivity + "' " + this.appPackage +
             ".selendroid/org.openqa.selendroid.ServerInstrumentation";
   logger.info("Starting instrumentation process for selendroid with cmd: " +

--- a/app/appium.js
+++ b/app/appium.js
@@ -471,6 +471,7 @@ Appium.prototype.invoke = function() {
           , appDeviceReadyTimeout: this.args.androidDeviceReadyTimeout
           , reset: !this.args.noReset
           , fastReset: this.fastReset
+          , selendroidPort: this.args.selendroidPort
         };
         this.devices[this.deviceType] = selendroid(selendroidOpts);
       } else if (this.isFirefoxOS()) {

--- a/app/appium.js
+++ b/app/appium.js
@@ -470,6 +470,7 @@ Appium.prototype.invoke = function() {
           , appDeviceReadyTimeout: this.args.androidDeviceReadyTimeout
           , reset: !this.args.noReset
           , fastReset: !this.args.fullReset && !this.args.noReset
+          , selendroidPort: this.args.selendroidPort
         };
         this.devices[this.deviceType] = selendroid(selendroidOpts);
       } else if (this.isFirefoxOS()) {

--- a/app/parser.js
+++ b/app/parser.js
@@ -217,7 +217,17 @@ var args = [
     , type: 'int'
     , example: "4242"
     , help: 'port for robot'
+  }],
+
+  [['-sp', '--selendroid-port'] , {
+    defaultValue: -1
+    , dest: 'selendroidPort'
+    , required: false
+    , type: 'int'
+    , example: "8081"
+    , help: 'port for selendroid'
   }]
+
 ];
 
 // Setup all the command line argument parsing

--- a/app/parser.js
+++ b/app/parser.js
@@ -247,7 +247,17 @@ var args = [
     , type: 'int'
     , example: "4242"
     , help: 'port for robot'
+  }],
+
+  [['-sp', '--selendroid-port'] , {
+    defaultValue: -1
+    , dest: 'selendroidPort'
+    , required: false
+    , type: 'int'
+    , example: "8081"
+    , help: 'port for selendroid'
   }]
+
 ];
 
 // Setup all the command line argument parsing

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -21,7 +21,11 @@ var Selendroid = function(opts) {
   this.adb = null;
   this.isProxy = true;
   this.proxyHost = 'localhost';
-  this.proxyPort = 8080;
+  if(opts.selendroidPort === -1){
+    this.proxyPort = 8080;
+  } else {
+    this.proxyPort = opts.selendroidPort;
+  }
 };
 
 Selendroid.prototype.start = function(cb) {

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -21,11 +21,7 @@ var Selendroid = function(opts) {
   this.adb = null;
   this.isProxy = true;
   this.proxyHost = 'localhost';
-  if (opts.selendroidPort === -1) {
-    this.proxyPort = 8080;
-  } else {
-    this.proxyPort = opts.selendroidPort;
-  }
+  this.proxyPort = opts.selendroidPort === -1 ? 8080 : opts.selendroidPort;
 };
 
 Selendroid.prototype.start = function(cb) {

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -21,7 +21,7 @@ var Selendroid = function(opts) {
   this.adb = null;
   this.isProxy = true;
   this.proxyHost = 'localhost';
-  if(opts.selendroidPort === -1){
+  if (opts.selendroidPort === -1) {
     this.proxyPort = 8080;
   } else {
     this.proxyPort = opts.selendroidPort;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "automation",
     "javascript"
   ],
-  "version": "0.6.1",
+  "version": "0.7.0",
   "author": "appium-discuss@googlegroups.com",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When running multiple appium server instances with selendroid, this caused conflicts as the selendroid port was fixed.
By making it configurable, we can run multiple instances of appium with it's own selendroid server connected to it's own device/emulator which allows you to run  webview tests in parallel.
