### PR TITLE
Add app wait package

### DIFF
--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -31,6 +31,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--merciful`, `-m`|false|Don't run the watcher process that will force-kill an unresponsive instruments||
 |`--app-pkg`|null|(Android-only) Java package of the Android app you want to run (e.g., com.example.android.myApp)|`--app-pkg com.example.android.myApp`|
 |`--app-activity`|null|(Android-only) Activity name for the Android activity you want to launch from your package (e.g., MainActivity)|`--app-activity MainActivity`|
+|`--app-wait-package`|false|(Android-only) Package name for the Android activity you want to wait for (e.g., com.example.android.myApp)|`--app-wait-package com.example.android.myApp`|
 |`--app-wait-activity`|false|(Android-only) Activity name for the Android activity you want to wait for (e.g., SplashActivity)|`--app-wait-activity SplashActivity`|
 |`--avd`|null|name of the avd to launch|`--avd @default`|
 |`--device-ready-timeout`|5|(Android-only) Timeout in seconds while waiting for device to become ready|`--device-ready-timeout 5`|

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -180,6 +180,7 @@ Appium.prototype.setAndroidArgs = function (desiredCaps) {
   }.bind(this);
   setArgFromCaps("androidPackage", "app-package");
   setArgFromCaps("androidActivity", "app-activity");
+  setArgFromCaps("androidWaitPackage", "app-wait-package");
   setArgFromCaps("androidWaitActivity", "app-wait-activity");
   setArgFromCaps("androidDeviceReadyTimeout", "device-ready-timeout");
   setArgFromCaps("compressXml", "compressXml");
@@ -595,6 +596,7 @@ Appium.prototype.initDevice = function () {
     , udid: this.args.udid
     , appPackage: this.args.androidPackage
     , appActivity: this.args.androidActivity
+    , appWaitPackage: this.args.androidWaitPackage
     , appWaitActivity: this.args.androidWaitActivity
     , compressXml: this.args.compressXml
     , avdName: this.args.avd
@@ -626,6 +628,7 @@ Appium.prototype.initDevice = function () {
     , udid: this.args.udid
     , appPackage: this.args.androidPackage
     , appActivity: this.args.androidActivity
+    , appWaitPackage: this.args.androidWaitPackage
     , appWaitActivity: this.args.androidWaitActivity
     , avdName: this.args.avd
     , appDeviceReadyTimeout: this.args.androidDeviceReadyTimeout

--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -778,8 +778,14 @@ ADB.prototype.killProcessByPID = function (pid, cb) {
   this.shell("kill " + pid, cb);
 };
 
-ADB.prototype.startApp = function (pkg, activity, waitActivity, retry, stopApp, cb) {
-  if (typeof waitActivity === "function") {
+ADB.prototype.startApp = function (pkg, activity, waitPkg, waitActivity, retry, stopApp, cb) {
+  if (typeof waitPkg === "function") {
+    cb = waitPkg;
+    waitPkg = false;
+    waitActivity = false;
+    retry = true;
+    stopApp = true;
+  } else if (typeof waitActivity === "function") {
     cb = waitActivity;
     waitActivity = false;
     retry = true;
@@ -812,7 +818,8 @@ ADB.prototype.startApp = function (pkg, activity, waitActivity, retry, stopApp, 
         logger.info("We tried to start an activity that doesn't exist, " +
                     "retrying with . prepended to activity");
         activity = "." + activity;
-        return this.startApp(pkg, activity, cb);
+        retry = false;
+        return this.startApp(pkg, activity, waitPkg, waitActivity, retry, stopApp, cb);
       } else {
         var msg = "Activity used to start app doesn't exist! Make sure " +
                   "it exists";
@@ -822,7 +829,7 @@ ADB.prototype.startApp = function (pkg, activity, waitActivity, retry, stopApp, 
     }
 
     if (waitActivity) {
-      this.waitForActivity(pkg, waitActivity, cb);
+      this.waitForActivity(waitPkg, waitActivity, cb);
     } else {
       cb();
     }

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -24,7 +24,7 @@ androidCommon.background = function (secs, cb) {
       if (err) return cb(err);
 
       setTimeout(function () {
-        this.adb.startApp(this.appPackage, this.appActivity, activity, true, false, function (err) {
+        this.adb.startApp(this.appPackage, this.appActivity, pack, activity, true, false, function (err) {
           if (err) return cb(err);
           cb(null, {
             status: status.codes.Success.code

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -36,6 +36,7 @@ Android.prototype.initialize = function (opts) {
   this.appPackage = opts.appPackage;
   this.appActivity = opts.appActivity;
   this.appMd5Hash = null;
+  this.appWaitPackage = opts.appWaitPackage || opts.appPackage;
   this.appWaitActivity = opts.appWaitActivity || opts.appActivity;
   this.avdName = opts.avdName || null;
   this.appDeviceReadyTimeout = opts.appDeviceReadyTimeout;
@@ -303,8 +304,8 @@ Android.prototype.pushAppium = function (cb) {
 };
 
 Android.prototype.startApp = function (cb) {
-  this.adb.startApp(this.appPackage, this.appActivity, this.appWaitActivity,
-      cb);
+  this.adb.startApp(this.appPackage, this.appActivity, this.appWaitPackage,
+      this.appWaitActivity, cb);
 };
 
 Android.prototype.requestXmlCompression = function (cb) {
@@ -445,7 +446,7 @@ Android.prototype.wakeUp = function (cb) {
 };
 
 Android.prototype.waitForActivityToStop = function (cb) {
-  this.adb.waitForNotActivity(this.appPackage, this.appWaitActivity, cb);
+  this.adb.waitForNotActivity(this.appWaitPackage, this.appWaitActivity, cb);
 };
 
 Android.prototype.waitForCondition = deviceCommon.waitForCondition;

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -23,6 +23,7 @@ var Selendroid = function (opts) {
   this.skipUninstall = opts.fastReset || !opts.reset;
   this.opts.systemPort = opts.systemPort;
   this.avdName = opts.avdName || null;
+  this.appWaitPackage = opts.appWaitPackage || opts.appPackage;
   this.appWaitActivity = opts.appWaitActivity || opts.appActivity;
   this.serverApk = null;
   this.appPackage = opts.appPackage;
@@ -279,13 +280,13 @@ Selendroid.prototype.createSession = function (cb) {
     if (res.statusCode === 301 && body.sessionId) {
       logger.info("Successfully started selendroid session");
       this.selendroidSessionId = body.sessionId;
-      this.adb.waitForActivity(this.appPackage, this.appWaitActivity, 1800,
+      this.adb.waitForActivity(this.appWaitPackage, this.appWaitActivity, 1800,
           function (err) {
         if (err) {
           logger.info("Selendroid hasn't started app yet, let's do it " +
                       "manually with adb.startApp");
           return this.adb.startApp(this.appPackage, this.appActivity,
-              this.appWaitActivity, false, function (err) {
+              this.appWaitPackage, this.appWaitActivity, false, function (err) {
             if (err) return cb(err);
             return cb(null, body.sessionId);
           }.bind(this));

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -202,6 +202,15 @@ var args = [
           "to launch from your package (e.g., MainActivity)"
   }],
 
+  [['--app-wait-package'], {
+    dest: 'androidWaitPackage'
+  , defaultValue: false
+  , required: false
+  , example: "com.example.android.myApp"
+  , help: "(Android-only) Package name for the Android activity you want " +
+          "to wait for (e.g., com.example.android.myApp)"
+  }],
+
   [['--app-wait-activity'], {
     dest: 'androidWaitActivity'
   , defaultValue: false

--- a/test/harmony/helpers/driverblock_harmony.js
+++ b/test/harmony/helpers/driverblock_harmony.js
@@ -116,7 +116,7 @@ describeForChrome.only = function () {
   return describeForChrome(true);
 };
 
-var describeForApp = function (app, device, appPackage, appActivity, appWaitActivity) {
+var describeForApp = function (app, device, appPackage, appActivity, appWaitPackage, appWaitActivity) {
   if (typeof device === "undefined") {
     device = "ios";
   }
@@ -157,6 +157,11 @@ var describeForApp = function (app, device, appPackage, appActivity, appWaitActi
       newExtraCaps['app-activity'] = appActivity;
       if (typeof appWaitActivity !== "undefined") {
         newExtraCaps['app-wait-activity'] = appWaitActivity;
+        if (typeof appWaitPackage !== "undefined") {
+          newExtraCaps['app-wait-package'] = appWaitPackage;
+        } else {
+          newExtraCaps['app-wait-package'] = appPackage;
+        }
       }
     }
     extraCaps = _.extend(extraCaps, newExtraCaps);


### PR DESCRIPTION
Regarding issue #1693

Allow the user to specify the package (through `app-wait-package` desired capability) of the activity to wait for, in Android tests.
