### PR TITLE
Added a shortcut for UIACollectionCell and another for UIATableCell.

### DIFF
--- a/app/uiauto/lib/mechanic.js
+++ b/app/uiauto/lib/mechanic.js
@@ -31,6 +31,7 @@ var mechanic = (function() {
         'UIAAlert' : ['alert'],
         'UIAButton' : ['button'],
         'UIACollectionView': ['collection'],
+        'UIACollectionCell': ['collectionCell'],
         'UIAElement' : ['\\*'], // TODO: sort of a hack
         'UIAImage' : ['image'],
         'UIALink' : ['link'],
@@ -50,6 +51,7 @@ var mechanic = (function() {
         'UIATabBar' : ['tabbar'],
         'UIATableView' : ['tableview'],
         'UIATableCell' : ['cell'],
+        'UIATableCell' : ['tableCell'],
         'UIATableGroup' : ['group'],
         'UIATextField' : ['textfield'],
         'UIATextView' : ['textview'],


### PR DESCRIPTION
I added a shortcut to retrive UIACollectionCell's.  There is currently no way of searching for collection cells by tag.  In order to retrive just collection cells without this patch, you'd have to search using a wild card \* and then filter the results yourself.

I also added an alternative shortcut for retrieving tableview cells.  I did this because it seemed logical to have a shortcut named tableCell since there is now one named collectionCell.  The current tablecell shortcut, which is just "cell", seemed ambiguous.  Despite the ambiguity, I left the old shortcut to keep the change passive.  What do you guys think?
