### PR TITLE
Update Sauce examples with reporting, cleaner layout

### DIFF
--- a/sample-code/examples/ruby/android_on_sauce.rb
+++ b/sample-code/examples/ruby/android_on_sauce.rb
@@ -21,7 +21,10 @@ require 'selenium/webdriver/remote/http/persistent'
 require "rspec"
 require "rest_client"
 
-def capabilities
+SAUCE_USERNAME = ENV['SAUCE_USERNAME']
+SAUCE_ACCESS_KEY = ENV['SAUCE_ACCESS_KEY']
+
+def desired_capabilites
   {
     "device" => "Android",
     "browserName" => "",
@@ -32,9 +35,9 @@ def capabilities
   }
 end
 
-def url_with_credentials
-  un = ENV["SAUCE_USERNAME"]
-  pw = ENV["SAUCE_ACCESS_KEY"]
+def auth_details
+  un = SAUCE_USERNAME
+  pw = SAUCE_ACCESS_KEY
   
   unless un && pw
     STDERR.puts <<-EOF
@@ -51,7 +54,15 @@ def url_with_credentials
     exit
   end
 
-  return "http://#{un}:#{pw}@ondemand.saucelabs.com:80/wd/hub"
+  return "#{un}:#{pw}"
+end
+
+def server_url
+  return "http://#{auth_details}@ondemand.saucelabs.com:80/wd/hub"
+end
+
+def rest_jobs_url
+  "https://#{auth_details}@saucelabs.com/rest/v1/#{SAUCE_USERNAME}/jobs"
 end
 
 # Because WebDriver doesn't have the concept of test failure, use the Sauce
@@ -67,8 +78,8 @@ describe "Notepad" do
     
     @driver ||= Selenium::WebDriver.for(
       :remote, 
-      :desired_capabilities => capabilities,
-      :url => url_with_credentials,
+      :desired_capabilities => desired_capabilites,
+      :url => server_url,
       :http_client => http_client
     )
     
@@ -81,10 +92,6 @@ describe "Notepad" do
     job_id = @driver.send(:bridge).session_id
     update_job_success(job_id, example.exception.nil?)
     @driver.quit
-  end
-
-  after :all do
-    @driver.quit if @driver
   end
 
   it "can create and save new notes" do

--- a/sample-code/examples/ruby/android_on_sauce.rb
+++ b/sample-code/examples/ruby/android_on_sauce.rb
@@ -24,7 +24,46 @@ require "rest_client"
 SAUCE_USERNAME = ENV['SAUCE_USERNAME']
 SAUCE_ACCESS_KEY = ENV['SAUCE_ACCESS_KEY']
 
-def desired_capabilites
+describe "Notepad" do
+  before :each do
+    http_client = ::Selenium::WebDriver::Remote::Http::Persistent.new
+    http_client.timeout = 300 # Allow for slow network or boot time
+    
+    @driver = Selenium::WebDriver.for(
+      :remote, 
+      :desired_capabilities => desired_caps,
+      :url => server_url,
+      :http_client => http_client
+    )
+    
+    http_client.timeout = 90
+  end
+
+  after(:each) do
+    # Get the success by checking for assertion exceptions,
+    # and log them against the job, which is exposed by the session_id
+    job_id = @driver.send(:bridge).session_id
+    update_job_success(job_id, example.exception.nil?)
+    @driver.quit
+  end
+
+  it "can create and save new notes" do
+    new_button = @driver.find_element(:name, "New note")
+    new_button.click
+
+    text_field = @driver.find_element(:tag_name, "textfield")
+    text_field.send_keys "This is a new note, from Ruby"
+
+    save_button = @driver.find_element(:name, "Save")
+    save_button.click
+
+    notes = @driver.find_elements(:tag_name, "text")
+    puts "The number of notes is: #{notes.length}"
+    notes[2].text.should eq "This is a new note, from Ruby"
+  end
+end
+
+def desired_caps
   {
     "device" => "Android",
     "browserName" => "",
@@ -69,43 +108,4 @@ end
 # Labs REST API to record job success or failure
 def update_job_success(job_id, success)
     RestClient.put "#{rest_jobs_url}/#{job_id}", {"passed" => success}.to_json, :content_type => :json
-end
-
-describe "Notepad" do
-  before :all do
-    http_client = ::Selenium::WebDriver::Remote::Http::Persistent.new
-    http_client.timeout = 300 # Allow for slow network or boot time
-    
-    @driver ||= Selenium::WebDriver.for(
-      :remote, 
-      :desired_capabilities => desired_capabilites,
-      :url => server_url,
-      :http_client => http_client
-    )
-    
-    http_client.timeout = 90
-  end
-
-  after(:each) do
-    # Get the success by checking for assertion exceptions,
-    # and log them against the job, which is exposed by the session_id
-    job_id = @driver.send(:bridge).session_id
-    update_job_success(job_id, example.exception.nil?)
-    @driver.quit
-  end
-
-  it "can create and save new notes" do
-    new_button = @driver.find_element(:name, "New note")
-    new_button.click
-
-    text_field = @driver.find_element(:tag_name, "textfield")
-    text_field.send_keys "This is a new note, from Ruby"
-
-    save_button = @driver.find_element(:name, "Save")
-    save_button.click
-
-    notes = @driver.find_elements(:tag_name, "text")
-    puts "The number of notes is: #{notes.length}"
-    notes[2].text.should eq "This is a new note, from Ruby"
-  end
 end

--- a/sample-code/examples/ruby/sauce_example.rb
+++ b/sample-code/examples/ruby/sauce_example.rb
@@ -16,13 +16,16 @@ require 'rest_client'
 APP_PATH = 'http://appium.s3.amazonaws.com/TestApp6.0.app.zip'
 SAUCE_USERNAME = ENV['SAUCE_USERNAME']
 SAUCE_ACCESS_KEY = ENV['SAUCE_ACCESS_KEY']
-AUTH_DETAILS = "#{SAUCE_USERNAME}:#{SAUCE_ACCESS_KEY}"
 
 # This is the test itself
 describe "Computation" do
   before(:each) do
-    @driver = Selenium::WebDriver.for(:remote, :desired_capabilities => desired_caps, :url => server_url)
-   end
+    @driver = Selenium::WebDriver.for(
+      :remote, 
+      :desired_capabilities => desired_caps, 
+      :url => server_url
+    )
+  end
 
   after(:each) do
     # Get the success by checking for assertion exceptions,
@@ -57,12 +60,34 @@ def desired_caps
   }
 end
 
+def auth_details
+  un = SAUCE_USERNAME
+  pw = SAUCE_ACCESS_KEY
+  
+  unless un && pw
+    STDERR.puts <<-EOF
+      Your SAUCE_USERNAME or SAUCE_ACCESS_KEY environment variables 
+      are empty or missing.
+      
+      You need to set these values to your Sauce Labs username and access
+      key, respectively.
+
+      If you don't have a Sauce Labs account, you can get one for free at
+      http://www.saucelabs.com/signup
+    EOF
+
+    exit
+  end
+
+  return "#{un}:#{pw}"
+end
+
 def server_url
-  "http://#{AUTH_DETAILS}@ondemand.saucelabs.com:80/wd/hub"
+  "http://#{auth_details}@ondemand.saucelabs.com:80/wd/hub"
 end
 
 def rest_jobs_url
-  "https://#{AUTH_DETAILS}@saucelabs.com/rest/v1/#{SAUCE_USERNAME}/jobs"
+  "https://#{auth_details}@saucelabs.com/rest/v1/#{SAUCE_USERNAME}/jobs"
 end
 
 # Because WebDriver doesn't have the concept of test failure, use the Sauce


### PR DESCRIPTION
Make the layout the same for Android and iOS examples:
- Test at the top
- Helpers at the bottom

Create drivers for each test, not all tests, for Android example.

Do result reporting for Android example.

Create authentication string separately to server URLs.

Fix "capabilities" private method snafu for Android example.
