### PR TITLE
Fix cleanupAppState logging messages

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -715,7 +715,7 @@ IOS.prototype.getSimulatorApplications = function(cb) {
 };
 
 IOS.prototype.cleanupAppState = function(cb) {
-  logger.info("Deleting plists for bundle: " + this.bundleId);
+  logger.info("Deleting simulator folders.");
   this.getSimulatorApplications(function(err, files) {
     if (err) {
       logger.error("Could not remove: " + err.message);
@@ -734,9 +734,28 @@ IOS.prototype.cleanupAppState = function(cb) {
             filesExamined++;
             maybeNext();
           });
+
+          var root = path.dirname(file);
+          var tcc = path.join(root, 'Library/TCC');
+          if (fs.existsSync(tcc)) {
+            rimraf.sync(tcc);
+            logger.info("Deleted " + tcc);
+          }
+
+          var caches = path.join(root, 'Library/Caches');
+          if (fs.existsSync(caches)) {
+            rimraf.sync(caches);
+            logger.info("Deleted " + caches);
+          }
+
+          var media = path.join(root, 'Media');
+          if (fs.existsSync(media)) {
+            rimraf.sync(media);
+            logger.info("Deleted " + media);
+          }
         });
       } else {
-        logger.info("No plist files found to remove");
+        logger.info("No folders found to remove");
         if (this.realDevice) {
           this.realDevice.remove(this.bundleId, function (err) {
             if (err) {


### PR DESCRIPTION
We're deleting the entire Application folder not just plist files.

> info: Deleted /Users/user/Library/Application Support/iPhone Simulator/7.0.3/Library/Caches
> info: Deleted /Users/user/Library/Application Support/iPhone Simulator/7.0.3/Media
> info: Deleted /Users/user/Library/Application Support/iPhone Simulator/7.0.3/Library/TCC
> info: Deleted /Users/user/Library/Application Support/iPhone Simulator/7.0.3/Applications

Fix #1639
