### PR TITLE
uiautomator returns false on successful click.

### DIFF
--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/Click.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/Click.java
@@ -39,8 +39,8 @@ public class Click extends CommandHandler {
     if (command.isElementCommand()) {
       try {
         final AndroidElement el = command.getElement();
-        final boolean res = el.click();
-        return getSuccessResult(res);
+        el.click();
+        return getSuccessResult(true);
       } catch (final UiObjectNotFoundException e) {
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());


### PR DESCRIPTION
To work around this bug, always return true.

Fix https://github.com/appium/appium/issues/1100
