### PR TITLE
Appium now responds to the last command it received when instruments exits.

### DIFF
--- a/instruments/instruments.js
+++ b/instruments/instruments.js
@@ -159,6 +159,12 @@ Instruments.prototype.launch = function() {
 
       self.proc.on('exit', function(code) {
         self.debug("Instruments exited with code " + code);
+        if (self.curCommand && self.curCommand.cb) {
+          self.curCommand.cb({
+            status: code,
+            value: "Instruments exited with code " + code
+          });
+        }
         self.exitCode = code;
         self.exitHandler(self.exitCode, self.traceDir);
         self.proc.stdin.end();

--- a/sample-code/apps/TestApp/Test App 2/TestApp-Info.plist
+++ b/sample-code/apps/TestApp/Test App 2/TestApp-Info.plist
@@ -28,6 +28,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIApplicationExitsOnSuspend</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/test/functional/testapp/device.js
+++ b/test/functional/testapp/device.js
@@ -1,0 +1,17 @@
+/*global it:true */
+"use strict";
+
+var describeWd = require("../../helpers/driverblock.js").describeForApp('TestApp')
+  , should = require('should');
+
+describeWd('device target actions', function(h) {
+  it("should die in background and respond within (+/- 6 secs)", function(done) {
+    var before = new Date().getTime() / 1000;
+    h.driver.execute("mobile: background", [{seconds: 1}], function(err) {
+      should.not.exist(err);
+      var after = new Date().getTime() / 1000;
+      should.ok((after - before) <= 10);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
If an iOS app configured to die when sent to the background gets sent to the background during testing, appium does not inform the selenium driver that instruments has exited when the app dies. The selenium driver will wait 60 seconds (the default timeout) until it dies on its own.

This patch allows appium to inform the selenium driver that instruments has exited, thus the selenium driver won't idle until its timeout.

This fixes the issue reported here: https://github.com/appium/appium/issues/1013
