### PR TITLE
Always relaunch on protocol fault

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -91,6 +91,7 @@ Android.prototype.start = function(cb, onDie) {
     var relaunchOn = [
       'Could not find a connected Android device'
       , 'Device did not become ready'
+      , 'protocol fault (no status)'
     ];
     var checkShouldRelaunch = function(msg) {
       var relaunch = false;


### PR DESCRIPTION
Does this do anything? I want adb to keep restarting until `protocol fault (no status)` is not returned.
