### PR TITLE
Fix for 1279 by adding call back on socket disconnect.

### DIFF
--- a/app/hybrid/ios/webkit-remote-debugger.js
+++ b/app/hybrid/ios/webkit-remote-debugger.js
@@ -35,6 +35,7 @@ var WebKitRemoteDebugger = function(onDisconnect) {
   this.dataMethods = {};
   this.host = 'localhost';
   this.port = 27753;
+  this.socketDisconnectCb = null;
   this.init(1, onDisconnect);
 };
 
@@ -58,6 +59,10 @@ WebKitRemoteDebugger.prototype.connect = function(pageId, cb, pageChangeCb) {
   this.socket.on('close', function() {
     logger.info("Disconnecting from remote debugger");
     this.socket = null;
+    if(this.socketDisconnectCb){
+      this.socketDisconnectCb();
+      this.socketDisconnectCb = null;
+    }
   }.bind(this));
   this.socket.on('error', function(exception) {
     console.log('Debugger web socket error %s', exception);
@@ -68,9 +73,12 @@ WebKitRemoteDebugger.prototype.connect = function(pageId, cb, pageChangeCb) {
   }.bind(this));
 };
 
-WebKitRemoteDebugger.prototype.disconnect = function() {
+WebKitRemoteDebugger.prototype.disconnect = function(cb) {
   if(this.isConnected()){
     this.socket.close(1001);
+    this.socketDisconnectCb = cb;
+  } else {
+    cb();
   }
 };
 

--- a/app/ios.js
+++ b/app/ios.js
@@ -1956,6 +1956,7 @@ IOS.prototype.getWindowHandles = function(cb) {
 };
 
 IOS.prototype.setWindow = function(name, cb) {
+  var me = this;
   if (_.contains(_.pluck(this.windowHandleCache, 'id'), name)) {
     var pageIdKey = parseInt(name, 10);
     var next = function() {
@@ -1977,12 +1978,13 @@ IOS.prototype.setWindow = function(name, cb) {
             , value: name
           });
         } else if (_.contains(_.pluck(this.windowHandleCache, 'id'), name)) {
-          this.remote.disconnect();
-          this.curWindowHandle = name;
-          this.remote.connect(name, function(){
-            cb(null, {
-              status: status.codes.Success.code
-            , value: name
+          this.remote.disconnect(function(){
+            me.curWindowHandle = name;
+            me.remote.connect(name, function(){
+              cb(null, {
+                status: status.codes.Success.code
+                , value: name
+              });
             });
           });
         } else {


### PR DESCRIPTION
Added a call back for disconnect so that we wait for the disconnect to occur before we reconnect. 

Previously this was causing the socket variable to be set to null for the second window after it had been instantiated. Causing a cannot call send of null.
