### PR TITLE
Update adb.js: fix typo error

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -508,7 +508,7 @@ ADB.prototype.launchAVD = function(avdName, cb) {
     } catch (err) {
       return cb(err);
     }
-    this.getDeviceWithRetry(120000, cb);
+    this.getDevicesWithRetry(120000, cb);
   }.bind(this));
 };
 


### PR DESCRIPTION
line 511

this.getDeviceWithRetry(120000, cb);
changed to
this.getDevicesWithRetry(120000, cb);
