### PR TITLE
More robust unlock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "submodules/udidetect"]
 	path = submodules/udidetect
 	url = https://github.com/vaskas/udidetect.git
+[submodule "submodules/unlock_apk"]
+	path = submodules/unlock_apk
+	url = https://github.com/appium/unlock_apk.git

--- a/android/device_state.js
+++ b/android/device_state.js
@@ -1,0 +1,38 @@
+"use strict";
+
+var exec = require('child_process').exec
+  , logger = require('../logger').get('appium');
+
+function log(msg) {
+  logger.info("[ADB] " + msg);
+}
+
+module.exports = {
+  isScreenLocked: function(adbCmd, cb) {
+    var cmd = adbCmd + " shell dumpsys window";
+    log("Checking if screen is unlocked via `dumpsys window`...");
+    exec(cmd, {maxBuffer: 524288}, function(err, stdout, stderr) {
+      if (err) {
+        cb(err);
+      } else {
+        var screenLocked = /mShowingLockscreen=\w+/gi.exec(stdout);
+        var samsungNoteUnlocked = /mScreenOnFully=\w+/gi.exec(stdout);
+        if (screenLocked && screenLocked[0]) {
+          if (screenLocked[0].split('=')[1] == 'false') {
+            cb(null, false);
+          } else {
+            cb(null, true);
+          }
+        } else if (samsungNoteUnlocked && samsungNoteUnlocked[0]) {
+          if (samsungNoteUnlocked[0].split('=')[1] == 'true') {
+            cb(null, false);
+          } else {
+            cb(null, true);
+          }
+        } else {
+          cb(null, true);
+        }
+      }
+    });
+  }
+};

--- a/reset.sh
+++ b/reset.sh
@@ -181,6 +181,11 @@ reset_android() {
     run_cmd $grunt configAndroidBootstrap
     echo "* Building Android bootstrap"
     run_cmd $grunt buildAndroidBootstrap
+    echo "* Building unlock.apk"
+    run_cmd git submodule update --init submodules/unlock_apk
+    run_cmd pushd submodules/unlock_apk
+    run_cmd ant clean && ant debug
+    run_cmd popd
     if $include_dev ; then
         reset_apidemos
         reset_gps_demo

--- a/test/functional/android/device_state.js
+++ b/test/functional/android/device_state.js
@@ -1,0 +1,52 @@
+var deviceState = require('../../../android/device_state')
+    , should = require('should')
+    , childProcess = require('child_process')
+    , ADB = require('../../../android/adb');
+
+describe('Android Device State module', function() {
+  beforeEach(function(done) {
+    // ensure a device or emu is connected 
+    childProcess.exec("adb devices", function(err, stdout, stderr) {
+      should.not.exist(err);
+      var device = /\n([A-Za-z0-9\-]+)\W+device\n/.exec(stdout);
+      device = device[1];
+      should.exist(device);
+      done();
+    });
+  });
+
+  describe('isScreenLocked method', function() {
+    it('should return true if screen is locked', function(done) {
+      // Press POWER btn to lock screen first
+      childProcess.exec('adb shell input keyevent 26', function(err, stdout, stderr) {
+        should.not.exist(err);
+
+        childProcess.exec('adb shell input keyevent 26', function(err, stdout, stderr) {
+          should.not.exist(err);
+          deviceState.isScreenLocked('adb', function(err, isLocked) {
+            should.not.exist(err);
+            isLocked.should.be.true;
+            done();
+          });
+        });
+      });
+    });
+    it('should return false is screen is unlocked', function(done) {
+      // Push unlock.apk first
+      var adb = new ADB();
+      adb.pushUnlock(function(err) {
+        should.not.exist(err);
+        childProcess.exec('adb shell am start -n io.appium.unlock/.Unlock', function(err, stdout, stderr) {
+          should.not.exist(err);
+          setTimeout(function() {
+            deviceState.isScreenLocked('adb', function(err, isLocked) {
+              should.not.exist(err);
+              isLocked.should.be.false;
+              done();
+            });
+          }, 2500);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces several changes/additions aimed at fixing appium's ability to unlock real Samsung Android devices. This is based on work done by @rockbot.

I've tested this on an Intel HAX emulator running 4.3,a Nexus 4 running 4.3, and a first-gen Nexus 7 running 4.3.
## Summary of Changes
1. A submodule to [unlock_apk](github.com/appium/unlock_apk) (an Android application tasked with unlocking an Android) is added, and a build step for unlock_apk is also added to `reset.sh --android`.
2. A `pushUnlock` method is added and hooked into `adb.js`'s `startAppium` function. `pushUnlock` calls `adb` to install `unlock.apk` on an available Android device or emulator.
3. A `device_state.js` module is added under `android/`. This module is to handle determining various useful things about a connected Android device or emulator's state. As a start, it has a single `isScreenLocked` function. I am hoping we can start teasing out `adb.js`' massive 1500+ lines of code into smaller, easier-to-digest, focused modules, at the existing committers blessing, of course. (/cc @jlipps @bootstraponline)
## Potential Issues
- Should we uninstall unlock.apk after every test? If so, this would need to be added. Related question: does this happen for other tools we rely on, like Android Bootstrap?
- I would like to confirm that this works with a real Samsung device (I do not have one handy at this time, boo).  @rockbot, if you have time, could you help with that?
## Contribution Questions
- On how many different kinds of devices / emulators do committers to appium usually test on before deeming a new feature or bug fix acceptable?
- For this pull request, what kind of functional and/or unit tests would committers expect to exist to cover this functionality? I am trying to get a feel for the project so any pointers here would be appreciated :) (and I'll do my best to integrate into some manner of contributor guidelines document).
