### PR TITLE
invoke global instruments_client script using node

### DIFF
--- a/app/uiauto/lib/instruments_client.js
+++ b/app/uiauto/lib/instruments_client.js
@@ -186,13 +186,15 @@ var isAppiumApp = (function() {
 var sendResultAndGetNext = function(result) {
   curAppiumCmdId++;
   var args = ['-s', '/tmp/instruments_sock'], res
-    , binaryPath = globalPath;
+    , binaryPath = nodePath;
   if (isAppiumApp) {
     globalPath = null;
   }
   if (globalPath === null) {
-    binaryPath = nodePath;
     args.unshift(clientPath);
+  }
+  else {
+    args.unshift(globalPath);
   }
   if (typeof result !== "undefined") {
     args = args.concat(['-r', JSON.stringify(result)]);


### PR DESCRIPTION
Running Appium on a Mac where node/npm is installed via MacPorts, and Appium has been globally installed (`npm install -g appium`) does not work. The root cause of this is that the global `instruments_client` script cannot be run because the `PATH` envvar does not contain the MacPorts bin folder.

Here's the detailed analysis:
- When Appium runs shell commands, the shell environment has its `HOME` variable set to the simulator folder, for instance `/Users/foo/Library/Application Support/iPhone Simulator/6.1`
- As a result, the shell does not find the user's usual initialization script `~/.bashrc`. Unfortunately, this script is where usually the `PATH` envvar is set up to contain the MacPorts bin folder (`/opt/local/bin` by default)
- The `sysExec()` function in has been cleverly engineered to work around this, however no such engineering exists for the UI Automation function `performTaskWithPathArgumentsTimeout()`. So whenever some shell command is executed via `performTaskWithPathArgumentsTimeout()`, the `PATH` envvar does **not** contain the MacPorts bin folder!
- This leads us to `sendResultAndGetNext()`, which when it is called tries to run the globally installed `/opt/local/bin/instruments_client` (obtained from the `globalPath` variable) via `performTaskWithPathArgumentsTimeout()`
- Looking into `instruments_client` we see that it contains this shebang: `#!/usr/bin/env node`
- `env` is supposed to locate node via `PATH`, but this fails because, as we have seen above, the MacPorts bin folder is not in `PATH`

The change in this pull request works around the problem by invoking `instruments_client` with `node`, using the full node path obtained from the `nodePath` variable.

I have tested the change both with Appium installed globally and locally, using Appium's `simplest.js` test script.
