### PR TITLE
Fix dismissAlert for UICatalog on iOS 7

### DIFF
--- a/lib/devices/ios/uiauto/appium/app.js
+++ b/lib/devices/ios/uiauto/appium/app.js
@@ -474,7 +474,7 @@ $.extend(au, {
       }
     }
 
-  , getElementsByXpath: function(xpath, ctx) {
+  , _getElementsByXpath: function(xpath, ctx) {
       var _ctx = this.mainApp
         , elems = [];
 
@@ -537,8 +537,12 @@ $.extend(au, {
           }
         }
         this.target.popTimeout();
-        return this._returnElems(elems);
+        return elems;
       }
+    }
+
+  , getElementsByXpath: function(xpath, ctx) {
+      return this._returnElems(this._getElementsByXpath(xpath, ctx));
     }
 
   , getElementByXpath: function(xpath, ctx) {
@@ -948,14 +952,14 @@ $.extend(au, {
 
   , dismissAlert: function() {
       var alert = this.mainApp.alert();
-      if (!alert.cancelButton().isNil()) {
+      if (!alert.isNil() && !alert.cancelButton().isNil()) {
         alert.cancelButton().tap();
         this.waitForAlertToClose(alert);
         return {
           status: codes.Success.code,
           value: null
         };
-      } else if (alert.buttons().length > 0) {
+      } else if (!alert.isNil() && alert.buttons().length > 0) {
         alert.buttons()[0].tap(); // first button is dismiss
         this.waitForAlertToClose(alert);
         return {
@@ -963,7 +967,16 @@ $.extend(au, {
           value: null
         };
       } else {
-        return this.acceptAlert();
+        var ios7AlertButtons = this._getElementsByXpath("actionsheet/button");
+        if (ios7AlertButtons.length > 0) {
+          ios7AlertButtons[ios7AlertButtons.length - 1].tap();
+          return {
+            status: codes.Success.code,
+            value: null
+          };
+        } else {
+          return this.acceptAlert();
+        }
       }
     }
 


### PR DESCRIPTION
Fix the dismiss issue from #1437

@jlipps Before I make the same change for accept, what do you think about this approach? To repro the problem:
1. Open UICatalog.app on iOS 7
2. Click Alerts
3. Click Show OK-Cancel
4. Observe all of Appium's alert methods fail
