### PR TITLE
The latest webview should be the last element of getWindowHandles() returns

### DIFF
--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -70,8 +70,9 @@ Safari.prototype.navToView = function (cb) {
         }
         cb(new Error("Could not navigate to webview; there aren't any!"));
       } else {
-        logger.info("Picking webview " + res.value[0]);
-        this.setWindow(res.value[res.value.length - 1], function (err) {
+        var latestWindow = res.value[res.value.length - 1];
+        logger.info("Picking webview " + latestWindow);
+        this.setWindow(latestWindow, function (err) {
           if (err) return cb(err);
           this.remote.cancelPageLoad();
           cb();


### PR DESCRIPTION
Obviously,   res.value[0] !== res.value[res.value.length - 1]. 
According to context, the latest window handle should be the last one element in the res.value array. 
