### PR TITLE
(Android) Don't uninstall the app on fast reset.

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -420,7 +420,7 @@ ADB.prototype.getDevicesWithRetry = function(timeoutMs, cb) {
       } else {
         cb(null, devices);
       }
-    });
+    }.bind(this));
   }.bind(this);
   getDevices();
 };

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -24,7 +24,7 @@ var Android = function(opts) {
 
 Android.prototype.initialize = function(opts) {
   this.compressXml = opts.compressXml;
-  this.skipUninstall = opts.skipUninstall;
+  this.skipUninstall = opts.fastReset;
   this.rest = opts.rest;
   this.webSocket = opts.webSocket;
   opts.systemPort = opts.systemPort || 4724;

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -82,7 +82,7 @@ var args = [
     , action: 'storeTrue'
     , required: false
     , help: '(Android-only) Reset app state by uninstalling app instead of ' +
-            'using clean.apk'
+            'clearing app data'
     , nargs: 0
   }],
 


### PR DESCRIPTION
After the recent refactorings, skipUninstall is not initialized anymore  which resulted in the app being uninstalled/installed by default (fast reset).
