### PR TITLE
Fix checkApkKeystoreMatch argument order

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -336,7 +336,7 @@ ADB.prototype.checkCustomApkCert = function(apk, pkg, cb) {
 
   this.getKeystoreMd5(keytool, md5, function(err, keystoreHash) {
     if (err) return cb(err);
-    this.checkApkKeystoreMatch(keytool, md5, keystoreHash, apk, pkg, cb);
+    this.checkApkKeystoreMatch(keytool, md5, keystoreHash, pkg, apk, cb);
   }.bind(this));
 };
 


### PR DESCRIPTION
#1523

This helps. It's still broken though.
