### PR TITLE
allow activities without periods in front

### DIFF
--- a/app/appium.js
+++ b/app/appium.js
@@ -300,7 +300,12 @@ Appium.prototype.configureLocalApp = function(appPath, origin, cb) {
   if (ext === this.getAppExt()) {
     this.args.app = appPath;
     logger.info("Using local app from " + origin + ": " + appPath);
-    fs.stat(appPath, cb);
+    fs.stat(appPath, function(err) {
+      if (err) {
+        return cb(new Error("Error locating the app: " + err.message));
+      }
+      cb();
+    });
   } else if (ext === ".zip") {
     logger.info("Using local zip from " + origin + ": " + appPath);
     this.unzipLocalApp(appPath, _.bind(function(zipErr, newAppPath) {

--- a/test/functional/apidemos/basic.js
+++ b/test/functional/apidemos/basic.js
@@ -6,8 +6,14 @@ var path = require('path')
   , badAppPath = path.resolve(__dirname, "../../../sample-code/apps/ApiDemos/bin/ApiDemos-debugz.apk")
   , appPkg = "com.example.android.apis"
   , appAct = ".ApiDemos"
+  , appAct2 = "ApiDemos"
+  , appAct3 = "com.example.android.apis.ApiDemos"
+  , appAct4 = ".Blargimarg"
   , driverBlock = require("../../helpers/driverblock.js")
   , describeWd = driverBlock.describeForApp(appPath, "android", appPkg, appAct)
+  , describeWd2 = driverBlock.describeForApp(appPath, "android", appPkg, appAct2)
+  , describeWd3 = driverBlock.describeForApp(appPath, "android", appPkg, appAct3)
+  , describeWd4 = driverBlock.describeForApp(appPath, "android", appPkg, appAct4)
   , describeBad = driverBlock.describeForApp(badAppPath, "android", appPkg,
       appAct)
   , should = require('should');
@@ -56,11 +62,32 @@ describeWd('basic', function(h) {
   });
 });
 
+describeWd2('activity style: no period', function(h) {
+  it('should should still find activity', function(done) {
+    done();
+  });
+}, null, null, null, {expectConnError: true});
+
+describeWd3('activity style: fully qualified', function(h) {
+  it('should still find activity', function(done) {
+    done();
+  });
+});
+
+describeWd4('activity style: non-existent', function(h) {
+  it('should throw an error', function(done) {
+    should.exist(h.connError);
+    var err = JSON.parse(h.connError.data);
+    err.value.origValue.should.include("Activity used to start app doesn't exist");
+    done();
+  });
+}, null, null, null, {expectConnError: true});
+
 describeBad('bad app path', function(h) {
   it('should throw an error', function(done) {
     should.exist(h.connError);
     var err = JSON.parse(h.connError.data);
-    err.value.origValue.should.include("Error locating the app apk");
+    err.value.origValue.should.include("Error locating the app");
     done();
   });
 }, null, null, null, {expectConnError: true});


### PR DESCRIPTION
I don't think it's good to be so restrictive with activities. This is a proposal for a way to be more lenient with initial periods, by checking for the appPackage's existence in the activity string. If it's not there, and it doesn't start with a period, we add one. This should handle all the cases.

Added some tests that this works too. This has been tripping too many people up, in my opinion.
