### PR TITLE
navigate to url fix which speeds up execution on real devices

### DIFF
--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -353,7 +353,7 @@ RemoteDebugger.prototype.navToUrl = function(url, cb) {
     me.waitForFrameNavigated(function() {
       me.waitForDom(cb);
     });
-  }, 500);
+  }, 1000);
 };
 
 RemoteDebugger.prototype.pageLoad = function() {

--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -349,14 +349,11 @@ RemoteDebugger.prototype.navToUrl = function(url, cb) {
   var navToUrl = messages.setUrl(url, this.appIdKey, this.connId,
       this.senderId, this.pageIdKey, this.debuggerType);
   this.send(navToUrl, noop);
-
   setTimeout(function(){
     me.waitForFrameNavigated(function() {
       me.waitForDom(cb);
     });
   }, 500);
-
-
 };
 
 RemoteDebugger.prototype.pageLoad = function() {

--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -349,7 +349,7 @@ RemoteDebugger.prototype.navToUrl = function(url, cb) {
   var navToUrl = messages.setUrl(url, this.appIdKey, this.connId,
       this.senderId, this.pageIdKey, this.debuggerType);
   this.send(navToUrl, noop);
-  setTimeout(function(){
+  setTimeout(function() {
     me.waitForFrameNavigated(function() {
       me.waitForDom(cb);
     });

--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -349,19 +349,21 @@ RemoteDebugger.prototype.navToUrl = function(url, cb) {
   var navToUrl = messages.setUrl(url, this.appIdKey, this.connId,
       this.senderId, this.pageIdKey, this.debuggerType);
   this.send(navToUrl, noop);
-  this.waitForFrameNavigated(function() {
-    me.checkPageIsReady(function(err, isReady) {
-      if (isReady) return cb();
+
+  setTimeout(function(){
+    me.waitForFrameNavigated(function() {
       me.waitForDom(cb);
     });
-  });
+  }, 500);
+
+
 };
 
 RemoteDebugger.prototype.pageLoad = function() {
   clearTimeout(this.loadingTimeout);
   var me = this
     , cbs = this.pageLoadedCbs
-    , waitMs = 10000
+    , waitMs = 60000
     , intMs = 500
     , start = Date.now();
   logger.debug("Page loaded, verifying through readyState");
@@ -401,11 +403,12 @@ RemoteDebugger.prototype.pageUnload = function(cb) {
 };
 
 RemoteDebugger.prototype.waitForDom = function(cb) {
+  var me = this;
   logger.debug("Waiting for dom...");
   if (typeof cb === "function") {
     this.pageLoadedCbs.push(cb);
   }
-  this.loadingTimeout = setTimeout(_.bind(this.pageLoad, this), 60000);
+  me.pageLoad();
 };
 
 RemoteDebugger.prototype.waitForFrameNavigated = function(cb) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -391,17 +391,17 @@ IOS.prototype.listWebFrames = function(cb, exitCb) {
 
   this.processingRemoteCmd = true;
   if (this.remote !== null && this.bundleId !== null) {
-    if( this.udid !== null) {
-      me.remote.pageArrayFromJson(function(pageArray){
+    if (this.udid !== null) {
+      me.remote.pageArrayFromJson(function(pageArray) {
         cb(pageArray);
       });
     } else {
       this.remote.selectApp(this.bundleId, onDone);
     }
   } else {
-      if(this.udid !== null){
+      if (this.udid !== null) {
         this.remote = wkrd.init(exitCb);
-        me.remote.pageArrayFromJson(function(pageArray){
+        me.remote.pageArrayFromJson(function(pageArray) {
           cb(pageArray);
         });
       } else {

--- a/app/ios.js
+++ b/app/ios.js
@@ -391,7 +391,13 @@ IOS.prototype.listWebFrames = function(cb, exitCb) {
 
   this.processingRemoteCmd = true;
   if (this.remote !== null && this.bundleId !== null) {
-    this.remote.selectApp(this.bundleId, onDone);
+    if( this.udid !== null) {
+      me.remote.pageArrayFromJson(function(pageArray){
+        cb(pageArray);
+      });
+    } else {
+      this.remote.selectApp(this.bundleId, onDone);
+    }
   } else {
       if(this.udid !== null){
         this.remote = wkrd.init(exitCb);
@@ -1786,7 +1792,8 @@ IOS.prototype.leaveWebView = function(cb) {
     this.curWindowHandle = null;
     //TODO: this condition should be changed to check if the webkit protocol is being used.
     if(this.udid){
-        this.stopRemote();
+      this.remote.disconnect();
+      this.curWindowHandle = null;
     }
     cb(null, {
       status: status.codes.Success.code

--- a/test/functional/safari/safari.js
+++ b/test/functional/safari/safari.js
@@ -63,22 +63,22 @@ _.each(devices, function(sim) {
       });
     });
 
-
     it('should be able to go back and forward', function(done) {
       loadWebView("safari", h.driver, function() {
         h.driver.elementByLinkText('i am a link', function(err, el) {
-          el.click();
-          h.driver.elementById('only_on_page_2', function(err) {
-            should.not.exist(err);
-            h.driver.back(function(err) {
+          el.click(function(){
+            h.driver.elementById('only_on_page_2', function(err) {
               should.not.exist(err);
-              h.driver.elementById('i_am_a_textbox', function(err) {
+              h.driver.back(function(err) {
                 should.not.exist(err);
-                h.driver.forward(function(err) {
+                h.driver.elementById('i_am_a_textbox', function(err) {
                   should.not.exist(err);
-                  h.driver.elementById('only_on_page_2', function(err) {
+                  h.driver.forward(function(err) {
                     should.not.exist(err);
-                    done();
+                    h.driver.elementById('only_on_page_2', function(err) {
+                      should.not.exist(err);
+                      done();
+                    });
                   });
                 });
               });

--- a/test/functional/safari/safari.js
+++ b/test/functional/safari/safari.js
@@ -66,7 +66,7 @@ _.each(devices, function(sim) {
     it('should be able to go back and forward', function(done) {
       loadWebView("safari", h.driver, function() {
         h.driver.elementByLinkText('i am a link', function(err, el) {
-          el.click(function(){
+          el.click(function() {
             h.driver.elementById('only_on_page_2', function(err) {
               should.not.exist(err);
               h.driver.back(function(err) {


### PR DESCRIPTION
This fix only works on real devices and leaves the simulator un-affected.

We have a minor 500 ms wait as it was asking if the page had finished loading whilst sending the is ready request. Sometimes it came back as true before it had even done anything.

Move the required 60 seconds timeout into the pageLoad method (which check the page status every 500 ms for 60 seconds, rather than waiting 60 seconds).
