### PR TITLE
(Android) Don't uninstall the app when --no-reset is used.

### DIFF
--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -24,7 +24,7 @@ var Android = function(opts) {
 
 Android.prototype.initialize = function(opts) {
   this.compressXml = opts.compressXml;
-  this.skipUninstall = opts.fastReset;
+  this.skipUninstall = opts.fastReset || !opts.reset;
   this.rest = opts.rest;
   this.webSocket = opts.webSocket;
   opts.systemPort = opts.systemPort || 4724;


### PR DESCRIPTION
Should also skip uninstalling if --no-reset is used.
