### PR TITLE
Support for getClassName() from Android API level 18.

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
@@ -152,6 +152,15 @@ public class AndroidElement {
     return el.getChild(sel);
   }
 
+  public String getClassName() throws UiObjectNotFoundException {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      return el.getClassName();
+    } else {
+      Logger.error("Device does not support API >= 18!");
+      return "";
+    }
+  }
+
   public String getContentDesc() throws UiObjectNotFoundException {
     return el.getContentDescription();
   }
@@ -164,12 +173,14 @@ public class AndroidElement {
       throws UiObjectNotFoundException, NoAttributeFoundException {
     String res = "";
     if (attr.equals("name")) {
-      res = el.getContentDescription();
+      res = getContentDesc();
       if (res.equals("")) {
-        res = el.getText();
+        res = getText();
       }
     } else if (attr.equals("text")) {
-      res = el.getText();
+      res = getText();
+    } else if (attr.equals("className")) {
+      res = getClassName();
     } else {
       throw new NoAttributeFoundException(attr);
     }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
@@ -40,7 +40,8 @@ public class GetAttribute extends CommandHandler {
       try {
         final AndroidElement el = command.getElement();
         final String attr = params.get("attribute").toString();
-        if (attr.equals("name") || attr.equals("text")) {
+        if (attr.equals("name") || attr.equals("text")
+            || attr.equals("className")) {
           return getSuccessResult(el.getStringAttribute(attr));
         } else {
           return getSuccessResult(String.valueOf(el.getBoolAttribute(attr)));


### PR DESCRIPTION
Support for [getClassName] (http://developer.android.com/tools/help/uiautomator/UiObject.html#getClassName(\)) on Android. See #923.
