### PR TITLE
el.tag_name on Android should return element's className.

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -131,7 +131,8 @@ androidController.submit = function (elementId, cb) {
 };
 
 androidController.getName = function (elementId, cb) {
-  this.proxy(["element:getName", {elementId: elementId}], cb);
+  var p = {elementId: elementId, attribute: "className"};
+  this.proxy(["element:getAttribute", p], cb);
 };
 
 androidController.getText = function (elementId, cb) {


### PR DESCRIPTION
el.tag_name on Android returns the 'content-description (name)'. This is incompatible with the meaning of el.tag_name on iOS where it is translated to 'type'. I think we need to return the className (type of the element on Android) instead.

We can always get the content description using el.get_attribute('name').
