### PR TITLE
add to set and get the device orientation to the mobileCmdMap

### DIFF
--- a/app/controller.js
+++ b/app/controller.js
@@ -969,6 +969,8 @@ var mobileCmdMap = {
   , 'launchApp': exports.launchApp
   , 'closeApp': exports.closeApp
   , 'longClick' : exports.touchLongClick
+  , 'setOrientation' : exports.setOrientation
+  , 'getOrientation' : exports.getOrientation
 };
 
 exports.produceError = function(req, res) {


### PR DESCRIPTION
add to set and get the device orientation to the mobileCmdMap. feature looks like was already implemented but is missing in the map
