### PR TITLE
reset.sh fails to build UICatalog app

### DIFF
--- a/grunt-helpers.js
+++ b/grunt-helpers.js
@@ -240,7 +240,7 @@ module.exports.build = function(appRoot, cb, sdk) {
       return cb(stdout + "\n" + stderr);
     }
     console.log("Building app...");
-    var args = ['-sdk', sdk];
+    var args = ['-sdk', sdk, '-arch', 'i386'];
     xcode = spawn('xcodebuild', args, {
       cwd: appRoot
     });


### PR DESCRIPTION
Adds -arch argument to xcodebuild so that it builds properly.
