### PR TITLE
Setting newCommandTimeout capability to 0 disables timeout.

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -646,8 +646,10 @@ Appium.prototype.resetTimeout = function() {
   if (this.commandTimeout) {
     clearTimeout(this.commandTimeout);
   }
-  this.commandTimeout = setTimeout(this.timeoutWaitingForCommand.bind(this),
+  if (this.commandTimeoutMs > 0) {
+    this.commandTimeout = setTimeout(this.timeoutWaitingForCommand.bind(this),
       this.commandTimeoutMs);
+  }
 };
 
 Appium.prototype.setCommandTimeout = function(secs, cb) {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -138,7 +138,7 @@ exports.createSession = function(req, res) {
       res.set('Location', "http://"+reqHost+"/wd/hub/session/" + sessionId);
       res.send(303);
     };
-    if (desired && desired.newCommandTimeout) {
+    if (desired && desired.newCommandTimeout >= 0) {
       req.appium.setCommandTimeout(desired.newCommandTimeout, redirect);
     } else {
       redirect();


### PR DESCRIPTION
The new command timeout has caused a couple of headaches for us. Rather than set it to some huge number, we figured we'd add the ability to disable it. 
