### PR TITLE
allow user to let instruments launch device with --default-device

### DIFF
--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -32,6 +32,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--device-ready-timeout`|5|(Android-only) Timeout in seconds while waiting for device to become ready|`--device-ready-timeout 5`|
 |`--safari`|false|(IOS-Only) Use the safari app||
 |`--device-name`|null|(IOS-Simulator-only) name of the iOS device to use|`--device-name iPhone Retina (4-inch)`|
+|`--default-device`|false|(IOS-Simulator-only) use the default simulator that instruments launches on its own||
 |`--force-iphone`|false|(IOS-only) Use the iPhone Simulator no matter what the app wants||
 |`--force-ipad`|false|(IOS-only) Use the iPad Simulator no matter what the app wants||
 |`--language`|null|(IOS-only) language for the iOS simulator|`--language en`|
@@ -48,4 +49,4 @@ All flags are optional, but some are required in conjunction with certain others
 |`--keystore-password`|android|(Android-only) Password to keystore||
 |`--key-alias`|androiddebugkey|(Android-only) Key alias||
 |`--key-password`|android|(Android-only) Key password||
-|`--show-config`|true|Show info about the appium server configuration and exit||
+|`--show-config`|false|Show info about the appium server configuration and exit||

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -532,6 +532,7 @@ Appium.prototype.initDevice = function() {
       , launchTimeout: this.desiredCapabilities.launchTimeout
       , version: this.desiredCapabilities.version
       , deviceName: this.desiredCapabilities.deviceName || this.desiredCapabilities.device || this.args.deviceName
+      , defaultDevice: this.args.defaultDevice
       , forceiPhone: this.args.forceIphone
       , forceiPad: this.args.forceIpad
       , language: this.desiredCapabilities.language || this.args.language

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -49,6 +49,7 @@ IOS.prototype.init = function(args) {
   this.verbose = args.verbose;
   this.autoWebview = args.autoWebview;
   this.withoutDelay = args.withoutDelay;
+  this.useDefaultDevice = args.defaultDevice;
   this.xcodeFolder = null;
   this.xcodeVersion = null;
   this.iOSSDKVersion = null;
@@ -623,6 +624,11 @@ IOS.prototype.setDeviceAndLaunchSimulator = function(cb) {
   } else if (!this.deviceName && this.forceiPhone === null && this.forceiPad === null) {
     logger.info("No device specified, current device in the iOS simulator will be used.");
     cb(null);
+  } else if (this.useDefaultDevice) {
+    logger.info("User specified default device, letting instruments launch it");
+    var iosDeviceString = this.getDeviceString();
+    var isiPhone = iosDeviceString.toLowerCase().indexOf("ipad") === -1;
+    this.setDeviceTypeInInfoPlist(isiPhone ? 1 : 2, cb);
   } else {
     var iosSimPath = path.resolve(this.xcodeFolder, "Platforms/iPhoneSimulator.platform/Developer/Applications"+
       "/iPhone Simulator.app/Contents/MacOS/iPhone Simulator");

--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -96,6 +96,7 @@ var checkArgs = function(args) {
     , ['ipa', 'safari']
     , ['app', 'safari']
     , ['forceIphone', 'forceIpad']
+    , ['deviceName', 'defaultDevice']
   ];
 
   _.each(exclusives, function(exSet) {

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -207,6 +207,15 @@ var args = [
     , help: "(IOS-Simulator-only) name of the iOS device to use"
   }],
 
+  [['--default-device'], {
+    dest: 'defaultDevice'
+    , defaultValue: false
+    , action: 'storeTrue'
+    , required: false
+    , help: "(IOS-Simulator-only) use the default simulator that instruments " +
+            "launches on its own"
+  }],
+
   [['--force-iphone'], {
     defaultValue: false
     , dest: 'forceIphone'


### PR DESCRIPTION
On some systems, calling the iPhone Sim binary on its own results in errors and crashes, and the app never loads. I think this functionality should be optionally turned off so that instruments can launch devices on its own.
