### PR TITLE
Fixed a crash when there is a URL in an alert's title.

### DIFF
--- a/lib/devices/ios/uiauto/appium/app.js
+++ b/lib/devices/ios/uiauto/appium/app.js
@@ -894,7 +894,7 @@ $.extend(au, {
       var text = alert.name() || "";
       if (textRes.value.length > 1) {
         // Safari alerts have the URL as a title
-        if (text.indexOf('http') != -1 || text == "") {
+        if (text.indexOf('http') == 0 || text == "") {
           textId = textRes.value[textRes.value.length-1].ELEMENT;
           text = this.getElement(textId).name();
         } else {


### PR DESCRIPTION
Given an alert that contains a URL in the title, the title won't be grabbed. If there is no body to the alert, no body will be grabbed. Thus, the text will be nil when pulled from the alert even though a title exists.

I propose to check for a URL at the beginning of the title, to maintain compatibility with Safari.
