### PR TITLE
Fixed broken isDisplayed() and isEnabled() protocol.

### DIFF
--- a/app/ios.js
+++ b/app/ios.js
@@ -1354,7 +1354,7 @@ IOS.prototype.elementDisplayed = function(elementId, cb) {
       this.executeAtom('is_displayed', [atomsElement], cb);
     }, this));
   } else {
-    var command = ["au.getElement('", elementId, "').isDisplayed() ? true : false"].join('');
+    var command = ["au.getElement('", elementId, "').isDisplayed()"].join('');
     this.proxy(command, cb);
   }
 };
@@ -1365,7 +1365,7 @@ IOS.prototype.elementEnabled = function(elementId, cb) {
       this.executeAtom('is_enabled', [atomsElement], cb);
     }, this));
   } else {
-    var command = ["au.getElement('", elementId, "').isEnabled() ? true : false"].join('');
+    var command = ["au.getElement('", elementId, "').isEnabled()"].join('');
     this.proxy(command, cb);
   }
 };


### PR DESCRIPTION
The method [here](https://github.com/appium/appium/blob/623119da6e62b7ecb3f6b4d103efc4c0e7b0a637/app/ios.js#L1351) and [here](https://github.com/appium/appium/blob/623119da6e62b7ecb3f6b4d103efc4c0e7b0a637/app/ios.js#L1362) are returning a boolean value when they should be returning an object with fields status and value.

Prior to this fix, asking an element if it was enabled/visible would always return true as discussed [here](https://github.com/appium/appium/issues/725).
