### PR TITLE
add 19.0.0 build tools search path for figuring out where aapt is

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -70,7 +70,8 @@ ADB.prototype.checkSdkBinaryPresent = function(binary, cb) {
         , path.resolve(this.sdkRoot, "build-tools", "17.0.0", binaryName)
         , path.resolve(this.sdkRoot, "build-tools", "android-4.2.2", binaryName)
         , path.resolve(this.sdkRoot, "build-tools", "18.0.1", binaryName)
-        , path.resolve(this.sdkRoot, "build-tools", "android-4.3", binaryName)];
+        , path.resolve(this.sdkRoot, "build-tools", "android-4.3", binaryName)
+        , path.resolve(this.sdkRoot, "build-tools", "19.0.0", binaryName)];
     _.each(binaryLocs, function(loc) {
       if (fs.existsSync(loc)) binaryLoc = loc;
     });


### PR DESCRIPTION
helps w/ support for new android sdks.
