### PR TITLE
Fix for installing/removing app on device when a .app path is used.

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -457,8 +457,11 @@ IOS.prototype.installToRealDevice = function (cb) {
                 "id";
       logger.error(msg);
       cb(new Error(msg));
+    } else if (this.app) {
+      this.installApp(this.app, cb);
+      this.realDevice = new IDevice(this.udid);
     } else {
-      logger.debug("Real device specified but no ipa, assuming bundle ID is " +
+      logger.debug("Real device specified but no ipa or app path, assuming bundle ID is " +
                    "on device");
       cb();
     }
@@ -723,12 +726,20 @@ IOS.prototype.cleanupAppState = function(cb) {
       } else {
         logger.info("No folders found to remove");
         if (this.realDevice) {
-          this.realDevice.remove(this.bundleId, function (err) {
+          var bundleId = this.bundleId;
+          this.realDevice.remove(bundleId, function (err) {
             if (err) {
-              logger.error("Could not remove " + this.bundleId + " from device");
-              cb(err);
+              this.removeApp(bundleId, function (err) {
+                if (err) {
+                  logger.error("Could not remove " + bundleId + " from device");
+                  cb(err);
+                } else {
+                  logger.info("Removed " + bundleId);
+                  cb();
+                }
+              }.bind(this));
             } else {
-              logger.info("Removed " + this.bundleId);
+              logger.info("Removed " + bundleId);
               cb();
             }
           }.bind(this));


### PR DESCRIPTION
Appium does not install and remove the app correctly with `-U UDID --app foo.app`. This fix makes sure that `foo.app` is correctly installed and removed. 
