### PR TITLE
Fix Android system setup link

### DIFF
--- a/docs/running-tests.md
+++ b/docs/running-tests.md
@@ -56,8 +56,10 @@ all set now!
 First, make sure you have one and only one Android emulator or device
 connected. If you run `adb devices`, for example, you should see one device
 connected. This is the device Appium will use for tests. Of course, to have
-a device connected, you'll need to have made an Android AVD (see [system
-setup](https://github.com/appium/appium/blob/master/docs/system-setup.md#android)
+a device connected, you'll need to have made an Android AVD (see system
+setup ([Windows](https://github.com/appium/appium/blob/master/docs/running-on-windows.md#setup),
+[Mac](https://github.com/appium/appium/blob/master/docs/running-on-osx.md#system-setup-android),
+or [Linux](https://github.com/appium/appium/blob/master/docs/running-on-linux.md#setup))
 for more information). If the Android SDK tools are on your path, you can
 simply run:
 


### PR DESCRIPTION
Separate non-existent "system setup" link into Windows, Mac, and Linux versions. 

@jlipps
