### PR TITLE
Give write permission to strings.json for all.

### DIFF
--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -206,6 +206,7 @@ Android.prototype.pushStrings = function(cb) {
         return cb(new Error("Could not make strings from apk"));
       }
       var jsonFile = path.resolve(outputPath, stringsJson);
+      fs.chmod(jsonFile, "666");
       this.adb.push(jsonFile, remotePath, function(err) {
         if (err) return cb(new Error("Could not push strings.json"));
         cb();


### PR DESCRIPTION
Appium fails due to insufficient write permissions for strings.json
on multi-user systems. 

I have a jenkins setup on my box (where Appium is run by the 'jenkins' user) and I get this error when I try to run Appium with my user:

```
debug: Exception in thread "main" java.io.FileNotFoundException: /tmp/com.opera.browser/strings.json (Permission denied)
    at java.io.FileOutputStream.open(Native Method)
    at java.io.FileOutputStream.<init>(FileOutputStream.java:212)
    at java.io.FileOutputStream.<init>(FileOutputStream.java:165)
    at strings.StringsXML.toJSON(StringsXML.java:44)
    at strings.StringsXML.run(StringsXML.java:100)
    at strings.StringsXML.main(StringsXML.java:151)
```

This fix makes sure everyone has write access to it (when it's created the first time).
