### PR TITLE
Update Android Touchevent for long press

### DIFF
--- a/docs/touch-actions.md
+++ b/docs/touch-actions.md
@@ -1,11 +1,24 @@
 # Touch Actions
 
+
 WebDriver provides an API to send some kinds of touch gestures to the devices,
 for example, to long press an element you can do:
+
+For iOS Application:
 
 ```java
 final WebElement imageView = searchResults.findElement(By.tagName("ImageView"));
 new TouchActions(driver).longPress(imageView).perform();
+```
+
+For Android Application:
+
+```java
+WebElement element = wd.findElement(By.name("API Demo"));
+JavascriptExecutor js = (JavascriptExecutor) wd;
+HashMap<String, String> tapObject = new HashMap<String, String>();
+tapObject.put("element", ((RemoteWebElement) element).getId());
+js.executeScript("mobile: longClick", tapObject);
 ```
 
 Currently Appium support some of the gestures in the Touch Actions API:
@@ -16,4 +29,5 @@ Currently Appium support some of the gestures in the Touch Actions API:
 
 Some other gestures are supported through the "Alternative access method"
 explained in [Automating mobile gestures](gestures.md)
+
 


### PR DESCRIPTION
This long press code supports only for iOS application. So I am updating the Android Touchevent for long press.
