### PR TITLE
Fix for #1364 (unable to build unlock_apk on Windows)

### DIFF
--- a/reset.bat
+++ b/reset.bat
@@ -51,7 +51,7 @@ if %doAndroid% == 1 (
   ECHO.
   ECHO =====Resetting Unlock.apk=====
   ECHO.
-  CALL :runCmd "RD /S /Q build\unlock_apk"
+  CALL :runCmd "RD /S /Q build\unlock_apk | VER > NUL"
   CALL :runCmd "MKDIR build\unlock_apk"
   ECHO Building Unlock.apk
   CALL :runCmd "git submodule update --init submodules\unlock_apk"


### PR DESCRIPTION
With this fix on my Windows 7 system I can run successfully
reset.bat --android
even if build\unlock_apk does not yet exist.
