### PR TITLE
adds check for API level; stops test if device is 'android' but API < 17

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -428,6 +428,19 @@ ADB.prototype.getDevicesWithRetry = function(timeoutMs, cb) {
   getDevices();
 };
 
+ADB.prototype.getApiLevel = function(cb) {
+  logger.info("Getting device API level");
+  this.shell("getprop ro.build.version.sdk", function (err, stdout) {
+    if (err) {
+      logger.warn(err);
+      cb(err);
+    } else {
+      logger.info("Device is at API Level " + stdout.trim());
+      cb(null, stdout);
+    }
+  });
+};
+
 ADB.prototype.getEmulatorPort = function(cb) {
   logger.info("Getting running emulator port");
   if (this.emulatorPort !== null) {

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -80,6 +80,7 @@ Android.prototype.start = function(cb, onDie) {
 
     async.series([
       this.prepareDevice.bind(this),
+      this.checkApiLevel.bind(this),
       this.pushStrings.bind(this),
       this.requestXmlCompression.bind(this),
       this.uninstallApp.bind(this),
@@ -178,6 +179,20 @@ Android.prototype.checkShouldRelaunch = function(launchErr) {
     relaunch = relaunch || msg.indexOf(relaunchMsg) !== -1;
   });
   return relaunch;
+};
+
+Android.prototype.checkApiLevel = function(cb) {
+  this.adb.getApiLevel(function(err, apiLevel) {
+    if (err) return cb(err);
+
+    if (parseInt(apiLevel) < 17) {
+      var msg = "Android devices must be of API level 17 or higher. Please change your device to Selendroid or upgrade Android on your device.";
+      logger.error(msg); // logs the error when we encounter it
+      return cb(new Error(msg)); // send the error up the chain
+    }
+
+    cb();
+  });
 };
 
 Android.prototype.pushStrings = function(cb) {


### PR DESCRIPTION
Here's my first attempt to address #1623 - comments/feedback welcome!
