### PR TITLE
Shell compatibility w/ test.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,8 @@ Now you are ready to run the Appium server via `node .`.
 Since Appium uses dev versions of some packages, it often becomes necessary to
 install new `npm` packages or update various things. There's a handy shell script
 to do all this for all platforms (the `--dev` flag gets dev npm dependencies
-and test applications used in the Appium test suite):
+and test applications used in the Appium test suite). You will also need to do
+this when Appium bumps its version up:
 
     ./reset.sh --dev
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Gecko-based platforms.
 
 ## Contributing
 
-Please take a look at our [contribution documentation](https://github.com/appium/appium/blob/master/CONTRIBUTING.md).
+Please take a look at our [contribution documentation](https://github.com/appium/appium/blob/master/CONTRIBUTING.md)
+for instructions on how to build, test and run Appium from source.
 
 ## Project Credits & Inspiration
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -5,10 +5,13 @@ ios_only=false
 ios7_only=false
 android_only=false
 all_tests=true
-xcode_path="$(xcode-select -print-path | sed s/\\/Contents\\/Developer//g)"
+xcode_path=""
+if command -v xcode-select 2>/dev/null; then
+    xcode_path="$(xcode-select -print-path | sed s/\\/Contents\\/Developer//g)"
+fi
 did_switch_xcode=false
 
-function join_testfiles {
+join_testfiles () {
     testtype=$1
     shift
     outfile=$1
@@ -32,16 +35,16 @@ function join_testfiles {
 }
 
 for arg in "$@"; do
-    if [[ "$arg" = "--ios" ]]; then
+    if [ "$arg" = "--ios" ]; then
         ios_only=true
         all_tests=false
-    elif [[ "$arg" = "--android" ]]; then
+    elif [ "$arg" = "--android" ]; then
         android_only=true
         all_tests=false
-    elif [[ "$arg" = "--ios7" ]]; then
+    elif [ "$arg" = "--ios7" ]; then
         ios7_only=true
         all_tests=false
-    elif [[ "$arg" =~ " " ]]; then
+    elif [ "$arg" =~ " " ]; then
         mocha_args="$mocha_args \"$arg\""
     else
         mocha_args="$mocha_args $arg"


### PR DESCRIPTION
Made test.sh compatible with non-bash and non-mac environments (no expectation of `xcode-select` to exist). Small documentation tweaks in readme and contributing doc.
