### PR TITLE
Fixed WebDriver's capability name for taking screenshot

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -45,7 +45,7 @@ var Android = function(opts) {
     , browserName: 'Android'
     , version: '4.1'
     , webStorageEnabled: false
-    , takesScreenshots: true
+    , takesScreenshot: true
     , javascriptEnabled: true
     , databaseEnabled: false
   };

--- a/app/firefoxos.js
+++ b/app/firefoxos.js
@@ -36,7 +36,7 @@ var Firefox = function(opts) {
     , browserName: 'FirefoxOS'
     , version: '18.0'
     , webStorageEnabled: false
-    , takesScreenshots: true
+    , takesScreenshot: true
     , javascriptEnabled: true
     , databaseEnabled: false
   };


### PR DESCRIPTION
The correct name for the capability that takes screenshot is "takesScreenshot", not in the plural as it was in the code.

Fixed for both Android and Firefox OS drivers.

Here's an example of how to take screenshots using the WebDriver's java API:

``` java
  WebDriver augmentedDriver = new Augmenter().augment(driver);
  File screenshot = ((TakesScreenshot) augmentedDriver).getScreenshotAs(OutputType.FILE);

  File destFile = new File("foo.png");
  FileUtils.copyFile(screenshot, destFile);
```

Make sure your driver's class has an empty constructor because the augmenter will need it.
