### PR TITLE
Changes to allow installApp, removeApp and isAppInstalled to be called without providing a device id

### DIFF
--- a/app/controller.js
+++ b/app/controller.js
@@ -55,58 +55,46 @@ exports.getStatus = function(req, res) {
 };
 
 exports.installApp = function(req, res) {
-  if (req.appium.args.udid || req.appium.args.avdName) {
-    req.body = JSON.parse(req.body);
-    req.device.unpackApp(req, function(unpackedAppPath) {
-      if (unpackedAppPath === null) {
-        respondError(req, res, 'Only a (zipped) app/apk files can be installed using this endpoint');
-      } else {
-        req.device.installApp(unpackedAppPath, function(error, response) {
-          if (error !== null) {
-            respondError(req, res, response);
-          } else {
-            respondSuccess(req, res, response);
-          }
-        });
-      }
-    });
-  } else {
-    respondSuccess(req, res, 'No udid/avdName was provided, therefore the app [' + req.body.appPath + '] was not installed');
-  }
+  req.body = JSON.parse(req.body);
+  req.device.unpackApp(req, function(unpackedAppPath) {
+    if (unpackedAppPath === null) {
+      respondError(req, res, 'Only a (zipped) app/apk files can be installed using this endpoint');
+    } else {
+      req.device.installApp(unpackedAppPath, function(error, response) {
+        if (error !== null) {
+          respondError(req, res, response);
+        } else {
+          respondSuccess(req, res, response);
+        }
+      });
+    }
+  });
 };
 
 exports.removeApp = function(req, res) {
-  if (req.device.udid || req.device.avdName) {
-    req.body = JSON.parse(req.body);
-    req.device.removeApp(req.body.bundleId, function(error, response) {
-      if (error !== null) {
-        respondError(req, res, response);
-      } else {
-        respondSuccess(req, res, response);
-      }
-    });
-  } else {
-    respondSuccess(req, res, 'No udid/advName was provided, therefore the app [' + req.body.bundleId + '] was not removed');
-  }
+  req.body = JSON.parse(req.body);
+  req.device.removeApp(req.body.bundleId, function(error, response) {
+    if (error !== null) {
+      respondError(req, res, response);
+    } else {
+      respondSuccess(req, res, response);
+    }
+  });
 };
 
 exports.isAppInstalled = function(req, res) {
-  if (req.device.udid || req.device.avdName) {
-    req.body = JSON.parse(req.body);
-    req.device.isAppInstalled(req.body.bundleId, function(error, stdout) {
-      if (error !== null) {
-        respondSuccess(req, res, false);
+  req.body = JSON.parse(req.body);
+  req.device.isAppInstalled(req.body.bundleId, function(error, stdout) {
+    if (error !== null) {
+      respondSuccess(req, res, false);
+    } else {
+      if ((req.appium.args.udid && req.appium.args.udid.length === 40) || (typeof stdout[0] !== "undefined")) {
+        respondSuccess(req, res, true);
       } else {
-        if ((req.appium.args.udid && req.appium.args.udid.length === 40) || (typeof stdout[0] !== "undefined")) {
-          respondSuccess(req, res, true);
-        } else {
-          respondSuccess(req, res, false);
-        }
+        respondSuccess(req, res, false);
       }
-    });
-  } else {
-    respondSuccess(req, res, 'No udid/avdName was provided, therefore no check was done for app [' + req.body.bundleId + ']');
-  }
+    }
+  });
 };
 
 exports.launchApp = function(req, res) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -2007,18 +2007,30 @@ IOS.prototype.getLogTypes = function(cb) {
 };
 
 IOS.prototype.isAppInstalled = function(bundleId, cb) {
-  var isInstalledCommand = 'build/fruitstrap/fruitstrap isInstalled --id ' + this.udid + ' --bundle ' + bundleId;
-  deviceCommon.isAppInstalled(isInstalledCommand, cb);
+  if (this.udid) {
+      var isInstalledCommand = 'build/fruitstrap/fruitstrap isInstalled --id ' + this.udid + ' --bundle ' + bundleId;
+      deviceCommon.isAppInstalled(isInstalledCommand, cb);
+  } else {
+    cb(new Error("You can not call isInstalled for the iOS simulator!"));
+  }
 };
 
 IOS.prototype.removeApp = function(bundleId, cb) {
-  var removeCommand = 'build/fruitstrap/fruitstrap uninstall --id ' + this.udid + ' --bundle ' + bundleId;
-  deviceCommon.removeApp(removeCommand, this.udid, bundleId, cb);
+  if (this.udid) {
+    var removeCommand = 'build/fruitstrap/fruitstrap uninstall --id ' + this.udid + ' --bundle ' + bundleId;
+    deviceCommon.removeApp(removeCommand, this.udid, bundleId, cb);
+  } else {
+    cb(new Error("You can not call removeApp for the iOS simulator!"));
+  }
 };
 
 IOS.prototype.installApp = function(unzippedAppPath, cb) {
-  var installationCommand = 'build/fruitstrap/fruitstrap install --id ' + this.udid + ' --bundle ' + unzippedAppPath;
-  deviceCommon.installApp(installationCommand, this.udid, unzippedAppPath, cb);
+  if (this.udid) {
+    var installationCommand = 'build/fruitstrap/fruitstrap install --id ' + this.udid + ' --bundle ' + unzippedAppPath;
+    deviceCommon.installApp(installationCommand, this.udid, unzippedAppPath, cb);
+  } else {
+    cb(new Error("You can not call installApp for the iOS simulator!"));
+  }
 };
 
 IOS.prototype.unpackApp = function(req, cb) {


### PR DESCRIPTION
Added a check for iOS as these calls will not work on a simulator and removed the checks from device.js so that they can be called without providing an ID for Android. 

Tested on Android device (with and without id) and on iOS device and simulator.
