### PR TITLE
Implementing scroll() method for WebDriver bindings

### DIFF
--- a/app/controller.js
+++ b/app/controller.js
@@ -284,6 +284,26 @@ exports.fireEvent = function(req, res) {
   req.device.fireEvent(evt, elementId, getResponseHandler(req, res));
 };
 
+exports.longPress = function(req, res) {
+    req.body = _.defaults(req.body, {
+        tapCount: 1
+        , touchCount: 1
+        , duration: 1.5
+        , x: 0.5
+        , y: 0.5
+        , element: null
+    });
+    var tapCount = req.body.tapCount
+        , touchCount = req.body.touchCount
+        , duration = req.body.duration
+        , element = req.body.element
+        , x = req.body.x
+        , y = req.body.y;
+
+    req.device.complexTap(tapCount, touchCount, duration, x, y, element,
+        getResponseHandler(req, res));
+};
+
 exports.mobileTap = function(req, res) {
   req.body = _.defaults(req.body, {
     tapCount: 1
@@ -390,6 +410,26 @@ exports.mobileSwipe = function(req, res) {
     req.device.swipe(startX, startY, endX, endY, duration, touchCount,
         element, getResponseHandler(req, res));
   }
+};
+
+exports.mobileScroll = function(req, res) {
+    req.body = _.defaults(req.body, {
+        touchCount: 1
+        , offsetX: 0.5
+        , offsetY: 0.5
+        , duration: 0.8
+        , element: null
+    });
+    var touchCount = req.body.touchCount
+        , element = req.body.element
+        , duration = req.body.duration
+        , startX = 0.5
+        , startY = 0.5
+        , endX = startX + req.body.offsetX
+        , endY = startY + req.body.offsetY;
+
+      req.device.swipe(startX, startY, endX, endY, duration, touchCount,
+          element, getResponseHandler(req, res));
 };
 
 exports.mobileScrollTo = function(req, res) {

--- a/app/routing.js
+++ b/app/routing.js
@@ -136,6 +136,7 @@ module.exports = function(appium) {
   rest.post('/wd/hub/session/:sessionId?/cookie', controller.setCookie);
   rest.delete('/wd/hub/session/:sessionId?/cookie', controller.deleteCookies);
   rest.delete('/wd/hub/session/:sessionId?/cookie/:name', controller.deleteCookie);
+  rest.post('/wd/hub/session/:sessionId?/touch/longclick', controller.longPress);
 
   // allow appium to receive async response
   rest.post('/wd/hub/session/:sessionId?/receive_async_response', controller.receiveAsyncResponse);
@@ -150,6 +151,7 @@ module.exports = function(appium) {
   rest.post('/wd/hub/session/:sessionId/touch/tap', controller.mobileTap);
   rest.post('/wd/hub/session/:sessionId/touch/flick_precise', controller.mobileFlick);
   rest.post('/wd/hub/session/:sessionId/touch/swipe', controller.mobileSwipe);
+  rest.post('/wd/hub/session/:sessionId?/touch/scroll', controller.mobileScroll);
 
   // keep this at the very end!
   rest.all('/*', controller.unknownCommand);
@@ -185,9 +187,7 @@ var routeNotYetImplemented = function(rest) {
   rest.post('/wd/hub/session/:sessionId?/touch/down', controller.notYetImplemented);
   rest.post('/wd/hub/session/:sessionId?/touch/up', controller.notYetImplemented);
   rest.post('/wd/hub/session/:sessionId?/touch/move', controller.notYetImplemented);
-  rest.post('/wd/hub/session/:sessionId?/touch/scroll', controller.notYetImplemented);
   rest.post('/wd/hub/session/:sessionId?/touch/doubleclick', controller.notYetImplemented);
-  rest.post('/wd/hub/session/:sessionId?/touch/longclick', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/location', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/session_storage', controller.notYetImplemented);
   rest.post('/wd/hub/session/:sessionId?/session_storage', controller.notYetImplemented);

--- a/test/functional/uicatalog/gestures.js
+++ b/test/functional/uicatalog/gestures.js
@@ -9,6 +9,7 @@ var describeWd = require("../../helpers/driverblock.js").describeForApp('UICatal
   , textBlock = "Now is the time for all good developers to come to serve their country.\n\nNow is the time for all good developers to come to serve their country.\n\nThis text view can also use attributed strings.";
 
 describeWd('flick gesture', function(h) {
+
   it('should work via webdriver method', function(done) {
     h.driver.elementByTagName('tableCell', function(err, element) {
       element.getLocation(function(err, location) {
@@ -324,6 +325,45 @@ describeWd('complex tap on element', function(h) {
           el.text(function(err, text) {
             should.not.exist(err);
             _s.trim(text).should.eql(textBlock);
+            done();
+          });
+        });
+      });
+    });
+  });
+});
+
+describeWd('scroll screen', function(h) {
+  it("should scroll the screen up a little (in pixels)", function(done) {
+    h.driver.elementsByTagName('tableCell', function(err, els) {         // find a table cell element down the page a bit
+      var element = els[4];
+      var scrollOpts = {
+        offsetX: 0                                                       // Scrolling vertically, not horizontally
+        , offsetY: 150
+      };
+      element.getLocation(function(err, location) {                      // Get the initial location x and y of the element
+        h.driver.execute("mobile: scroll", [scrollOpts], function(err) { // scroll the screen
+          element.getLocation(function(err, location2) {                 // get the new location of the cell, affirm that its y changed, but not its x
+            assert.equal(location.x, location.x);
+            assert.notEqual(location.y, location2.y);
+            done();
+          });
+        });
+      });
+    });
+  });
+  it("should scroll the screen up a little (in relative units)", function(done) {
+    h.driver.elementsByTagName('tableCell', function(err, els) {
+      var element = els[4];
+      var scrollOpts = {
+        offsetX: 0.0
+        , offsetY: 0.4
+      };
+      element.getLocation(function(err, location) {
+        h.driver.execute("mobile: scroll", [scrollOpts], function(err) {
+          element.getLocation(function(err, location2) {
+            assert.equal(location.x, location.x);
+            assert.notEqual(location.y, location2.y);
             done();
           });
         });


### PR DESCRIPTION
I attempted to implement the 2-parm scroll() method from the WebDriver TouchScreen interface. The way I did it takes 2 "offset" parameters, then calculates them as startX/startY, endX/endY arguments to the existing swipe method.

I'm not 100% sure this will work, because there might be implications of starting at 0.5/0.5 in the middle of the screen--we might have to determine a better start position for the scroll. I was able to test it against my own native app, but I had a few problems, and probably need some help in getting things right:
- I could only scroll down, not up (I tried using negative numbers in the Y, but it didin't seem to matter--is it using abs() somewhere?)
- It would be nice to allow it to take floating point or integer arguments like the js API does
- Do I need to submit a unit test or app-base test to go against UICatalog? I'm glad to do it, but didn't know the standard

I hope I can learn enough from this to be able to implement things in the future without bothering you much. It was pretty frustrating, but never to the point where I considered giving up. I'd also like to contribute to documentation, like a "how-to" guide for the nuts & bolts of contributing. You guys have written about the process from a high-level, but I think we can do a lot more to help people who aren't familiar with nodeJS and the other technologies involved...

Let me know what you think and where to go from here.

Thanks!
MM
