### PR TITLE
Adding flag to show simulator logs on the appium console

### DIFF
--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -42,6 +42,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--language`|null|(IOS-only) language for the iOS simulator|`--language en`|
 |`--locale`|null|(IOS-only) locale for the iOS simulator|`--locale en_US`|
 |`--calendar-format`|null|(IOS-only) calendar format for the iOS simulator|`--calendar-format gregorian`|
+|`--show-sim-log`|false|Show the iOS Simulator Log on the console||
 |`--orientation`|null|(IOS-only) use LANDSCAPE or PORTRAIT to initialize all requests to this orientation|`--orientation LANDSCAPE`|
 |`--tracetemplate`|null|(IOS-only) .tracetemplate file to use with Instruments|`--tracetemplate /Users/me/Automation.tracetemplate`|
 |`--nodeconfig`|null|Configuration JSON file to register appium with selenium grid|`--nodeconfig /abs/path/to/nodeconfig.json`|

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -512,6 +512,7 @@ Appium.prototype.initDevice = function() {
       , locale: this.desiredCapabilities.locale || this.args.locale
       , calendarFormat: this.desiredCapabilities.calendarFormat || this.args.calendarFormat
       , startingOrientation: this.desiredCapabilities.deviceOrientation || this.args.orientation
+      , showSimulatorLog: this.args.showSimulatorLog
       , robotPort: this.args.robotPort
       , robotAddress: this.args.robotAddress
       , isSafariLauncherApp: this.isSafariLauncherApp

--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -157,7 +157,7 @@ IosLog.prototype.onOutput = function(data, prefix) {
         };
         this.logs.push(logObj);
         this.logsSinceLastRequest.push(logObj);
-        if (this.debugMode && this.debugTrace) {
+        if (this.debugMode || this.debugTrace) {
           logger.debug('[IOS_SYSLOG_ROW ' + prefix + '] ' + log);
         }
       }

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -67,6 +67,7 @@ IOS.prototype.init = function(args) {
   this.locale = args.locale;
   this.calendarFormat = args.calendarFormat;
   this.logs = null;
+  this.showSimulatorLog = args.showSimulatorLog;
   this.startingOrientation = args.startingOrientation || "PORTRAIT";
   this.curOrientation = this.startingOrientation;
   this.instruments = null;
@@ -938,7 +939,7 @@ IOS.prototype.startLogCapture = function(cb) {
     udid: this.udid
     , xcodeVersion: this.xcodeVersion
     , debug: false
-    , debugTrace: false
+    , debugTrace: this.showSimulatorLog
   });
   this.logs.startCapture(cb);
 };

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -308,6 +308,15 @@ var args = [
     , help: "(IOS-only) .tracetemplate file to use with Instruments"
   }],
 
+  [['--show-sim-log'], {
+    defaultValue: false
+    , dest: 'showSimulatorLog'
+    , action: 'storeTrue'
+    , required: false
+    , help: "(IOS-only) if set, the iOS simulator log will be written to the console"
+    , nargs: 0
+  }],
+
   [['--nodeconfig'] , {
     required: false
     , defaultValue: null


### PR DESCRIPTION
This is useful for people who want to view the simulator log alongside the appium log in real time. It prevents the end user from having to write code to find the files and then tail them.
