### PR TITLE
Add exceptions to accent check

### DIFF
--- a/lib/devices/ios/uiauto/appium/element.js
+++ b/lib/devices/ios/uiauto/appium/element.js
@@ -83,6 +83,12 @@ var isAccented = function (value) {
     var c = value.charCodeAt(i);
     if (c > 127) {
       // this is not simple ascii
+      if (c >= parseInt("E000", 16) && c <= parseInt("E040", 16)) {
+        // Selenium uses a Unicode PUA to cover certain special characters
+        // see https://code.google.com/p/selenium/source/browse/java/client/src/org/openqa/selenium/Keys.java
+        return false;
+      }
+
       return true;
     }
   }

--- a/test/functional/ios/testapp/accents-specs.js
+++ b/test/functional/ios/testapp/accents-specs.js
@@ -3,7 +3,7 @@
 var setup = require("../../common/setup-base"),
     desired = require('./desired');
 
-// TODO: check why this doesn't work 
+// TODO: check why this doesn't work
 describe('testapp - accented characters @skip-ios-all', function () {
   var driver;
   setup(this, desired).then(function (d) { driver = d; });
@@ -14,6 +14,16 @@ describe('testapp - accented characters @skip-ios-all', function () {
         .sendKeys("é Œ ù ḍ")
         .text()
         .should.become("é Œ ù ḍ")
+      .nodeify(done);
+  });
+
+  it('should send delete key', function (done) {
+    driver
+      .elementsByTagName('textField').at(1)
+        .sendKeys("abc")
+        .sendKeys('\uE003')
+        .text()
+        .should.become("")
       .nodeify(done);
   });
 });


### PR DESCRIPTION
Allow certain characters through the check for accented characters, as per [special chars](https://code.google.com/p/selenium/source/browse/java/client/src/org/openqa/selenium/Keys.java) from Selenium. 

There may be other cases that need to be excepted at some point.

Apropos, kinda, of Issue #1883

@jlipps
