### PR TITLE
Safari launcher integration with simulator and physical devices

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,4 +24,4 @@
 	url = https://github.com/appium/unlock_apk.git
 [submodule "submodules/SafariLauncher"]
 	path = submodules/SafariLauncher
-	url = https://github.com/budhash/SafariLauncher.git
+	url = https://github.com/snevesbarros/SafariLauncher.git

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -242,7 +242,18 @@ Appium.prototype.configureApp = function(desiredCaps, hasAppInCaps, cb) {
   } else if (appPath.substring(0, 4) === "http") {
     this.configureDownloadedApp(appPath, origin, cb);
   } else if (this.isIos() && appPath.toLowerCase() === "safari") {
-    this.configureSafari(desiredCaps, cb);
+    if (this.args.udid) {
+      this.desiredCapabilities.safari = true;
+      this.configureLocalApp("./build/SafariLauncher/SafariLauncher.zip", origin, cb);
+    } else {
+      if (parseFloat(this.desiredCapabilities.version) >= 7) {
+        this.configureSafariForLauncher(desiredCaps, function() {
+          this.configureLocalApp("./build/SafariLauncher/SafariLauncherSim.zip", origin, cb);
+        }.bind(this));
+      } else {
+        this.configureSafari(desiredCaps, cb);
+      }
+    }
   } else if (this.isIos() && isPackageOrBundle) {
     // we have a bundle ID
     logger.info("App is an iOS bundle, will attempt to run as pre-existing");
@@ -387,6 +398,25 @@ Appium.prototype.configureSafari = function(desiredCaps, cb) {
   }.bind(this));
 };
 
+Appium.prototype.configureSafariForLauncher = function (desiredCaps, cb) {
+  this.desiredCapabilities.safari = true;
+  var safariVer = "6.1";
+  var usingDefaultVer = true;
+  if (typeof desiredCaps.version !== "undefined") {
+    safariVer = desiredCaps.version;
+    usingDefaultVer = false;
+  }
+
+  cleanSafari(safariVer, function(err) {
+    if (err) {
+      logger.error(err.message);
+      cb(err);
+    } else {
+      cb(null);
+    }
+  });
+};
+
 Appium.prototype.configureChromeAndroid = function() {
   this.deviceType = "android";
   this.args.androidPackage = "com.android.chrome";
@@ -451,7 +481,11 @@ Appium.prototype.invoke = function(cb) {
                     (this.commandTimeoutMs / 1000) + "secs)");
         this.resetTimeout();
         cb(null, this.device);
-      }.bind(this), this.cleanupSession.bind(this));
+      }.bind(this), function() {
+        if (!this.isSafariLauncherApp) {
+          this.cleanupSession.bind(this);
+        }
+      });
     }
 
   } else {
@@ -617,11 +651,15 @@ Appium.prototype.stop = function(cb) {
 
   logger.info('Shutting down appium session...');
   if (this.device.isSafariLauncherApp === true) {
-    this.device.stopRemote();
-    if (this.device.udid === null){
-      this.device.instruments.shutdown();
-    }
-    this.cleanupSession(null, cb);
+    this.device.leaveWebView(function() {
+      if (this.device.udid === null) {
+        this.device.instruments.shutdown(function() {
+          this.cleanupSession(null, cb);
+        }.bind(this));
+       } else {
+         this.cleanupSession(null, cb);
+       }
+    }.bind(this));
   } else {
     this.device.stop(function(code) {
       var err;

--- a/lib/devices/ios/instruments.js
+++ b/lib/devices/ios/instruments.js
@@ -32,6 +32,7 @@ var Instruments = function(opts) {
   this.hasConnected = false;
   this.traceDir = null;
   this.proc = null;
+  this.killProcessCb = null;
   this.debugMode = false;
   this.onReceiveCommand = null;
   this.guid = uuid.create();
@@ -65,17 +66,12 @@ Instruments.prototype.start = function(readyCb, exitCb) {
     if (this.proc !== null) {
       this.proc.kill('SIGTERM');
     }
+
     this.exitHandler(1);
   };
 
-  // for safari launcher app we simply let the socket timeout and catch it.
-  var socketConnectTimeout = null;
-  if (this.isSafariLauncherApp) {
-    socketConnectTimeout = setTimeout(onSocketNeverConnect.bind(this), 8000);
-  } else {
-    socketConnectTimeout = setTimeout(onSocketNeverConnect.bind(this),
+  var socketConnectTimeout = setTimeout(onSocketNeverConnect.bind(this),
         this.launchTimeout);
-  }
 
   this.socketServer = net.createServer({allowHalfOpen: true}, function(conn) {
     if (!this.hasConnected) {
@@ -166,6 +162,10 @@ Instruments.prototype.launch = function() {
 
       self.proc.on('exit', function(code) {
         self.debug("Instruments exited with code " + code);
+        if (self.killProcessCb !== null) {
+          self.killProcessCb();
+          self.killProcessCb = null;
+        }
         if (self.isSafariLauncherApp){
           self.readyHandler();
         }
@@ -278,8 +278,9 @@ Instruments.prototype.sendCommand = function(cmd, cb) {
 
 /* PROCESS MANAGEMENT */
 
-Instruments.prototype.shutdown = function() {
+Instruments.prototype.shutdown = function(cb) {
   this.proc.kill();
+  this.killProcessCb = cb;
 };
 
 Instruments.prototype.doExit = function() {

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1127,7 +1127,6 @@ iOSController.getWindowHandles = function(cb) {
 };
 
 iOSController.setWindow = function(name, cb) {
-  var me = this;
   if (_.contains(_.pluck(this.windowHandleCache, 'id'), name)) {
     var pageIdKey = parseInt(name, 10);
     var next = function() {
@@ -1150,14 +1149,14 @@ iOSController.setWindow = function(name, cb) {
           });
         } else if (_.contains(_.pluck(this.windowHandleCache, 'id'), name)) {
           this.remote.disconnect(function(){
-            me.curWindowHandle = name;
-            me.remote.connect(name, function(){
+            this.curWindowHandle = name;
+            this.remote.connect(name, function() {
               cb(null, {
                 status: status.codes.Success.code
                 , value: name
               });
             });
-          });
+          }.bind(this));
         } else {
           cb(null, {
             status: status.codes.NoSuchWindow.code

--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -10,7 +10,13 @@ var iOSHybrid = {};
 
 iOSHybrid.navToInitialWebview = function(cb) {
   if (this.autoWebview) {
-    this.navToFirstAvailWebview(cb);
+    if (this.isSafariLauncherApp) {
+      setTimeout(function() {
+        this.navToFirstAvailWebview(cb);
+      }.bind(this), 6000);
+    } else {
+      this.navToFirstAvailWebview(cb);
+    }
   } else {
     cb();
   }
@@ -201,7 +207,12 @@ iOSHybrid.stopRemote = function() {
     logger.error("We don't appear to be in a web frame");
     throw new Error("Tried to leave a web frame but weren't in one");
   } else {
-    this.remote.disconnect();
+    //should probably add a callback to both debuggers.
+    if (this.udid) {
+      this.remote.disconnect(function(){});
+    } else {
+      this.remote.disconnect();
+    }
     this.curWindowHandle = null;
     this.curWebFrames = [];
     this.curWebCoords = null;

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -188,19 +188,29 @@ IOS.prototype.start = function(cb, onDie) {
   // createInstruments takes care of calling our launch callback,
   // so we don't do that in the series here
   async.series([
-    this.cleanup.bind(this),
-    this.setXcodeVersion.bind(this),
-    this.detectTraceTemplate.bind(this),
-    this.detectUdid.bind(this),
-    this.parseLocalizableStrings.bind(this),
-    this.setDeviceType.bind(this),
-    this.installToRealDevice.bind(this),
-    function(cb) { createInstruments(); cb(); }.bind(this)
-  ], function(err) {
-    if (err) {
-      cb(err);
-    }
-  });
+    function (cb) { this.cleanup(cb); }.bind(this),
+    function (cb) { this.setXcodeVersion(cb); }.bind(this),
+    function (cb) { this.detectTraceTemplate(cb); }.bind(this),
+    function (cb) { this.detectUdid(cb); }.bind(this),
+    function (cb) { this.parseLocalizableStrings(cb); }.bind(this),
+    function (cb) { this.setDeviceType(cb); }.bind(this),
+    function (cb) { this.installToRealDevice(cb); }.bind(this),
+    function (cb) {
+      if (this.isSafariLauncherApp && this.udid) {
+        this.isAppInstalled("com.bytearc.SafariLauncher", function(error, stdout){
+          if (error !== null) {
+            this.installApp(this.app, cb);
+          } else {
+            cb();
+          }
+        }.bind(this));
+      } else {
+        cb();
+      }
+    }.bind(this),
+    function (cb) { createInstruments(); cb(); }.bind(this),
+    function (cb) { this.navToInitialWebview(cb);}.bind(this)
+  ], function() {});
 };
 
 IOS.prototype.onInstrumentsLaunch = function(launchCb) {
@@ -208,15 +218,25 @@ IOS.prototype.onInstrumentsLaunch = function(launchCb) {
   logger.info('Instruments launched. Starting poll loop for new commands.');
   this.instruments.setDebug(true);
 
-  async.series([
-    this.setBundleId.bind(this),
-    this.setInitialOrientation.bind(this),
-    this.navToInitialWebview.bind(this)
-  ], function(err) {
-    if (err) return launchCb(err);
-    launchCb();
-  });
-
+  if (this.isSafariLauncherApp) {
+    if (!this.udid){
+      this.bundleId = "com.apple.mobilesafari";
+      this.navToInitialWebview(function(){
+        launchCb();
+      });
+    } else {
+      launchCb();
+    }
+  } else {
+    async.series([
+      this.setBundleId.bind(this),
+      this.setInitialOrientation.bind(this),
+      this.navToInitialWebview.bind(this)
+    ], function(err) {
+      if (err) return launchCb(err);
+      launchCb();
+    });
+  }
 };
 
 IOS.prototype.setBundleId = function(cb) {
@@ -570,7 +590,7 @@ IOS.prototype.stop = function(cb) {
     }
 
     this.stopping = true;
-    this.instruments.shutdown();
+    this.instruments.shutdown(function(){});
     this.queue = [];
     this.progress = 0;
   }


### PR DESCRIPTION
<b>This pull request:</b>
1. <b>Automatically builds the SafariLauncher</b> for Simulator (and for iOS devices when --launcher is added to reset.sh call)
2. It <b>automatically connects to webview</b> and calls leave webview when closing the browser (so no need to do that in the test.
3. I have <b>changed the reference for SafariLauncher repository</b> as there was no response to a pull request to change the default time to 2 seconds.
4. It <b>checks if the app is installed on physical device and installs it if not</b>.

<b>NOTE:</b> With simulator it opens a new tab every time (which i cannot seem to close). Any suggestions welcome. I am calling the configureSafari method to clean the local simulator directory. For physical devices this is not the case as it uses the current tab.

<b>NOTE:</b> I have not had time to verify if the changes affect Native App testing so please review thoroughly :).
