### PR TITLE
add zshrc param to exec

### DIFF
--- a/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
+++ b/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
@@ -27,9 +27,12 @@ var sysExec = function(cmd) {
       if (fileExists('/Users/' + user + '/.bash_profile')) {
         params = params.concat(['--rcfile', '/Users/' + user + '/.bash_profile']);
       } else {
-        if (fileExists('/Users/' + user + '/.bashrc')) {
-          params = params.concat(['--rcfile', '/Users/' + user + '/.bashrc']);
-        }
+        var target_shells = ['bash', 'zsh'];
+        target_shells.forEach(function(target_shell) {
+          if (fileExists('/Users/' + user + '/.' + target_shell + 'rc')) {
+            params = params.concat(['--rcfile', '/Users/' + user + '/.' + target_shell + 'rc']);
+          }
+        });
       }
     }
   }


### PR DESCRIPTION
I use appium0.13.0 by CLI and receive the exception of the following

```
"Could not find node using `which node`, at /usr/local/bin/node, at /opt/local/bin/node, at $NODE_BIN, or by querying Appium.app. Where is it
```

https://github.com/appium/appium/blob/master/lib/devices/ios/uiauto/lib/instruments_client_launcher.js#L200

I had set the $NODE_BIN, but it did not load because it did not write only to zshrc.
So I was modified to read the configuration from zshrc
