### PR TITLE
Allow starting Appium.app from commandline without global install of nodejs

### DIFF
--- a/app/uiauto/lib/instruments_client.js
+++ b/app/uiauto/lib/instruments_client.js
@@ -169,7 +169,7 @@ var nodePath = (function() {
                               "local/bin/node, at /opt/local/bin/node, at " +
                               "$NODE_BIN, or by querying Appium.app. Where is " +
                               "it?");
-            }                  
+            }
           }
         }
       } else {

--- a/app/uiauto/lib/instruments_client.js
+++ b/app/uiauto/lib/instruments_client.js
@@ -161,10 +161,15 @@ var nodePath = (function() {
             path = sysExec("ls /opt/local/bin/node");
             console.log("Found node at " + path);
           } catch (e) {
-            throw new Error("Could not find node using `which node`, at /usr/" +
-                            "local/bin/node, at /opt/local/bin/node, at " +
-                            "$NODE_BIN, or by querying Appium.app. Where is " +
-                            "it?");
+            try {
+              path = sysExec("ls /Applications/Appium.app/Contents/Resources/node/bin/node");
+              console.log("Found node at " + path);
+            } catch (e) {
+              throw new Error("Could not find node using `which node`, at /usr/" +
+                              "local/bin/node, at /opt/local/bin/node, at " +
+                              "$NODE_BIN, or by querying Appium.app. Where is " +
+                              "it?");
+            }                  
           }
         }
       } else {


### PR DESCRIPTION
WIthout this code modification, Appium.app won't start from the commandline when the machine doesn't have nodejs globally installed. Instead you hit the exception about not being able to find node.
