### PR TITLE
Use correct suffix (.zip or .apk) when downloading app from a url.

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -296,7 +296,7 @@ Appium.prototype.configureDownloadedApp = function(appPath, origin, cb) {
   var appUrl = appPath;
   if (appUrl.substring(appUrl.length - 4) === ".apk") {
     try {
-      downloadFile(appUrl, function(appPath) {
+      downloadFile(appUrl, ".apk", function(appPath) {
         this.tempFiles.push(appPath);
         this.args.app = appPath;
         cb(null);
@@ -406,7 +406,7 @@ Appium.prototype.configureChromeAndroid = function(appPath) {
 };
 
 Appium.prototype.downloadAndUnzipApp = function(appUrl, cb) {
-  downloadFile(appUrl, function(zipPath) {
+  downloadFile(appUrl, ".zip", function(zipPath) {
     this.unzipApp(zipPath, cb);
   }.bind(this));
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -15,10 +15,10 @@ var logger = require('./server/logger.js').get('appium')
   , AdmZip = require('adm-zip');
 
 
-exports.downloadFile = function(fileUrl, cb) {
+exports.downloadFile = function(fileUrl, suffix, cb) {
   // We will be downloading the files to a directory, so make sure it's there
   // This step is not required if you have manually created the directory
-  tempdir.open({prefix: 'appium-app', suffix: '.zip'}, function(err, info) {
+  tempdir.open({prefix: 'appium-app', suffix: suffix}, function(err, info) {
     var file = fs.createWriteStream(info.path);
     request(fileUrl).pipe(file).on('close', function() {
       logger.info(fileUrl + ' downloaded to ' + info.path);


### PR DESCRIPTION
md5calculator (used in lib/devices/android/android-common.js) can only handle files that end in .ipa or .apk, not .zip.
Currently urls that end in .apk (e.g. http://s3-us-west-2.amazonaws.com/XXX-builds/XXXApp-ci.apk) are downloaded as appium-app.zip, resulting in the md5 calculator raising an exception:

```
$ node . --full-reset
info: Welcome to Appium v0.13.0
info: Appium REST http interface listener started on 0.0.0.0:4723
   info  - socket.io started
info: Not spawning instruments force-quit watcher since it only works on 10.9 and you have 10.8.5
debug: Appium request initiated at /wd/hub/session
debug: Request received with params: {"sessionId":null,"desiredCapabilities":{"app-package":"com.XXX.messenger","app":"http://s3-us-west-2.amazonaws.com/XXX-builds/XXXApp-ci.apk","browserName":"","version":"4.2","device":"Android","app-activity":"StartupActivity"}}
info: http://s3-us-west-2.amazonaws.com/XXX-builds/XXXApp-ci.apk downloaded to /var/folders/v1/y34vbhp158x18m1dqjzb57mw0001yl/T/114010-19606-ilw91l/appium-app.zip
info: Creating new appium session 940667a0-4122-4767-b562-d8ce29fd4dcd
info: Starting android appium
debug: Using fast reset? false
info: Preparing device for session
info: Checking whether app is actually present
info: Checking whether adb is present
info: [ADB] Using adb from /Users/aw/Projects/adt-bundle-mac-x86_64/sdk/platform-tools/adb
info: Trying to find a connected android device
info: [ADB] Getting connected devices...
debug: executing: "/Users/aw/Projects/adt-bundle-mac-x86_64/sdk/platform-tools/adb" devices
info: [ADB] 1 device(s) connected
info: Setting device id to emulator-5554
info: [ADB] Waiting for device to be ready and to respond to shell commands (timeout = 5)
debug: executing: "/Users/aw/Projects/adt-bundle-mac-x86_64/sdk/platform-tools/adb" -s emulator-5554 wait-for-device
debug: executing: "/Users/aw/Projects/adt-bundle-mac-x86_64/sdk/platform-tools/adb" -s emulator-5554 shell "echo 'ready'"
info: Starting logcat capture
info: Getting device API level
debug: executing: "/Users/aw/Projects/adt-bundle-mac-x86_64/sdk/platform-tools/adb" -s emulator-5554 shell "getprop ro.build.version.sdk"
info: Device is at API Level 17
debug: java -jar "/Users/aw/Projects/dev/vendor/appium/lib/devices/android/helpers/strings_from_apk.jar" "/var/folders/v1/y34vbhp158x18m1dqjzb57mw0001yl/T/114010-19606-ilw91l/appium-app.zip" "/tmp/com.XXX.messenger"
debug: executing: "/Users/aw/Projects/adt-bundle-mac-x86_64/sdk/platform-tools/adb" -s emulator-5554 push "/tmp/com.XXX.messenger/strings.json" /data/local/tmp
info: Uninstalling com.XXX.messenger
debug: executing: "/Users/aw/Projects/adt-bundle-mac-x86_64/sdk/platform-tools/adb" -s emulator-5554 uninstall com.XXX.messenger
debug: App was not uninstalled, maybe it wasn't on device?
debug: Getting install status for com.XXX.messenger
debug: executing: "/Users/aw/Projects/adt-bundle-mac-x86_64/sdk/platform-tools/adb" -s emulator-5554 shell "pm list packages -3 com.XXX.messenger"
info: [ADB] App is not installed
debug: Checking app cert for /var/folders/v1/y34vbhp158x18m1dqjzb57mw0001yl/T/114010-19606-ilw91l/appium-app.zip: java -jar "/Users/aw/Projects/dev/vendor/appium/lib/devices/android/helpers/verify.jar" "/var/folders/v1/y34vbhp158x18m1dqjzb57mw0001yl/T/114010-19606-ilw91l/appium-app.zip"
debug: App not signed with debug cert.
debug: Resigning apks with: java -jar "/Users/aw/Projects/dev/vendor/appium/lib/devices/android/helpers/sign.jar" "/var/folders/v1/y34vbhp158x18m1dqjzb57mw0001yl/T/114010-19606-ilw91l/appium-app.zip" --override
debug: executing: "/Users/aw/Projects/adt-bundle-mac-x86_64/sdk/platform-tools/adb" -s emulator-5554 shell "mkdir -p /data/local/tmp/"
error: uncaughtException: Uncaught, unspecified "error" event. date=Fri Jan 10 2014 17:08:03 GMT-0500 (EST), pid=19606, uid=2003, gid=501, cwd=/Users/aw/Projects/dev/vendor/appium, execPath=/opt/local/bin/node, version=v0.10.22, argv=[node, /Users/aw/Projects/dev/vendor/appium, --full-reset], rss=48279552, heapTotal=34235136, heapUsed=20691688, loadavg=[1.7607421875, 2.1396484375, 2.208984375], uptime=1845098, trace=[column=null, file=null, function=TypeError, line=null, method=null, native=false, column=15, file=events.js, function=EventEmitter.emit, line=74, method=emit, native=false, column=15, file=/Users/aw/Projects/dev/vendor/appium/node_modules/md5calculator/src/calculator.js, function=module.exports, line=16, method=exports, native=false, column=3, file=/Users/aw/Projects/dev/vendor/appium/lib/devices/android/android-common.js, function=androidCommon.getAppMd5, line=173, method=getAppMd5, native=false, column=10, file=/Users/aw/Projects/dev/vendor/appium/lib/devices/android/android-common.js, function=androidCommon.getRemoteApk, line=113, method=getRemoteApk, native=false, column=16, file=/Users/aw/Projects/dev/vendor/appium/lib/devices/android/android-common.js, function=, line=149, method=null, native=false, column=5, file=/Users/aw/Projects/dev/vendor/appium/lib/devices/android/adb.js, function=null, line=123, method=null, native=false, column=7, file=child_process.js, function=ChildProcess.exithandler, line=635, method=exithandler, native=false, column=17, file=events.js, function=ChildProcess.EventEmitter.emit, line=98, method=EventEmitter.emit, native=false, column=16, file=child_process.js, function=maybeClose, line=735, method=null, native=false], stack=[TypeError: Uncaught, unspecified "error" event.,     at TypeError (<anonymous>),     at EventEmitter.emit (events.js:74:15),     at module.exports (/Users/aw/Projects/dev/vendor/appium/node_modules/md5calculator/src/calculator.js:16:15),     at androidCommon.getAppMd5 (/Users/aw/Projects/dev/vendor/appium/lib/devices/android/android-common.js:173:3),     at androidCommon.getRemoteApk (/Users/aw/Projects/dev/vendor/appium/lib/devices/android/android-common.js:113:10),     at null.<anonymous> (/Users/aw/Projects/dev/vendor/appium/lib/devices/android/android-common.js:149:16),     at /Users/aw/Projects/dev/vendor/appium/lib/devices/android/adb.js:123:5,     at ChildProcess.exithandler (child_process.js:635:7),     at ChildProcess.EventEmitter.emit (events.js:98:17),     at maybeClose (child_process.js:735:16)]
```
