### PR TITLE
Added some missing calls to bind(this).

### DIFF
--- a/app/hybrid/ios/remote-debugger.js
+++ b/app/hybrid/ios/remote-debugger.js
@@ -373,7 +373,7 @@ RemoteDebugger.prototype.pageLoad = function() {
         logger.debug("Page was not ready, retrying");
         setTimeout(verify, intMs);
       }
-    });
+    }.bind(this));
   }.bind(this);
   verify();
 };

--- a/app/ios.js
+++ b/app/ios.js
@@ -952,7 +952,7 @@ IOS.prototype.lookForAlert = function(cb, counter, looks, timeout) {
         }.bind(this));
       }
     }
-  }, timeout);
+  }.bind(this), timeout);
 };
 
 IOS.prototype.clickCurrent = function(button, cb) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -401,7 +401,7 @@ IOS.prototype.cleanupAppState = function(cb) {
         }
       }
     }
-  }.bind(this)).bind(this);
+  }.bind(this));
 };
 
 IOS.prototype.listWebFrames = function(cb, exitCb) {
@@ -1487,7 +1487,7 @@ IOS.prototype.getScreenshot = function(cb) {
       }.bind(this);
       read(onErr);
     }
-  });
+  }.bind(this));
 };
 
 IOS.prototype.fakeFlick = function(xSpeed, ySpeed, swipe, cb) {


### PR DESCRIPTION
Hi all.  This request fixes the following errors I encountered:

```
TypeError: Cannot set property 'pageLoadedCbs' of undefined, at appium/app/hybrid/ios/remote-debugger.js:367:28
TypeError: Object #<Glob> has no method 'bind', at IOS.cleanupAppState appium/app/ios.js:404:17
TypeError: Cannot read property '0' of undefined, at null._onTimeout appium/app/ios.js:931:40
TypeError: Cannot read property 'curOrientation' of undefined appium/app/ios.js:1472:17
```
