### PR TITLE
Auto config node host and port for Selenium Grid

### DIFF
--- a/docs/grid.md
+++ b/docs/grid.md
@@ -23,18 +23,16 @@ Once you start the appium server and it registers with the grid, you will see yo
           "browserName": "<e.g._iPhone5_or_iPad4>",
           "version":"<version_of_iOS_e.g._6.1>",
           "maxInstances": 1,
-          "platform":"MAC"
+          "platform":"<platform_e.g._MAC_or_ANDROID>"
         }
       ],
   "configuration":
   {
-  	"cleanUpCycle":2000,
-  	"timeout":30000,
+    "cleanUpCycle":2000,
+    "timeout":30000,
     "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
     "url":"http://<host_name_appium_server_or_ip-address_appium_server>:<appium_port>/wd/hub",
     "maxSession": 1,
-    "port": <appium_port>,
-    "host": "<host_name_appium_server_or_ip-address_appium_server>",
     "register": true,
     "registerCycle": 5000,
     "hubPort": <grid_port>,
@@ -42,3 +40,5 @@ Once you start the appium server and it registers with the grid, you will see yo
   }
 }
 ```
+
+Valid platforms are listed <a href="http://selenium.googlecode.com/git/docs/api/java/org/openqa/selenium/Platform.html">here</a>

--- a/lib/server/grid-register.js
+++ b/lib/server/grid-register.js
@@ -3,7 +3,7 @@ var request = require('request')
   , fs = require('fs')
   , logger = require('./logger.js').get('appium');
 
-exports.registerNode = function (configFile) {
+exports.registerNode = function (configFile, addr, port) {
   fs.readFile(configFile, 'utf-8', function (err, data) {
     if (err) {
       logger.error("Unable to load node configuration file to register with grid");
@@ -11,7 +11,7 @@ exports.registerNode = function (configFile) {
     }
     // Check presence of data before posting  it to the selenium grid
     if (data) {
-      postRequest(data);
+      postRequest(data, addr, port);
     } else {
       logger.error("No data found in the node configuration file to send to the grid");
     }
@@ -29,7 +29,7 @@ function registerToGrid(options_post, jsonObject) {
   });
 }
 
-function postRequest(data) {
+function postRequest(data, addr, port) {
   //parse json to get hub host and port
   var jsonObject;
   try {
@@ -37,6 +37,14 @@ function postRequest(data) {
   } catch (e) {
     return logger.error("Syntax error in node configuration file: " + e.message);
   }
+
+  // set the node's url config automatically
+  jsonObject.configuration.url = 'http://' + addr + ':' + port + '/wd/hub';
+  jsonObject.configuration.host = addr;
+  jsonObject.configuration.port = port;
+
+  // re-serialize the configuration with the auto populated data
+  data = JSON.stringify(jsonObject);
   // prepare the header
   var post_headers = {
     'Content-Type'  : 'application/json'
@@ -94,9 +102,3 @@ function isAlreadyRegistered(jsonObject, cb) {
   });
 
 }
-
-
-
-
-
-

--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -221,7 +221,7 @@ module.exports.startListening = function (server, args, appiumVer, appiumRev, ap
     logger.info(logMessage);
     startAlertSocket(server, appiumServer, !args.logNoColors);
     if (args.nodeconfig !== null) {
-      gridRegister.registerNode(args.nodeconfig);
+      gridRegister.registerNode(args.nodeconfig, args.address, args.port);
     }
   });
   server.on('error', function (err) {


### PR DESCRIPTION
This will auto update the contents of the node config JSON and data string with the host and port of the Appium instance. This reduces the amount of things users have to setup in their node config JSONs.

Tested:
- With default port
- With custom port
- Restarting Selenium Grid while Appium was still running
- Restarting Appium while Selenium Grid was still running

Question:
- Is there any case where the node's URL won't be `localhost`?
