### PR TITLE
Retrieve logcat logs for android

### DIFF
--- a/android/logcat.js
+++ b/android/logcat.js
@@ -1,0 +1,91 @@
+"use strict";
+
+var spawn = require('win-spawn')
+  , through = require('through')
+  , _ = require('underscore')
+  , logger = require('../logger').get('appium');
+
+var Logcat = function(opts) {
+  this.adbCmd = opts.adbCmd;
+  this.debug = opts.debug;
+  this.debugTrace = opts.debugTrace;
+  this.proc = null;
+  this.onLogcatStart = null;
+  this.logcatStarted = false;
+  this.calledBack = false;
+  this.logs = [];
+};
+
+Logcat.prototype.startCapture = function(cb) {
+  this.onLogcatStart = cb;
+  logger.info("Starting logcat capture");
+  this.proc = spawn(this.adbCmd, ['logcat']);
+  this.proc.stdout.setEncoding('utf8');
+  this.proc.stderr.setEncoding('utf8');
+  this.proc.on('error', function(err) {
+    logger.error('Logcat capture failed: ' + err.message);
+    if (!this.calledBack) {
+      this.calledBack = true;
+      cb(err);
+    }
+  }.bind(this));
+  this.proc.stdout.pipe(through(this.onStdout.bind(this)));
+  this.proc.stderr.pipe(through(this.onStderr.bind(this)));
+};
+
+Logcat.prototype.stopCapture = function() {
+  logger.info("Stopping logcat capture");
+  this.proc.kill();
+  this.proc = null;
+};
+
+Logcat.prototype.onStdout = function(data) {
+  this.onOutput(data, '');
+};
+
+Logcat.prototype.onStderr = function(data) {
+  if (/execvp\(\)/.test(data)) {
+    logger.error('Logcat process failed to start');
+    if (!this.calledBack) {
+      this.calledBack = true;
+      this.onLogcatStart(new Error("Logcat process failed to start"));
+      return;
+    }
+  }
+  this.onOutput(data, ' STDERR');
+};
+
+Logcat.prototype.onOutput = function(data, prefix) {
+  if (!this.logcatStarted) {
+    this.logcatStarted = true;
+    if (!this.calledBack) {
+      this.calledBack = true;
+      this.onLogcatStart();
+    }
+  }
+  data = data.trim();
+  data = data.replace(/\r\n/g, "\n");
+  var logs = data.split("\n");
+  _.each(logs, function(log) {
+    log = log.trim();
+    if (log) {
+      this.logs.push({
+        timestamp: Date.now()
+        , level: 'ALL'
+        , message: log
+      });
+      var isTrace = /W\/Trace/.test(data);
+      if (this.debug && (!isTrace || this.debugTrace)) {
+        logger.debug('[LOGCAT' + prefix + '] ' + log);
+      }
+    }
+  }.bind(this));
+};
+
+Logcat.prototype.getLogs = function() {
+  return this.logs;
+};
+
+module.exports = function(opts) {
+  return new Logcat(opts);
+};

--- a/app/android.js
+++ b/app/android.js
@@ -941,6 +941,31 @@ Android.prototype.unpackApp = function(req, cb) {
   deviceCommon.unpackApp(req, '.apk', cb);
 };
 
+Android.prototype.getLog = function(logType, cb) {
+  // go ahead and respond with 'logcat' type no matter what they send in
+  if (logType !== 'logcat') {
+    logger.warn("Trying to get log type of " + logType + ", giving logcat " +
+                "instead");
+  }
+  var logs;
+  try {
+    logs = this.adb.getLogcatLogs();
+  } catch (e) {
+    return cb(e);
+  }
+  cb(null, {
+    status: status.codes.Success.code
+    , value: logs
+  });
+};
+
+Android.prototype.getLogTypes = function(cb) {
+  return cb(null, {
+    status: status.codes.Success.code
+    , value: ['logcat']
+  });
+};
+
 module.exports = function(opts) {
   return new Android(opts);
 };

--- a/app/controller.js
+++ b/app/controller.js
@@ -973,6 +973,18 @@ exports.findElementNameContains = function(req, res) {
   }
 };
 
+exports.getLog = function(req, res) {
+  var logType = req.body.type;
+
+  if (checkMissingParams(res, {logType: logType})) {
+    req.device.getLog(logType, getResponseHandler(req, res));
+  }
+};
+
+exports.getLogTypes = function(req, res) {
+  req.device.getLogTypes(getResponseHandler(req, res));
+};
+
 exports.unknownCommand = function(req, res) {
   logger.info("Responding to client that we did not find a valid resource");
   res.set('Content-Type', 'text/plain');

--- a/app/ios.js
+++ b/app/ios.js
@@ -1992,6 +1992,14 @@ IOS.prototype.getCurrentActivity= function(cb) {
   cb(new NotYetImplementedError(), null);
 };
 
+IOS.prototype.getLogs = function(logType, cb) {
+  cb(new NotYetImplementedError(), null);
+};
+
+IOS.prototype.getLogTypes = function(cb) {
+  cb(new NotYetImplementedError(), null);
+};
+
 IOS.prototype.isAppInstalled = function(bundleId, cb) {
   var isInstalledCommand = 'build/fruitstrap/fruitstrap isInstalled --id ' + this.udid + ' --bundle ' + bundleId;
   deviceCommon.isAppInstalled(isInstalledCommand, cb);

--- a/app/routing.js
+++ b/app/routing.js
@@ -190,8 +190,8 @@ var routeNotYetImplemented = function(rest) {
   rest.get('/wd/hub/session/:sessionId?/session_storage/key/:key', controller.notYetImplemented);
   rest.delete('/wd/hub/session/:sessionId?/session_storage/key/:key', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/session_storage/size', controller.notYetImplemented);
-  rest.post('/wd/hub/session/:sessionId?/log', controller.notYetImplemented);
-  rest.get('/wd/hub/session/:sessionId?/log/types', controller.notYetImplemented);
+  rest.post('/wd/hub/session/:sessionId?/log', controller.getLog);
+  rest.get('/wd/hub/session/:sessionId?/log/types', controller.getLogTypes);
   rest.get('/wd/hub/session/:sessionId?/application_cache/status', controller.notYetImplemented);
 };
 

--- a/test/functional/apidemos/basic.js
+++ b/test/functional/apidemos/basic.js
@@ -60,6 +60,23 @@ describeWd('basic', function(h) {
       done();
     });
   });
+  it('should be able to get logcat log type', function(done) {
+    h.driver.logTypes(function(err, logTypes) {
+      should.not.exist(err);
+      logTypes.should.include('logcat');
+      done();
+    });
+  });
+  it('should be able to get logcat logs', function(done) {
+    h.driver.log('logcat', function(err, logs) {
+      should.not.exist(err);
+      logs.length.should.be.above(0);
+      logs[0].message.should.not.include("\n");
+      logs[0].level.should.equal("ALL");
+      should.exist(logs[0].timestamp);
+      done();
+    });
+  });
 });
 
 describeWd2('activity style: no period', function(h) {


### PR DESCRIPTION
we use the selenium facility for getting log types and log entries.
in this case, simply ask for logs of type 'logcat' and you'll get them.

the tests require dev version of wd, which should make it into publishing soon.
