### PR TITLE
Fix activity detection

### DIFF
--- a/android/adb.js
+++ b/android/adb.js
@@ -518,6 +518,7 @@ ADB.prototype.pushSelendroid = function(cb) {
   var cmd = this.adbCmd + " shell am instrument -e main_activity '" +
             this.appPackage + "." + this.appActivity + "' " + this.appPackage +
             ".selendroid/io.selendroid.ServerInstrumentation";
+  cmd = cmd.replace(/\.+/g,'.'); // Fix pkg..activity error
   logger.info("Starting instrumentation process for selendroid with cmd: " +
               cmd);
   exec(cmd, function(err, stdout) {

--- a/android/adb.js
+++ b/android/adb.js
@@ -1023,12 +1023,19 @@ ADB.prototype.startApp = function(cb) {
       hasNoPrefix = false;
     }
   });
+
+  // Let's not break regular activities.
+  // https://github.com/appium/appium/issues/782
+  if (activityString[0] === ".") {
+    hasNoPrefix = false;
+  }
+
   if (hasNoPrefix) {
     activityString = this.appPackage + "." + activityString;
   }
   var cmd = this.adbCmd + " shell am start -n " + this.appPackage + "/" +
             activityString;
-  this.debug("Starting app " + this.appPackage + "/" + activityString);
+  this.debug("Starting app\n" + cmd);
   exec(cmd, _.bind(function(err) {
     if(err) {
       logger.error(err);
@@ -1057,7 +1064,7 @@ ADB.prototype.getFocusedPackageAndActivity = function(cb) {
   logger.info("Getting focused package and activity");
   this.requireDeviceId();
   var cmd = this.adbCmd + " shell dumpsys window windows"
-    , searchRe = new RegExp(/mFocusedApp.+ ([a-zA-Z0-9\.]+)\/\.?([^\}]+)\}/);
+    , searchRe = new RegExp(/mFocusedApp.+ ([a-zA-Z0-9\.]+)\/(\.?[^\}]+)\}/);
 
   exec(cmd, _.bind(function(err, stdout) {
     if (err) {

--- a/app/routing.js
+++ b/app/routing.js
@@ -51,7 +51,7 @@ module.exports = function(appium) {
       request(url, req.route.method.toUpperCase(), req.body,
               req.headers['content-type'], function(err, response, body) {
         if (err) return next(err);
-        if (body.value) {
+        if (body && body.value) {
           var resStatusCode = body.status;
           if (resStatusCode !== 0) {
             var resErrorMessage = body.value.message;

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -108,6 +108,7 @@ Selendroid.prototype.waitForServer = function(cb) {
 Selendroid.prototype.createSession = function(cb) {
   logger.info("Creating Selendroid session");
   var data = {desiredCapabilities: this.desiredCaps};
+  var me = this;
   this.proxyTo('/wd/hub/session', 'POST', data, _.bind(function(err, res, body) {
     if (err) return cb(err);
 
@@ -115,6 +116,7 @@ Selendroid.prototype.createSession = function(cb) {
       logger.info("Successfully started selendroid session");
       this.selendroidSessionId = body.sessionId;
       cb(null, body.sessionId);
+      me.adb.startApp(function(){});
     } else {
       logger.error("Selendroid create session did not work. Status was " +
                    res.statusCode + " and body was " + body);


### PR DESCRIPTION
The old logic was completely broken.

The pkg must not be prepended to the activity. This is invalid.
shell am start -n
com.thehomedepot/com.thehomedepot..Foundation.Controller.SetServicesActivity

The activity must not have the first bit chopped off. This is invalid:
Foundation.Controller.SetServicesActivity

The correct command is adb shell am start -n
com.thehomedepot/.Foundation.Controller.SetServicesActivity

Notice there's no prepended activity and that the string after the / starts with
a "."
