### PR TITLE
iOS logs like "adb logcat" for simulator and real device

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,6 +71,7 @@ module.exports = function(grunt) {
         reporter: 'spec'
       }
     }
+    , maxBuffer: 2000*1024,
   });
 
   grunt.loadNpmTasks('grunt-mocha-test');

--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -14,6 +14,7 @@ var logTypesSupported = {
   'logcat' : 'Logs for Android applications, both emulator and real device'
   , 'idevice' : 'Logs for iOS applications on real device'
   , 'isimulator' : 'Logs for iOS applications on simulator'
+  , 'ideviceinfo' : ''
 }
 
 exports.respond = function(response, cb) {
@@ -248,6 +249,7 @@ exports.getLog = function(logType, cb) {
   }
   var logs;
   // Check that current logType and instance is compartible
+  // Android device and emulators
   if (logType == 'logcat' && this.hasOwnProperty('adb')) {
     try {
       logs = this.adb.getLogcatLogs();
@@ -255,9 +257,10 @@ exports.getLog = function(logType, cb) {
       return cb(e);
     }  
   }
-  if (logType == ('idevice' || 'isimulator') && this.hasOwnProperty('deviceType')) {
+  // iOS device and simulators
+  if (this.hasOwnProperty('deviceType')) {
     try {
-      logs = this.getDeviceLogs();
+      logs = this.getDeviceLogs(logType);
     } catch (e) {
       return cb(e);
     }  
@@ -278,13 +281,6 @@ exports.getLog = function(logType, cb) {
 };
 
 exports.getLogTypes = function(cb) {
-  return cb(null, {
-    status: status.codes.Success.code
-    , value: logTypesSupported
-  });
-};
-
-exports.getDeviceInfo = function(cb) {
   return cb(null, {
     status: status.codes.Success.code
     , value: logTypesSupported

--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -10,6 +10,11 @@ var errors = require('../server/errors.js')
 var UnknownError = errors.UnknownError
   , ProtocolError = errors.ProtocolError;
 
+var logTypesSupported = {
+  'logcat' : 'Logs for Android applications, both emulator and real device'
+  , 'idevice' : 'Logs for iOS applications on real device'
+  , 'isimulator' : 'Logs for iOS applications on simulator'
+}
 
 exports.respond = function(response, cb) {
   if (typeof response === 'undefined') {
@@ -234,27 +239,48 @@ exports.convertElementForAtoms = function(args, cb) {
 };
 
 exports.getLog = function(logType, cb) {
-  // go ahead and respond with 'logcat' type no matter what they send in
-  if (logType !== 'logcat') {
-    logger.warn("Trying to get log type of " + logType + ", giving logcat " +
-                "instead");
+  // Check if passed logType is supported
+  if (!logTypesSupported.hasOwnProperty(logType)) {
+    cb(null, {
+      status: status.codes.UnknownError.code
+      , value: "Unsupported log type '" + logType + "', supported types : " + JSON.stringify(logTypesSupported)
+    });
   }
   var logs;
-  try {
-    logs = this.adb.getLogcatLogs();
-  } catch (e) {
-    return cb(e);
+  // Check that current logType and instance is compartible
+  if (logType == 'logcat' && this.hasOwnProperty('adb')) {
+    try {
+      logs = this.adb.getLogcatLogs();
+    } catch (e) {
+      return cb(e);
+    }  
   }
-  cb(null, {
-    status: status.codes.Success.code
-    , value: logs
-  });
+  if (logType == ('idevice' || 'isimulator') && this.hasOwnProperty('deviceType')) {
+    try {
+      logs = this.getDeviceLogs();
+    } catch (e) {
+      return cb(e);
+    }  
+  }
+  // If logs captured sucessfully send response with data, else send error
+  if (logs) {
+    cb(null, {
+      status: status.codes.Success.code
+      , value: logs
+    });
+  }
+  else {
+    cb(null, {
+      status: status.codes.UnknownError.code
+      , value: "Incompartible logType for this device"
+    });  
+  }
 };
 
 exports.getLogTypes = function(cb) {
   return cb(null, {
     status: status.codes.Success.code
-    , value: ['logcat']
+    , value: logTypesSupported
   });
 };
 

--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -14,7 +14,6 @@ var logTypesSupported = {
   'logcat' : 'Logs for Android applications, both emulator and real device'
   , 'idevice' : 'Logs for iOS applications on real device'
   , 'isimulator' : 'Logs for iOS applications on simulator'
-  , 'ideviceinfo' : ''
 }
 
 exports.respond = function(response, cb) {

--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -284,3 +284,10 @@ exports.getLogTypes = function(cb) {
   });
 };
 
+exports.getDeviceInfo = function(cb) {
+  return cb(null, {
+    status: status.codes.Success.code
+    , value: logTypesSupported
+  });
+};
+

--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -10,14 +10,15 @@ var IosLog = function(opts) {
   this.debug = opts.debug;
   this.debugTrace = opts.debugTrace;
   this.proc = null;
-  this.onLogcatStart = null;
-  this.logcatStarted = false;
+  this.onIosLogStart = null;
+  this.iosLogStarted = false;
   this.calledBack = false;
   this.logs = [];
+  this.logRow;
 };
 
 IosLog.prototype.startCapture = function(cb) {
-  this.onLogcatStart = cb;
+  this.onIosLogStart = cb;
   logger.info("Starting idevicesyslog capture");
   // Select cmd for log capture
   if (this.udid) {
@@ -54,7 +55,7 @@ IosLog.prototype.onStderr = function(data) {
     logger.error('iOS log capture process failed to start');
     if (!this.calledBack) {
       this.calledBack = true;
-      this.onLogcatStart(new Error("iOS log capture process failed to start"));
+      this.onIosLogStart(new Error("iOS log capture process failed to start"));
       return;
     }
   }
@@ -62,17 +63,16 @@ IosLog.prototype.onStderr = function(data) {
 };
 
 IosLog.prototype.onOutput = function(data, prefix) {
-  if (!this.logcatStarted) {
-    this.logcatStarted = true;
+  if (!this.iosLogStarted) {
+    this.iosLogStarted = true;
     if (!this.calledBack) {
       this.calledBack = true;
-      this.onLogcatStart();
+      this.onIosLogStart();
     }
   }
-  //console.log(data);
-  data = data.trim();
-  data = data.replace(/\r\n/g, "\n");
-  var logs = data.split("\n");
+  // Idevicesyslogs return strange log string, it will be concatenated 
+  this.logRow += data
+  var logs = this.logRow.split("\n");
   _.each(logs, function(log) {
     log = log.trim();
     if (log) {

--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -1,0 +1,98 @@
+"use strict";
+
+var spawn = require('win-spawn')
+  , through = require('through')
+  , _ = require('underscore')
+  , logger = require('../../server/logger.js').get('appium');
+
+var IosLog = function(opts) {
+  this.udid = opts.udid;
+  this.debug = opts.debug;
+  this.debugTrace = opts.debugTrace;
+  this.proc = null;
+  this.onLogcatStart = null;
+  this.logcatStarted = false;
+  this.calledBack = false;
+  this.logs = [];
+};
+
+IosLog.prototype.startCapture = function(cb) {
+  this.onLogcatStart = cb;
+  logger.info("Starting idevicesyslog capture");
+  // Select cmd for log capture
+  if (this.udid) {
+    this.proc = spawn("idevicesyslog", ["-u", this.udid]);
+  }
+  else {
+    this.proc = spawn("tail", ["-f", "/var/log/system.log"]);
+  }
+  this.proc.stdout.setEncoding('utf8');
+  this.proc.stderr.setEncoding('utf8');
+  this.proc.on('error', function(err) {
+    logger.error('iOS log capture failed: ' + err.message);
+    if (!this.calledBack) {
+      this.calledBack = true;
+      cb(err);
+    }
+  }.bind(this));
+  this.proc.stdout.pipe(through(this.onStdout.bind(this)));
+  this.proc.stderr.pipe(through(this.onStderr.bind(this)));
+};
+
+IosLog.prototype.stopCapture = function() {
+  logger.info("Stopping iOS log capture");
+  this.proc.kill();
+  this.proc = null;
+};
+
+IosLog.prototype.onStdout = function(data) {
+  this.onOutput(data, '');
+};
+
+IosLog.prototype.onStderr = function(data) {
+  if (/execvp\(\)/.test(data)) {
+    logger.error('iOS log capture process failed to start');
+    if (!this.calledBack) {
+      this.calledBack = true;
+      this.onLogcatStart(new Error("iOS log capture process failed to start"));
+      return;
+    }
+  }
+  this.onOutput(data, ' STDERR');
+};
+
+IosLog.prototype.onOutput = function(data, prefix) {
+  if (!this.logcatStarted) {
+    this.logcatStarted = true;
+    if (!this.calledBack) {
+      this.calledBack = true;
+      this.onLogcatStart();
+    }
+  }
+  //console.log(data);
+  data = data.trim();
+  data = data.replace(/\r\n/g, "\n");
+  var logs = data.split("\n");
+  _.each(logs, function(log) {
+    log = log.trim();
+    if (log) {
+      this.logs.push({
+        timestamp: Date.now()
+        , level: 'ALL'
+        , message: log
+      });
+      var isTrace = /W\/Trace/.test(data);
+      if (this.debug && (!isTrace || this.debugTrace)) {
+        logger.debug('[IOS_LOG_CAPTURE' + prefix + '] ' + log);
+      }
+    }
+  }.bind(this));
+};
+
+IosLog.prototype.getLogs = function() {
+  return this.logs;
+};
+
+module.exports = function(opts) {
+  return new IosLog(opts);
+};

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -2284,12 +2284,12 @@ IOS.prototype.getDeviceLogs = function() {
   return this.iosLogs.getLogs();
 };
 
-IOS.prototype.getSimulatorLogs = function() {
-  return this.iosLogs.getLogs();
-};
-
 IOS.prototype.getLog = deviceCommon.getLog;
 IOS.prototype.getLogTypes = deviceCommon.getLogTypes;
+
+IOS.prototype.getDeviceInfo = function() {
+  return this.iosLogs.getDeviceInfo();
+};
 
 IOS.prototype.isAppInstalled = function(bundleId, cb) {
   if (this.udid) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -20,6 +20,7 @@ var path = require('path')
   , wkrd = require('./webkit-remote-debugger.js')
   , errors = require('../../server/errors.js')
   , deviceCommon = require('../common.js')
+  , IosLog = require('./ios-log.js')
   , status = require("../../server/status.js")
   , IDevice = require('node-idevice')
   , async = require('async')
@@ -45,6 +46,7 @@ var IOS = function(args) {
   this.automationTraceTemplatePath = args.automationTraceTemplatePath;
   this.removeTraceDir = args.removeTraceDir;
   this.deviceType = args.deviceType;
+  this.iosLogs = null;
   this.startingOrientation = args.startingOrientation || "PORTRAIT";
   this.curOrientation = this.startingOrientation;
   this.instruments = null;
@@ -202,6 +204,7 @@ IOS.prototype.start = function(cb, onDie) {
     function (cb) { this.parseLocalizableStrings(cb); }.bind(this),
     function (cb) { this.setDeviceType(cb); }.bind(this),
     function (cb) { this.installToRealDevice(cb); }.bind(this),
+    function (cb) { this.startLogCapture(cb); }.bind(this),
     function (cb) { createInstruments(); cb(); }.bind(this)
   ], function() {});
 };
@@ -308,7 +311,11 @@ IOS.prototype.onInstrumentsExit = function(code, traceDir, launchCb) {
     }
   }.bind(this);
 
-  async.series([removeTraceDir, cleanup], function() {});
+  if (this.iosLogs !== null) {
+    this.iosLogs.stopCapture();
+  }
+
+  async.series([this.stopLogCapture, removeTraceDir, cleanup], function() {});
 
 };
 
@@ -2260,13 +2267,29 @@ IOS.prototype.getCurrentActivity= function(cb) {
   cb(new NotYetImplementedError(), null);
 };
 
-IOS.prototype.getLogs = function(logType, cb) {
-  cb(new NotYetImplementedError(), null);
+IOS.prototype.startLogCapture = function(cb) {
+  if (this.iosLogs !== null) {
+    cb(new Error("Trying to start iOS log capture but it's already started!"));
+    return;
+  }
+  this.iosLogs = new IosLog({
+    udid: this.udid
+    , debug: true
+    , debugTrace: true
+  });
+  this.iosLogs.startCapture(cb);
 };
 
-IOS.prototype.getLogTypes = function(cb) {
-  cb(new NotYetImplementedError(), null);
+IOS.prototype.getDeviceLogs = function() {
+  return this.iosLogs.getLogs();
 };
+
+IOS.prototype.getSimulatorLogs = function() {
+  return this.iosLogs.getLogs();
+};
+
+IOS.prototype.getLog = deviceCommon.getLog;
+IOS.prototype.getLogTypes = deviceCommon.getLogTypes;
 
 IOS.prototype.isAppInstalled = function(bundleId, cb) {
   if (this.udid) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -2274,22 +2274,19 @@ IOS.prototype.startLogCapture = function(cb) {
   }
   this.iosLogs = new IosLog({
     udid: this.udid
-    , debug: true
-    , debugTrace: true
+    , debug: false
+    , debugTrace: false
   });
   this.iosLogs.startCapture(cb);
 };
 
-IOS.prototype.getDeviceLogs = function() {
+IOS.prototype.getDeviceLogs = function(logType) {
   return this.iosLogs.getLogs();
 };
 
 IOS.prototype.getLog = deviceCommon.getLog;
-IOS.prototype.getLogTypes = deviceCommon.getLogTypes;
 
-IOS.prototype.getDeviceInfo = function() {
-  return this.iosLogs.getDeviceInfo();
-};
+IOS.prototype.getLogTypes = deviceCommon.getLogTypes;
 
 IOS.prototype.isAppInstalled = function(bundleId, cb) {
   if (this.udid) {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -901,6 +901,10 @@ exports.getLogTypes = function(req, res) {
   req.device.getLogTypes(getResponseHandler(req, res));
 };
 
+exports.getDeviceInfo = function(req, res) {
+  req.device.getDeviceInfo(getResponseHandler(req, res));
+};
+
 exports.getStrings = function(req, res) {
   req.device.getStrings(getResponseHandler(req, res));
 };

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -901,10 +901,6 @@ exports.getLogTypes = function(req, res) {
   req.device.getLogTypes(getResponseHandler(req, res));
 };
 
-exports.getDeviceInfo = function(req, res) {
-  req.device.getDeviceInfo(getResponseHandler(req, res));
-};
-
 exports.getStrings = function(req, res) {
   req.device.getStrings(getResponseHandler(req, res));
 };

--- a/reset.sh
+++ b/reset.sh
@@ -146,9 +146,19 @@ reset_ios() {
     run_cmd rm -rf build/SafariLauncher
     run_cmd mkdir -p build/SafariLauncher
     run_cmd zip -r build/SafariLauncher/SafariLauncher submodules/SafariLauncher/build/Release-iphoneos/SafariLauncher.app
-    #echo "* Cloning/updating libimobiledevice-macosx"
-    #run_cmd git clone https://github.com/benvium/libimobiledevice-macosx.git 
-
+    echo "* Cloning/updating libimobiledevice-macosx"
+    if [ -d "build/libimobiledevice-macosx" ]; then
+        run_cmd rm -r build/libimobiledevice-macosx
+    fi
+    run_cmd git clone https://github.com/benvium/libimobiledevice-macosx.git build/libimobiledevice-macosx
+    USER_HOME=$(eval echo ~${SUDO_USER})
+    echo "* Configuring environment variable for libimobiledevice-macosx (DYLD_LIBRARY_PATH and PATH)"
+    if [ ! -f "${USER_HOME}/.bashrc" ]  || ! grep -q "build/libimobiledevice-macosx" "${USER_HOME}/.bashrc"
+    then
+        echo "export DYLD_LIBRARY_PATH=${PWD}/build/libimobiledevice-macosx/:$DYLD_LIBRARY_PATH" >> ${USER_HOME}/.bashrc
+        echo "export PATH=${PATH}:${PWD}/build/libimobiledevice-macosx/" >> ${USER_HOME}/.bashrc
+        source ${USER_HOME}/.bashrc
+    fi
 }
 
 get_apidemos() {

--- a/reset.sh
+++ b/reset.sh
@@ -146,6 +146,8 @@ reset_ios() {
     run_cmd rm -rf build/SafariLauncher
     run_cmd mkdir -p build/SafariLauncher
     run_cmd zip -r build/SafariLauncher/SafariLauncher submodules/SafariLauncher/build/Release-iphoneos/SafariLauncher.app
+    #echo "* Cloning/updating libimobiledevice-macosx"
+    #run_cmd git clone https://github.com/benvium/libimobiledevice-macosx.git 
 
 }
 


### PR DESCRIPTION
#### Setting up new features

``` sh
./reset.sh --ios --verbose
```
###### Supported log types : logcat, idevice, isimulator

``` python
self.driver.log_types
```
###### iOS logs for simulator

``` python
self.driver.get_log("isimulator")
```
###### iOS logs for real device

``` python
self.driver.get_log("idevice")
```

<br/>
#### Fixed an issue in grunt configuration

maxBuffer increased to 2000*1024 due to problems with "maxBuffer exceeded" for selendroid building 
