### PR TITLE
mobile: localScreenshot

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -670,6 +670,30 @@ Android.prototype.setOrientation = function(orientation, cb) {
   this.proxy(["orientation", {orientation: orientation}], cb);
 };
 
+Android.prototype.localScreenshot = function(file, cb) {
+  this.adb.requireDeviceId();
+  async.series([
+    function(cb) {
+      this.proxy(["takeScreenshot"], cb);
+    }.bind(this),
+    function(cb) {
+      var cmd = this.adb.adbCmd + ' pull /data/local/tmp/screenshot.png "' + file + '"';
+      exec(cmd, { maxBuffer: 524288 }, function(err, stdout, stderr) {
+        if (err) {
+          logger.warn(stderr);
+          return cb(err);
+        }
+        cb(null);
+      });
+    }.bind(this),
+  ],
+  function(){
+    cb(null, {
+      status: status.codes.Success.code
+    });
+  });
+};
+
 Android.prototype.getScreenshot = function(cb) {
   this.adb.requireDeviceId();
   var localfile = temp.path({prefix: 'appium', suffix: '.png'});

--- a/app/controller.js
+++ b/app/controller.js
@@ -885,6 +885,14 @@ exports.unknownCommand = function(req, res) {
   res.send(404, "That URL did not map to a valid JSONWP resource");
 };
 
+exports.localScreenshot = function(req, res) {
+  var file = req.body.file;
+
+  if (checkMissingParams(res, {file: file})) {
+    req.device.localScreenshot(file, getResponseHandler(req, res));
+  }
+};
+
 exports.notYetImplemented = notYetImplemented;
 var mobileCmdMap = {
   'tap': exports.mobileTap
@@ -921,6 +929,7 @@ var mobileCmdMap = {
   , 'longClick' : exports.touchLongClick
   , 'pinchClose': exports.mobilePinchClose
   , 'pinchOpen': exports.mobilePinchOpen
+  , 'localScreenshot': exports.localScreenshot
 };
 
 exports.produceError = function(req, res) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -1424,6 +1424,32 @@ IOS.prototype.setOrientation = function(orientation, cb) {
   }.bind(this));
 };
 
+IOS.prototype.localScreenshot = function(desiredFile, cb) {
+  // Instruments automatically adds .png
+  var screenshotFolder = "/tmp/appium-instruments/Run 1/";
+  var filename = path.basename(desiredFile, path.extname(desiredFile));
+  var command = "au.capture('" + filename + "')";
+  var filePath = screenshotFolder + filename;
+
+  // Must delete the png if it exists or instruments will
+  // add a sequential integer to the file name.
+  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+
+  async.series([
+    function (cb) { this.proxy(command, cb); }.bind(this),
+    function (cb) {
+      // must exist or rename will fail.
+      var desiredFolder = path.dirname(desiredFile);
+      mkdirp.sync(desiredFolder);
+      fs.rename(filePath + ".png", desiredFile, cb);
+    }.bind(this),
+  ], function(){
+    cb(null, {
+       status: status.codes.Success.code
+     });
+  });
+};
+
 IOS.prototype.getScreenshot = function(cb) {
   var guid = uuid.create();
   var command = ["au.capture('screenshot", guid ,"')"].join('');

--- a/test/functional/apidemos/screenshot.js
+++ b/test/functional/apidemos/screenshot.js
@@ -7,9 +7,23 @@ var path = require('path')
   , appAct = ".ApiDemos"
   , describeWd = require("../../helpers/driverblock.js").describeForApp(appPath,
       "android", appPkg, appAct)
+  , fs = require('fs')
   , should = require('should');
 
 describeWd('screenshot', function(h) {
+  it('should get a local screenshot', function(done) {
+    var localScreenshotFile = '/tmp/test_screenshot_appium.png';
+    if (fs.existsSync(localScreenshotFile)) {
+      fs.unlinkSync(localScreenshotFile);
+    }
+    h.driver.execute("mobile: localScreenshot", [{file: localScreenshotFile}], function(err) {
+      should.not.exist(err);
+      var screenshot = fs.readFileSync(localScreenshotFile);
+      should.exist(screenshot);
+      screenshot.length.should.be.above(1000);
+      done();
+    });
+  });
   it('should get an app screenshot', function(done) {
     h.driver.takeScreenshot(function(err, screenshot) {
       should.not.exist(err);

--- a/test/functional/safari/screenshot.js
+++ b/test/functional/safari/screenshot.js
@@ -3,10 +3,24 @@
 
 var desc = require("../../helpers/driverblock.js").describeForSafari()
   , _ = require("underscore")
+  , fs = require('fs')
   , should = require('should');
 
 _.each(["iPhone", "iPad"], function(device) {
   desc('screenshots (' + device + ')', function(h) {
+    it('should get a local screenshot', function(done) {
+      var localScreenshotFile = '/tmp/test_screenshot_appium.png';
+      if (fs.existsSync(localScreenshotFile)) {
+        fs.unlinkSync(localScreenshotFile);
+      }
+      h.driver.execute("mobile: localScreenshot", [{file: localScreenshotFile}], function(err) {
+        should.not.exist(err);
+        var screenshot = fs.readFileSync(localScreenshotFile);
+        should.exist(screenshot);
+        screenshot.length.should.be.above(1000);
+        done();
+      });
+    });
     it('should get an app screenshot', function(done){
       h.driver.takeScreenshot(function(err, screenshot){
         should.not.exist(err);


### PR DESCRIPTION
This is useful for using Java server commands directly.
On iOS, these commands are already accessible via execute_script.

Android example:

``` ruby
mobile :proxy, command: :takeScreenshot
```

iOS example:

``` ruby
mobile :proxy, command: 'au.capture("screenshot")'
```

On iOS, that's the same as

``` ruby
execute_script  'au.capture("screenshot")'
```
## 

If the code looks good, then I'll add some JavaScript tests to this pull request.
