### PR TITLE
Fix to recognise ‘ios’ as a device in the capabilities list

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -106,6 +106,8 @@ Appium.prototype.getDeviceType = function(desiredCaps) {
       return "ios";
     } else if (desiredCaps.device.toLowerCase().indexOf('ipad') !== -1) {
       return "ios";
+    } else if (desiredCaps.device.toLowerCase().indexOf('ios') !== -1) {
+      return "ios";
     } else if (desiredCaps.device.toLowerCase().indexOf('selendroid') !== -1) {
       return "selendroid";
     } else if (desiredCaps.device.toLowerCase().indexOf('firefox') !== -1) {


### PR DESCRIPTION
The documentation here https://github.com/appium/appium/blob/master/docs/caps.md states that ‘ios’ can be specified as a device. However, when using that device Appium fails with the error: “A new session could not be created. (Original error: A valid device type is required in the capabilities list) (Selenium::WebDriver::Error::WebDriverError)”.
