### PR TITLE
Escape single quotes for iOS id search

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -48,6 +48,7 @@ iOSController.findUIElementOrElements = function(strategy, selector, ctx, many, 
     } else if (strategy === "xpath") {
       command = ["au.getElement", ext, "ByXpath('", selector, "'", ctx, ")"].join('');
     } else if (strategy === "id") {
+      selector = selector.replace(/'/g, "\\\\'"); // must escape single quotes
       command = ["var exact = au.mainApp.getFirstWithPredicateWeighted(\"name == '", selector,
                  "' || label == '", selector, "' || value == '", selector, "'\");"].join('');
       command += ["exact && exact.status == 0 ? exact : au.mainApp.getFirstWith",


### PR DESCRIPTION
Fix #1821
