### PR TITLE
Adding ability to find node under parts/ directory if buildout.cfg exists

### DIFF
--- a/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
+++ b/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
@@ -134,6 +134,25 @@ var nodePath = (function() {
     path = sysExec("echo $NODE_BIN");
     console.log("Found node using $NODE_BIN: " + path);
   } catch(e) {
+    if (fileExists("./buildout.cfg")) {
+      try {
+        path = sysExec('find ./parts -name node -type f');
+        console.log("Found node using `find ./parts -name node -type -f`: " +
+                    path);
+        return path;
+      } catch (e) {
+        // Ideally code should not fall through here & go on to to try
+        // 'which node' because not using buildout to setup your node is the
+        // wrong thing to do. To avoid weird situations where build sometimes
+        // works on your machine but not on others, you have to do everything
+        // in your power to sandbox node within buildout.
+        // - Currently falling through to not break users who rely on using
+        //   Appium.app, /usr/local/bin/node, or /opt/local/bin/node along
+        //   with buildout.
+        console.log("WARN: Found buildout.cfg file, but did not find node " +
+                    "under ./parts directory");
+      }
+    }
     try {
       path = sysExec('which node');
       console.log("Found node using `which node`: " + path);


### PR DESCRIPTION
Having node/npm/appium all sandboxed under a single directory is the ideal situation when using buildout.
This change allows the sandboxed 'node' to be found, not the one in the user's PATH or defaulting to standard node install locations.
