### PR TITLE
Don't accept the alert when we're trying to dismiss it

### DIFF
--- a/app/uiauto/appium/app.js
+++ b/app/uiauto/appium/app.js
@@ -932,9 +932,16 @@ $.extend(au, {
     }
 
   , dismissAlert: function() {
-      if (!this.mainApp.alert().cancelButton().isNil()) {
-        var alert = this.mainApp.alert();
+      var alert = this.mainApp.alert();
+      if (!alert.cancelButton().isNil()) {
         alert.cancelButton().tap();
+        this.waitForAlertToClose(alert);
+        return {
+          status: codes.Success.code,
+          value: null
+        };
+      } else if (alert.buttons().length > 0) {
+        alert.buttons()[0].tap(); // first button is dismiss
         this.waitForAlertToClose(alert);
         return {
           status: codes.Success.code,


### PR DESCRIPTION
If cancelButton().isNil() that doesn't mean there isn't a cancel button.
The cancel button is always button[0]. Press the dismiss button when requested
instead of calling acceptAlert().

Fix #1253
