### PR TITLE
Pipe force quit logs to console

### DIFF
--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -28,6 +28,7 @@ var http = require('http')
   , isWindows = require('../helpers.js').isWindows()
   , exec = require('child_process').exec
   , spawn = require('child_process').spawn
+  , through = require('through')
   , endInstrumentsPath = path.resolve(__dirname, '../../build/force_quit/ForceQuitUnresponsiveApps.app/Contents/MacOS/ForceQuitUnresponsiveApps');
 
 var watchForUnresponsiveInstruments = function(cb) {
@@ -38,7 +39,18 @@ var watchForUnresponsiveInstruments = function(cb) {
     };
 
     var startNewprocess = function(cb) {
-      spawn(endInstrumentsPath);
+      var process = spawn(endInstrumentsPath);
+      process.stdout.setEncoding('utf8');
+      process.stderr.setEncoding('utf8');
+
+      process.stderr.pipe(through(function(data) {
+        logger.info('[ForceQuitUnresponsiveApps] ' + data.trim());
+      }));
+
+      process.stdout.pipe(through(function(data) {
+        logger.info('[ForceQuitUnresponsiveApps STDERR] ' + data.trim());
+      }));
+
       cb();
     };
 


### PR DESCRIPTION
> info: [ForceQuitUnresponsiveApps] 2013-12-10 15:11:16.424 ForceQuitUnresponsiveApps[56799:507] Force quit unresponsive instruments v0.0.1
> info: [ForceQuitUnresponsiveApps] 2013-12-10 15:11:42.708 ForceQuitUnresponsiveApps[56799:507] Force quitting: 'freeze2' at 'file:///Users/user/ForceQuitUnresponsiveApps/freeze2/./bin/freeze2.app/Contents/MacOS/instruments'

Fix #1600

I'm not sure why `ForceQuitUnresponsiveApps` is repeated twice. I guess it's in the stdout.
