### PR TITLE
Changed git to http for instruments-without-delay in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "submodules/instruments-without-delay"]
 	path = submodules/instruments-without-delay
-	url = git://github.com/facebook/instruments-without-delay.git
+	url = https://github.com/facebook/instruments-without-delay.git
 [submodule "submodules/ApiDemos"]
 	path = submodules/ApiDemos
 	url = https://github.com/appium/android-apidemos.git


### PR DESCRIPTION
Running ./reset.sh causes the following message to appear:

Cloning into 'submodules/instruments-without-delay'...
fatal: read error: Operation timed out

Changing the git to http fixes the issue.
