### PR TITLE
give the appium server a very big http socket timeout.

### DIFF
--- a/server.js
+++ b/server.js
@@ -200,6 +200,9 @@ var main = function(args, readyCb, doneCb) {
         cb(err);
       }
     });
+    server.on('connection', function(socket) {
+      socket.setTimeout(600 * 1000); // 10 minute timeout
+    });
     setTimeout(function() {
       if (!alreadyReturned) {
         alreadyReturned = true;


### PR DESCRIPTION
sometimes it can take a very long time to start an app, during which we haven't responded
with a new session response yet. the server was dropping the connection to the client
in these cases. the timeout prevents the connection from being dropped.
