### PR TITLE
Added iOS --full-reset capability (wipes out 'iPhone Simulator' folder)

### DIFF
--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -19,7 +19,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`-k`, `--keep-artifacts`|false|(IOS-only) Keep Instruments trace directories||
 |`-r`, `--backend-retries`|3|(iOS-only) How many times to retry launching Instruments before saying it crashed or timed out|`--backend-retries 3`|
 |`--session-override`|false|Enables session override (clobbering)||
-|`--full-reset`|false|(Android-only) Reset app state by uninstalling app instead of clearing app data||
+|`--full-reset`|false|IOS: reset app state by removing the entire simulator directory; Android: reset app state by uninstalling app instead of clearing app data||
 |`--no-reset`|false|Don't reset app state between sessions (IOS: don't delete app plist files; Android: don't uninstall app before new session)||
 |`-l`, `--pre-launch`|false|Pre-launch the application before allowing the first session (Requires --app and, for Android, --app-pkg and --app-activity)||
 |`-lt`, `--launch-timeout`|90000|(iOS-only) how long in ms to wait for Instruments to launch||

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -559,6 +559,7 @@ Appium.prototype.initDevice = function () {
     , withoutDelay: !(typeof this.desiredCapabilities.nativeInstrumentsLib !== 'undefined' ?
       this.desiredCapabilities.nativeInstrumentsLib : this.args.nativeInstrumentsLib)
     , reset: !this.args.noReset
+    , fullReset: this.args.fullReset
     , launchTimeout: this.desiredCapabilities.launchTimeout || this.args.launchTimeout
     , version: this.desiredCapabilities.version
     , deviceName: this.desiredCapabilities.deviceName || this.desiredCapabilities.device || this.args.deviceName

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -61,6 +61,7 @@ IOS.prototype.init = function (args) {
   this.xcodeVersion = null;
   this.iOSSDKVersion = null;
   this.reset = args.reset;
+  this.fullReset = args.fullReset;
   this.automationTraceTemplatePath = args.automationTraceTemplatePath;
   this.removeTraceDir = args.removeTraceDir;
   this.deviceName = args.deviceName;
@@ -666,7 +667,9 @@ IOS.prototype.setDeviceAndLaunchSimulator = function (cb) {
     } else {
 
       var cleanup = function (cb) {
-        if (this.reset) {
+        if (this.fullReset) {
+          this.removeAppState(cb);
+        } else if (this.reset) {
           this.cleanupAppState(cb);
         } else {
           cb();
@@ -738,7 +741,6 @@ IOS.prototype.parseLocalizableStrings = function (cb) {
     }.bind(this));
   }
 };
-
 
 IOS.prototype.getSimulatorApplications = function (cb) {
   var user = process.env.USER;
@@ -825,6 +827,16 @@ IOS.prototype.cleanupAppState = function (cb) {
   }.bind(this));
 };
 
+IOS.prototype.removeAppState = function (cb) {
+  var user = process.env.USER;
+  var simDir = "/Users/" + user + "/Library/Application\\ " +
+               "Support/iPhone\\ Simulator";
+  logger.info("Removing entire simulator folder");
+  rimraf.sync(simDir);
+  logger.info("Deleted " + simDir);
+  cb();
+};
+
 IOS.prototype.postCleanup = function (cb) {
   this.curCoords = null;
   this.curOrientation = null;
@@ -838,7 +850,9 @@ IOS.prototype.postCleanup = function (cb) {
     this.stopRemote();
   }
 
-  if (this.reset) {
+  if (this.fullReset) {
+    this.endSimulator(cb);
+  } else if (this.reset) {
     // The simulator process must be ended before we delete applications.
     async.series([
       function (cb) { this.endSimulator(cb); }.bind(this),
@@ -867,7 +881,6 @@ IOS.prototype.endSimulator = function (cb) {
       }
     }.bind(this));
   }
-
 };
 
 IOS.prototype.endSimulatorDaemons = function (cb) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -851,7 +851,11 @@ IOS.prototype.postCleanup = function (cb) {
   }
 
   if (this.fullReset) {
-    this.endSimulator(cb);
+    // The simulator process must be ended before we delete the simulator folder.
+    async.series([
+      function (cb) { this.endSimulator(cb); }.bind(this),
+      function (cb) { this.removeAppState(cb); }.bind(this),
+    ], cb);
   } else if (this.reset) {
     // The simulator process must be ended before we delete applications.
     async.series([

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -98,7 +98,8 @@ var args = [
   , dest: 'fullReset'
   , action: 'storeTrue'
   , required: false
-  , help: '(Android-only) Reset app state by uninstalling app instead of ' +
+  , help: 'IOS: reset app state by removing the entire simulator directory; ' +
+          'Android: reset app state by uninstalling app instead of ' +
           'clearing app data'
   , nargs: 0
   }],


### PR DESCRIPTION
...It doesn't seem to actually delete the folder, though. I wanted to submit a pull request to have someone look at it - I've never done any node.js programming, so it may be something obvious. First, I thought it was a race condition where the 'iPhone Simulator' folder isn't actually being deleted before the Simulator launches, but after adding the code to delete the folder in postCleanup I saw that the folder isn't deleted when called there, either. So now I'm a bit stumped.

The folder is deleted in `IOS.prototype.removeAppState`. Calling `rimraf()` asynchronously doesn't give an error (not sure how to check for error when using `rimraf.sync()`). Executing `ls ~/Library/Application Support` before and after deleting the folder still lists 'iPhone Simulator' as present, though the `ls` afterwards may have been executed after the Simulator was launched (I was uncertain how to do this synchronously in order to debug). Calling `rimraf()` on a random folder in my Documents dir worked fine.

```
drwxr-xr-x    3 lkung  staff    102 Jan 31 19:33 iPhone Simulator
drwxr-xr-x    2 lkung  staff     68 Jan 31 19:44 foo
```

Come to think of it, `foo` is empty while `iPhone Simulator` is not. However, I was under the impression that `rimraf()` is `rm -rf`?

Adding this `--full-reset` iOS capability resolves [#1799](https://github.com/appium/appium/issues/1799). The app I'm testing saves state that only wiping out the 'iPhone Simulator' folder can erase, so this change also allows me to run my tests on the grid (since there's no way to wipe out the folder before a test runs on a node since I don't know the IP address of the node until a session is created).

Currently passes all lint, unit, and functional iOS tests.
