### PR TITLE
Now possible to use resource-id for finding elements.

### DIFF
--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -32,6 +32,8 @@ import com.android.uiautomator.core.UiObjectNotFoundException;
 import com.android.uiautomator.core.UiScrollable;
 import com.android.uiautomator.core.UiSelector;
 
+import android.os.Build;
+
 /**
  * This handler is used to find elements in the Android UI.
  * 
@@ -388,7 +390,7 @@ public class Find extends CommandHandler {
         }
         break;
       case ID:
-        if (text.contains(":")) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
           // Handle this as a resource id
           sel = sel.resourceId(text);
           if (!many)

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -388,16 +388,26 @@ public class Find extends CommandHandler {
         }
         break;
       case ID:
-        try {
-          text = apkStrings.getString(text);
-          Logger.debug("Searching for text: " + text);
-        } catch (final Exception e) { // JSONException and NullPointerException
+        if (text.contains(":")) {
+          // Handle this as a resource id
+          sel = sel.resourceId(text);
+          if (!many)
+            sel = sel.instance(0);
+          selectors.add(sel);
+          // Don't fall through when using resource id
+          break;
+        } else {
+          try {
+            text = apkStrings.getString(text);
+            Logger.debug("Searching for text: " + text);
+          } catch (final Exception e) { // JSONException and NullPointerException
 
-          final StringWriter string = new StringWriter();
-          e.printStackTrace(new PrintWriter(string));
+            final StringWriter string = new StringWriter();
+            e.printStackTrace(new PrintWriter(string));
 
-          throw new InvalidStrategyException("Unable to search by ID for "
-              + text + ".\n" + string.toString());
+            throw new InvalidStrategyException("Unable to search by ID for "
+                + text + ".\n" + string.toString());
+          }
         }
         // now fall through and do a name search
       case NAME:

--- a/test/functional/apidemos/findElement.js
+++ b/test/functional/apidemos/findElement.js
@@ -122,6 +122,20 @@ describeWd('find element(s)', function(h) {
       });
     });
   });
+  it('should find a single element by resource-id', function(done) {
+    h.driver.elementById('android:id/home', function(err, element) {
+      should.not.exist(err);
+      should.exist(element.value);
+      done();
+    });
+  });
+  it('should find multiple elements by resource-id', function(done) {
+    h.driver.elementsById('android:id/text1', function(err, els) {
+      should.not.exist(err);
+      els.length.should.equal(11);
+      done();
+    });
+  });
 });
 
 describeWd('find element(s) from element', function(h) {


### PR DESCRIPTION
Partial fix for https://github.com/appium/appium/issues/923

When finding by id it will use resourceId's if there is a colon in the search text, otherwise it will use the old find by id.
Since resourceId's are of the form com.package.package:id/name this seems to work fine.

Any idea for improvements are welcome. 
