### PR TITLE
Handle accented characters sent to text fields in iOS

### DIFF
--- a/lib/devices/ios/uiauto/appium/element.js
+++ b/lib/devices/ios/uiauto/appium/element.js
@@ -62,7 +62,11 @@ UIAElement.prototype.setValueByType = function (newValue) {
     if (this.hasKeyboardFocus() === 0) {
       this.tap();
     }
-    au.sendKeysToActiveElement(newValue);
+    if (isAccented(newValue)) {
+      this.setValue(newValue);
+    } else {
+      au.sendKeysToActiveElement(newValue);
+    }
   } else if (type === "UIAPickerWheel") {
     this.selectValue(newValue);
   } else if (type === "UIASlider") {
@@ -72,6 +76,18 @@ UIAElement.prototype.setValueByType = function (newValue) {
   } else {
     this.setValue(newValue);
   }
+};
+
+var isAccented = function (value) {
+  for (var i = 0; i < value.length; i++) {
+    var c = value.charCodeAt(i);
+    if (c > 127) {
+      // this is not simple ascii
+      return true;
+    }
+  }
+
+  return false;
 };
 
 UIAElement.prototype.type = function () {

--- a/test/functional/testapp/accents.js
+++ b/test/functional/testapp/accents.js
@@ -1,0 +1,19 @@
+"use strict";
+
+var setup = require("../common/setup-base"),
+    desired = require('./desired');
+
+describe('testapp - accented characters', function () {
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('should send accented text', function (done) {
+    driver
+      .elementsByTagName('textField').then(function (elems) {
+        return elems[1];
+      }).then(function (elem) {
+        elem.sendKeys("é Œ ù ḍ");
+        elem.text().should.become("é Œ ù ḍ");
+      }).nodeify(done);
+  });
+});


### PR DESCRIPTION
Associated with Appium issue #1793

A test case for sending accented characters to iOS text fields (outside of Safari, which works). 

The test for accented characters just tests if it is outside the code space (i.e., > 127) for basic ASCII. Is there a better way?

@jlipps
