### PR TITLE
Added ability to close tabs in safari when using safariLauncher 

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -678,7 +678,7 @@ Appium.prototype.stop = function(cb) {
 
   logger.info('Shutting down appium session...');
   if (this.isSafariLauncherApp === true) {
-    this.device.leaveWebView(function() {
+    this.device.closeWindow(function() {
       if (this.device.udid === null && this.device.instruments !== null) {
         this.device.instruments.shutdown(function() {
           this.cleanupSession(null, cb);

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1180,7 +1180,7 @@ iOSController.setWindow = function(name, cb) {
 
 iOSController.closeWindow = function(cb) {
   if (this.curWindowHandle) {
-    var script = "return window.setTimeout(function() { window.close(); }, 1000);";
+    var script = "return window.open('','_self').close();";
     this.executeAtom('execute_script', [script, []], function(err, res) {
       setTimeout(function() {
         cb(err, res);

--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -12,7 +12,8 @@ iOSHybrid.navToInitialWebview = function(cb) {
   if (this.autoWebview) {
     if (this.isSafariLauncherApp) {
       setTimeout(function() {
-        this.navToFirstAvailWebview(cb);
+        //the latest window is the one newly created by Safari launcher.
+        this.navToLatestAvailableWebview(cb);
       }.bind(this), 6000);
     } else {
       this.navToFirstAvailWebview(cb);
@@ -42,6 +43,19 @@ iOSHybrid.navToFirstAvailWebview = function(cb) {
   }.bind(this));
 };
 
+iOSHybrid.navToLatestAvailableWebview = function(cb) {
+  logger.info("Navigating to latest webview");
+  this.getWindowHandles(function(err, res) {
+    if (res.status !== 0) {
+      cb(new Error("Could not navigate to webview! Code: " + res.status));
+    } else if (res.value.length === 0) {
+      cb(new Error("Could not navigate to webview; there aren't any!"));
+    } else {
+      logger.info("Picking webview " + res.value[0]);
+      this.setWindow(res.value[res.value.length - 1], cb);
+    }
+  }.bind(this));
+};
 
 iOSHybrid.closeAlertBeforeTest = function(cb) {
   this.proxy("au.alertIsPresent()", function(err, res) {
@@ -207,11 +221,20 @@ iOSHybrid.stopRemote = function() {
     logger.error("We don't appear to be in a web frame");
     throw new Error("Tried to leave a web frame but weren't in one");
   } else {
-    //should probably add a callback to both debuggers.
-    if (this.udid) {
-      this.remote.disconnect(function(){});
+    if (this.isSafariLauncherApp) {
+      this.closeWindow(function(){
+        if (this.udid) {
+          this.remote.disconnect(function(){});
+        } else {
+          this.remote.disconnect();
+        }
+      });
     } else {
-      this.remote.disconnect();
+      if (this.udid) {
+        this.remote.disconnect(function(){});
+      } else {
+        this.remote.disconnect();
+      }
     }
     this.curWindowHandle = null;
     this.curWebFrames = [];


### PR DESCRIPTION
By changing the window.close() javascript call we can now close tabs for mobile safari on physical devices as well. This solution bypasses the rule that javascript can only close a tab opened by javascript.

In addition we automatically connect to the latest window (rather than the first) as this is the one opened by SafariLauncher.

Tested this on Sim (iOS6 and iOS7) with:
<i>mocha -t 60000 -R spec test/functional/safari -g "findElement"</i>

And on physical iOS6 (iPhone) and iOS7 iPad and I was able to close tabs and run safari tests.
