### PR TITLE
Alerts with no title will return the text as null, instead of the alert's message content.

### DIFF
--- a/lib/devices/ios/uiauto/appium/app.js
+++ b/lib/devices/ios/uiauto/appium/app.js
@@ -890,16 +890,21 @@ $.extend(au, {
       }
 
       var textRes = this.getElementsByType('text', alert);
-      var text = alert.name();
+      // If an alert does not have a title, alert.name() is null, use empty string
+      var text = alert.name() || "";
       if (textRes.value.length > 1) {
-        if (text.indexOf('http') != -1) {
+        // Safari alerts have the URL as a title
+        if (text.indexOf('http') != -1 || text == "") {
           textId = textRes.value[textRes.value.length-1].ELEMENT;
           text = this.getElement(textId).name();
         } else {
           var textId = textRes.value[textRes.value.length-2].ELEMENT;
           text = this.getElement(textId).name();
           textId = textRes.value[textRes.value.length-1].ELEMENT;
-          text = text + ' ' + this.getElement(textId).name();
+          var subtext = this.getElement(textId).name();
+          if(subtext != null) {
+              text = text + ' ' + subtext;
+          }
         }
       }
       return {


### PR DESCRIPTION
When getting the text of an alert with no title, null is returned. In this case, we want the body of the alert to be returned instead.
