### PR TITLE
Return accessibilityHint as element's attribute 'hint'

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -532,7 +532,7 @@ iOSController.getAttribute = function(elementId, attributeName, cb) {
       this.executeAtom('get_attribute_value', [atomsElement, attributeName], cb);
     }
   } else {
-    if (_.contains(['label', 'name', 'value', 'values'], attributeName)) {
+    if (_.contains(['label', 'name', 'value', 'values', 'hint'], attributeName)) {
       var command = ["au.getElement('", elementId, "').", attributeName, "()"].join('');
       this.proxy(command, cb);
     } else {

--- a/lib/devices/ios/uiauto/appium/element.js
+++ b/lib/devices/ios/uiauto/appium/element.js
@@ -136,6 +136,7 @@ UIAElement.prototype.getTree = function() {
       , valid: element.isValid() ? true : false
       , visible: element.isVisible() === 1 ? true : false
       , children: []
+      , hint: element.hint()
     };
     var children = element.elements();
     var numChildren = children.length;


### PR DESCRIPTION
As we had discuss in this thread (https://github.com/appium/appium/pull/750) I added the hint attribute to the element to retrieve the accessibilityHint.
