### PR TITLE
Fixed uncaught exception which was not allowing execution of  "mochaTest:appiumutils" (mochaTest) task. In server.js the gridRegister.registerNode(args.nodeconfig) was getting executed if args.nodeconfig is not null. In the appiumutils.js it was not set a

### DIFF
--- a/test/functional/appium/appiumutils.js
+++ b/test/functional/appium/appiumutils.js
@@ -22,7 +22,8 @@ describe("appiumutils", function() {
       , log: path.resolve(__dirname, "../../../appium.log")
       , port: 4723
       , address: '127.0.0.1'
-      , remove: true }
+      , remove: true
+      , nodeconfig: null }
       , function(appiumServer) {
           appium = appiumServer;
           done();


### PR DESCRIPTION
Fixed uncaught exception which was not allowing execution of  "mochaTest:appiumutils" (mochaTest) task. In server.js the gridRegister.registerNode(args.nodeconfig) was getting executed if args.nodeconfig is not null. In the appiumutils.js it was not set as null.

Please find below the exception details.

error: uncaughtException date=Mon Jul 08 2013 12:06:22 GMT+0530 (IST), pid=602, uid=503, gid=20, cwd=/Users/saikat/github/appium, execPath=/usr/local/Cellar/node/0.10.12/bin/node, version=v0.10.12, argv=[node, /usr/local/share/npm/bin/grunt], rss=89673728, heapTotal=70583040, heapUsed=45145584, loadavg=[2.95458984375, 1.9453125, 1.11328125], uptime=2044, trace=[column=11, file=fs.js, function=Object.fs.open, line=418, method=fs.open, native=false, column=16, file=/Users/saikat/github/appium/node_modules/grunt/node_modules/rimraf/node_modules/graceful-fs/graceful-fs.js, function=open, line=60, method=null, native=false, column=3, file=[as open] (/Users/saikat/github/appium/node_modules/grunt/node_modules/rimraf/node_modules/graceful-fs/graceful-fs.js, function=Object.gracefulOpen, line=45, method=gracefulOpen, native=false, column=6, file=fs.js, function=Object.fs.readFile, line=206, method=fs.readFile, native=false, column=6, file=/Users/saikat/github/appium/grid_register.js, function=Object.exports.registerNode, line=8, method=exports.registerNode, native=false, column=22, file=/Users/saikat/github/appium/server.js, function=, line=190, method=null, native=false, column=14, file=events.js, function=Server.g, line=175, method=g, native=false, column=17, file=events.js, function=Server.EventEmitter.emit, line=92, method=EventEmitter.emit, native=false, column=10, file=net.js, function=null, line=1052, method=null, native=false, column=13, file=node.js, function=process._tickCallback, line=415, method=_tickCallback, native=false], stack=[TypeError: path must be a string,     at Object.fs.open (fs.js:418:11),     at open (/Users/saikat/github/appium/node_modules/grunt/node_modules/rimraf/node_modules/graceful-fs/graceful-fs.js:60:16),     at Object.gracefulOpen [as open](/Users/saikat/github/appium/node_modules/grunt/node_modules/rimraf/node_modules/graceful-fs/graceful-fs.js:45:3),     at Object.fs.readFile (fs.js:206:6),     at Object.exports.registerNode (/Users/saikat/github/appium/grid_register.js:8:6),     at Server.<anonymous> (/Users/saikat/github/appium/server.js:190:22),     at Server.g (events.js:175:14),     at Server.EventEmitter.emit (events.js:92:17),     at net.js:1052:10,     at process._tickCallback (node.js:415:13)]
