### PR TITLE
Catch exception

### DIFF
--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
@@ -43,8 +43,10 @@ public class Clear extends CommandHandler {
       } catch (final ElementNotInHashException e) {
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());
+      } catch (final Exception e) { // handle NullPointerException
+        return getErrorResult("Unknown error clearing text");
       }
     }
-    return getErrorResult("Unknown error clearing text");
+    return getErrorResult("Unknown error");
   }
 }

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/Click.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/Click.java
@@ -47,6 +47,8 @@ public class Click extends CommandHandler {
       } catch (final ElementNotInHashException e) {
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());
+      } catch (final Exception e) { // handle NullPointerException
+        return getErrorResult("Unknown error");
       }
     } else {
       final Hashtable<String, Object> params = command.params();

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/Drag.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/Drag.java
@@ -50,9 +50,10 @@ public class Drag extends CommandHandler {
         if (params.get("elementId") != JSONObject.NULL) {
           el = command.getElement();
         }
-      } catch (final ElementNotInHashException e) {
+      } catch (final Exception e) {
         el = null;
       }
+
       try {
         if (params.get("destElId") != JSONObject.NULL) {
           destEl = command.getDestElement();

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/Flick.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/Flick.java
@@ -5,7 +5,6 @@ import io.appium.android.bootstrap.AndroidCommandResult;
 import io.appium.android.bootstrap.AndroidElement;
 import io.appium.android.bootstrap.CommandHandler;
 import io.appium.android.bootstrap.Logger;
-import io.appium.android.bootstrap.exceptions.ElementNotInHashException;
 import io.appium.android.bootstrap.exceptions.InvalidCoordinatesException;
 import io.appium.android.bootstrap.utils.Point;
 
@@ -14,7 +13,6 @@ import java.util.Hashtable;
 import org.json.JSONException;
 
 import com.android.uiautomator.core.UiDevice;
-import com.android.uiautomator.core.UiObjectNotFoundException;
 
 /**
  * This handler is used to flick elements in the Android UI.
@@ -83,11 +81,7 @@ public class Flick extends CommandHandler {
         end.x = start.x + xoffset;
         end.y = start.y + yoffset;
 
-      } catch (final ElementNotInHashException e) {
-        return getErrorResult(e.getMessage());
-      } catch (final UiObjectNotFoundException e) {
-        return getErrorResult(e.getMessage());
-      } catch (final InvalidCoordinatesException e) {
+      } catch (final Exception e) {
         return getErrorResult(e.getMessage());
       }
     } else {

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
@@ -54,7 +54,7 @@ public class GetAttribute extends CommandHandler {
       } catch (final ElementNotInHashException e) {
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());
-      } catch (final NullPointerException e) { // el is null
+      } catch (final Exception e) { // el is null
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());
       }

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/GetName.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/GetName.java
@@ -41,6 +41,8 @@ public class GetName extends CommandHandler {
       return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT, e.getMessage());
     } catch (final ElementNotInHashException e) {
       return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT, e.getMessage());
+    } catch (final Exception e) { // handle NullPointerException
+      return getErrorResult("Unknown error");
     }
   }
 }

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/GetSize.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/GetSize.java
@@ -48,6 +48,8 @@ public class GetSize extends CommandHandler {
       } catch (final ElementNotInHashException e) {
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());
+      } catch (final Exception e) { // handle NullPointerException
+        return getErrorResult("Unknown error");
       }
       return getSuccessResult(res);
     } else {

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/GetText.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/GetText.java
@@ -41,6 +41,8 @@ public class GetText extends CommandHandler {
       } catch (final ElementNotInHashException e) {
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());
+      } catch (final Exception e) { // handle NullPointerException
+        return getErrorResult("Unknown error");
       }
     } else {
       return getErrorResult("Unable to get text without an element.");

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/SetAttribute.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/SetAttribute.java
@@ -46,7 +46,10 @@ public class SetAttribute extends CommandHandler {
       } catch (final ElementNotInHashException e) {
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());
+      } catch (final Exception e) { // handle NullPointerException
+        return getErrorResult("Unknown error");
       }
+
     } else {
       final Hashtable<String, Object> params = command.params();
 

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
@@ -58,6 +58,8 @@ public class SetText extends CommandHandler {
       } catch (final ElementNotInHashException e) {
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());
+      } catch (final Exception e) { // handle NullPointerException
+        return getErrorResult("Unknown error");
       }
     } else {
       return getErrorResult("Unable to set text without an element.");

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/Swipe.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/Swipe.java
@@ -55,6 +55,8 @@ public class Swipe extends CommandHandler {
         return getErrorResult(e.getMessage());
       } catch (final InvalidCoordinatesException e) {
         return getErrorResult(e.getMessage());
+      } catch (final Exception e) { // handle NullPointerException
+        return getErrorResult("Unknown error");
       }
     } else {
       try {


### PR DESCRIPTION
command.getElement() may return null. Appium must catch exception or it'll crash
with a NullPointerException.

Fix #1140
