### PR TITLE
Real safari ios7

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -48,6 +48,7 @@ iOSController.findUIElementOrElements = function(strategy, selector, ctx, many, 
     } else if (strategy === "xpath") {
       command = ["au.getElement", ext, "ByXpath('", selector, "'", ctx, ")"].join('');
     } else if (strategy === "id") {
+      selector = selector.replace(/'/g, "\\\\'"); // must escape single quotes
       command = ["var exact = au.mainApp.getFirstWithPredicateWeighted(\"name == '", selector,
                  "' || label == '", selector, "' || value == '", selector, "'\");"].join('');
       command += ["exact && exact.status == 0 ? exact : au.mainApp.getFirstWith",

--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -68,8 +68,8 @@ Safari.prototype.navToLatestAvailableWebview = function (cb) {
 };
 
 Safari.prototype._click = IOS.prototype.click;
-Safari.prototype.click = function (elementId, cb) {
-  if (parseInt(this.iOSSDKVersion, 10) >= 7) {
+Safari.prototype.click = function(elementId, cb) {
+  if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.udid) {
     // atoms-based clicks don't always work in safari 7
     this.nonSyntheticWebClick(elementId, cb);
   } else {

--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -57,7 +57,7 @@ Safari.prototype.navToLatestAvailableWebview = function (cb) {
   }.bind(this);
   if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.udid) {
     logger.info("We're on iOS7 simulator: clicking apple button to get into a webview");
-    this.findAndAct('xpath', '//window[2]/scrollview[1]/button[1]', 0, 'click', [], function(err, res) {
+    this.findAndAct('xpath', '//window[2]/scrollview[1]/button[1]', 0, 'click', [], function (err, res) {
       if (this.checkSuccess(err, res, cb)) {
         navToView();
       }
@@ -68,7 +68,7 @@ Safari.prototype.navToLatestAvailableWebview = function (cb) {
 };
 
 Safari.prototype._click = IOS.prototype.click;
-Safari.prototype.click = function(elementId, cb) {
+Safari.prototype.click = function (elementId, cb) {
   if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.udid) {
     // atoms-based clicks don't always work in safari 7
     this.nonSyntheticWebClick(elementId, cb);

--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -55,8 +55,8 @@ Safari.prototype.navToLatestAvailableWebview = function(cb) {
     }.bind(this);
     spinHandles();
   }.bind(this);
-  if (parseInt(this.iOSSDKVersion, 10) >= 7) {
-    logger.info("We're on iOS7: clicking apple button to get into a webview");
+  if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.udid) {
+    logger.info("We're on iOS7 simulator: clicking apple button to get into a webview");
     this.findAndAct('xpath', '//window[2]/scrollview[1]/button[1]', 0, 'click', [], function(err, res) {
       if (this.checkSuccess(err, res, cb)) {
         navToView();

--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -55,9 +55,9 @@ Safari.prototype.navToLatestAvailableWebview = function (cb) {
     }.bind(this);
     spinHandles();
   }.bind(this);
-  if (parseInt(this.iOSSDKVersion, 10) >= 7) {
-    logger.info("We're on iOS7: clicking apple button to get into a webview");
-    this.findAndAct('xpath', '//window[2]/scrollview[1]/button[1]', 0, 'click', [], function (err, res) {
+  if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.udid) {
+    logger.info("We're on iOS7 simulator: clicking apple button to get into a webview");
+    this.findAndAct('xpath', '//window[2]/scrollview[1]/button[1]', 0, 'click', [], function(err, res) {
       if (this.checkSuccess(err, res, cb)) {
         navToView();
       }

--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -69,7 +69,7 @@ Safari.prototype.navToLatestAvailableWebview = function(cb) {
 
 Safari.prototype._click = IOS.prototype.click;
 Safari.prototype.click = function(elementId, cb) {
-  if (parseInt(this.iOSSDKVersion, 10) >= 7) {
+  if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.udid) {
     // atoms-based clicks don't always work in safari 7
     this.nonSyntheticWebClick(elementId, cb);
   } else {


### PR DESCRIPTION
For a real device the SafariLauncher starts Safari with an active web view. As such there is no apple button to click and the execution fails as it cannot find the element, i.e.

info: We're on iOS7: clicking apple button to get into a webview
info: Pushing command to appium work queue: "au.elemForAction(au.getElementByXpath('//window[2]/scrollview[1]/button[1]'), 0).tap()"
debug: Sending command to instruments: au.elemForAction(au.getElementByXpath('//window[2]/scrollview[1]/button[1]'), 0).tap()
info: [INSTSERVER] Sending command to instruments: au.elemForAction(au.getElementByXpath('//window[2]/scrollview[1]/button[1]'), 0).tap()
info: [INSTSERVER] Socket data received (50 bytes)
info: [INSTSERVER] Socket data being routed for 'cmd' event
info: [INSTSERVER] Got result from instruments: {"status":7,"value":null}

Adding a check whether a udid has been set and not clicking the apple button resolves this issue.

In addition, click() results in the following error on a real device:

org.openqa.selenium.WebDriverException: An unknown server-side error occurred while processing the command. (WARNING: The server did not provide any stacktrace information)

This is caused by calling the nonSyntheticWebClick for iOS 7.
