### PR TITLE
Add id support on iOS

### DIFF
--- a/test/functional/uicatalog/findElement.js
+++ b/test/functional/uicatalog/findElement.js
@@ -6,6 +6,16 @@ var describeWd = require("../../helpers/driverblock.js").describeForApp('UICatal
   , spinWait = require("../../helpers/spin.js").spinWait
   , should = require('should');
 
+describeWd('find by id', function(h) {
+  it('should find a single element by id', function(done) {
+    // ButtonsExplain: 'Various uses of UIButton'
+    h.driver.elementById('ButtonsExplain', function(err, els) {
+      should.not.exist(err);
+      done();
+    });
+  });
+});
+
 describeWd('findElementNameContains', function(h) {
   it('should find a single element by name', function(done) {
     h.driver.execute("mobile: findElementNameContains", [{name: 'uses of UIButton'}], function(err, el) {


### PR DESCRIPTION
Localizable.strings is equivalent to strings.xml on Android

Find by id now works the same on iOS & Android enabling cross platform tests.

Fix #752
Fix #1079

If this looks good, then I'll add a test before merging.
