### PR TITLE
Running tests against Safari using the SafariLauncher app

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "submodules/unlock_apk"]
 	path = submodules/unlock_apk
 	url = https://github.com/appium/unlock_apk.git
+[submodule "submodules/SafariLauncher"]
+	path = submodules/SafariLauncher
+	url = https://github.com/budhash/SafariLauncher.git

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,7 @@ var path = require('path')
   , authorize = gruntHelpers.authorize
   , tail = gruntHelpers.tail
   , buildApp = gruntHelpers.buildApp
+  , buildSafariLauncherApp = gruntHelpers.buildSafariLauncherApp
   , signApp = gruntHelpers.signApp
   , setupAndroidBootstrap = gruntHelpers.setupAndroidBootstrap
   , setupAndroidApp = gruntHelpers.setupAndroidApp
@@ -106,6 +107,9 @@ module.exports = function(grunt) {
   });
   grunt.registerTask('buildApp', "Build the test app", function(appDir, sdk) {
     buildApp(appDir, this.async(), sdk);
+  });
+  grunt.registerTask('buildSafariLauncherApp', "Build the SafariLauncher app", function(sdk) {
+    buildSafariLauncherApp(this.async(), sdk);
   });
   grunt.registerTask('signApp', "Sign the test app", function(certName) {
     signApp("TestApp", certName, this.async());

--- a/app/appium.js
+++ b/app/appium.js
@@ -628,7 +628,7 @@ Appium.prototype.stop = function(cb) {
   }
 
   logger.info('Shutting down appium session...');
-  if (typeof this.device.isSafariLauncherApp !== "undefined" && this.device.isSafariLauncherApp === true) {
+  if (this.device.isSafariLauncherApp === true) {
     this.device.stopRemote();
     if (this.device.udid === null){
       this.device.instruments.shutdown();

--- a/app/appium.js
+++ b/app/appium.js
@@ -630,6 +630,9 @@ Appium.prototype.stop = function(cb) {
   logger.info('Shutting down appium session...');
   if (typeof this.device.isSafariLauncherApp !== "undefined" && this.device.isSafariLauncherApp === true) {
     this.device.stopRemote();
+    if (this.device.udid === null){
+      this.device.instruments.shutdown();
+    }
     this.onDeviceDie(0, cb);
   } else {
     this.device.stop(function(code) {

--- a/app/appium.js
+++ b/app/appium.js
@@ -633,9 +633,14 @@ Appium.prototype.stop = function(cb) {
   }
 
   logger.info('Shutting down appium session...');
-  this.device.stop(function(code) {
-    this.onDeviceDie(code, cb);
-  }.bind(this));
+  if (typeof this.device.isSafariLauncherApp !== "undefined" && this.device.isSafariLauncherApp === true) {
+    this.device.stopRemote();
+    this.onDeviceDie(0, cb);
+  } else {
+    this.device.stop(function(code) {
+      this.onDeviceDie(code, cb);
+    }.bind(this));
+  }
 };
 
 

--- a/app/appium.js
+++ b/app/appium.js
@@ -628,9 +628,14 @@ Appium.prototype.stop = function(cb) {
   }
 
   logger.info('Shutting down appium session...');
-  this.device.stop(function(code) {
-    this.onDeviceDie(code, cb);
-  }.bind(this));
+  if (typeof this.device.isSafariLauncherApp !== "undefined" && this.device.isSafariLauncherApp === true) {
+    this.device.stopRemote();
+    this.onDeviceDie(0, cb);
+  } else {
+    this.device.stop(function(code) {
+      this.onDeviceDie(code, cb);
+    }.bind(this));
+  }
 };
 
 

--- a/app/appium.js
+++ b/app/appium.js
@@ -635,6 +635,9 @@ Appium.prototype.stop = function(cb) {
   logger.info('Shutting down appium session...');
   if (typeof this.device.isSafariLauncherApp !== "undefined" && this.device.isSafariLauncherApp === true) {
     this.device.stopRemote();
+    if (this.device.udid === null){
+      this.device.instruments.shutdown();
+    }
     this.onDeviceDie(0, cb);
   } else {
     this.device.stop(function(code) {

--- a/app/ios.js
+++ b/app/ios.js
@@ -70,6 +70,8 @@ var IOS = function(args) {
   this.onPageChangeCb = null;
   this.useRobot = args.robotPort > 0;
   this.robotUrl = this.useRobot ? "http://" + args.robotAddress + ":" + args.robotPort + "" : null;
+  this.safariLauncherAppName = "/safarilauncher.app";
+  this.isSafariLauncherApp = (typeof args.app !== "undefined") && (args.app.toLowerCase().indexOf(this.safariLauncherAppName, args.app.length - this.safariLauncherAppName.length) !== -1);
   this.capabilities = {
       version: '6.0'
       , webStorageEnabled: false
@@ -177,6 +179,7 @@ IOS.prototype.start = function(cb, onDie) {
     this.instruments = instruments(
       this.app || this.bundleId
       , this.udid
+      , this.isSafariLauncherApp
       , path.resolve(__dirname, 'uiauto/bootstrap.js')
       , this.automationTraceTemplatePath
       , sock
@@ -572,7 +575,7 @@ IOS.prototype.cleanupAppState = function(cb) {
 
 IOS.prototype.listWebFrames = function(cb, exitCb) {
   var isDone = false;
-  if (!this.bundleId) {
+  if (!this.bundleId && !this.isSafariLauncherApp) {
     logger.error("Can't enter web frame without a bundle ID");
     return cb(new Error("Tried to enter web frame without a bundle ID"));
   }

--- a/app/ios.js
+++ b/app/ios.js
@@ -71,6 +71,8 @@ var IOS = function(args) {
   this.onPageChangeCb = null;
   this.useRobot = args.robotPort > 0;
   this.robotUrl = this.useRobot ? "http://" + args.robotAddress + ":" + args.robotPort + "" : null;
+  this.safariLauncherAppName = "/safarilauncher.app";
+  this.isSafariLauncherApp = (typeof args.app !== "undefined") && (args.app.toLowerCase().indexOf(this.safariLauncherAppName, args.app.length - this.safariLauncherAppName.length) !== -1);
   this.capabilities = {
       version: '6.0'
       , webStorageEnabled: false
@@ -178,6 +180,7 @@ IOS.prototype.start = function(cb, onDie) {
     this.instruments = instruments(
       this.app || this.bundleId
       , this.udid
+      , this.isSafariLauncherApp
       , path.resolve(__dirname, 'uiauto/bootstrap.js')
       , this.automationTraceTemplatePath
       , sock
@@ -580,7 +583,7 @@ IOS.prototype.cleanupAppState = function(cb) {
 
 IOS.prototype.listWebFrames = function(cb, exitCb) {
   var isDone = false;
-  if (!this.bundleId) {
+  if (!this.bundleId && !this.isSafariLauncherApp) {
     logger.error("Can't enter web frame without a bundle ID");
     return cb(new Error("Tried to enter web frame without a bundle ID"));
   }

--- a/grunt-helpers.js
+++ b/grunt-helpers.js
@@ -247,7 +247,7 @@ module.exports.build = function(appRoot, cb, sdk) {
         return cb(stdout + "\n" + stderr);
       }
       console.log("Building app...");
-      var args = ['-sdk', sdk, '-arch', 'i386'];
+      var args = ['-sdk', sdk];
       xcode = spawn('xcodebuild', args, {
         cwd: appRoot
       });
@@ -302,6 +302,19 @@ module.exports.signApp = function(appName, certName, cb) {
     }
   });
 };
+
+module.exports.buildSafariLauncherApp = function(cb, sdk) {
+  var appRoot = path.resolve(__dirname, "submodules", "SafariLauncher");
+  module.exports.build(appRoot, function(err) {
+    if (err !== null) {
+      console.log(err);
+      cb(false);
+    } else {
+      cb(true);
+    }
+  }, sdk);
+};
+
 
 var setupAndroidProj = function(grunt, projPath, args, cb) {
   if (!process.env.ANDROID_HOME) {

--- a/instruments/instruments.js
+++ b/instruments/instruments.js
@@ -13,9 +13,10 @@ var spawn = require('child_process').spawn
   , mkdirp = require('mkdirp')
   , codes = require('../app/uiauto/lib/status.js').codes;
 
-var Instruments = function(app, udid, bootstrap, template, sock, withoutDelay, xcodeVersion, webSocket, cb, exitCb) {
+var Instruments = function(app, udid, isSafariLauncherApp, bootstrap, template, sock, withoutDelay, xcodeVersion, webSocket, cb, exitCb) {
   this.app = app;
   this.udid = udid;
+  this.isSafariLauncherApp = isSafariLauncherApp;
   this.bootstrap = bootstrap;
   this.template = template;
   this.withoutDelay = withoutDelay;
@@ -69,7 +70,13 @@ Instruments.prototype.startSocketServer = function(sock) {
     this.exitHandler(1);
   };
 
-  var socketConnectTimeout = setTimeout(onSocketNeverConnect.bind(this), 90000);
+  // for safari launcher app we simply let the socket timeout and catch it.
+  var socketConnectTimeout = null;
+  if (this.isSafariLauncherApp) {
+    socketConnectTimeout = setTimeout(onSocketNeverConnect.bind(this), 8000);
+  } else {
+    socketConnectTimeout = setTimeout(onSocketNeverConnect.bind(this), 90000);
+  }
 
   this.socketServer = net.createServer({allowHalfOpen: true}, function(conn) {
     if (!this.hasConnected) {
@@ -160,6 +167,9 @@ Instruments.prototype.launch = function() {
 
       self.proc.on('exit', function(code) {
         self.debug("Instruments exited with code " + code);
+        if (self.isSafariLauncherApp){
+          self.readyHandler();
+        }
         if (self.curCommand && self.curCommand.cb) {
           self.curCommand.cb({
             status: code,
@@ -354,7 +364,7 @@ Instruments.prototype.debug = function(msg) {
 
 /* NODE EXPORTS */
 
-module.exports = function(server, app, udid, bootstrap, template, sock, withoutDelay, webSocket, cb, exitCb) {
-  return new Instruments(server, app, udid, bootstrap, template, sock, withoutDelay, webSocket, cb, exitCb);
+module.exports = function(server, app, isSafariLauncherApp, udid, bootstrap, template, sock, withoutDelay, webSocket, cb, exitCb) {
+  return new Instruments(server, app, isSafariLauncherApp, udid, bootstrap, template, sock, withoutDelay, webSocket, cb, exitCb);
 };
 

--- a/reset.sh
+++ b/reset.sh
@@ -128,10 +128,17 @@ reset_ios() {
     run_cmd pushd $appium_home/submodules/fruitstrap/
     run_cmd make fruitstrap
     run_cmd popd
-    echo "* Copying fruitstrap to build/"
+    echo "* Copying fruitstrap to build"
     run_cmd rm -rf build/fruitstrap
     run_cmd mkdir -p build/fruitstrap
     run_cmd cp submodules/fruitstrap/fruitstrap build/fruitstrap
+    echo "* Building SafariLauncher"
+    run_cmd $grunt buildSafariLauncherApp:iphoneos
+    echo "* Copying SafariLauncher to build"
+    run_cmd zip -r submodules/SafariLauncher/SafariLauncher submodules/SafariLauncher/build/Release-iphoneos/SafariLauncher.app
+    run_cmd mkdir -p build/SafariLauncher
+    run_cmd cp submodules/SafariLauncher/SafariLauncher.zip build/SafariLauncher/
+
 }
 
 get_apidemos() {


### PR DESCRIPTION
This solution allows you to run tests against safari <b>without any delay</b> using the SafariLauncher app.

It catches the instruments connection timeout (decreased to speed up test execution) and returns an all OK, which allows the test to continue. When stopping the test it closes the remote debugger connection and cleans up.

I was able to run multiple consecutive tests using safari without any issues and quite speedy as well ;).

<b>Steps</b>:
1. Clone the <a href="github.com/budhash/SafariLauncher">SafariLauncher App</a> and change the delay to be 0.
2. Deploy the app to your device and take a reference to the app in derived data (and set that as app).
3. The code looks for this app and has certain catches in place (e.g. when instruments times out)
4. Write a script that launches the app (which then launches safari) and in the second step just switch to the web view and your off.

<b>Note:</b> safari is left open after the test. Anyway of closing it? I tried javascript "window.close()" but that didn't work. You can however clear all cookies to clear the previous session.
