### PR TITLE
Selendroid won't build properly without JAVA_HOME set

### DIFF
--- a/reset.sh
+++ b/reset.sh
@@ -165,6 +165,7 @@ reset_selendroid() {
     run_cmd rm -rf submodules/selendroid/selendroid-server/target
     run_cmd git submodule update --init submodules/selendroid
     run_cmd rm -rf selendroid
+    run_cmd [ -z "$JAVA_HOME" ] && echo "Warning: Make sure JAVA_HOME is set properly for Java builds."
     echo "* Building selendroid server and supporting libraries"
     run_cmd $grunt buildSelendroidServer
     if $include_dev ; then


### PR DESCRIPTION
Ran into this problem earlier. Selendroid build will work but its tests will fail without JAVA_HOME set. Display warning in reset.sh if not set.

Please merge.

Thanks,
Sebastian
