### PR TITLE
Support mobile method 'launchApp' for selendroid

### DIFF
--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -47,6 +47,7 @@ var Selendroid = function(opts) {
     , 'removeApp'
     , 'closeApp'
     , 'isAppInstalled'
+    , 'launchApp'
   ];
   this.proxyHost = 'localhost';
   this.proxyPort = opts.systemPort;


### PR DESCRIPTION
I am using the methods closeApp and launchApp to simulate restarting the app.

``` python
        """ restart the application """
        logger.info("Restart the app")
        self.driver.execute_script("mobile: closeApp")
        self.driver.execute_script("mobile: launchApp")
```
