### PR TITLE
Added ability to select code signing identity (and if required profile).

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -108,8 +108,8 @@ module.exports = function(grunt) {
   grunt.registerTask('buildApp', "Build the test app", function(appDir, sdk) {
     buildApp(appDir, this.async(), sdk);
   });
-  grunt.registerTask('buildSafariLauncherApp', "Build the SafariLauncher app", function(sdk) {
-    buildSafariLauncherApp(this.async(), sdk);
+  grunt.registerTask('buildSafariLauncherApp', "Build the SafariLauncher app", function(sdk, xcconfig) {
+    buildSafariLauncherApp(this.async(), sdk, xcconfig);
   });
   grunt.registerTask('signApp', "Sign the test app", function(certName) {
     signApp("TestApp", certName, this.async());

--- a/grunt-helpers.js
+++ b/grunt-helpers.js
@@ -234,7 +234,7 @@ module.exports.authorize = function(grunt, cb) {
   });
 };
 
-module.exports.build = function(appRoot, cb, sdk) {
+module.exports.build = function(appRoot, cb, sdk, xcconfig) {
   var next = function() {
     var cmd = 'xcodebuild -sdk ' + sdk + ' clean';
     console.log('Using sdk: ' + sdk + '...');
@@ -246,6 +246,9 @@ module.exports.build = function(appRoot, cb, sdk) {
       }
       console.log("Building app...");
       var args = ['-sdk', sdk];
+      if (typeof xcconfig !== "undefined") {
+        args = args.concat(['-xcconfig', xcconfig]);
+      }
       xcode = spawn('xcodebuild', args, {
         cwd: appRoot
       });
@@ -301,7 +304,7 @@ module.exports.signApp = function(appName, certName, cb) {
   });
 };
 
-module.exports.buildSafariLauncherApp = function(cb, sdk) {
+module.exports.buildSafariLauncherApp = function(cb, sdk, xcconfig) {
   var appRoot = path.resolve(__dirname, "submodules", "SafariLauncher");
   module.exports.build(appRoot, function(err) {
     if (err !== null) {
@@ -310,7 +313,7 @@ module.exports.buildSafariLauncherApp = function(cb, sdk) {
     } else {
       cb(true);
     }
-  }, sdk);
+  }, sdk, xcconfig);
 };
 
 

--- a/reset.sh
+++ b/reset.sh
@@ -28,8 +28,8 @@ do
         "--android") should_reset_android=true;;
         "--ios") should_reset_ios=true;;
         "--real-safari") should_reset_realsafari=true;;
-        "-code-sign") code_sign_identity=$2;;
-        "-profile") provisioning_profile=$2;;
+        "--code-sign") code_sign_identity=$2;;
+        "--profile") provisioning_profile=$2;;
         "--selendroid") should_reset_selendroid=true;;
         "--firefoxos") should_reset_firefoxos=true;;
         "--gappium") should_reset_gappium=true;;
@@ -38,7 +38,12 @@ do
         "--verbose") verbose=true;;
         "--hardcore") hardcore=true;;
     esac
-    shift
+    if [[ $2 != --* ]]; then
+      shift
+      shift
+    else
+      shift
+    fi
 done
 
 if ! $should_reset_android && ! $should_reset_ios && ! $should_reset_selendroid && ! $should_reset_gappium && ! $should_reset_firefoxos ; then

--- a/reset.sh
+++ b/reset.sh
@@ -11,6 +11,8 @@ should_reset_selendroid=false
 should_reset_gappium=false
 should_reset_firefoxos=false
 should_reset_realsafari=false
+code_sign_identity='';
+provisioning_profile='';
 include_dev=false
 appium_home=$(pwd)
 reset_successful=false
@@ -26,6 +28,8 @@ do
         "--android") should_reset_android=true;;
         "--ios") should_reset_ios=true;;
         "--real-safari") should_reset_realsafari=true;;
+        "-code-sign") code_sign_identity=$2;;
+        "-profile") provisioning_profile=$2;;
         "--selendroid") should_reset_selendroid=true;;
         "--firefoxos") should_reset_firefoxos=true;;
         "--gappium") should_reset_gappium=true;;
@@ -158,7 +162,15 @@ reset_ios() {
     run_cmd zip -r build/SafariLauncher/SafariLauncherSim submodules/SafariLauncher/build/Release-iphonesimulator/SafariLauncher.app
     if $should_reset_realsafari; then
         echo "* Building SafariLauncher for real devices"
-        run_cmd $grunt buildSafariLauncherApp:iphoneos
+        run_cmd rm -f submodules/Safarilauncher/target.xcconfig
+        echo "BUNDLE_ID = com.bytearc.SafariLauncher" >> submodules/Safarilauncher/target.xcconfig
+        if [[ ! -z $code_sign_identity ]]; then
+          echo "IDENTITY_NAME = " $code_sign_identity >> submodules/Safarilauncher/target.xcconfig
+        else
+          echo "IDENTITY_NAME = iPhone Developer" >> submodules/Safarilauncher/target.xcconfig
+        fi
+        echo "IDENTITY_CODE = " $provisioning_profile >> submodules/Safarilauncher/target.xcconfig
+        run_cmd $grunt buildSafariLauncherApp:iphoneos:"target.xcconfig"
         echo "* Copying SafariLauncher for real devices to build"
         run_cmd zip -r build/SafariLauncher/SafariLauncher submodules/SafariLauncher/build/Release-iphoneos/SafariLauncher.app
     fi


### PR DESCRIPTION
For the safariLauncher for real devices you can now use the following command to run reset.sh and build safari launcher:

./reset.sh --ios --real-safari --code-sign <b><code sign identity (e.g.  'iPhone Developer')></b>
or 
./reset.sh --ios --real-safari <b>--code-sign <code sign identity>  --profile '<profile (e.g. AAAAA123-BBBB-AAAA-AAAAAAA)>'</b>

if neither are provided then default code sign identity will be set to 'iPhone Developer'. Code sign is mandatory, profile is optional (as it will automatically pick one base on code sign identity).

After this I will look to update the docs related to the Safari Launcher changes.
