### PR TITLE
Recover from unresponsive instruments process

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "submodules/libimobiledevice-macosx"]
 	path = submodules/libimobiledevice-macosx
 	url = https://github.com/benvium/libimobiledevice-macosx.git
+[submodule "submodules/ForceQuitUnresponsiveApps"]
+	path = submodules/ForceQuitUnresponsiveApps
+	url = https://github.com/appium/ForceQuitUnresponsiveApps.git

--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -24,7 +24,29 @@ var http = require('http')
   , _ = require("underscore")
   , io = require('socket.io')
   , gridRegister = require('./grid-register.js')
-  , bytes = require('bytes');
+  , bytes = require('bytes')
+  , isWindows = require('../helpers.js').isWindows()
+  , exec = require('child_process').exec
+  , spawn = require('child_process').spawn
+  , endInstrumentsPath = path.resolve(__dirname, '../../build/force_quit/ForceQuitUnresponsiveApps.app/Contents/MacOS/ForceQuitUnresponsiveApps');
+
+var watchForUnresponsiveInstruments = function(cb) {
+    if (isWindows) return;
+
+    var endOldProcess = function(cb) {
+      exec("killall -9 ForceQuitUnresponsiveApps", { maxBuffer: 524288 }, function(err) { cb(); });
+    };
+
+    var startNewprocess = function(cb) {
+      spawn(endInstrumentsPath);
+      cb();
+    };
+
+    async.series([
+      endOldProcess,
+      startNewprocess
+    ], cb);
+};
 
 var allowCrossDomain = function(req, res, next) {
   res.header('Access-Control-Allow-Origin', '*');
@@ -33,7 +55,7 @@ var allowCrossDomain = function(req, res, next) {
 
   // need to respond 200 to OPTIONS
 
-  if ('OPTIONS' == req.method) {
+  if ('OPTIONS' === req.method) {
     res.send(200);
   } else {
     next();
@@ -201,6 +223,7 @@ var main = function(args, readyCb, doneCb) {
   var startListening = function(cb) {
     var alreadyReturned = false;
     server.listen(args.port, args.address, function() {
+      watchForUnresponsiveInstruments(function(){});
       var welcome = "Welcome to Appium v" + appiumVer;
       if (appiumRev) {
         welcome += " (REV " + appiumRev + ")";

--- a/reset.sh
+++ b/reset.sh
@@ -96,6 +96,16 @@ reset_general() {
 
 reset_ios() {
     echo "RESETTING IOS"
+    echo "* Cloning/updating ForceQuitUnresponsiveApps"
+    run_cmd git submodule update --init submodules/ForceQuitUnresponsiveApps
+    echo "* Building ForceQuitUnresponsiveApps"
+    run_cmd pushd submodules/ForceQuitUnresponsiveApps
+    run_cmd ./build_force_quit.sh
+    run_cmd popd
+    echo "* Moving ForceQuitUnresponsiveApps into build/force_quit"
+    run_cmd rm -rf build/force_quit
+    run_cmd mkdir build/force_quit
+    run_cmd cp -R submodules/ForceQuitUnresponsiveApps/bin/* build/force_quit
     echo "* Cloning/updating instruments-without-delay"
     run_cmd git submodule update --init submodules/instruments-without-delay
     echo "* Building instruments-without-delay"


### PR DESCRIPTION
Register for kCGSNotificationAppUnresponsive and if the process is Instruments then terminate it.
This enables Appium to continue even when instruments is unresponsive. The current behavior is to wait forever.

To test this feature works properly, run ./instruments.sh from https://github.com/appium/ForceQuitUnresponsiveApps

instruments.sh will launch a process that's unresponsive and appium will force quit the process. The unresponsive process can be visually confirmed by using OS X Activity Monitor.

Fix #1306
