### PR TITLE
look for ~/.profile in sysExec()

### DIFF
--- a/app/uiauto/lib/instruments_client.js
+++ b/app/uiauto/lib/instruments_client.js
@@ -22,11 +22,15 @@ var fileExists = function(filename) {
 var sysExec = function(cmd) {
   var params = [];
   if (user !== null) {
-    if (fileExists('/Users/' + user + '/.bash_profile')) {
-      params = params.concat(['--rcfile', '/Users/' + user + '/.bash_profile']);
+    if (fileExists('/Users/' + user + '/.profile')) {
+      params = params.concat(['--rcfile', '/Users/' + user + '/.profile']);
     } else {
-      if (fileExists('/Users/' + user + '/.bashrc')) {
-        params = params.concat(['--rcfile', '/Users/' + user + '/.bashrc']);
+      if (fileExists('/Users/' + user + '/.bash_profile')) {
+        params = params.concat(['--rcfile', '/Users/' + user + '/.bash_profile']);
+      } else {
+        if (fileExists('/Users/' + user + '/.bashrc')) {
+          params = params.concat(['--rcfile', '/Users/' + user + '/.bashrc']);
+        }
       }
     }
   }


### PR DESCRIPTION
Some people have a `~/.profile` instead of a `~/.bash_profile`, so `sysExec()` should take this into account as well.

`~/.profile` is checked before `~/.bash_profile` to reflect the order of precedence in which bash normally looks for these files.
