### PR TITLE
Add new command to press on the MENU button for Android.

### DIFF
--- a/android/bootstrap/src/io/appium/android/bootstrap/AndroidCommandExecutor.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/AndroidCommandExecutor.java
@@ -26,6 +26,7 @@ import io.appium.android.bootstrap.handler.TakeScreenshot;
 import io.appium.android.bootstrap.handler.TouchLongClick;
 import io.appium.android.bootstrap.handler.WaitForIdle;
 import io.appium.android.bootstrap.handler.Wake;
+import io.appium.android.bootstrap.handler.PressMenu;
 
 import java.util.HashMap;
 
@@ -67,6 +68,7 @@ class AndroidCommandExecutor {
     map.put("enableCompressedLayoutHeirarchy",
         new EnableCompressedLayoutHeirarchy());
     map.put("getStrings", new GetStrings());
+    map.put("pressMenu", new PressMenu());
   }
 
   /**

--- a/android/bootstrap/src/io/appium/android/bootstrap/handler/PressMenu.java
+++ b/android/bootstrap/src/io/appium/android/bootstrap/handler/PressMenu.java
@@ -1,0 +1,31 @@
+package io.appium.android.bootstrap.handler;
+
+import io.appium.android.bootstrap.AndroidCommand;
+import io.appium.android.bootstrap.AndroidCommandResult;
+import io.appium.android.bootstrap.CommandHandler;
+
+import com.android.uiautomator.core.UiDevice;
+
+/**
+ * This handler is used to press menu button.
+ * 
+ */
+public class PressMenu extends CommandHandler {
+
+  /*
+   * @param command The {@link AndroidCommand} used for this handler.
+   * 
+   * @return {@link AndroidCommandResult}
+   * 
+   * @throws JSONException
+   * 
+   * @see io.appium.android.bootstrap.CommandHandler#execute(io.appium.android.
+   * bootstrap.AndroidCommand)
+   */
+  @Override
+  public AndroidCommandResult execute(final AndroidCommand command) {
+    boolean status = UiDevice.getInstance().pressMenu();
+    // Press menu button and returns true if successfully.
+    return getSuccessResult(status);
+  }
+}

--- a/app/android.js
+++ b/app/android.js
@@ -1015,6 +1015,10 @@ Android.prototype.unpackApp = function(req, cb) {
 Android.prototype.getLog = deviceCommon.getLog;
 Android.prototype.getLogTypes = deviceCommon.getLogTypes;
 
+Android.prototype.pressMenu = function(cb) {
+  this.proxy(["pressMenu"], cb);
+};
+
 module.exports = function(opts) {
   return new Android(opts);
 };

--- a/app/controller.js
+++ b/app/controller.js
@@ -919,6 +919,10 @@ exports.localScreenshot = function(req, res) {
   }
 };
 
+exports.pressMenu = function(req, res) {
+  req.device.pressMenu(getResponseHandler(req, res));
+};
+
 exports.notYetImplemented = notYetImplemented;
 var mobileCmdMap = {
   'tap': exports.mobileTap
@@ -955,6 +959,7 @@ var mobileCmdMap = {
   , 'pinchOpen': exports.mobilePinchOpen
   , 'localScreenshot': exports.localScreenshot
   , 'getStrings': exports.getStrings
+  , 'pressMenu' : exports.pressMenu
 };
 
 exports.produceError = function(req, res) {


### PR DESCRIPTION
The Android UiDevice has method to press the MENU button. To support this a new mobile command is added 'pressMenu'.

For python binding, the client code will be...

``` python
self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)    
self.driver.execute_script("mobile: pressMenu")
```
