### PR TITLE
Page source now retrieves source for all windows.

### DIFF
--- a/app/ios.js
+++ b/app/ios.js
@@ -1324,7 +1324,7 @@ IOS.prototype.frame = function(frame, cb) {
       }
     }
   } else {
-    frame = frame? frame : 'mainWindow';
+    frame = frame? frame : 'target.frontMostApp()';
     var command = ["wd_frame = ", frame].join('');
     this.proxy(command, cb);
   }

--- a/app/uiauto/bootstrap.js
+++ b/app/uiauto/bootstrap.js
@@ -5,7 +5,7 @@
 // automation globals
 var target = UIATarget.localTarget();
 var mainWindow = target.frontMostApp().mainWindow();
-var wd_frame = mainWindow;
+var wd_frame = target.frontMostApp();
 
 // safe default
 target.setTimeout(1);

--- a/test/functional/testapp/basic.js
+++ b/test/functional/testapp/basic.js
@@ -92,9 +92,10 @@ describeWd('calc app', function(h) {
   it('should return app source', function(done){
     h.driver.source(function(err, source) {
       var obj = JSON.parse(source);
-      assert.equal(obj.type, "UIAWindow");
-      assert.equal(obj.children[0].label, "TextField1");
-      assert.equal(obj.children[3].name, "SumLabel");
+      assert.equal(obj.type, "UIAApplication");
+      assert.equal(obj.children[0].type, "UIAWindow");
+      assert.equal(obj.children[0].children[0].label, "TextField1");
+      assert.equal(obj.children[0].children[3].name, "SumLabel");
       done();
     });
   });

--- a/test/functional/testapp/source.js
+++ b/test/functional/testapp/source.js
@@ -11,10 +11,14 @@ describeWd('get source', function(h) {
       var obj = JSON.parse(source);
       should.not.exist(err);
       should.ok(obj);
-      obj.children[2].name.should.equal("ComputeSumButton");
-      obj.children[3].rect.origin.x.should.equal(129);
-      should.ok(obj.children[4].visible);
+      obj.type.should.equal("UIAApplication");
+      obj.children[0].type.should.equal("UIAWindow");
+      obj.children[0].children[2].name.should.equal("ComputeSumButton");
+      obj.children[0].children[3].rect.origin.x.should.equal(129);
+      should.ok(obj.children[0].children[4].visible);
       done();
     });
   });
 });
+
+


### PR DESCRIPTION
Page source is currently retrieving only the elements on the mainWindow().  This patch allows it to retrieve elements for all windows.  This means that the statusbar window, keyboard window, and any actionsheet/popover/alert windows will be viewable in the page source.

This also makes things consistant with element search calls.  Element search calls currently search all windows whereas page source is currently logging only the main window.  In other words, without this patch, its possible to retrive an element from a search that is not viewable in the page source.

This fixes issue [#569](https://github.com/appium/appium/issues/569).
