### PR TITLE
Add new command to press on the Home button for Android.

### DIFF
--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -487,6 +487,10 @@ Android.prototype.back = function(cb) {
   this.proxy(["pressBack"], cb);
 };
 
+Android.prototype.home = function(cb) {
+    this.proxy(["pressHome"], cb);
+};
+
 Android.prototype.forward = function(cb) {
   cb(new NotYetImplementedError(), null);
 };

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidCommandExecutor.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidCommandExecutor.java
@@ -18,6 +18,7 @@ import io.appium.android.bootstrap.handler.GetText;
 import io.appium.android.bootstrap.handler.Orientation;
 import io.appium.android.bootstrap.handler.Pinch;
 import io.appium.android.bootstrap.handler.PressBack;
+import io.appium.android.bootstrap.handler.PressHome;
 import io.appium.android.bootstrap.handler.PressKeyCode;
 import io.appium.android.bootstrap.handler.ScrollTo;
 import io.appium.android.bootstrap.handler.SetText;
@@ -61,6 +62,7 @@ class AndroidCommandExecutor {
     map.put("getSize", new GetSize());
     map.put("wake", new Wake());
     map.put("pressBack", new PressBack());
+    map.put("pressHome", new PressHome());
     map.put("dumpWindowHierarchy", new DumpWindowHierarchy());
     map.put("pressKeyCode", new PressKeyCode());
     map.put("takeScreenshot", new TakeScreenshot());

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/PressHome.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/PressHome.java
@@ -1,0 +1,32 @@
+package io.appium.android.bootstrap.handler;
+
+import io.appium.android.bootstrap.AndroidCommand;
+import io.appium.android.bootstrap.AndroidCommandResult;
+import io.appium.android.bootstrap.CommandHandler;
+
+import com.android.uiautomator.core.UiDevice;
+
+/**
+ * This handler is used to press home.
+ *
+ */
+public class PressHome extends CommandHandler {
+
+    /*
+     * @param command The {@link AndroidCommand} used for this handler.
+     *
+     * @return {@link AndroidCommandResult}
+     *
+     * @throws JSONException
+     *
+     * @see io.appium.android.bootstrap.CommandHandler#execute(io.appium.android.
+     * bootstrap.AndroidCommand)
+     */
+    @Override
+    public AndroidCommandResult execute(final AndroidCommand command) {
+        boolean status = UiDevice.getInstance().pressHome();
+
+        // Press home button and returns true if successfully.
+        return getSuccessResult(status);
+    }
+}

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -919,6 +919,10 @@ exports.localScreenshot = function(req, res) {
   }
 };
 
+exports.home = function(req, res) {
+      req.device.home(getResponseHandler(req, res));
+};
+
 exports.notYetImplemented = notYetImplemented;
 var mobileCmdMap = {
   'tap': exports.mobileTap
@@ -955,6 +959,7 @@ var mobileCmdMap = {
   , 'pinchOpen': exports.mobilePinchOpen
   , 'localScreenshot': exports.localScreenshot
   , 'getStrings': exports.getStrings
+  , 'home': exports.home
 };
 
 exports.produceError = function(req, res) {


### PR DESCRIPTION
The Android UiDevice has method to press the Home button. To support this a new mobile command is added 'home'.

For Java binding, the client code will be...

((JavascriptExecutor)driver).executeScript("mobile: home");

This same functionality can also be achieved with the following client code but the above looks much cleaner.

HashMap<String, Integer> keycode = new HashMap<String, Integer>();
keycode.put("keycode", 3);
((JavascriptExecutor)driver).executeScript("mobile: keyevent", keycode);
