### PR TITLE
Support mobile method 'launchApp' for selendroid

### DIFF
--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -46,6 +46,7 @@ var Selendroid = function(opts) {
     , 'removeApp'
     , 'closeApp'
     , 'isAppInstalled'
+    , 'launchApp'
   ];
   this.proxyHost = 'localhost';
   this.proxyPort = opts.systemPort;


### PR DESCRIPTION
Hi

I used the method closeApp and launchApp to simulate restart the app when a test has failed before the next test start.
<code>
        """ restart the application """
        logger.info("Restart the app")
        self.driver.execute_script("mobile: closeApp")
        self.driver.execute_script("mobile: launchApp")
</code>
