### PR TITLE
/session/:sessionId/element/:id/enabled should return a boolean value.

### DIFF
--- a/app/ios.js
+++ b/app/ios.js
@@ -1307,7 +1307,7 @@ IOS.prototype.elementEnabled = function(elementId, cb) {
       this.executeAtom('is_enabled', [atomsElement], cb);
     }, this));
   } else {
-    var command = ["au.getElement('", elementId, "').isEnabled()"].join('');
+    var command = ["au.getElement('", elementId, "').isEnabled() === 1"].join('');
     this.proxy(command, cb);
   }
 };


### PR DESCRIPTION
WebDriver wire protocol specifies that /session/:sessionId/element/:id/enabled should return true or false as opposed to 1 or 0. Java RemoteWebDriver throws an exception when calling isEnabled on WebElements as a result.
