### PR TITLE
Update and fix to installApp mobile command

### DIFF
--- a/app/controller.js
+++ b/app/controller.js
@@ -55,20 +55,27 @@ exports.getStatus = function(req, res) {
 };
 
 exports.installApp = function(req, res) {
-  if (checkMissingParams(res, {appPath: req.body.appPath}, true)) {
+  var install = function(appPath) {
+    req.device.installApp(appPath, function(error, response) {
+      if (error !== null) {
+        respondError(req, res, response);
+      } else {
+        respondSuccess(req, res, response);
+      }
+    });
+  };
+  if (typeof req.body.appPath !== "undefined") {
     req.device.unpackApp(req, function(unpackedAppPath) {
       if (unpackedAppPath === null) {
         respondError(req, res, 'Only a (zipped) app/apk files can be installed using this endpoint');
       } else {
-        req.device.installApp(unpackedAppPath, function(error, response) {
-          if (error !== null) {
-            respondError(req, res, response);
-          } else {
-            respondSuccess(req, res, response);
-          }
-        });
+        install(unpackedAppPath);
       }
     });
+  } else if (typeof req.appium.args.app !== "undefined") {
+      install(req.appium.args.app);
+  } else {
+    respondError(req, res, "No app defined (either through desired capabilities or as an argument)");
   }
 };
 

--- a/sample-code/examples/java/testng/src/main/java/com/example/LocalWebDriver.java
+++ b/sample-code/examples/java/testng/src/main/java/com/example/LocalWebDriver.java
@@ -47,7 +47,12 @@ public class LocalWebDriver  {
 	 */
 	public void installApp(){
 		if (desired.getCapability("app") != null){
-			this.installApp(desired.getCapability("app").toString());
+			try {
+				Object result = remoteWebDriver.executeScript("mobile: installApp");
+				logger.info(result.toString());
+			} catch (WebDriverException e) {
+				logger.error(e.getMessage());
+			}
 		} else {
 			logger.error("You have to supply the app parameter before calling the install app.");
 		}
@@ -61,7 +66,9 @@ public class LocalWebDriver  {
 	 */
 	public void installApp(String appPath){
 		try {
-			Object result = remoteWebDriver.executeScript("mobile: installApp","{\"appPath\":\"" + appPath + "\"}");
+			Map<String, String> args = new HashMap<String, String>();
+			args.put("appPath", appPath);
+			Object result = remoteWebDriver.executeScript("mobile: installApp", args);
 			logger.info(result.toString());
 		} catch (WebDriverException e) {
 			logger.error(e.getMessage());
@@ -100,7 +107,9 @@ public class LocalWebDriver  {
 	 */
 	public void unInstallApp(String bundleId){
 		try {
-			Object result = remoteWebDriver.executeScript("mobile: removeApp","{\"bundleId\":\"" + bundleId + "\"}");
+			Map<String, String> args = new HashMap<String, String>();
+			args.put("bundleId", bundleId);
+			Object result = remoteWebDriver.executeScript("mobile: removeApp", args);
 			logger.info(result.toString());
 		} catch (WebDriverException e) {
 			logger.error(e.getMessage());
@@ -117,7 +126,9 @@ public class LocalWebDriver  {
 	 */
 	public boolean isAppInstalled(String bundleId){
 		try {
-			Object result = remoteWebDriver.executeScript("mobile: isAppInstalled","{\"bundleId\":\"" + bundleId + "\"}");
+			Map<String, String> args = new HashMap<String, String>();
+			args.put("bundleId", bundleId);
+			Object result = remoteWebDriver.executeScript("mobile: isAppInstalled", args);
 			if (result.toString().toLowerCase().equals("true")) {
 				return true;
 			} else if (result.toString().toLowerCase().equals("false")) {


### PR DESCRIPTION
Fixed an issue with the install app where it would download and unzip the same app twice (as this had already been done as part of the create session request).

Made the appPath optional as this has already been passed in the desired capabilities (as part of the create session). If you do pass an appPath we unpack and install it.

Also update the example driver to match recent fix by @jlipps
