### PR TITLE
Fixed pattern for output on unzipFile

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -110,7 +110,7 @@ exports.unzipApp = function(zipPath, appExt, cb) {
     if (!error) {
       exports.unzipFile(zipPath, function(err, output) {
         if (!err) {
-          var reg = new RegExp("(?:creating|inflating|extracting): (.+" + appExt + ")/?$", 'm');
+          var reg = new RegExp("(?:creating|inflating|extracting): (.+" + appExt + ")/?", 'm');
           var match = reg.exec(output);
           if (match) {
             var appPath = path.resolve(path.dirname(zipPath), match[1]);


### PR DESCRIPTION
In this case we can't expect that the string ends with the specified appExt, string may contain several spaces and line break.

For example: 

<pre> 'Archive:  /var/folders/4w/nmpy2_2961v2tdpyp2ln0zzm0000gn/T/114014-95194-qetvmq/appium-app.zip\n
  inflating: usr/share/nginx/www/payload/someapp-2.0.apk  \n'
</pre>
