### PR TITLE
multiple real android devices running separate tests in parallel

### DIFF
--- a/android/adb.js
+++ b/android/adb.js
@@ -23,6 +23,7 @@ var spawn = require('win-spawn')
 var noop = function() {};
 
 var ADB = function(opts, android) {
+  // console.log('INSIDE ADB: ', opts);
   if (!opts) {
     opts = {};
   }
@@ -837,14 +838,19 @@ ADB.prototype.getConnectedDevices = function(cb) {
 
 ADB.prototype.forwardPort = function(cb) {
   this.requireDeviceId();
-  this.debug("Forwarding system:" + this.systemPort + " to device:" +
+  this.debug("Forwarding system:" + this.devicePort + " to device:" +
              this.devicePort);
-  var arg = "tcp:" + this.systemPort + " tcp:" + this.devicePort;
+  var arg = "tcp:" + this.devicePort + " tcp:" + this.devicePort;
+  // this.debug("Forwarding system:" + this.systemPort + " to device:" +
+  //            this.devicePort);
+  // var arg = "tcp:" + this.systemPort + " tcp:" + this.devicePort;
   exec(this.adbCmd + " forward " + arg, { maxBuffer: 524288 }, function(err) {
     if (err) {
+      console.log('boom err')
       logger.error(err);
       cb(err);
     } else {
+      console.log('boom success')
       this.portForwarded = true;
       cb(null);
     }
@@ -855,7 +861,7 @@ ADB.prototype.runBootstrap = function(readyCb, exitCb) {
   logger.info("Running bootstrap");
   this.requireDeviceId();
   var args = ["-s", this.curDeviceId, "shell", "uiautomator", "runtest",
-      "AppiumBootstrap.jar", "-c", "io.appium.android.bootstrap.Bootstrap"];
+      "AppiumBootstrap.jar", "-c", "io.appium.android.bootstrap.Bootstrap", "-e", "devicePort", this.devicePort];
   logger.info(this.adb + " " + args.join(" "));
   this.proc = spawn(this.adb.substr(1, this.adb.length - 2), args);
   this.onSocketReady = readyCb;

--- a/android/adb.js
+++ b/android/adb.js
@@ -816,15 +816,16 @@ ADB.prototype.getConnectedDevices = function(cb) {
       var devices = [];
       _.each(stdout.split("\n"), function(line) {
         if (line.trim() !== "" && line.indexOf("List of devices") === -1 && line.indexOf("* daemon") === -1 && line.indexOf("offline") == -1) {
-          devices.push(line.split("\t"));
+          var lineInfo = line.split("\t");
+          devices.push({udid: lineInfo[0], state: lineInfo[1]}); // state is either "device" or "offline", afaict
         }
       });
       this.debug(devices.length + " device(s) connected");
       if (devices.length) {
-        this.debug("Setting device id to " + (this.udid || devices[0][0]));
+        this.debug("Setting device id to " + (this.udid || devices[0].udid));
         this.emulatorPort = null;
-        var emPort = this.getPortFromEmulatorString(devices[0][0]);
-        this.setDeviceId(this.udid || devices[0][0]);
+        var emPort = this.getPortFromEmulatorString(devices[0].udid);
+        this.setDeviceId(this.udid || devices[0].udid);
         if (emPort && !this.udid) {
           this.emulatorPort = emPort;
         }

--- a/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
@@ -4,8 +4,6 @@ import io.appium.android.bootstrap.exceptions.SocketServerException;
 
 import com.android.uiautomator.testrunner.UiAutomatorTestCase;
 
-import android.os.Bundle;
-
 /**
  * The Bootstrap class runs the socket server.
  * 
@@ -14,12 +12,8 @@ public class Bootstrap extends UiAutomatorTestCase {
 
   public void testRunServer() {
     SocketServer server;
-    Bundle params;
-    String devicePort;
     try {
-      params = getParams();
-      devicePort = params.getString("devicePort", "4724");
-      server = new SocketServer(Integer.parseInt(devicePort));
+      server = new SocketServer(4724);
       server.listenForever();
     } catch (final SocketServerException e) {
       Logger.error(e.getError());

--- a/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
@@ -4,6 +4,8 @@ import io.appium.android.bootstrap.exceptions.SocketServerException;
 
 import com.android.uiautomator.testrunner.UiAutomatorTestCase;
 
+import android.os.Bundle;
+
 /**
  * The Bootstrap class runs the socket server.
  * 
@@ -12,8 +14,12 @@ public class Bootstrap extends UiAutomatorTestCase {
 
   public void testRunServer() {
     SocketServer server;
+    Bundle params;
+    String devicePort;
     try {
-      server = new SocketServer(4724);
+      params = getParams();
+      devicePort = params.getString("devicePort", "4724");
+      server = new SocketServer(Integer.parseInt(devicePort));
       server.listenForever();
     } catch (final SocketServerException e) {
       Logger.error(e.getError());

--- a/app/appium.js
+++ b/app/appium.js
@@ -515,13 +515,12 @@ Appium.prototype.invoke = function() {
           , keystorePassword: this.args.keystorePassword
           , keyAlias: this.args.keyAlias
           , keyPassword: this.args.keyPassword
-          , devicePort: this.args.devicePort
+          , systemPort: this.args.devicePort
         };
         if (this.isChrome()) {
           androidOpts.chromium = this.args.chromium;
           this.devices[this.deviceType] = chrome(androidOpts);
         } else {
-          // console.log('APPIUM ANDROID OPTS: ', androidOpts)
           this.devices[this.deviceType] = android(androidOpts);
         }
       } else if (this.isSelendroid()) {
@@ -536,7 +535,7 @@ Appium.prototype.invoke = function() {
           , avdName: this.args.avd
           , appDeviceReadyTimeout: this.args.androidDeviceReadyTimeout
           , reset: !this.args.noReset
-          , port: this.args.selendroidPort
+          , systemPort: this.args.selendroidPort
           , fastReset: this.fastReset
           , useKeystore: this.args.useKeystore
           , keystorePath: this.args.keystorePath

--- a/app/appium.js
+++ b/app/appium.js
@@ -515,11 +515,13 @@ Appium.prototype.invoke = function() {
           , keystorePassword: this.args.keystorePassword
           , keyAlias: this.args.keyAlias
           , keyPassword: this.args.keyPassword
+          , devicePort: this.args.devicePort
         };
         if (this.isChrome()) {
           androidOpts.chromium = this.args.chromium;
           this.devices[this.deviceType] = chrome(androidOpts);
         } else {
+          // console.log('APPIUM ANDROID OPTS: ', androidOpts)
           this.devices[this.deviceType] = android(androidOpts);
         }
       } else if (this.isSelendroid()) {

--- a/app/parser.js
+++ b/app/parser.js
@@ -49,6 +49,15 @@ var args = [
     , help: 'port to listen on'
   }],
 
+  [['-dp', '--device-port'] , {
+    defaultValue: 4724
+    , dest: 'devicePort'
+    , required: false
+    , type: 'int'
+    , example: "4724"
+    , help: 'port to connect to device on'
+  }],
+
   [['-k', '--keep-artifacts'] , {
     defaultValue: false
     , dest: 'keepArtifacts'

--- a/app/selendroid.js
+++ b/app/selendroid.js
@@ -26,7 +26,7 @@ var Selendroid = function(opts) {
   this.adb = null;
   this.isProxy = true;
   this.proxyHost = 'localhost';
-  this.proxyPort = opts.port;
+  this.proxyPort = opts.systemPort;
   this.avoidProxy = [
     ['GET', new RegExp('^/wd/hub/session/[^/]+/log/types$')]
     , ['POST', new RegExp('^/wd/hub/session/[^/]+/log')]

--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -14,6 +14,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`-U`, `--udid`|null|Unique device identifier of the connected physical device|`--udid 1adsf-sdfas-asdf-123sdf`|
 |`-a`, `--address`|0.0.0.0|IP Address to listen on|`--address 0.0.0.0`|
 |`-p`, `--port`|4723|port to listen on|`--port 4723`|
+|`-dp`, `--device-port`|4724|port to connect to device on|`--device-port 4724`|
 |`-k`, `--keep-artifacts`|false|(IOS-only) Keep Instruments trace directories||
 |`--no-session-override`|false|Disables session override||
 |`--full-reset`|false|(Android-only) Reset app state by uninstalling app instead of using clean.apk||
@@ -36,7 +37,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`-rp`, `--robot-port`|-1|port for robot|`--robot-port 4242`|
 |`--selendroid-port`|8080|Local port used for communication with Selendroid|`--selendroid-port 8080`|
 |`--use-keystore`|false|(Android-only) When set the keystore will be used to sign apks.||
-|`--keystore-path`|/Users/jlipps/.android/debug.keystore|(Android-only) Path to keystore||
+|`--keystore-path`|/Users/rockbot/.android/debug.keystore|(Android-only) Path to keystore||
 |`--keystore-password`|android|(Android-only) Password to keystore||
 |`--key-alias`|androiddebugkey|(Android-only) Key alias||
 |`--key-password`|android|(Android-only) Key password||


### PR DESCRIPTION
Basically, this PR adds a device port flag that allows a test to specify the system port by which appium talks to a real device (was previously hard-coded/never updated)
