### PR TITLE
Fix --avd flag by removing double quotes

### DIFF
--- a/android/adb.js
+++ b/android/adb.js
@@ -783,7 +783,7 @@ ADB.prototype.prepareEmulator = function(cb) {
             if (this.avdName[0] !== "@") {
               this.avdName = "@" + this.avdName;
             }
-            var emulatorProc = spawn(emulatorBinaryPath, [this.avdName]);
+            var emulatorProc = spawn(emulatorBinaryPath.substr(1, emulatorBinaryPath.length - 2), [this.avdName]);
             var timeoutMs = 120000;
             var now = Date.now();
             var checkEmulatorAlive = function() {


### PR DESCRIPTION
Fixes #730 
This is the same fix made for the adb command in e422d23435cca824d1b423089bd0df232df64fec

This was broken by a change in 0.7.0 where we added quotes around checkSDKBinary present to appease the exec method which expects them.

Spawn does not expect them and fails when double quotes are present
