### PR TITLE
enable appium to tap on UITableViewCell

### DIFF
--- a/app/uiauto/appium/app.js
+++ b/app/uiauto/appium/app.js
@@ -192,10 +192,14 @@ $.extend(au, {
           // element may still be null.
           element.tap();
         } catch(e) {
-          return {
-            status: codes.UnknownError.code,
-            value: 'elementId ' + elementId + ' is null and can\'t be tapped.'
-          };
+          try {
+            target.tap(element.rect());
+          } catch(e2) {
+            return {
+              status: codes.UnknownError.code,
+              value: 'elementId ' + elementId + ' is null and can\'t be tapped. ' + e + ', ' + e2
+            };
+          }
         }
         return {
           status: codes.Success.code,


### PR DESCRIPTION
tapping UITableViewCell using UI Automation does not work and it is a known bug with apple, work around for tapping on UITableViewCell is tappium on the element's coordinates using .rect function,  this is now added that to appium
