### PR TITLE
Minor fix to clear session before releasing the session

### DIFF
--- a/app/appium.js
+++ b/app/appium.js
@@ -608,14 +608,16 @@ Appium.prototype.onDeviceDie = function(code, cb) {
   } else {
     logger.info('Not clearing out appium devices');
   }
-  if (cb) {
-    cb(null, {status: status.codes.Success.code, value: null,
-              sessionId: dyingSession});
-  }
+
   // if we're not restarting internally, call invoke again, in case we have
   // sessions queued
   if (!this.resetting) {
     this.clearPreviousSession();
+  }
+
+  if (cb) {
+    cb(null, {status: status.codes.Success.code, value: null,
+      sessionId: dyingSession});
   }
 };
 


### PR DESCRIPTION
This caused some issues when running on the grid as the previous session was being cleared when a new session was being created.

By allowing the previous session to be cleared and then "releasing" the session this problem no longer occurs.

Sergio
