### PR TITLE
fix android swipe duration

### DIFF
--- a/app/android.js
+++ b/app/android.js
@@ -45,7 +45,7 @@ Android.prototype.initialize = function(opts) {
   this.commandTimeout = null;
   this.shuttingDown = false;
   this.adb = null;
-  this.swipeStepsPerSec = 200;
+  this.swipeStepsPerSec = 28;
   this.asyncWaitMs = 0;
   this.remote = null;
   this.webElementIds = [];
@@ -775,18 +775,13 @@ Android.prototype.swipe = function(startX, startY, endX, endY, duration, touchCo
     , startY: startY
     , endX: endX
     , endY: endY
-    , steps: Math.round((duration * 1000) / this.swipeStepsPerSec)
-  };
-  var swipeCb = function(err, res) {
-    setTimeout(function() {
-      cb(err, res);
-    }, duration * 1000);
+    , steps: Math.round(duration * this.swipeStepsPerSec)
   };
   if (elId !== null) {
     swipeOpts.elementId = elId;
-    this.proxy(["element:swipe", swipeOpts], swipeCb);
+    this.proxy(["element:swipe", swipeOpts], cb);
   } else {
-    this.proxy(["swipe", swipeOpts], swipeCb);
+    this.proxy(["swipe", swipeOpts], cb);
   }
 };
 
@@ -814,7 +809,7 @@ Android.prototype.flick = function(startX, startY, endX, endY, touchCount, elId,
     , startY: startY
     , endX: endX
     , endY: endY
-    , steps: 20
+    , steps: Math.round(0.2 * this.swipeStepsPerSec)
   };
   if (elId !== null) {
     swipeOpts.elementId = elId;


### PR DESCRIPTION
- the swipeStepsPerSec value was wrong. Android docs says it's about 200 steps per sec. Using a bunch of different swipe times and linear regression I determined it to be about 28 on my GPU-enabled emulator. Not sure if this varies widely for others.
- the logic for converting duration to steps was wrong and has been fixed
- I took out a needless post-swipe timeout. I don't think uiautomator actually returns control before the swipe is done

WARNING: this might require testers to change swipe durations if tests rely on them.
