### PR TITLE
'android' command is 'android.bat' on Windows.

### DIFF
--- a/grunt-helpers.js
+++ b/grunt-helpers.js
@@ -293,7 +293,11 @@ var setupAndroidProj = function(grunt, projPath, args, cb) {
   if (!process.env.ANDROID_HOME) {
     grunt.fatal("Could not find Android SDK, make sure to export ANDROID_HOME");
   }
-  var cmd = path.resolve(process.env.ANDROID_HOME, "tools", "android");
+  var tool = "android";
+  if (isWindows) {
+    tool = "android.bat";
+  }
+  var cmd = path.resolve(process.env.ANDROID_HOME, "tools", tool);
   if (!fs.existsSync(cmd)) {
     grunt.fatal("The `android` command was not found at \"" + cmd + "\", are you sure ANDROID_HOME is set properly?");
   }


### PR DESCRIPTION
Fix for a bug in compilation on Windows introduced by https://github.com/appium/appium/commit/8e54a2100d36d24108785ac47a8d7bc559abd283.
