### PR TITLE
Implementing mobile:background command for Android and Selendroid

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -720,17 +720,29 @@ ADB.prototype.killProcessByPID = function(pid, cb) {
   this.shell("kill " + pid, cb);
 };
 
-ADB.prototype.startApp = function(pkg, activity, waitActivity, retry, cb) {
+ADB.prototype.startApp = function(pkg, activity, waitActivity, retry, stopApp, cb) {
   if (typeof waitActivity === "function") {
     cb = waitActivity;
     waitActivity = false;
     retry = true;
+    stopApp = true;
   } else if (typeof retry === "function") {
     cb = retry;
     retry = true;
+    stopApp = true;
+  } else if (typeof stopApp === "function") {
+    cb = stopApp;
+    stopApp = true;
+  } else if (typeof stopApp === "undefined") {
+    stopApp = true;
   }
 
-  var cmd = "am start -S -n " + pkg + "/" + activity;
+  var stop = stopApp ? "-S " : "";
+
+  var cmd = "am start " + stop +
+            "-a android.intent.action.MAIN " +
+            "-c android.intent.category.LAUNCHER -f 0x10200000 " +
+            "-n " + pkg + "/" + activity;
   this.shell(cmd, function(err, stdout) {
     if(err) return cb(err);
     if (stdout.indexOf("Error: Activity class") !== -1 &&

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -14,6 +14,26 @@ var logTypesSupported = {
 
 var androidCommon = {};
 
+androidCommon.background = function(secs, cb) {
+  this.adb.getFocusedPackageAndActivity(function(err, pack, activity) {
+    if (err) return cb(err);
+
+    this.adb.keyevent("3", function(err) {
+      if (err) return cb(err);
+
+      setTimeout(function() {
+        this.adb.startApp(this.appPackage, this.appActivity, activity, true, false, function(err) {
+          if (err) return cb(err);
+          cb(null, {
+            status: status.codes.Success.code
+            , value: null
+          });
+        });
+      }.bind(this), secs * 1000);
+    }.bind(this));
+  }.bind(this));
+};
+
 androidCommon.prepareDevice = function(onReady) {
   logger.info("Preparing device for session");
   async.series([

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -352,10 +352,6 @@ androidController.lock = function(secs, cb) {
     cb(new NotYetImplementedError(), null);
 };
 
-androidController.background = function(secs, cb) {
-    cb(new NotYetImplementedError(), null);
-};
-
 androidController.getOrientation = function(cb) {
   this.proxy(["orientation", {}], cb);
 };

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -39,6 +39,7 @@ var Selendroid = function(opts) {
     , 'getCommandTimeout'
     , 'reset'
     , 'lock'
+    , 'background'
     , 'keyevent'
     , 'currentActivity'
     , 'installApp'


### PR DESCRIPTION
Replay commit 1c6b495cd2f3fbbb8622a9fb43f3e50aa79ab82e

Remove debug log

Tidy up spaces according to pull request review

Fixed indentation according to Appium project style guide (2 spaces indent)

Fixed error management in background method

Add an argument to ADB.startApp in order to choose whether to stop the app prior to starting it

Conflicts:
    lib/devices/android/adb.js

Refactored mobile:background method for Android: using ADB.startApp rather than directly issuing am start command to ADB shell, do not return to callback until app is back to foreground

Mimick the launcher start intent for the app when starting it

The Android launcher uses the following settings to start apps:
- MAIN action
- LAUNCHER category
- FLAG_ACTIVITY_NEW_TASK
- FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
  Without those settings there were discrepancies between Selendroid and
  Android when trying to bring the app back to foreground: it would not
  bring back the existing Activity stack but create new activities

Adapt background code to new startApp signature

Added "retry" argument

Missing space
