### PR TITLE
Added an option to suppress excessive logging from UIALogger.

### DIFF
--- a/lib/devices/ios/uiauto/lib/console.js
+++ b/lib/devices/ios/uiauto/lib/console.js
@@ -10,9 +10,10 @@ var console = {
       msg = "(null)";
     }
     var newMsg = msg + "\n";
-    for (var i = 0; i < bufLen - msg.length; i++) {
+    for (var i = 0; i < bufLen - msg.length - 1; i++) {
       newMsg += "*";
     }
-    UIALogger.logMessage(newMsg);
+
+    if (typeof isVerbose !== "undefined" && isVerbose) UIALogger.logMessage(newMsg);
   }
 };

--- a/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
+++ b/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
@@ -88,6 +88,8 @@ settings = function() {
   }
 }();
 
+var isVerbose = (typeof settings !== "undefined" && 'verbose' in settings && settings.verbose === 'true');
+
 // get npm-installed instruments_client bin if necessary
 var globalPath = (function() {
   try {

--- a/lib/devices/ios/uiauto/lib/mechanic.js
+++ b/lib/devices/ios/uiauto/lib/mechanic.js
@@ -366,8 +366,10 @@ var $ = $ || mechanic;  // expose $ shortcut
             level = level || 'message';
             if (level === 'error') UIALogger.logError(s);
             else if (level === 'warn') UIALogger.logWarning(s);
-            else if (level === 'debug') UIALogger.logDebug(s);
-            else UIALogger.logMessage(s);
+            else if (isVerbose) {
+                if (level === 'debug') UIALogger.logDebug(s);
+                else UIALogger.logMessage(s);
+            }
         },
         error: function(s) { $.log(s, 'error'); },
         warn: function(s) { $.log(s, 'warn'); },


### PR DESCRIPTION
The code change is aimed to provide an option to suppress excessive logging from UIALogger.  This is done by adding the following key-value pair in file '~/.instruments.conf'

```
  # Suppress excessive logging
  verbose=false
```

As a result, the file size of 'Automation Results.plist' under  folder '/tmp/appium-instruments/Run 1' becomes much smaller after a test run (see attached before and after images).  Another side benefit is that instruments can dump out screenshots quicker to the same folder when we decrease the logging verbosity.  This has helped us to mitigate an issue which we have recently run into, with similar symptoms to issue 253 [https://github.com/appium/appium/issues/253].

![verbose mode](https://f.cloud.github.com/assets/4976735/1494279/d3ed0b5a-47d9-11e3-912c-b3d6734f05d8.png)
![nonverbose mode](https://f.cloud.github.com/assets/4976735/1494283/d89864e2-47d9-11e3-8445-d5233c73d82b.png)
