### PR TITLE
Adding UIAMapView as mapView to tag_name selector style on ios;

### DIFF
--- a/lib/devices/ios/uiauto/lib/mechanic.js
+++ b/lib/devices/ios/uiauto/lib/mechanic.js
@@ -60,7 +60,8 @@ var mechanic = (function() {
         'UIAToolbar' : ['toolbar'],
         'UIAWebView' : ['webview'],
         'UIAWindow' : ['window'],
-        'UIANavigationBar': ['navigationBar']
+        'UIANavigationBar': ['navigationBar'],
+        'UIAMapView': ['mapView']
     };
 
     // Build a RegExp for picking out type selectors.


### PR DESCRIPTION
The ios TestApp as a MapView with no IDs, would be nice to have the UIAMapView work with tag_name to allow for better example code;
