### PR TITLE
Adding the ability to get node path out of .appiumconfig (for users who ...

### DIFF
--- a/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
+++ b/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
@@ -121,6 +121,29 @@ var clientPath = (function() {
   }
 })();
 
+var nodePathAppiumConfig = function() {
+  var appiumconfig = 'node_modules/appium/.appiumconfig';
+  // Adding "|| echo 'file not found'" in case "cat config file" fails - this
+  // avoids sysExec throwing execption and returns data string here which will
+  // then not parse for node_bin.
+  var data = sysExec("/bin/cat " + appiumconfig + " || echo 'file not found'");
+  if (!data) {
+    console.log("WARN: Could not get .appiumconfig file: " + appiumconfig);
+    return null;
+  }
+  var parts = data.split('"node_bin":"')
+  if (!parts || parts.length <= 1) {
+    // This setup does not have node_bin configured in .appiumconfig
+    return null;
+  }
+  parts = parts[1].split('"');
+  if (!parts || parts.length <= 1) {
+    console.log("WARN: Could not parse node_bin data in file: " + appiumconfig);
+    return null;
+  }
+  return parts[0];
+};
+
 // figure out where node is
 var nodePath = (function() {
   var path = null;
@@ -136,6 +159,11 @@ var nodePath = (function() {
     path = sysExec("echo $NODE_BIN");
     console.log("Found node using $NODE_BIN: " + path);
   } catch(e) {
+    path = nodePathAppiumConfig();
+    if (path !== null) {
+      console.log("Found node through node_bin in .appiumconfig: " + path);
+      return path;
+    }
     try {
       path = sysExec('which node');
       console.log("Found node using `which node`: " + path);

--- a/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
+++ b/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
@@ -122,26 +122,30 @@ var clientPath = (function() {
 })();
 
 var nodePathAppiumConfig = function() {
-  var appiumconfig = 'node_modules/appium/.appiumconfig';
+  var appiumconfig = '.appiumconfig';
+  var module = 'node_modules/appium/';
+
   // Adding "|| echo 'file not found'" in case "cat config file" fails - this
   // avoids sysExec throwing execption and returns data string here which will
   // then not parse for node_bin.
   var data = sysExec("/bin/cat " + appiumconfig + " || echo 'file not found'");
-  if (!data) {
-    console.log("WARN: Could not get .appiumconfig file: " + appiumconfig);
-    return null;
+  if (!data || data === 'file not found') {
+    var data = sysExec("/bin/cat " + module + appiumconfig + " || echo 'file not found'");
+    if (!data || data === 'file not found') {
+      console.log("WARN: Could not load " + appiumconfig + " or " + module + appiumconfig);
+      return null;
+    }
   }
-  var parts = data.split('"node_bin":"')
-  if (!parts || parts.length <= 1) {
-    // This setup does not have node_bin configured in .appiumconfig
-    return null;
+  try {
+    var jsonobj = JSON.parse(data.toString('utf8'));
+    if (jsonobj.node_bin !== undefined) {
+      return jsonobj.node_bin;
+    }
+    // This setup does not have node_bin configured in appiumconfig.
+  } catch(e) {
+    console.log("WARN: JSON parse of .appiumconfig failed: " + e);
   }
-  parts = parts[1].split('"');
-  if (!parts || parts.length <= 1) {
-    console.log("WARN: Could not parse node_bin data in file: " + appiumconfig);
-    return null;
-  }
-  return parts[0];
+  return null;
 };
 
 // figure out where node is

--- a/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
+++ b/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
@@ -135,8 +135,7 @@ var nodePathAppiumConfig = function() {
       console.log("WARN: Could not load " + appiumconfig + " or " + module + appiumconfig);
       return null;
     }
-  }
-  try {
+  } try {
     var jsonobj = JSON.parse(data.toString('utf8'));
     if (jsonobj.node_bin !== undefined) {
       return jsonobj.node_bin;

--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -140,7 +140,7 @@ var main = function(args, readyCb, doneCb) {
       }
       var versionMismatches = {};
       _.each(rawConfig, function(deviceConfig, key) {
-        if (deviceConfig.version !== appiumVer && key !== "git-sha") {
+        if (deviceConfig.version !== appiumVer && key !== "git-sha" && key !== "node_bin") {
           versionMismatches[key] = deviceConfig.version;
         } else if (key === "git-sha") {
           appiumRev = rawConfig['git-sha'];


### PR DESCRIPTION
Users who want to use this feature modify node_modules/appium/.appiumconfig & add a "node_bin":"/path/to/node" key/val pair.
The NODE_BIN in ~/.instruments.conf is always checked first, then $NODE_BIN and if both of those don't have node configured then it looks in node_modules/appium/.appiumconfig for the node_bin entry & if it exist the code then uses that node, otherwise it falls back to using 'which node' & looking in the standard places to find node (like /usr/local/bin).
The main purpose for this change is for projects using buildout and that might not have node installed globally on the machine and want to use the sandboxed (local) node (even if node is installed globally).  This allows different projects to use different node versions side by side.
