### PR TITLE
Avoid crashing when device is null

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -715,7 +715,8 @@ Appium.prototype.reset = function(cb) {
     this.resetting = true;
     this.stop(function() {
       logger.info("Restarting app");
-      this.start(this.oldDesiredCapabilities, function() {
+      this.start(this.oldDesiredCapabilities, function(err) {
+        if (err) return cb(err);
         this.resetting = false;
         this.device.implicitWaitMs = oldImpWait;
         this.sessionId = oldId;


### PR DESCRIPTION
Appium is crashing without this fix.

> error: uncaughtException: Cannot set property 'implicitWaitMs' of null date=Mon Nov 18 2013 10:35:17 GMT-0500 (EST), pid=2505, uid=1522729602, gid=1920007995, cwd=/woven/appium, execPath=/usr/local/Cellar/node/0.10.21/bin/node, version=v0.10.21, argv=[node, /woven/appium], rss=61186048, heapTotal=54084096, heapUsed=34139376, loadavg=[1.9052734375, 1.763671875, 1.81982421875], uptime=10977, trace=[column=36, file=/woven/appium/lib/appium.js, function=, line=711, method=null, native=false, column=7, file=/woven/appium/lib/appium.js, function=, line=89, method=null, native=false, column=5, file=/woven/appium/lib/appium.js, function=Appium.configure, line=241, method=configure, native=false, column=8, file=/woven/appium/lib/appium.js, function=Appium.start, line=85, method=start, native=false, column=12, file=/woven/appium/lib/appium.js, function=, line=709, method=null, native=false, column=5, file=/woven/appium/lib/appium.js, function=Appium.cleanupSession, line=631, method=cleanupSession, native=false, column=12, file=/woven/appium/lib/appium.js, function=, line=694, method=null, native=false, column=14, file=/woven/appium/lib/devices/ios/ios.js, function=, line=302, method=null, native=false, column=13, file=/woven/appium/node_modules/async/lib/async.js, function=null, line=229, method=null, native=false, column=25, file=/woven/appium/node_modules/async/lib/async.js, function=null, line=139, method=null, native=false], stack=[TypeError: Cannot set property 'implicitWaitMs' of null,     at null.<anonymous> (/woven/appium/lib/appium.js:711:36),     at null.<anonymous> (/woven/appium/lib/appium.js:89:7),     at Appium.configure (/woven/appium/lib/appium.js:241:5),     at Appium.start (/woven/appium/lib/appium.js:85:8),     at null.<anonymous> (/woven/appium/lib/appium.js:709:12),     at Appium.cleanupSession (/woven/appium/lib/appium.js:631:5),     at null.<anonymous> (/woven/appium/lib/appium.js:694:12),     at null.<anonymous> (/woven/appium/lib/devices/ios/ios.js:302:14),     at /woven/appium/node_modules/async/lib/async.js:229:13,     at /woven/appium/node_modules/async/lib/async.js:139:25]
