### PR TITLE
fix for issue 1445.

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -665,7 +665,7 @@ Appium.prototype.stop = function(cb) {
   logger.info('Shutting down appium session...');
   if (this.isSafariLauncherApp === true) {
     this.device.leaveWebView(function() {
-      if (this.device.udid === null) {
+      if (this.device.udid === null && this.device.instruments !== null) {
         this.device.instruments.shutdown(function() {
           this.cleanupSession(null, cb);
         }.bind(this));


### PR DESCRIPTION
Added a check to see if instruments is null.

Without the flag <b>"--native-instruments-lib"</b> we still have an instance of instruments when calling the appium stop function. With the flag in place instruments is null at that point and we don't need to shut it down.

Therefore a simple check did the trick. Ran tests on xcode5 with iOS7 sim with and without flag and both worked fine, although it was much slower with the flag.
