### PR TITLE
mobile :screenshotFolder

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -670,6 +670,14 @@ Android.prototype.setOrientation = function(orientation, cb) {
   this.proxy(["orientation", {orientation: orientation}], cb);
 };
 
+Android.prototype.getScreenshotFolder = function(cb) {
+  var screenshotPath = "/data/local/tmp/";
+  cb(null, {
+    status: status.codes.Success.code
+    , value: screenshotPath
+  });
+};
+
 Android.prototype.getScreenshot = function(cb) {
   this.adb.requireDeviceId();
   var localfile = temp.path({prefix: 'appium', suffix: '.png'});

--- a/app/controller.js
+++ b/app/controller.js
@@ -973,6 +973,10 @@ exports.findElementNameContains = function(req, res) {
   }
 };
 
+exports.getScreenshotFolder = function(req, res) {
+  req.device.getScreenshotFolder(getResponseHandler(req, res));
+};
+
 exports.unknownCommand = function(req, res) {
   logger.info("Responding to client that we did not find a valid resource");
   res.set('Content-Type', 'text/plain');
@@ -1039,6 +1043,7 @@ var mobileCmdMap = {
   , 'longClick' : exports.touchLongClick
   , 'pinchClose': exports.mobilePinchClose
   , 'pinchOpen': exports.mobilePinchOpen
+  , 'screenshotFolder': exports.getScreenshotFolder
 };
 
 exports.produceError = function(req, res) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -1431,6 +1431,14 @@ IOS.prototype.setOrientation = function(orientation, cb) {
   }.bind(this));
 };
 
+IOS.prototype.getScreenshotFolder = function(cb) {
+  var screenshotPath = "/tmp/" + this.instruments.guid + "/Run 1/";
+  cb(null, {
+    status: status.codes.Success.code
+    , value: screenshotPath
+  });
+};
+
 IOS.prototype.getScreenshot = function(cb) {
   var guid = uuid.create();
   var command = ["au.capture('screenshot", guid ,"')"].join('');


### PR DESCRIPTION
Fix #983

I didn't see any other way of accessing `this.instruments.guid` to find the screenshot folder.
