### PR TITLE
Added a settings file to instruments that it can read in for "sudo envir...

### DIFF
--- a/app/uiauto/lib/instruments_client.js
+++ b/app/uiauto/lib/instruments_client.js
@@ -5,9 +5,34 @@ var system = UIATarget.localTarget().host();
 var defWaitForDataTimeout = 3600;
 var waitForDataTimeout = defWaitForDataTimeout;
 var curAppiumCmdId = -1;
+var user = null;
+var settings = null;
+
+var fileExists = function(filename) {
+  var params = [];
+  params = params.concat(['-f', filename]);
+  var res = system.performTaskWithPathArgumentsTimeout("/bin/test", params, 3);
+  if (res.exitCode === 0) {
+    return true;
+  } else {
+    return false;
+  }
+};
 
 var sysExec = function(cmd) {
-  var res = system.performTaskWithPathArgumentsTimeout('/bin/bash', ['-c', cmd], 3);
+  var params = [];
+  if (user !== null) {
+    if (fileExists('/Users/' + user + '/.bash_profile') === true) {
+      params = params.concat(['--rcfile', '/Users/' + user + '/.bash_profile']);
+    } else {
+      if (fileExists('/Users/' + user + '/.bashrc') === true) {
+        params = params.concat(['--rcfile', '/Users/' + user + '/.bashrc']);
+      }
+    }
+  }
+  params = params.concat(['-c', cmd]);
+  var res = system.performTaskWithPathArgumentsTimeout("/bin/bash",
+      params, 3);
   if (res.exitCode !== 0) {
     throw new Error("Failed executing the command " + cmd + " (exit code " + res.exitCode + ")");
   } else {
@@ -15,10 +40,48 @@ var sysExec = function(cmd) {
     if (output.length) {
       return output;
     } else {
-      throw new Error("Executing " + cmd + " failed!");
+      throw new Error("Executing " + cmd + " failed since there was no output");
     }
   }
 };
+
+user = function() {
+  try {
+    var ret = sysExec("whoami");
+    console.log("Instruments shell user: " + ret);
+    return ret;
+  } catch (e) {
+    console.log("Error getting user: " + e.message);
+    return null;
+  }
+}();
+
+settings = function() {
+  var data = {};
+  var settingsFile = "/Users/"+user+"/.instruments.conf";
+
+  if (fileExists(settingsFile) === true) {
+    var lines = sysExec("/bin/cat " + settingsFile).split('\n');
+    for (var index = 0; index < lines.length; index++) {
+      var line = lines[index];
+      if (line[0] === '#') continue;
+      if (line.indexOf('=') != -1) {
+        var parts = line.split('=');
+        if (parts.length !== 2) {
+          throw new Error("Error reading " + settingsFile);
+        }
+        data[parts[0]] = parts[1];
+      }
+    }
+    if (data.length > 0) {
+      console.log("Read in settings: ");
+    }
+    for (var key in data) {
+      console.log("  " + key + ": " + data[key]);
+    }
+    return data;
+  }
+}();
 
 // get npm-installed instruments_client bin if necessary
 var globalPath = (function() {
@@ -44,7 +107,7 @@ var clientPath = (function() {
     } catch(e) {
       if (globalPath === null) {
         console.log("WARNING: could not find instruments/client.js in its " +
-                    "usual place, and global instruments_client not aroudn " +
+                    "usual place, and global instruments_client not around " +
                     "either. This could cause problems");
       }
     }
@@ -54,37 +117,56 @@ var clientPath = (function() {
 // figure out where node is
 var nodePath = (function() {
   var path = null;
+  if (typeof settings !== "undefined") {
+    if ('NODE_BIN' in settings) {
+      console.log("Using settings override for NODE_BIN: " + settings.NODE_BIN);
+      return settings.NODE_BIN;
+    }
+  }
+
+  // not in the settings file, so let's try and find it...
   try {
-    path = sysExec('which node');
-  } catch (e) {
-    var appScript = [
-        'try'
-      , '  set appiumIsRunning to false'
-      , '  tell application "System Events"'
-      , '    set appiumIsRunning to name of every process contains "Appium"'
-      , '  end tell'
-      , '  if appiumIsRunning then'
-      , '    tell application "Appium" to return node path'
-      , '  end if'
-      , 'end try'
-      , 'return "NULL"'
-    ].join("\n");
-    var appNodeWorked = false;
+    path = sysExec("echo $NODE_BIN");
+    console.log("Found node using $NODE_BIN: " + path);
+  } catch(e) {
     try {
-      path = sysExec("osascript -e '" + appScript + "'");
-      appNodeWorked = path !== "NULL";
-    } catch(e) {}
-    if (!appNodeWorked) {
+      path = sysExec('which node');
+      console.log("Found node using `which node`: " + path);
+    } catch (e) {
+      var appScript = [
+          'try'
+        , '  set appiumIsRunning to false'
+        , '  tell application "System Events"'
+        , '    set appiumIsRunning to name of every process contains "Appium"'
+        , '  end tell'
+        , '  if appiumIsRunning then'
+        , '    tell application "Appium" to return node path'
+        , '  end if'
+        , 'end try'
+        , 'return "NULL"'
+      ].join("\n");
+      var appNodeWorked = false;
       try {
-        path = sysExec("ls /usr/local/bin/node");
-      } catch (e) {
+        path = sysExec("osascript -e '" + appScript + "'");
+        appNodeWorked = path !== "NULL";
+      } catch(e) {}
+      if (!appNodeWorked) {
         try {
-          path = sysExec("ls /opt/local/bin/node");
+          path = sysExec("ls /usr/local/bin/node");
+          console.log("Found node at " + path);
         } catch (e) {
-          throw new Error("Could not find node using `which node`, at /usr/" +
-                          "local/bin/node, at /opt/local/bin/node, or by " +
-                          "querying Appium.app. Where is it?");
+          try {
+            path = sysExec("ls /opt/local/bin/node");
+            console.log("Found node at " + path);
+          } catch (e) {
+            throw new Error("Could not find node using `which node`, at /usr/" +
+                            "local/bin/node, at /opt/local/bin/node, at " +
+                            "$NODE_BIN, or by querying Appium.app. Where is " +
+                            "it?");
+          }
         }
+      } else {
+        console.log("Found node in Appium.app");
       }
     }
   }


### PR DESCRIPTION
...onment variables".

Structured as key=value pairs, it will ignore lines that don't have a '=' in them, and throw
and error if the split on '=' is more then two.

The only thing using it in this pull request is the location of node.

This pull request started as https://github.com/appium/appium/pull/757, but I added the settings file.
