### PR TITLE
Missing callback parameter causing Appium to crash

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1389,7 +1389,7 @@ iOSController.deleteCookies = function(cb) {
     return cb(new NotImplementedError(), null);
   }
   this.getCookies(function(err, res) {
-    if (this.checkSuccess(err, res)) {
+    if (this.checkSuccess(err, res, cb)) {
       var numCookies = res.value.length;
       var cookies = res.value;
       if (numCookies) {


### PR DESCRIPTION
Reproducible by using this modified spock-example: https://github.com/peterschwarz/spock-example
1. Startup Appium
2. Run `mvn test -Dgeb.env=remote_ios` from the Spock example

Expected:  Appium to continue running (even though the above maven build fails)

Actual:

```
error: uncaughtException: undefined is not a function date=Mon Oct 28 2013 12:19:04 GMT-0500 (CDT), pid=43748, uid=501, gid=20, cwd=/Users/pschwarz/Development/opensource/appium, execPath=/usr/local/Cellar/node/0.10.21/bin/node, version=v0.10.21, argv=[node, /Users/pschwarz/Development/opensource/appium/bin/appium.js], rss=54325248, heapTotal=34223104, heapUsed=18983808, loadavg=[2.39794921875, 1.591796875, 1.38720703125], uptime=341809, trace=[column=5, file=/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js, function=iOSController.checkSuccess, line=1220, method=checkSuccess, native=false, column=14, file=/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js, function=, line=1392, method=null, native=false, column=5, file=/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js, function=iOSController.checkSuccess, line=1220, method=checkSuccess, native=false, column=14, file=/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js, function=, line=1334, method=null, native=false, column=7, file=/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js, function=, line=269, method=null, native=false, column=7, file=/Users/pschwarz/Development/opensource/appium/lib/devices/ios/remote-debugger.js, function=Object.15, line=279, method=15, native=false, column=28, file=/Users/pschwarz/Development/opensource/appium/lib/devices/ios/remote-debugger.js, function=handlers._rpc_applicationSentData:, line=480, method=_rpc_applicationSentData:, native=false, column=30, file=/Users/pschwarz/Development/opensource/appium/lib/devices/ios/remote-debugger.js, function=RemoteDebugger.handleMessage, line=423, method=handleMessage, native=false, column=12, file=/Users/pschwarz/Development/opensource/appium/lib/devices/ios/remote-debugger.js, function=RemoteDebugger.receive, line=637, method=receive, native=false, column=17, file=events.js, function=Socket.EventEmitter.emit, line=95, method=EventEmitter.emit, native=false], stack=[TypeError: undefined is not a function,     
at iOSController.checkSuccess (/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js:1220:5),     
at null.<anonymous> (/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js:1392:14),     
at iOSController.checkSuccess (/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js:1220:5),     
at null.<anonymous> (/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js:1334:14),     
at null.<anonymous> (/Users/pschwarz/Development/opensource/appium/lib/devices/ios/ios-controller.js:269:7),     
at Object.15 (/Users/pschwarz/Development/opensource/appium/lib/devices/ios/remote-debugger.js:279:7),     
at handlers._rpc_applicationSentData: (/Users/pschwarz/Development/opensource/appium/lib/devices/ios/remote-debugger.js:480:28),     
at RemoteDebugger.handleMessage (/Users/pschwarz/Development/opensource/appium/lib/devices/ios/remote-debugger.js:423:30),     
at RemoteDebugger.receive (/Users/pschwarz/Development/opensource/appium/lib/devices/ios/remote-debugger.js:637:12),     
at Socket.EventEmitter.emit (events.js:95:17)]
```

Appium Exists at this point.
