### PR TITLE
Ensure APK is signed

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -1443,7 +1443,18 @@ ADB.prototype.installAppApk = function(apk, cb) {
     });
   }.bind(this);
 
+  var signLocalApk = function(cb) {
+    this.checkApkCert(apk, function(appSigned) {
+      if (!appSigned) {
+        this.sign([apk], cb);
+      } else {
+        cb(null);
+      }
+    }.bind(this));
+  }.bind(this);
+
   async.waterfall([
+    function(cb) { signLocalApk(cb); },
     function(cb) { adbMakeFolder(cb); },
     function(cb) { getMD5(cb); },
     function(cb) { this.removeOldApks(cb); }.bind(this),


### PR DESCRIPTION
With the new reset on Android, it's not necessary to sign the apk. However people are using unsigned apks with appium. An unsigned apk will not install on Android. I've restored the sign by default behavior.

Fix #1322
