### PR TITLE
fix for #1835

### DIFF
--- a/lib/devices/ios/instruments.js
+++ b/lib/devices/ios/instruments.js
@@ -305,7 +305,7 @@ Instruments.prototype.onInstrumentsExit = function (code) {
     return this.launchHandler(new Error(ERR_NEVER_CHECKED_IN));
   }
 
-  if (!this.didLaunch) {
+  if (!this.didLaunch && !this.isSafariLauncherApp) {
     return this.launchHandler(new Error(ERR_CRASHED_ON_STARTUP));
   }
 

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -301,6 +301,9 @@ IOS.prototype.setInitialOrientation = function (cb) {
 };
 
 IOS.prototype.setBootstrapConfig = function (cb) {
+  if (this.isSafariLauncherApp) {
+    return cb();
+  }
   logger.info("Setting bootstrap config keys/values");
   var pre = "setBootstrapConfig: ";
   var cmd = pre + "autoAcceptAlerts=" + JSON.stringify(this.autoAcceptAlerts);


### PR DESCRIPTION
Added two minor fixes:
1. Added the is not safariLauncher to the didLaunch check as the safari launcher app will crash, but that is the point.
2. Added an immediate call back for the setBootstrapConfig when using safariLauncher as it tries to put a command in the queue even though instruments has lost connection.

Tested it on simulator and real devices (iOS 7.0.4) with xcode 4.6 and xcode 5.0 and it work fine (when re-running a basic safari script multiple times).
