### PR TITLE
Android packages may have underscores

### DIFF
--- a/android/adb.js
+++ b/android/adb.js
@@ -1254,7 +1254,7 @@ ADB.prototype.getFocusedPackageAndActivity = function(cb) {
   logger.info("Getting focused package and activity");
   this.requireDeviceId();
   var cmd = this.adbCmd + " shell dumpsys window windows"
-    , searchRe = new RegExp(/mFocusedApp.+ ([a-zA-Z0-9\.]+)\/(\.?[^\}]+)\}/);
+    , searchRe = new RegExp(/mFocusedApp.+ ([a-zA-Z0-9\._]+)\/(\.?[^\}]+)\}/);
 
   exec(cmd, { maxBuffer: 524288 }, function(err, stdout) {
     if (err) {


### PR DESCRIPTION
var str = "mFocusedApp=AppWindowToken{41ac2030 token=Token{41797308
ActivityRecord{419b9290 u0 com.example.webviewapp_18_api/.MainActivity}}}";

// undefined
/mFocusedApp.+ ([a-zA-Z0-9.]+)\/(.?[^}]+)}/.exec(str)

Fix #1159
