### PR TITLE
Allow multiple ChromeDrivers to be running

### DIFF
--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -49,6 +49,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`-ra`, `--robot-address`|0.0.0.0|IP Address of robot|`--robot-address 0.0.0.0`|
 |`-rp`, `--robot-port`|-1|port for robot|`--robot-port 4242`|
 |`--selendroid-port`|8080|Local port used for communication with Selendroid|`--selendroid-port 8080`|
+|`--chromedriver-port`|9515|(Android-only) Local port used for running ChromeDriver|`--chromedriver-port 9515`|
 |`--use-keystore`|false|(Android-only) When set the keystore will be used to sign apks.||
 |`--keystore-path`|/Users/user/.android/debug.keystore|(Android-only) Path to keystore||
 |`--keystore-password`|android|(Android-only) Password to keystore||

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -610,6 +610,7 @@ Appium.prototype.initDevice = function () {
     , systemPort: this.args.devicePort
     , desiredCapabilities: this.desiredCapabilities
     , logNoColors: this.args.logNoColors
+    , port: this.args.chromeDriverPort
     };
     if (this.isChrome()) {
       this.device = new Chrome(androidOpts);

--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -60,8 +60,19 @@ ChromeAndroid.prototype.ensureChromedriverExists = function (cb) {
 };
 
 ChromeAndroid.prototype.killOldChromedrivers = function (cb) {
-  var cmd = isWindows ? "TASKKILL /IM chromedriver.exe" : "killall chromedriver";
-  logger.info("Killing any old chromedrivers");
+  var cmd;
+  if (isWindows) {
+    cmd = "FOR /F \"usebackq tokens=5\" %%a in (`netstat -nao ^| findstr /R /C:\"" + this.proxyPort + " \"`) do (" +
+            "FOR /F \"usebackq\" %%b in (`TASKLIST /FI \"PID eq %%a\" ^| findstr /I chromedriver.exe`) do (" +
+              "IF NOT %%b==\"\" TASKKILL /F /PID %%b" +
+            ")" +
+          ")";
+  } else {
+    cmd = "ps -e | grep " + this.chromedriver + " | grep -v grep |" +
+      "grep -e '--port=" + this.proxyPort + "$' | awk '{ print $1 }' | " +
+      "xargs kill -15";
+  }
+  logger.info("Killing any old chromedrivers, running: " + cmd);
   exec(cmd, function (err) {
     if (err) {
       logger.info("No old chromedrivers seemed to exist");
@@ -76,7 +87,7 @@ ChromeAndroid.prototype.startChromedriver = function (cb) {
   this.onChromedriverStart = cb;
   logger.info("Spawning chromedriver with: " + this.chromedriver);
   var alreadyReturned = false;
-  var args = ["--url-base=wd/hub"];
+  var args = ["--url-base=wd/hub", "--port=" + this.proxyPort];
   this.proc = spawn(this.chromedriver, args);
   this.proc.stdout.setEncoding('utf8');
   this.proc.stderr.setEncoding('utf8');

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -350,6 +350,15 @@ var args = [
   , help: 'Local port used for communication with Selendroid'
   }],
 
+  [['--chromedriver-port'], {
+    defaultValue: 9515
+  , dest: 'chromeDriverPort'
+  , required: false
+  , type: 'int'
+  , example: '9515'
+  , help: 'Port upon which ChromeDriver will run'
+  }],
+
   [['--use-keystore'], {
     defaultValue: false
   , dest: 'useKeystore'


### PR DESCRIPTION
Regarding Issue #1811

Checks for running ChromeDriver instances with the same port, and kills that, rather than all ChromeDrivers running. Then starts up ChromeDriver on specified port.

Added a --chromedriver-port command line option to allow for specification.

Attn: @jlipps
