### PR TITLE
Change Android Bootstrap README to include SDK version for compiling

### DIFF
--- a/android/bootstrap/README.md
+++ b/android/bootstrap/README.md
@@ -9,4 +9,4 @@ To install the Android Maven dependencies in your local environment, run the fol
 
 You can then compile the bootstrap project by running
 
-    mvn package
+    mvn package -P 4.2


### PR DESCRIPTION
If version isn't specified, Maven tries to compile with an older version of the Android SDK.
