### PR TITLE
Fix for keyevent

### DIFF
--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/PressKeyCode.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/PressKeyCode.java
@@ -38,9 +38,10 @@ public class PressKeyCode extends CommandHandler {
 
       if (params.get("metastate") != JSONObject.NULL) {
         metaState = (Integer) params.get("metastate");
+        UiDevice.getInstance().pressKeyCode(keyCode, metaState);
+      } else {
+        UiDevice.getInstance().pressKeyCode(keyCode);
       }
-
-      UiDevice.getInstance().pressKeyCode(keyCode, metaState);
 
       return getSuccessResult(true);
     } catch (final Exception e) {


### PR DESCRIPTION
- Make sure keyevent works if metastate is null.
- Added a default keyInjectionDelay = 100ms (default value is 0), so that the text input is similar to how a user inputs the text.
