### PR TITLE
 Fixed an issue where 'stdout maxBuffer exceeded' throws when unzipping a lot of files.

### DIFF
--- a/app/helpers.js
+++ b/app/helpers.js
@@ -80,7 +80,7 @@ exports.testZipArchive = function(zipPath, cb) {
     }
   } else {
     var execOpts = {cwd: path.dirname(zipPath)};
-    exec("unzip -t " + zipPath, execOpts, function(err, stderr, stdout) {
+    exec("unzip -tq " + zipPath, execOpts, function(err, stderr, stdout) {
       if (!err) {
         if(/No errors detected/.exec(stderr)) {
           logger.info("Zip archive tested clean");
@@ -96,7 +96,7 @@ exports.testZipArchive = function(zipPath, cb) {
         logger.error("Test zip archive threw error " + err);
         logger.error("Stderr: " + stderr);
         logger.error("Stdout: " + stdout);
-        cb("Error testing zip archive, are you sure this is a zip file?", null);
+        cb("Error testing zip archive, are you sure this is a zip file? " + err, null);
       }
     });
   }


### PR DESCRIPTION
Max buffer was introduced to 'app/helpers.js' in commit/daf8ba84bab10d9d1e9fbc404c08863989d11533

As a result, we are getting 'stdout maxBuffer exceeded' when unzipping a lot of files.  To fix it, we use the -q switch to prevent the 'testing...' messages from being dumped out to STDOUT.  In addition, we have to include the err message in the callback since logger.error on line 96 of 'app/helpers.js' does not take effect in case of 'stdout maxBuffer exceeded' 
