### PR TITLE
Fixed bootstrap build error to download dependencies

### DIFF
--- a/lib/devices/android/bootstrap/pom.xml
+++ b/lib/devices/android/bootstrap/pom.xml
@@ -36,13 +36,13 @@
         <dependency>
           <groupId>android</groupId>
           <artifactId>android</artifactId>
-          <version>4.3_r1</version>
+          <version>4.3_r2</version>
         </dependency>
 
         <dependency>
           <groupId>android.test.uiautomator</groupId>
           <artifactId>uiautomator</artifactId>
-          <version>4.3_r1</version>
+          <version>4.3_r2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Below is error message. 

[ERROR] Failed to execute goal on project bootstrap: Could not resolve dependencies for project io.appium.android:bootstrap:jar:1.0.0-SNAPSHOT: The following artifacts could not be resolved: android:android:jar:4.3_r1, android.test.uiautomator:uiautomator:jar:4.3_r1: Could not find artifact android:android:jar:4.3_r1 in central (http://repo1.maven.org/maven2) -> [Help 1]
