### PR TITLE
Make sure there's no color in the console output when --log-no-colors is used.

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -532,6 +532,7 @@ Appium.prototype.initDevice = function() {
       , robotAddress: this.args.robotAddress
       , isSafariLauncherApp: this.isSafariLauncherApp
       , desiredCapabilities: this.desiredCapabilities
+      , logNoColors: this.args.logNoColors
     };
     this.device = ios(iosOpts);
   } else if (this.isAndroid()) {
@@ -556,6 +557,7 @@ Appium.prototype.initDevice = function() {
       , keyPassword: this.args.keyPassword
       , systemPort: this.args.devicePort
       , desiredCapabilities: this.desiredCapabilities
+      , logNoColors: this.args.logNoColors
     };
     if (this.isChrome()) {
       androidOpts.chromium = this.args.chromium;

--- a/lib/devices/android/uiautomator.js
+++ b/lib/devices/android/uiautomator.js
@@ -20,6 +20,7 @@ var UiAutomator = function(adb, opts) {
   this.webSocket = opts.webSocket;
   this.systemPort = opts.systemPort;
   this.resendLastCommand = function() {};
+  this.logNoColors = opts.logNoColors;
 };
 
 UiAutomator.prototype.start = function(readyCb) {
@@ -189,7 +190,11 @@ UiAutomator.prototype.handleBootstrapOutput = function(output) {
         if (line.indexOf("UiAutomationService not connected") !== -1) {
           this.restartBootstrap = true;
         }
-        logger.info(("[UIAUTOMATOR STDOUT] " + line).grey);
+        var log = "[UIAUTOMATOR STDOUT] " + line;
+        if (!this.logNoColors) {
+          log = log.grey;
+        }
+        logger.info(log);
       }
     }
   }, this);

--- a/lib/devices/ios/instruments.js
+++ b/lib/devices/ios/instruments.js
@@ -42,7 +42,7 @@ var Instruments = function(opts) {
     'cmd': this.commandHandler
   };
   this.socketServer = null;
-
+  this.logNoColors = opts.logNoColors;
 };
 
 
@@ -360,7 +360,12 @@ Instruments.prototype.setDebug = function(debug) {
 };
 
 Instruments.prototype.debug = function(msg) {
-  logger.info(("[INSTSERVER] " + msg).grey);
+  var log = "[INSTSERVER] " + msg;
+  if (!this.logNoColors) {
+    log = log.grey;
+  }
+
+  logger.info(log);
 };
 
 

--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -21,11 +21,16 @@ var IosLog = function(opts) {
   this.logs = [];
   this.logRow = "";
   this.logsSinceLastRequest = [];
+  this.logNoColors = opts.logNoColors;
 };
 
 IosLog.prototype.debug = function(msg) {
   if (this.debugMode) {
-    logger.debug(("[IOS_SYSLOG_CAPTURE] " + msg).grey);
+    var log = "[IOS_SYSLOG_CAPTURE] " + msg;
+    if (!this.logNoColors) {
+      log = log.grey;
+    }
+    logger.debug(log);
   }
 };
 

--- a/lib/server/grid-register.js
+++ b/lib/server/grid-register.js
@@ -24,7 +24,7 @@ function registerToGrid(options_post, jsonObject) {
       logger.error("Request to register with grid was Unsuccessful...");
     } else {
       var logMessage = "Appium successfully registered with the grid on " + jsonObject.configuration.hubHost + ":" + jsonObject.configuration.hubPort;
-      logger.info(logMessage.cyan);
+      logger.info(logMessage);
     }
   });
 }

--- a/lib/server/logger.js
+++ b/lib/server/logger.js
@@ -22,7 +22,7 @@ var logger = null;
 
 module.exports.init = function(args) {
   var options = _.extend(defaults, {
-    colorize: !args.logNoColor
+    colorize: !args.logNoColors
     , timestamp: args.logTimestamp
   });
 

--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -23,7 +23,8 @@ var http = require('http')
   , async = require('async')
   , _ = require("underscore")
   , io = require('socket.io')
-  , gridRegister = require('./grid-register.js');
+  , gridRegister = require('./grid-register.js')
+  , bytes = require('bytes');
 
 var allowCrossDomain = function(req, res, next) {
   res.header('Access-Control-Allow-Origin', '*');
@@ -91,7 +92,19 @@ var main = function(args, readyCb, doneCb) {
     rest.use(express.static(path.join(__dirname, 'static')));
     rest.use(allowCrossDomain);
     if (!args.quiet) {
-      rest.use(express.logger('dev'));
+      if (args.logNoColors) {
+        var devNoColor = function(tokens, req, res){
+          var status = res.statusCode
+          , len = parseInt(res.getHeader('Content-Length'), 10);
+
+          len = isNaN(len) ? '' : ' - ' + bytes(len);
+          return req.method + ' ' + req.originalUrl + ' ' +
+            res.statusCode + ' '+ (new Date() - req._startTime) + 'ms' + len;
+        };
+        rest.use(express.logger(devNoColor));
+      } else {
+        rest.use(express.logger('dev'));
+      }
     }
     if (args.log || args.webhook) {
       rest.use(express.logger({stream: winstonStream}));
@@ -150,7 +163,7 @@ var main = function(args, readyCb, doneCb) {
 
   var conditionallyPreLaunch = function(cb) {
     if (args.launch) {
-      logger.info("Starting Appium in pre-launch mode".cyan);
+      logger.info("Starting Appium in pre-launch mode");
       appiumServer.preLaunch(function(err) {
         if (err) {
           logger.error("Could not pre-launch appium: " + err);
@@ -165,7 +178,7 @@ var main = function(args, readyCb, doneCb) {
   };
 
   var startAlertSocket = function() {
-    var alerts = io.listen(server, {'flash policy port': -1});
+    var alerts = io.listen(server, {'flash policy port': -1, 'log colors': !args.logNoColors});
     alerts.configure(function() {
       alerts.set('log level', 1);
       alerts.set("polling duration", 10);
@@ -192,10 +205,10 @@ var main = function(args, readyCb, doneCb) {
       if (appiumRev) {
         welcome += " (REV " + appiumRev + ")";
       }
-      logger.info(welcome.cyan);
+      logger.info(welcome);
       var logMessage = "Appium REST http interface listener started on " +
                        args.address + ":" + args.port;
-      logger.info(logMessage.cyan);
+      logger.info(logMessage);
       startAlertSocket();
       if (args.nodeconfig !== null) {
         gridRegister.registerNode(args.nodeconfig);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "socket.io" : "~0.9.16",
     "MD5" : "~1.1.0",
     "through": "~2.3.4",
-    "date-utils": "~1.2.14"
+    "date-utils": "~1.2.14",
+    "bytes": "~0.2.1"
   },
   "scripts": {
     "test": "grunt travis"


### PR DESCRIPTION
There are still several places where colors are used in the console output, even though --log-no-colors is provided.
This pull request should fix them.
