### PR TITLE
Add a check for existence of `android` command in grunt-helpers.js.

### DIFF
--- a/android/adb.js
+++ b/android/adb.js
@@ -99,8 +99,8 @@ ADB.prototype.checkSdkBinaryPresent = function(binary, cb) {
     });
 
     if (binaryLoc === null) {
-      cb(new Error("Could not find " + binary + " in tools, platform-tools, or build-tools; " +
-                   "do you have android SDK installed?"),
+      cb(new Error("Could not find " + binary + " in tools, platform-tools, or build-tools under \"" + this.sdkRoot + "\"; " +
+                   "do you have android SDK installed into this location?"),
          null);
       return;
     }
@@ -114,8 +114,9 @@ ADB.prototype.checkSdkBinaryPresent = function(binary, cb) {
         this.debug("Using " + binary + " from " + stdout);
         cb(null, stdout);
       } else {
-        cb(new Error("Could not find " + binary + "; do you have android " +
-                     "SDK installed?"),
+        cb(new Error("Could not find " + binary + "; do you have the Android " +
+                     "SDK installed and the tools + platform-tools folders " + 
+		     "added to your PATH?"),
            null);
       }
     }.bind(this));

--- a/grunt-helpers.js
+++ b/grunt-helpers.js
@@ -294,6 +294,9 @@ var setupAndroidProj = function(grunt, projPath, args, cb) {
     grunt.fatal("Could not find Android SDK, make sure to export ANDROID_HOME");
   }
   var cmd = path.resolve(process.env.ANDROID_HOME, "tools", "android");
+  if (!fs.existsSync(cmd)) {
+    grunt.fatal("The `android` command was not found at \"" + cmd + "\", are you sure ANDROID_HOME is set properly?");
+  }
   var proc = spawn(cmd, args, {cwd: projPath});
   proc.stdout.setEncoding('utf8');
   proc.stderr.setEncoding('utf8');
@@ -312,6 +315,7 @@ module.exports.setupAndroidBootstrap = function(grunt, cb) {
   var projPath = path.resolve(__dirname, "android", "bootstrap");
   var args = ["create", "uitest-project", "-n", "AppiumBootstrap", "-t",
               "android-18", "-p", "."];
+  // TODO: possibly check output of `android list target` to make sure api level 18 is available?
   setupAndroidProj(grunt, projPath, args, cb);
 };
 


### PR DESCRIPTION
I had an incorrectly-set `ANDROID_HOME` env variable, and got a very cryptic error message when running `reset.sh --dev --android` - the same error message reported in #1064.

This pull request verifies the existence of the necessary `android` command-line tool and reports a clearer error message.

Side note: expanded the error messages returned in adb.js a little bit.
