### PR TITLE
Location services and safari capabilities

### DIFF
--- a/docs/caps.md
+++ b/docs/caps.md
@@ -35,6 +35,7 @@ Appium server capabilities
 |`launchTimeout`| Amount of time in ms to wait for instruments before assuming it hung and failing the session|e.g. `20000`|
 |`locale`| Locale to set for the iOS Simulator|e.g. `fr_CA`|
 |`locationServicesEnabled`| Force location services to be either on or off|`true` or `false`|
+|`locationServicesAuthorized`| Allow location services for app|`true` or `false`|
 |`autoAcceptAlerts`| Accept iOS privacy access permission alerts (e.g., location, contacts, photos). Default is false.|
 |`nativeInstrumentsLib`| Use native intruments lib (ie disable instruments-without-delay).|
 |`nonSyntheticWebClick`| Enable/Disable non synthetic web clicks in Safari.|

--- a/docs/caps.md
+++ b/docs/caps.md
@@ -29,13 +29,13 @@ Appium server capabilities
 
 |Capability|Description|Values|
 |----|-----------|-------|
-|`calendarFormat`| Calendar format to set for the iOS Simulator|e.g. `gregorian`|
-|`deviceName`| name of the device to set for the iOS Simulator|e.g. `iPhone Retina (3.5-inch)`|
-|`language`| Language to set for the iOS Simulator|e.g. `fr`|
+|`calendarFormat`| (Sim-only) Calendar format to set for the iOS Simulator|e.g. `gregorian`|
+|`deviceName`| (Sim-only) name of the device to set for the iOS Simulator|e.g. `iPhone Retina (3.5-inch)`|
+|`language`| (Sim-only) Language to set for the iOS Simulator|e.g. `fr`|
 |`launchTimeout`| Amount of time in ms to wait for instruments before assuming it hung and failing the session|e.g. `20000`|
-|`locale`| Locale to set for the iOS Simulator|e.g. `fr_CA`|
-|`locationServicesEnabled`| Force location services to be either on or off|`true` or `false`|
-|`locationServicesAuthorized`| Allow location services for app|`true` or `false`|
-|`autoAcceptAlerts`| Accept iOS privacy access permission alerts (e.g., location, contacts, photos). Default is false.|
+|`locale`| (Sim-only) Locale to set for the iOS Simulator|e.g. `fr_CA`|
+|`locationServicesEnabled`| (Sim-only) Force location services to be either on or off|`true` or `false`|
+|`locationServicesAuthorized`| (Sim-only) Set location services to be authorized or not authorized for app via plist, so that location services alert doesn't pop up|`true` or `false`|
+|`autoAcceptAlerts`| Accept iOS privacy access permission alerts (e.g., location, contacts, photos) automatically if they pop up. Default is false.|
 |`nativeInstrumentsLib`| Use native intruments lib (ie disable instruments-without-delay).|
-|`nonSyntheticWebClick`| Enable/Disable non synthetic web clicks in Safari.|
+|`nonSyntheticWebClick`| (Sim-only) Enable/Disable non synthetic web clicks in Safari.|

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -554,7 +554,7 @@ Appium.prototype.initDevice = function () {
     , webSocket: this.webSocket
     , app: this.args.app
     , ipa: this.args.ipa
-    , bundleId: this.args.bundleId
+    , bundleId: this.args.bundleId || this.desiredCapabilities.bundleId
     , udid: this.args.udid
     , fullReset: this.fullReset
     , verbose: !this.args.quiet

--- a/lib/devices/ios/instruments.js
+++ b/lib/devices/ios/instruments.js
@@ -66,17 +66,8 @@ Instruments.prototype.start = function (launchCb, unexpectedExitCb) {
   this.launchHandlerCb = launchCb;
   this.exitHandler = unexpectedExitCb;
 
-  exec('xcrun -find instruments', function (err, stdout) {
-    if (typeof stdout === "undefined") stdout = "";
-    this.instrumentsPath = stdout.trim();
-    if (err || !this.instrumentsPath) {
-      logger.error("Could not find instruments binary");
-      if (err) logger.error(err.message);
-      return this.launchHandler(new Error("Could not find the instruments " +
-          "binary. Please ensure `xcrun -find instruments` can locate it."));
-    }
-    logger.info("Instruments is at: " + this.instrumentsPath);
-
+  this.setInstrumentsPath(function (err) {
+    if (err) return this.launchHandler(err);
     this.initSocketServer(function (err) {
       if (err) return this.launchHandler(err);
       this.launch(function (err) {
@@ -86,6 +77,21 @@ Instruments.prototype.start = function (launchCb, unexpectedExitCb) {
         // server, or when instruments times out, in onSocketNeverConnect
       }.bind(this));
     }.bind(this));
+  }.bind(this));
+};
+
+Instruments.prototype.setInstrumentsPath = function (cb) {
+  exec('xcrun -find instruments', function (err, stdout) {
+    if (typeof stdout === "undefined") stdout = "";
+    this.instrumentsPath = stdout.trim();
+    if (err || !this.instrumentsPath) {
+      logger.error("Could not find instruments binary");
+      if (err) logger.error(err.message);
+      return cb(new Error("Could not find the instruments " +
+          "binary. Please ensure `xcrun -find instruments` can locate it."));
+    }
+    logger.info("Instruments is at: " + this.instrumentsPath);
+    cb();
   }.bind(this));
 };
 
@@ -218,6 +224,30 @@ Instruments.prototype.onSocketConnect = function (conn) {
       this.debug("Socket data being routed for '" + data.event + "' event");
       this.eventRouter[data.event].bind(this)(data, conn);
     }
+  }.bind(this));
+};
+
+Instruments.prototype.launchAndKill = function (msToLetLive, cb) {
+  logger.info("Launching instruments briefly then killing it");
+  this.setInstrumentsPath(function (err) {
+    if (err) return cb(err);
+    var diedTooYoung = this.spawnInstruments("/tmp");
+    var returned = false;
+    diedTooYoung.on("error", function (err) {
+      if (err.message.indexOf("ENOENT") !== -1) {
+        if (!returned) {
+          returned = true;
+          cb(new Error("Unable to spawn instruments: " + err.message));
+        }
+      }
+    });
+    setTimeout(function () {
+      diedTooYoung.kill("SIGKILL");
+      if (!returned) {
+        returned = true;
+        cb();
+      }
+    }, msToLetLive);
   }.bind(this));
 };
 

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -172,14 +172,6 @@ IOS.prototype.getNumericVersion = function () {
 };
 
 IOS.prototype.start = function (cb, onDie) {
-  if (this.app && this.bundleId) {
-    var err = new Error("You tried to launch instruments with both an app " +
-                        "specification and a bundle ID. Choose one or the " +
-                        "other");
-    logger.error(err.message);
-    return cb(err);
-  }
-
   if (this.instruments !== null) {
     var msg = "Trying to start a session but instruments is still around";
     logger.error(msg);
@@ -425,12 +417,42 @@ IOS.prototype.setPreferences = function (cb) {
                 "device");
   } else {
     logger.info("Setting iOS and app preferences");
-    if (typeof this.capabilities.locationServicesEnabled !== "undefined") {
-      var locServ = this.capabilities.locationServicesEnabled ? 1 : 0;
+    if (!settings.simDirsExist(this.iOSSDKVersion)) {
+      logger.error("Sim files for this SDK do not yet exist, settings " +
+          "will not take effect on this run");
+      return cb();
+    }
+    if (typeof this.capabilities.locationServicesEnabled !== "undefined" ||
+        this.capabilities.locationServicesAuthorized) {
+      var locServ = this.capabilities.locationServicesEnabled;
+      locServ = locServ || this.capabilities.locationServicesAuthorized;
+      locServ = locServ ? 1 : 0;
       logger.info("Setting location services to " + locServ);
       try {
         settings.updateSettings(this.iOSSDKVersion, 'locationServices',
-            {LocationServicesEnabled: locServ});
+            {
+              LocationServicesEnabled: locServ,
+              'LocationServicesEnabledIn7.0': locServ
+            });
+      } catch (e) {
+        err = e;
+      }
+    }
+    if (typeof this.capabilities.locationServicesAuthorized !== "undefined") {
+      if (!this.bundleId) {
+        var msg = "Can't set location services for app without bundle ID";
+        logger.error(msg);
+        return cb(new Error(msg));
+      }
+      var locAuth = !!this.capabilities.locationServicesAuthorized;
+      if (locAuth) {
+        logger.info("Authorizing location services for app");
+      } else {
+        logger.info("De-authorizing location services for app");
+      }
+      try {
+        settings.updateLocationSettings(this.iOSSDKVersion, this.bundleId,
+            locAuth);
       } catch (e) {
         err = e;
       }
@@ -649,7 +671,7 @@ IOS.prototype.setDeviceAndLaunchSimulator = function (cb) {
   if (this.udid) {
     logger.info("Not setting device type since we're connected to a device");
     cb();
-  } else if (this.bundleId) {
+  } else if (!this.app && this.bundleId) {
     logger.info("Not setting device type since we're using bundle ID and " +
                 "assuming app is already installed");
     cb(null);
@@ -804,11 +826,11 @@ IOS.prototype.cleanupAppState = function (cb) {
             logger.info("Deleted " + tcc);
           }
 
-          var caches = path.join(root, 'Library/Caches');
-          if (fs.existsSync(caches)) {
-            rimraf.sync(caches);
-            logger.info("Deleted " + caches);
-          }
+          //var caches = path.join(root, 'Library/Caches');
+          //if (fs.existsSync(caches)) {
+            //rimraf.sync(caches);
+            //logger.info("Deleted " + caches);
+          //}
 
           var media = path.join(root, 'Media');
           if (fs.existsSync(media)) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -429,7 +429,7 @@ IOS.prototype.setPreferences = function (cb) {
     if (_.has(this.capabilities), cap) {
       needToSet = true;
     }
-  });
+  }.bind(this));
   if (!needToSet) {
     logger.info("No iOS / app preferences to set");
     return cb();
@@ -484,25 +484,25 @@ IOS.prototype.setLocServicesPrefs = function () {
 
 
 IOS.prototype.setSafariPrefs = function () {
-  var settings = {};
+  var safariSettings = {};
   var val;
   if (_.has(this.capabilities, 'safariAllowPopups')) {
     val = !!this.capabilities.safariAllowPopups;
     logger.info("Setting javascript window opening to " + val);
-    settings.WebKitJavaScriptCanOpenWindowsAutomatically = val;
+    safariSettings.WebKitJavaScriptCanOpenWindowsAutomatically = val;
   }
   if (_.has(this.capabilities, 'safariIgnoreFraudWarning')) {
     val = !this.capabilities.safariIgnoreFraudWarning;
     logger.info("Setting fraudulent website warning to " + val);
-    settings.WarnAboutFraudulentWebsites = val;
+    safariSettings.WarnAboutFraudulentWebsites = val;
   }
   if (_.has(this.capabilities, 'safariOpenLinksInBackground')) {
     val = this.capabilities.safariOpenLinksInBackground ? 1 : 0;
     logger.info("Setting opening links in background to " + !!val);
-    settings.OpenLinksInBackground = val;
+    safariSettings.OpenLinksInBackground = val;
   }
   if (_.size(settings) > 0) {
-    settings.updateSafariSettings(this.iOSSDKVersion, settings);
+    settings.updateSafariSettings(this.iOSSDKVersion, safariSettings);
   }
 };
 

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -97,6 +97,7 @@ IOS.prototype.init = function (args) {
   this.curCoords = null;
   this.curWebCoords = null;
   this.onPageChangeCb = null;
+  this.dontDeleteSimApps = false;
   this.useRobot = args.robotPort > 0;
   this.robotUrl = this.useRobot ? "http://" + args.robotAddress + ":" + args.robotPort + "" : null;
   this.logNoColors = args.logNoColors;
@@ -428,12 +429,18 @@ IOS.prototype.setPreferences = function (cb) {
     'safariIgnoreFraudWarning',
     'safariOpenLinksInBackground'
   ];
+  var safariSettingsCaps = settingsCaps.slice(2, 4);
   var needToSet = false;
+  var needToSetSafari = false;
   _.each(settingsCaps, function (cap) {
     if (_.has(this.capabilities, cap)) {
       needToSet = true;
+      if (_.contains(safariSettingsCaps, cap)) {
+        needToSetSafari = true;
+      }
     }
   }.bind(this));
+
   if (!needToSet) {
     logger.info("No iOS / app preferences to set");
     return cb();
@@ -459,7 +466,8 @@ IOS.prototype.setPreferences = function (cb) {
   }.bind(this);
 
   logger.info("Setting iOS and app preferences");
-  if (!settings.simDirsExist(this.iOSSDKVersion)) {
+  if (!settings.simDirsExist(this.iOSSDKVersion) ||
+      (needToSetSafari && !settings.safari7DirsExist(this.iOSSDKVersion))) {
     logger.info("Sim files for this SDK do not yet exist, launching the sim " +
         "to populate the applications and preference dirs");
     this.instantLaunchAndQuit(setPrefs);
@@ -528,6 +536,7 @@ IOS.prototype.setSafariPrefs = function () {
   }
   if (_.size(settings) > 0) {
     settings.updateSafariSettings(this.iOSSDKVersion, safariSettings);
+    this.dontDeleteSimApps = true;
   }
 };
 
@@ -763,6 +772,11 @@ IOS.prototype.setDeviceAndLaunchSimulator = function (cb) {
     } else {
 
       var cleanup = function (cb) {
+        if ((this.fullReset || this.reset) && this.dontDeleteSimApps) {
+          logger.info("Not deleting simulator apps since we need to update " +
+                      "their plists before launch");
+          return cb();
+        }
         if (this.fullReset) {
           this.deleteSim(cb);
         } else if (this.reset) {
@@ -896,11 +910,11 @@ IOS.prototype.cleanupAppState = function (cb) {
             logger.info("Deleted " + tcc);
           }
 
-          //var caches = path.join(root, 'Library/Caches');
-          //if (fs.existsSync(caches)) {
-            //rimraf.sync(caches);
-            //logger.info("Deleted " + caches);
-          //}
+          var caches = path.join(root, 'Library/Caches');
+          if (fs.existsSync(caches)) {
+            rimraf.sync(caches);
+            logger.info("Deleted " + caches);
+          }
 
           var media = path.join(root, 'Media');
           if (fs.existsSync(media)) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -411,54 +411,99 @@ IOS.prototype.setLocale = function (cb) {
 };
 
 IOS.prototype.setPreferences = function (cb) {
-  var err = null;
   if (this.udid !== null) {
     logger.info("Not setting iOS and app preferences since we're on a real " +
                 "device");
-  } else {
-    logger.info("Setting iOS and app preferences");
-    if (!settings.simDirsExist(this.iOSSDKVersion)) {
-      logger.error("Sim files for this SDK do not yet exist, settings " +
-          "will not take effect on this run");
-      return cb();
-    }
-    if (typeof this.capabilities.locationServicesEnabled !== "undefined" ||
-        this.capabilities.locationServicesAuthorized) {
-      var locServ = this.capabilities.locationServicesEnabled;
-      locServ = locServ || this.capabilities.locationServicesAuthorized;
-      locServ = locServ ? 1 : 0;
-      logger.info("Setting location services to " + locServ);
-      try {
-        settings.updateSettings(this.iOSSDKVersion, 'locationServices',
-            {
-              LocationServicesEnabled: locServ,
-              'LocationServicesEnabledIn7.0': locServ
-            });
-      } catch (e) {
-        err = e;
-      }
-    }
-    if (typeof this.capabilities.locationServicesAuthorized !== "undefined") {
-      if (!this.bundleId) {
-        var msg = "Can't set location services for app without bundle ID";
-        logger.error(msg);
-        return cb(new Error(msg));
-      }
-      var locAuth = !!this.capabilities.locationServicesAuthorized;
-      if (locAuth) {
-        logger.info("Authorizing location services for app");
-      } else {
-        logger.info("De-authorizing location services for app");
-      }
-      try {
-        settings.updateLocationSettings(this.iOSSDKVersion, this.bundleId,
-            locAuth);
-      } catch (e) {
-        err = e;
-      }
-    }
+    return cb();
   }
-  cb(err);
+
+  var settingsCaps = [
+    'locationServicesEnabled',
+    'locationServicesAuthorized',
+    'safariAllowPopups',
+    'safariIgnoreFraudWarning',
+    'safariOpenLinksInBackground'
+  ];
+  var needToSet = false;
+  _.each(settingsCaps, function (cap) {
+    if (_.has(this.capabilities), cap) {
+      needToSet = true;
+    }
+  });
+  if (!needToSet) {
+    logger.info("No iOS / app preferences to set");
+    return cb();
+  }
+
+  logger.info("Setting iOS and app preferences");
+  if (!settings.simDirsExist(this.iOSSDKVersion)) {
+    logger.error("Sim files for this SDK do not yet exist, settings " +
+        "will not take effect on this run");
+    return cb();
+  }
+  try {
+    this.setLocServicesPrefs();
+  } catch (e) {
+    return cb(e);
+  }
+  try {
+    this.setSafariPrefs();
+  } catch (e) {
+    return cb(e);
+  }
+  cb();
+};
+
+IOS.prototype.setLocServicesPrefs = function () {
+  if (typeof this.capabilities.locationServicesEnabled !== "undefined" ||
+      this.capabilities.locationServicesAuthorized) {
+    var locServ = this.capabilities.locationServicesEnabled;
+    locServ = locServ || this.capabilities.locationServicesAuthorized;
+    locServ = locServ ? 1 : 0;
+    logger.info("Setting location services to " + locServ);
+    settings.updateSettings(this.iOSSDKVersion, 'locationServices', {
+      LocationServicesEnabled: locServ,
+      'LocationServicesEnabledIn7.0': locServ
+    });
+  }
+  if (typeof this.capabilities.locationServicesAuthorized !== "undefined") {
+    if (!this.bundleId) {
+      var msg = "Can't set location services for app without bundle ID";
+      logger.error(msg);
+      throw new Error(msg);
+    }
+    var locAuth = !!this.capabilities.locationServicesAuthorized;
+    if (locAuth) {
+      logger.info("Authorizing location services for app");
+    } else {
+      logger.info("De-authorizing location services for app");
+    }
+    settings.updateLocationSettings(this.iOSSDKVersion, this.bundleId, locAuth);
+  }
+};
+
+
+IOS.prototype.setSafariPrefs = function () {
+  var settings = {};
+  var val;
+  if (_.has(this.capabilities, 'safariAllowPopups')) {
+    val = !!this.capabilities.safariAllowPopups;
+    logger.info("Setting javascript window opening to " + val);
+    settings.WebKitJavaScriptCanOpenWindowsAutomatically = val;
+  }
+  if (_.has(this.capabilities, 'safariIgnoreFraudWarning')) {
+    val = !this.capabilities.safariIgnoreFraudWarning;
+    logger.info("Setting fraudulent website warning to " + val);
+    settings.WarnAboutFraudulentWebsites = val;
+  }
+  if (_.has(this.capabilities, 'safariOpenLinksInBackground')) {
+    val = this.capabilities.safariOpenLinksInBackground ? 1 : 0;
+    logger.info("Setting opening links in background to " + !!val);
+    settings.OpenLinksInBackground = val;
+  }
+  if (_.size(settings) > 0) {
+    settings.updateSafariSettings(this.iOSSDKVersion, settings);
+  }
 };
 
 IOS.prototype.detectTraceTemplate = function (cb) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -207,20 +207,7 @@ IOS.prototype.start = function (cb, onDie) {
 
 IOS.prototype.startInstruments = function (cb) {
   logger.debug("Creating instruments");
-  this.instruments = new Instruments({
-    app: this.app || this.bundleId
-  , udid: this.udid
-  , isSafariLauncherApp: this.isSafariLauncherApp
-  , bootstrap: path.resolve(__dirname, 'uiauto', 'bootstrap.js')
-  , template: this.automationTraceTemplatePath
-  , sock: sock
-  , withoutDelay: this.withoutDelay
-  , xcodeVersion: this.xcodeVersion
-  , webSocket: this.webSocket
-  , launchTimeout: this.launchTimeout
-  , flakeyRetries: this.flakeyRetries
-  , logNoColors: this.logNoColors
-  });
+  this.instruments = this.makeInstruments();
   this.instruments.start(function (err) {
     if (err) {
       if (!_.isEmpty(this.logs)) {
@@ -235,6 +222,23 @@ IOS.prototype.startInstruments = function (cb) {
   }.bind(this), function (code, tracedir) {
     this.onUnexpectedInstrumentsExit(code, tracedir);
   }.bind(this));
+};
+
+IOS.prototype.makeInstruments = function () {
+  return new Instruments({
+    app: this.app || this.bundleId
+  , udid: this.udid
+  , isSafariLauncherApp: this.isSafariLauncherApp
+  , bootstrap: path.resolve(__dirname, 'uiauto', 'bootstrap.js')
+  , template: this.automationTraceTemplatePath
+  , sock: sock
+  , withoutDelay: this.withoutDelay
+  , xcodeVersion: this.xcodeVersion
+  , webSocket: this.webSocket
+  , launchTimeout: this.launchTimeout
+  , flakeyRetries: this.flakeyRetries
+  , logNoColors: this.logNoColors
+  });
 };
 
 IOS.prototype.onInstrumentsLaunch = function (cb) {
@@ -426,7 +430,7 @@ IOS.prototype.setPreferences = function (cb) {
   ];
   var needToSet = false;
   _.each(settingsCaps, function (cap) {
-    if (_.has(this.capabilities), cap) {
+    if (_.has(this.capabilities, cap)) {
       needToSet = true;
     }
   }.bind(this));
@@ -435,23 +439,44 @@ IOS.prototype.setPreferences = function (cb) {
     return cb();
   }
 
+  var setPrefs = function (err) {
+    if (err) return cb(err);
+    try {
+      this.setLocServicesPrefs();
+    } catch (e) {
+      logger.error("Error setting location services preferences, prefs will not work");
+      logger.error(e);
+      logger.error(e.stack);
+    }
+    try {
+      this.setSafariPrefs();
+    } catch (e) {
+      logger.error("Error setting safari preferences, prefs will not work");
+      logger.error(e);
+      logger.error(e.stack);
+    }
+    cb();
+  }.bind(this);
+
   logger.info("Setting iOS and app preferences");
   if (!settings.simDirsExist(this.iOSSDKVersion)) {
-    logger.error("Sim files for this SDK do not yet exist, settings " +
-        "will not take effect on this run");
-    return cb();
+    logger.info("Sim files for this SDK do not yet exist, launching the sim " +
+        "to populate the applications and preference dirs");
+    this.instantLaunchAndQuit(setPrefs);
+  } else {
+    setPrefs();
   }
-  try {
-    this.setLocServicesPrefs();
-  } catch (e) {
-    return cb(e);
-  }
-  try {
-    this.setSafariPrefs();
-  } catch (e) {
-    return cb(e);
-  }
-  cb();
+};
+
+IOS.prototype.instantLaunchAndQuit = function (cb) {
+  this.setDeviceAndLaunchSimulator(function (err) {
+    if (err) return cb(err);
+    var instrumentsIsDeadLongLiveInstruments = this.makeInstruments();
+    instrumentsIsDeadLongLiveInstruments.launchAndKill(1000, function (err) {
+      if (err) return cb(err);
+      this.endSimulator(cb);
+    }.bind(this));
+  }.bind(this));
 };
 
 IOS.prototype.setLocServicesPrefs = function () {
@@ -947,7 +972,7 @@ IOS.prototype.postCleanup = function (cb) {
 };
 
 IOS.prototype.endSimulator = function (cb) {
-  logger.info("Killing the simulator process and daemons");
+  logger.info("Killing the simulator process");
   if (this.iosSimProcess) {
     this.iosSimProcess.kill("SIGHUP");
     this.iosSimProcess = null;
@@ -966,6 +991,7 @@ IOS.prototype.endSimulator = function (cb) {
 };
 
 IOS.prototype.endSimulatorDaemons = function (cb) {
+  logger.info("Killing any other simulator daemons");
   var stopCmd = 'launchctl list | grep com.apple.iphonesimulator.launchd | cut -f 3 | xargs -n 1 launchctl stop';
   exec(stopCmd, { maxBuffer: 524288 }, function () {
     var removeCmd = 'launchctl list | grep com.apple.iphonesimulator.launchd | cut -f 3 | xargs -n 1 launchctl remove';

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -910,10 +910,14 @@ IOS.prototype.cleanupAppState = function (cb) {
             logger.info("Deleted " + tcc);
           }
 
-          var caches = path.join(root, 'Library/Caches');
-          if (fs.existsSync(caches)) {
-            rimraf.sync(caches);
-            logger.info("Deleted " + caches);
+          if (this.fullReset) {
+            // only delete caches on full reset, otherwise we won't
+            // be able to set location services prefs etc
+            var caches = path.join(root, 'Library/Caches');
+            if (fs.existsSync(caches)) {
+              rimraf.sync(caches);
+              logger.info("Deleted " + caches);
+            }
           }
 
           var media = path.join(root, 'Media');

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -429,7 +429,7 @@ IOS.prototype.setPreferences = function (cb) {
     'safariIgnoreFraudWarning',
     'safariOpenLinksInBackground'
   ];
-  var safariSettingsCaps = settingsCaps.slice(2, 4);
+  var safariSettingsCaps = settingsCaps.slice(2, 5);
   var needToSet = false;
   var needToSetSafari = false;
   _.each(settingsCaps, function (cap) {
@@ -534,7 +534,7 @@ IOS.prototype.setSafariPrefs = function () {
     logger.info("Setting opening links in background to " + !!val);
     safariSettings.OpenLinksInBackground = val;
   }
-  if (_.size(settings) > 0) {
+  if (_.size(safariSettings) > 0) {
     settings.updateSafariSettings(this.iOSSDKVersion, safariSettings);
     this.dontDeleteSimApps = true;
   }

--- a/lib/devices/ios/settings.js
+++ b/lib/devices/ios/settings.js
@@ -128,7 +128,8 @@ var getSafari7Dirs = function (sdk) {
     }
     var safariDir = null;
     for (var i = 0; i < list.length; i++) {
-      if (fs.existsSync(path.resolve(appsDir, list[i], "MobileSafari.app"))) {
+      if (fs.existsSync(path.resolve(appsDir, list[i], "MobileSafari.app")) ||
+          fs.existsSync(path.resolve(appsDir, list[i], "Appium-MobileSafari.app"))) {
         safariDir = path.resolve(appsDir, list[i], "Library", "Preferences");
         break;
       }

--- a/lib/devices/ios/settings.js
+++ b/lib/devices/ios/settings.js
@@ -15,7 +15,9 @@ var plists = {
   webFoundation: 'com.apple.WebFoundation.plist',
   preferences: 'com.apple.Preferences.plist',
   locationClients: 'clients.plist',
-  locationCache: 'cache.plist'
+  locationCache: 'cache.plist',
+  userSettings: 'UserSettings.plist',
+  effUserSettings: 'EffectiveUserSettings.plist'
 };
 
 var prefs = {
@@ -61,13 +63,25 @@ var multiResolve = function (roots) {
 };
 
 var getPlistPaths = function (plist, sdk) {
+  var files;
   var file = plists[plist];
   var bases = getPrefsDirs(sdk);
   if (plist === 'mobileSafari' && parseFloat(sdk) >= 7) {
     bases = getSafari7Dirs(sdk);
   } else if (plist === 'locationClients') {
     bases = multiResolve(getSimDirs(sdk), "Library", "Caches", "locationd");
+  } else if (plist === 'locationCache') {
+    var bases2 = multiResolve(getSimDirs(sdk), "Library", "Caches", "locationd");
+    files = multiResolve(bases, file);
+    files = files.concat(multiResolve(bases2, file));
+    return files;
+  } else if (plist === 'userSettings') {
+    files = multiResolve(getSimDirs(sdk), "Library", "ConfigurationProfiles", file);
+    files = files.concat(multiResolve(getSimDirs(sdk), "Library", "ConfigurationProfiles",
+        "PublicInfo", 'EffectiveUserSettings.plist'));
+    return files;
   }
+
   return multiResolve(bases, file);
 };
 
@@ -200,16 +214,17 @@ settings.updateLocationSettings = function (sdk, bundleId, authorized) {
   };
   var newCachePrefs = {
     LastFenceActivityTimestamp: 412122103.232983,
-    CleanShutdown: false
+    CleanShutdown: true
   };
   var prefSetPerFile = {};
   var cachePrefSetPerFile = {};
   var curCacheSettings = settings.getSettings(sdk, 'locationCache');
   _.each(curCacheSettings, function (settingSet, file) {
-    cachePrefSetPerFile[file] = _.extend(newCachePrefs, settingSet);
+    cachePrefSetPerFile[file] = _.extend(_.clone(newCachePrefs), settingSet);
   });
   var curSettings = settings.getSettings(sdk, 'locationClients');
   _.each(curSettings, function (settingSet, file) {
+    // add this random data to the clients.plist since it always seems to be there
     if (!_.has(settingSet, weirdLocKey)) {
       settingSet[weirdLocKey] = {
         BundlePath: "/System/Library/PrivateFrameworks/AOSNotification.framework",
@@ -218,6 +233,7 @@ settings.updateLocationSettings = function (sdk, bundleId, authorized) {
         Registered: ""
       };
     }
+    // now add our app's data
     if (!_.has(settingSet, bundleId)) {
       settingSet[bundleId] = {};
     }
@@ -236,6 +252,33 @@ settings.updateLocationSettings = function (sdk, bundleId, authorized) {
   settings.writeSettings('locationClients', prefSetPerFile, true);
   settings.writeSettings('locationCache', cachePrefSetPerFile, true);
   console.log(settings.getSettings(sdk, 'locationClients'));
+};
+
+settings.updateSafariSettings = function (sdk, settings) {
+  settings.updateSafariUserSettings(sdk, settings);
+  settings.updateSettings(sdk, 'mobileSafari', settings);
+};
+
+settings.updateSafariUserSettings = function (sdk, settings) {
+  // add extra stuff to UserSettings.plist and EffectiveUserSettings.plist
+  var newUserSettings = {};
+  if (_.has(settings, 'WebKitJavaScriptEnabled')) {
+    newUserSettings.safariAllowJavaScript = settings.WebKitJavaScriptEnabled;
+  }
+  if (_.has(settings, 'WebKitJavaScriptCanOpenWindowsAutomatically')) {
+    newUserSettings.safariAllowPopups = settings.WebKitJavaScriptCanOpenWindowsAutomatically;
+  }
+  if (_.has(settings, 'WarnAboutFraudulentWebsites')) {
+    newUserSettings.safariForceFraudWarning = !settings.WarnAboutFraudulentWebsites;
+  }
+  if (_.size(newUserSettings) > 0) {
+    var userSettingsPerFile = {};
+    var curUserSettings = settings.getSettings(sdk, 'userSettings');
+    _.each(curUserSettings, function (settingSet, file) {
+      _.extend(settingSet.restrictedBool, newUserSettings);
+      userSettingsPerFile[file] = settingSet;
+    });
+  }
 };
 
 settings.getSettings = function (sdk, forPlist) {

--- a/lib/devices/ios/settings.js
+++ b/lib/devices/ios/settings.js
@@ -247,9 +247,6 @@ settings.updateLocationSettings = function (sdk, bundleId, authorized) {
       settingSet.Registered = "";
     }
     prefSetPerFile[file] = settingSet;
-    if (!_.has(cachePrefSetPerFile, file)) {
-      cachePrefSetPerFile[file] = newCachePrefs;
-    }
   });
   settings.writeSettings('locationClients', prefSetPerFile, true);
   settings.writeSettings('locationCache', cachePrefSetPerFile, true);

--- a/lib/devices/ios/settings.js
+++ b/lib/devices/ios/settings.js
@@ -136,9 +136,10 @@ var getSafari7Dirs = function (sdk) {
     }
     if (safariDir) {
       safariDirs.push(safariDir);
+    } else {
+      logger.warn("Could not find MobileSafari in sim applications at " +
+                  appsDir);
     }
-    logger.warn("Could not find MobileSafari in sim applications at " +
-        appsDir);
   });
   return safariDirs;
 };
@@ -252,7 +253,6 @@ settings.updateLocationSettings = function (sdk, bundleId, authorized) {
   });
   settings.writeSettings('locationClients', prefSetPerFile, true);
   settings.writeSettings('locationCache', cachePrefSetPerFile, true);
-  console.log(settings.getSettings(sdk, 'locationClients'));
 };
 
 settings.updateSafariSettings = function (sdk, settingSet) {
@@ -302,6 +302,14 @@ settings.getSettings = function (sdk, forPlist) {
 
 settings.simDirsExist = function (sdk) {
   return getSimDirs(sdk).length > 0;
+};
+
+settings.safari7DirsExist = function (sdk) {
+  try {
+    return getSafari7Dirs(sdk).length > 0;
+  } catch (e) {
+    return false;
+  }
 };
 
 module.exports = settings;

--- a/lib/devices/ios/settings.js
+++ b/lib/devices/ios/settings.js
@@ -28,7 +28,7 @@ var prefs = {
     SafariDoNotTrackEnabled: [true, false],
     SuppressSearchSuggestions: [true, false],
     SpeculativeLoading: [true, false],
-    WarnAboutFraudulentWebsite: [true, false],
+    WarnAboutFraudulentWebsites: [true, false],
     ReadingListCellularFetchingEnabled: [true, false],
     WebKitJavaScriptEnabled: [true, false]
   },
@@ -254,30 +254,32 @@ settings.updateLocationSettings = function (sdk, bundleId, authorized) {
   console.log(settings.getSettings(sdk, 'locationClients'));
 };
 
-settings.updateSafariSettings = function (sdk, settings) {
-  settings.updateSafariUserSettings(sdk, settings);
-  settings.updateSettings(sdk, 'mobileSafari', settings);
+settings.updateSafariSettings = function (sdk, settingSet) {
+  settings.updateSafariUserSettings(sdk, settingSet);
+  settings.updateSettings(sdk, 'mobileSafari', settingSet);
 };
 
-settings.updateSafariUserSettings = function (sdk, settings) {
+settings.updateSafariUserSettings = function (sdk, settingSet) {
   // add extra stuff to UserSettings.plist and EffectiveUserSettings.plist
   var newUserSettings = {};
   if (_.has(settings, 'WebKitJavaScriptEnabled')) {
-    newUserSettings.safariAllowJavaScript = settings.WebKitJavaScriptEnabled;
+    newUserSettings.safariAllowJavaScript = settingSet.WebKitJavaScriptEnabled;
   }
   if (_.has(settings, 'WebKitJavaScriptCanOpenWindowsAutomatically')) {
-    newUserSettings.safariAllowPopups = settings.WebKitJavaScriptCanOpenWindowsAutomatically;
+    newUserSettings.safariAllowPopups = settingSet.WebKitJavaScriptCanOpenWindowsAutomatically;
   }
   if (_.has(settings, 'WarnAboutFraudulentWebsites')) {
-    newUserSettings.safariForceFraudWarning = !settings.WarnAboutFraudulentWebsites;
+    newUserSettings.safariForceFraudWarning = !settingSet.WarnAboutFraudulentWebsites;
   }
   if (_.size(newUserSettings) > 0) {
+    logger.info("Updating UserSettings.plist and friends");
     var userSettingsPerFile = {};
     var curUserSettings = settings.getSettings(sdk, 'userSettings');
     _.each(curUserSettings, function (settingSet, file) {
       _.extend(settingSet.restrictedBool, newUserSettings);
       userSettingsPerFile[file] = settingSet;
     });
+    settings.writeSettings('userSettings', userSettingsPerFile, true);
   }
 };
 

--- a/lib/devices/ios/settings.js
+++ b/lib/devices/ios/settings.js
@@ -13,7 +13,9 @@ var plists = {
   webInspector: 'com.apple.webInspector.plist',
   mobileSafari: 'com.apple.mobilesafari.plist',
   webFoundation: 'com.apple.WebFoundation.plist',
-  preferences: 'com.apple.Preferences.plist'
+  preferences: 'com.apple.Preferences.plist',
+  locationClients: 'clients.plist',
+  locationCache: 'cache.plist'
 };
 
 var prefs = {
@@ -36,6 +38,7 @@ var prefs = {
   },
   locationServices: {
     LocationServicesEnabled: [0, 1],
+    'LocationServicesEnabledIn7.0': [0, 1],
     ObsoleteDataDeleted: [true, false]
   },
   preferences: {
@@ -47,13 +50,25 @@ var prefs = {
   }
 };
 
-var getPlistPath = function (plist, sdk) {
+var multiResolve = function (roots) {
+  var args = Array.prototype.slice.call(arguments, 1);
+  var paths = [];
+  _.each(roots, function (root) {
+    var resolveArgs = [root].concat(args);
+    paths.push(path.resolve.apply(null, resolveArgs));
+  });
+  return paths;
+};
+
+var getPlistPaths = function (plist, sdk) {
   var file = plists[plist];
-  var base = getPrefsDir(sdk);
+  var bases = getPrefsDirs(sdk);
   if (plist === 'mobileSafari' && parseFloat(sdk) >= 7) {
-    base = getSafari7Dir(sdk);
+    bases = getSafari7Dirs(sdk);
+  } else if (plist === 'locationClients') {
+    bases = multiResolve(getSimDirs(sdk), "Library", "Caches", "locationd");
   }
-  return path.resolve(base, file);
+  return multiResolve(bases, file);
 };
 
 settings.getSimRoot = function () {
@@ -62,38 +77,55 @@ settings.getSimRoot = function () {
     "iPhone Simulator");
 };
 
-var getSimDir = function (sdk) {
+var getSimDirs = function (sdk) {
   sdk = sdk.toString();
-  return path.resolve(settings.getSimRoot(), sdk);
-};
-
-var getPrefsDir = function (sdk) {
-  return path.resolve(getSimDir(sdk), "Library", "Preferences");
-};
-
-var getSafari7Dir = function (sdk) {
-  var appsDir = path.resolve(getSimDir(sdk), "Applications");
-  var list;
+  var base = settings.getSimRoot();
+  var list = [];
   try {
-    list = fs.readdirSync(appsDir);
+    list = fs.readdirSync(base);
   } catch (e) {
-    if (/ENOENT/.test(e.message)) {
-      throw new Error("Applications directory " + appsDir + " doesn't exist. " +
-          "Have you run this simulator before?");
+  }
+  var dirs = [];
+  _.each(list, function (sdkDir) {
+    if (sdkDir.indexOf(sdk) !== -1) {
+      dirs.push(path.resolve(base, sdkDir));
     }
-    throw e;
-  }
-  var safariDir = null;
-  for (var i = 0; i < list.length; i++) {
-    if (fs.existsSync(path.resolve(appsDir, list[i], "MobileSafari.app"))) {
-      safariDir = path.resolve(appsDir, list[i], "Library", "Preferences");
-      break;
+  });
+  return dirs;
+};
+
+var getPrefsDirs = function (sdk) {
+  return multiResolve(getSimDirs(sdk), "Library", "Preferences");
+};
+
+var getSafari7Dirs = function (sdk) {
+  var appsDirs = multiResolve(getSimDirs(sdk), "Applications");
+  var safariDirs = [];
+  _.each(appsDirs, function (appsDir) {
+    var list;
+    try {
+      list = fs.readdirSync(appsDir);
+    } catch (e) {
+      if (/ENOENT/.test(e.message)) {
+        throw new Error("Applications directory " + appsDir + " doesn't exist. " +
+            "Have you run this simulator before?");
+      }
+      throw e;
     }
-  }
-  if (safariDir) {
-    return safariDir;
-  }
-  throw new Error("Could not find MobileSafari in sim applications");
+    var safariDir = null;
+    for (var i = 0; i < list.length; i++) {
+      if (fs.existsSync(path.resolve(appsDir, list[i], "MobileSafari.app"))) {
+        safariDir = path.resolve(appsDir, list[i], "Library", "Preferences");
+        break;
+      }
+    }
+    if (safariDir) {
+      safariDirs.push(safariDir);
+    }
+    logger.warn("Could not find MobileSafari in sim applications at " +
+        appsDir);
+  });
+  return safariDirs;
 };
 
 var checkValidSettings = function (forPlist, prefSet) {
@@ -119,44 +151,111 @@ var checkValidSettings = function (forPlist, prefSet) {
   }
 };
 
-settings.writeSettings = function (sdk, forPlist, prefSet, bypassCheck) {
-  logger.info("Writing settings for " + forPlist + ":");
-  logger.info(JSON.stringify(prefSet));
-  if (!bypassCheck) {
-    checkValidSettings(forPlist, prefSet);
+settings.writeSettings = function (forPlist, prefSetPerFile, bypassCheck) {
+  var filesWritten = 0;
+  _.each(prefSetPerFile, function (prefSet, plistPath) {
+    logger.info("Writing settings for " + forPlist + " to " + plistPath + ":");
+    logger.info(JSON.stringify(prefSet));
+    if (!bypassCheck) {
+      checkValidSettings(forPlist, prefSet);
+    }
+    prefSet = [prefSet];  // need to wrap in an array to get written correctly
+    try {
+      fs.unlinkSync(plistPath);
+    } catch (e) {}
+    try {
+      fs.writeFileSync(plistPath, bplistCreate(prefSet));
+      filesWritten++;
+    } catch (e) {
+      logger.warn("Could not write to " + plistPath);
+    }
+  });
+  if (filesWritten === 0) {
+    logger.warn("Could not write any settings files; is the first time " +
+        "you've launched the sim? The directories might not exist yet");
   }
-  prefSet = [prefSet];  // need to wrap in an array to get written correctly
-  var plistPath = getPlistPath(forPlist, sdk);
-  try {
-    fs.unlinkSync(plistPath);
-  } catch (e) {}
-  fs.writeFileSync(plistPath, bplistCreate(prefSet));
 };
 
 settings.updateSettings = function (sdk, forPlist, prefSet) {
   logger.info("Updating settings for " + forPlist);
   checkValidSettings(forPlist, prefSet);
-  try {
-    var curSettings = settings.getSettings(sdk, forPlist);
+  var prefSetPerFile = {};
+  var curSettings = settings.getSettings(sdk, forPlist);
+  _.each(curSettings, function (settingSet, file) {
     _.each(prefSet, function (prefValue, prefName) {
-      curSettings[prefName] = prefValue;
+      settingSet[prefName] = prefValue;
     });
-    prefSet = curSettings;
-  } catch (e) {
-    logger.info("Settings file didn't seem to exist");
-  }
-  settings.writeSettings(sdk, forPlist, prefSet, true);
+    prefSetPerFile[file] = settingSet;
+  });
+  settings.writeSettings(forPlist, prefSetPerFile, true);
+};
+
+settings.updateLocationSettings = function (sdk, bundleId, authorized) {
+  var weirdLocKey = "com.apple.locationd.bundle-/System/Library/" +
+                    "PrivateFrameworks/AOSNotification.framework";
+  var newPrefs = {
+    BundleId: bundleId,
+    Authorized: !!authorized,
+    Whitelisted: false,
+  };
+  var newCachePrefs = {
+    LastFenceActivityTimestamp: 412122103.232983,
+    CleanShutdown: false
+  };
+  var prefSetPerFile = {};
+  var cachePrefSetPerFile = {};
+  var curCacheSettings = settings.getSettings(sdk, 'locationCache');
+  _.each(curCacheSettings, function (settingSet, file) {
+    cachePrefSetPerFile[file] = _.extend(newCachePrefs, settingSet);
+  });
+  var curSettings = settings.getSettings(sdk, 'locationClients');
+  _.each(curSettings, function (settingSet, file) {
+    if (!_.has(settingSet, weirdLocKey)) {
+      settingSet[weirdLocKey] = {
+        BundlePath: "/System/Library/PrivateFrameworks/AOSNotification.framework",
+        Whitelisted: false,
+        Executable: "",
+        Registered: ""
+      };
+    }
+    if (!_.has(settingSet, bundleId)) {
+      settingSet[bundleId] = {};
+    }
+    _.extend(settingSet[bundleId], newPrefs);
+    if (!_.has(settingSet, 'Executable')) {
+      settingSet.Executable = "";
+    }
+    if (!_.has(settingSet, 'Registered')) {
+      settingSet.Registered = "";
+    }
+    prefSetPerFile[file] = settingSet;
+    if (!_.has(cachePrefSetPerFile, file)) {
+      cachePrefSetPerFile[file] = newCachePrefs;
+    }
+  });
+  settings.writeSettings('locationClients', prefSetPerFile, true);
+  settings.writeSettings('locationCache', cachePrefSetPerFile, true);
+  console.log(settings.getSettings(sdk, 'locationClients'));
 };
 
 settings.getSettings = function (sdk, forPlist) {
-  logger.info("Getting current settings for " + forPlist);
-  var file = getPlistPath(forPlist, sdk);
-  if (fs.existsSync(file)) {
-    var data = fs.readFileSync(file);
-    return bplistParse.parseBuffer(data)[0];
-  } else {
-    throw new Error("Settings file " + file + " did not exist");
-  }
+  var files = getPlistPaths(forPlist, sdk);
+  var bplists = {};
+  _.each(files, function (file) {
+    logger.info("Getting current settings for " + forPlist + " from " + file);
+    if (fs.existsSync(file)) {
+      var data = fs.readFileSync(file);
+      bplists[file] = bplistParse.parseBuffer(data)[0];
+    } else {
+      bplists[file] = {};
+      logger.warn("Settings file " + file + " did not exist");
+    }
+  });
+  return bplists;
+};
+
+settings.simDirsExist = function (sdk) {
+  return getSimDirs(sdk).length > 0;
 };
 
 module.exports = settings;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -163,8 +163,17 @@ exports.checkBuiltInApp = function (appName, version, cb) {
         return cb(err);
       }
       if (checkApp(s, appPath, cb)) {
-        logger.info("Got app, trying to copy " + appPath + " to tmp dir");
-        exports.moveBuiltInApp(appPath, appName, newAppDir, cb);
+        if (parseInt(version, 10) < 7) {
+          logger.info("Got app, trying to copy " + appPath + " to tmp dir");
+          ncp(appPath, newAppDir, function (err) {
+            if (err) return cb(err);
+            logger.info("Copied " + appName);
+            cb();
+          });
+        } else {
+          logger.info("Got app, trying to move " + appPath + " to tmp dir");
+          exports.moveBuiltInApp(appPath, appName, newAppDir, cb);
+        }
       }
     });
   });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -168,7 +168,7 @@ exports.checkBuiltInApp = function (appName, version, cb) {
           ncp(appPath, newAppDir, function (err) {
             if (err) return cb(err);
             logger.info("Copied " + appName);
-            cb();
+            cb(null, newAppDir, null);
           });
         } else {
           logger.info("Got app, trying to move " + appPath + " to tmp dir");

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -151,6 +151,8 @@ exports.createSession = function (req, res) {
     req.appium.start(req.body.desiredCapabilities, function (err, instance) {
       if (err) {
         logger.error("Failed to start an Appium session, err was: " + err);
+        logger.info(err.stack);
+        delete err.stack;
         respondError(req, res, status.codes.SessionNotCreatedException, err);
       } else {
         logger.info("Appium session started with sessionId " + req.appium.sessionId);

--- a/sample-code/apps/TestApp/.gitignore
+++ b/sample-code/apps/TestApp/.gitignore
@@ -1,0 +1,1 @@
+xcshareddata

--- a/sample-code/apps/TestApp/Test App 2/GestureTestViewController.xib
+++ b/sample-code/apps/TestApp/Test App 2/GestureTestViewController.xib
@@ -1,334 +1,47 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">11G63b</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1138.51</string>
-		<string key="IBDocument.HIToolboxVersion">569.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">2083</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBMKMapView</string>
-			<string>IBNSLayoutConstraint</string>
-			<string>IBProxyObject</string>
-			<string>IBUIRotationGestureRecognizer</string>
-			<string>IBUIView</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="IBProxyObject" id="372490531">
-				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBProxyObject" id="975951072">
-				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIView" id="191373211">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="IBMKMapView" id="59640690">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">274</int>
-						<string key="NSFrame">{{35, 83}, {250, 250}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSWindow"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<bool key="IBUIMultipleTouchEnabled">YES</bool>
-						<array key="IBUIGestureRecognizers" id="0"/>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<bool key="IBMKShowsUserLocation">YES</bool>
-					</object>
-				</array>
-				<string key="NSFrame">{{0, 20}, {320, 548}}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="59640690"/>
-				<object class="NSColor" key="IBUIBackgroundColor">
-					<int key="NSColorSpace">3</int>
-					<bytes key="NSWhite">MQA</bytes>
-					<object class="NSColorSpace" key="NSCustomColorSpace">
-						<int key="NSID">2</int>
-					</object>
-				</object>
-				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
-				<object class="IBUIScreenMetrics" key="IBUISimulatedDestinationMetrics">
-					<string key="IBUISimulatedSizeMetricsClass">IBUIScreenMetrics</string>
-					<object class="NSMutableDictionary" key="IBUINormalizedOrientationToSizeMap">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<array key="dict.sortedKeys">
-							<integer value="1"/>
-							<integer value="3"/>
-						</array>
-						<array key="dict.values">
-							<string>{320, 568}</string>
-							<string>{568, 320}</string>
-						</array>
-					</object>
-					<string key="IBUITargetRuntime">IBCocoaTouchFramework</string>
-					<string key="IBUIDisplayName">Retina 4 Full Screen</string>
-					<int key="IBUIType">2</int>
-				</object>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIRotationGestureRecognizer" id="322244011"/>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">view</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="191373211"/>
-					</object>
-					<int key="connectionID">3</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">mapView</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="59640690"/>
-					</object>
-					<int key="connectionID">24</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletCollectionConnection" key="connection">
-						<string key="label">gestureRecognizers</string>
-						<reference key="source" ref="59640690"/>
-						<reference key="destination" ref="322244011"/>
-						<string key="cachedDesigntimeCollectionClassName">NSArray</string>
-						<bool key="addsContentToExistingCollection">YES</bool>
-					</object>
-					<int key="connectionID">15</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">handleRotation:</string>
-						<reference key="source" ref="322244011"/>
-						<reference key="destination" ref="372490531"/>
-					</object>
-					<int key="connectionID">16</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="322244011"/>
-						<reference key="destination" ref="372490531"/>
-					</object>
-					<int key="connectionID">25</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<reference key="object" ref="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1</int>
-						<reference key="object" ref="191373211"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="275850515">
-								<reference key="firstItem" ref="59640690"/>
-								<int key="firstAttribute">9</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">9</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">0.0</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">5</int>
-								<float key="scoringTypeFloat">22</float>
-								<int key="contentType">2</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="956516549">
-								<reference key="firstItem" ref="59640690"/>
-								<int key="firstAttribute">3</int>
-								<int key="relation">0</int>
-								<reference key="secondItem" ref="191373211"/>
-								<int key="secondAttribute">3</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">83</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="191373211"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">3</int>
-							</object>
-							<reference ref="59640690"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="372490531"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="975951072"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">4</int>
-						<reference key="object" ref="59640690"/>
-						<array class="NSMutableArray" key="children">
-							<object class="IBNSLayoutConstraint" id="127972450">
-								<reference key="firstItem" ref="59640690"/>
-								<int key="firstAttribute">8</int>
-								<int key="relation">0</int>
-								<nil key="secondItem"/>
-								<int key="secondAttribute">0</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">250</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="59640690"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">1</int>
-							</object>
-							<object class="IBNSLayoutConstraint" id="724525108">
-								<reference key="firstItem" ref="59640690"/>
-								<int key="firstAttribute">7</int>
-								<int key="relation">0</int>
-								<nil key="secondItem"/>
-								<int key="secondAttribute">0</int>
-								<float key="multiplier">1</float>
-								<object class="IBLayoutConstant" key="constant">
-									<double key="value">250</double>
-								</object>
-								<float key="priority">1000</float>
-								<reference key="containingView" ref="59640690"/>
-								<int key="scoringType">3</int>
-								<float key="scoringTypeFloat">9</float>
-								<int key="contentType">1</int>
-							</object>
-						</array>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">14</int>
-						<reference key="object" ref="322244011"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">18</int>
-						<reference key="object" ref="724525108"/>
-						<reference key="parent" ref="59640690"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">20</int>
-						<reference key="object" ref="127972450"/>
-						<reference key="parent" ref="59640690"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">22</int>
-						<reference key="object" ref="956516549"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">23</int>
-						<reference key="object" ref="275850515"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.CustomClassName">GestureTestViewController</string>
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="-2.CustomClassName">UIResponder</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<array class="NSMutableArray" key="1.IBViewMetadataConstraints">
-					<reference ref="956516549"/>
-					<reference ref="275850515"/>
-				</array>
-				<string key="14.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="18.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="20.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="22.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="23.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<array class="NSMutableArray" key="4.IBViewMetadataConstraints">
-					<reference ref="724525108"/>
-					<reference ref="127972450"/>
-				</array>
-				<boolean value="NO" key="4.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">25</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">GestureTestViewController</string>
-					<string key="superclassName">UIViewController</string>
-					<object class="NSMutableDictionary" key="actions">
-						<string key="NS.key.0">handleRotation:</string>
-						<string key="NS.object.0">UIRotationGestureRecognizer</string>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<string key="NS.key.0">handleRotation:</string>
-						<object class="IBActionInfo" key="NS.object.0">
-							<string key="name">handleRotation:</string>
-							<string key="candidateClassName">UIRotationGestureRecognizer</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">mapView</string>
-						<string key="NS.object.0">MKMapView</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">mapView</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">mapView</string>
-							<string key="candidateClassName">MKMapView</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/GestureTestViewController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">NSLayoutConstraint</string>
-					<string key="superclassName">NSObject</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/NSLayoutConstraint.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<bool key="IBDocument.UseAutolayout">YES</bool>
-		<string key="IBCocoaTouchPluginVersion">2083</string>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="12F45" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+    <dependencies>
+        <deployment defaultVersion="1552" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="GestureTestViewController">
+            <connections>
+                <outlet property="mapView" destination="4" id="24"/>
+                <outlet property="view" destination="1" id="3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <mapView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" mapType="standard" showsUserLocation="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4">
+                    <rect key="frame" x="35" y="83" width="250" height="250"/>
+                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                    <gestureRecognizers/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="250" id="18"/>
+                        <constraint firstAttribute="height" constant="250" id="20"/>
+                    </constraints>
+                    <connections>
+                        <outletCollection property="gestureRecognizers" destination="14" appends="YES" id="15"/>
+                    </connections>
+                </mapView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="4" firstAttribute="top" secondItem="1" secondAttribute="top" constant="83" id="22"/>
+                <constraint firstItem="4" firstAttribute="centerX" secondItem="1" secondAttribute="centerX" id="23"/>
+            </constraints>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+            <simulatedScreenMetrics key="simulatedDestinationMetrics" type="retina4"/>
+        </view>
+        <rotationGestureRecognizer id="14">
+            <connections>
+                <action selector="handleRotation:" destination="-1" id="16"/>
+                <outlet property="delegate" destination="-1" id="25"/>
+            </connections>
+        </rotationGestureRecognizer>
+    </objects>
+</document>

--- a/sample-code/apps/TestApp/Test App 2/MyViewControllerViewController.h
+++ b/sample-code/apps/TestApp/Test App 2/MyViewControllerViewController.h
@@ -20,17 +20,22 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <CoreLocation/CoreLocation.h>
 #import "GestureTestViewController.h"
 
-@interface MyViewControllerViewController : UIViewController <UITextFieldDelegate>
+@interface MyViewControllerViewController : UIViewController <UITextFieldDelegate,CLLocationManagerDelegate>
 @property (retain, nonatomic) IBOutlet UITextField *firstArg;
 @property (retain, nonatomic) IBOutlet UITextField *secondArg;
 @property (retain, nonatomic) IBOutlet UILabel *answerLabel;
+@property (retain, nonatomic) IBOutlet UISwitch *locationStatus;
 @property (retain, nonatomic) IBOutlet UIButton *computeSumButton;
-- (IBAction)testGesture:(id)sender;
+@property (nonatomic, retain) CLLocationManager *locationMgr;
 
+- (IBAction)testGesture:(id)sender;
 - (IBAction)computeAction:(id)sender;
 - (IBAction)showAlert:(id)sender;
 - (BOOL)textFieldShouldReturn:(UITextField *)textField;
+- (void)logLocationAuthFromTimer:(NSTimer *)timer;
+- (void)logLocationAuth;
 
 @end

--- a/sample-code/apps/TestApp/Test App 2/MyViewControllerViewController.m
+++ b/sample-code/apps/TestApp/Test App 2/MyViewControllerViewController.m
@@ -47,6 +47,7 @@
 	[secondArg setAccessibilityIdentifier:@"IntegerB"];
 	[computeSumButton setAccessibilityIdentifier:@"ComputeSumButton"];
 	[answerLabel setAccessibilityIdentifier:@"Answer"];
+    [locationStatus setAccessibilityIdentifier:@"locationStatus"];
     return self;
 }
 
@@ -72,7 +73,6 @@
 
 - (void)logLocationAuth
 {
-    //[self.locationMgr startUpdatingLocation];
     CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
     if (status == kCLAuthorizationStatusAuthorized) {
         locationStatus.on = YES;

--- a/sample-code/apps/TestApp/Test App 2/MyViewControllerViewController.m
+++ b/sample-code/apps/TestApp/Test App 2/MyViewControllerViewController.m
@@ -30,12 +30,18 @@
 @synthesize answerLabel;
 @synthesize firstArg;
 @synthesize secondArg;
+@synthesize locationMgr;
+@synthesize locationStatus;
 
 - (id)initWithNibName:(NSString *)nibNameOrNil bundle:(NSBundle *)nibBundleOrNil
 {
     self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
     if (self) {
         // Custom initialization
+        self.locationMgr = [[CLLocationManager alloc] init];
+        self.locationMgr.desiredAccuracy = kCLLocationAccuracyBest;
+        self.locationMgr.delegate = self;
+        [self logLocationAuth];
     }
 	[firstArg setAccessibilityIdentifier:@"IntegerA"];
 	[secondArg setAccessibilityIdentifier:@"IntegerB"];
@@ -52,6 +58,27 @@
     secondArg.returnKeyType = UIReturnKeyDone;
     firstArg.delegate = self;
     secondArg.delegate = self;
+    [NSTimer scheduledTimerWithTimeInterval:0.6
+                                     target:self
+                                   selector:@selector(logLocationAuthFromTimer:)
+                                   userInfo:nil
+                                    repeats:YES];
+}
+
+- (void)logLocationAuthFromTimer:(NSTimer *)timer
+{
+    [self logLocationAuth];
+}
+
+- (void)logLocationAuth
+{
+    //[self.locationMgr startUpdatingLocation];
+    CLAuthorizationStatus status = [CLLocationManager authorizationStatus];
+    if (status == kCLAuthorizationStatusAuthorized) {
+        locationStatus.on = YES;
+    } else {
+        locationStatus.on = NO;
+    }
 }
 
 - (void)viewDidUnload
@@ -75,6 +102,8 @@
 }
 
 - (void)dealloc {
+    [self.locationMgr release];
+    self.locationMgr = nil;
     [firstArg release];
     [secondArg release];
     [answerLabel release];

--- a/sample-code/apps/TestApp/Test App 2/MyViewControllerViewController.xib
+++ b/sample-code/apps/TestApp/Test App 2/MyViewControllerViewController.xib
@@ -1,526 +1,128 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
-	<data>
-		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">11G63b</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1138.51</string>
-		<string key="IBDocument.HIToolboxVersion">569.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">2083</string>
-		</object>
-		<array key="IBDocument.IntegratedClassDependencies">
-			<string>IBProxyObject</string>
-			<string>IBUIButton</string>
-			<string>IBUILabel</string>
-			<string>IBUISlider</string>
-			<string>IBUITextField</string>
-			<string>IBUIView</string>
-		</array>
-		<array key="IBDocument.PluginDependencies">
-			<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-		</array>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<array class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<object class="IBProxyObject" id="372490531">
-				<string key="IBProxiedObjectIdentifier">IBFilesOwner</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBProxyObject" id="975951072">
-				<string key="IBProxiedObjectIdentifier">IBFirstResponder</string>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-			<object class="IBUIView" id="191373211">
-				<reference key="NSNextResponder"/>
-				<int key="NSvFlags">274</int>
-				<array class="NSMutableArray" key="NSSubviews">
-					<object class="IBUIButton" id="1032139202">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{94, 122}, {113, 37}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSNextKeyView" ref="345291070"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<object class="IBUIAccessibilityConfiguration" key="IBUIAccessibilityConfiguration">
-							<string key="IBUIAccessibilityLabel">ComputeSumButton</string>
-						</object>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Compute Sum</string>
-						<object class="NSColor" key="IBUIHighlightedTitleColor" id="117515812">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MQA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
-						<object class="NSColor" key="IBUINormalTitleShadowColor" id="877481141">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MC41AA</bytes>
-						</object>
-						<object class="IBUIFontDescription" key="IBUIFontDescription" id="543225109">
-							<int key="type">2</int>
-							<double key="pointSize">15</double>
-						</object>
-						<object class="NSFont" key="IBUIFont" id="871252260">
-							<string key="NSName">Helvetica-Bold</string>
-							<double key="NSSize">15</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-					<object class="IBUITextField" id="331326436">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{102, 38}, {97, 31}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSNextKeyView" ref="1060849759"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<object class="IBUIAccessibilityConfiguration" key="IBUIAccessibilityConfiguration">
-							<string key="IBUIAccessibilityLabel">TextField1</string>
-						</object>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<string key="IBUIText"/>
-						<int key="IBUIBorderStyle">3</int>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MAA</bytes>
-							<object class="NSColorSpace" key="NSCustomColorSpace" id="712793226">
-								<int key="NSID">2</int>
-							</object>
-						</object>
-						<bool key="IBUIAdjustsFontSizeToFit">YES</bool>
-						<float key="IBUIMinimumFontSize">17</float>
-						<object class="IBUITextInputTraits" key="IBUITextInputTraits">
-							<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						</object>
-						<object class="IBUIFontDescription" key="IBUIFontDescription" id="464614108">
-							<int key="type">1</int>
-							<double key="pointSize">14</double>
-						</object>
-						<object class="NSFont" key="IBUIFont" id="530120124">
-							<string key="NSName">Helvetica</string>
-							<double key="NSSize">14</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-					<object class="IBUITextField" id="1060849759">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{102, 77}, {97, 31}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSNextKeyView" ref="1032139202"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<object class="IBUIAccessibilityConfiguration" key="IBUIAccessibilityConfiguration">
-							<string key="IBUIAccessibilityLabel">TextField2</string>
-						</object>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<string key="IBUIText"/>
-						<int key="IBUIBorderStyle">3</int>
-						<object class="NSColor" key="IBUITextColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MAA</bytes>
-							<reference key="NSCustomColorSpace" ref="712793226"/>
-						</object>
-						<bool key="IBUIAdjustsFontSizeToFit">YES</bool>
-						<float key="IBUIMinimumFontSize">17</float>
-						<object class="IBUITextInputTraits" key="IBUITextInputTraits">
-							<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						</object>
-						<reference key="IBUIFontDescription" ref="464614108"/>
-						<reference key="IBUIFont" ref="530120124"/>
-					</object>
-					<object class="IBUILabel" id="345291070">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{129, 167}, {42, 21}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSNextKeyView" ref="706685511"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<object class="IBUIAccessibilityConfiguration" key="IBUIAccessibilityConfiguration">
-							<string key="IBUIAccessibilityLabel">SumLabel</string>
-						</object>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">???</string>
-						<object class="NSColor" key="IBUITextColor" id="835328643">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MCAwIDAAA</bytes>
-							<string key="IBUIColorCocoaTouchKeyPath">darkTextColor</string>
-						</object>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">0</int>
-						<float key="IBUIMinimumFontSize">10</float>
-						<object class="IBUIFontDescription" key="IBUIFontDescription" id="735206737">
-							<int key="type">1</int>
-							<double key="pointSize">17</double>
-						</object>
-						<object class="NSFont" key="IBUIFont" id="575235018">
-							<string key="NSName">Helvetica</string>
-							<double key="NSSize">17</double>
-							<int key="NSfFlags">16</int>
-						</object>
-					</object>
-					<object class="IBUIButton" id="706685511">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{94, 208}, {113, 44}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSNextKeyView" ref="437918133"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">show alert</string>
-						<reference key="IBUIHighlightedTitleColor" ref="117515812"/>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
-						<reference key="IBUINormalTitleShadowColor" ref="877481141"/>
-						<reference key="IBUIFontDescription" ref="543225109"/>
-						<reference key="IBUIFont" ref="871252260"/>
-					</object>
-					<object class="IBUILabel" id="437918133">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{122, 259}, {56, 21}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSNextKeyView" ref="373721015"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<object class="IBUIAccessibilityConfiguration" key="IBUIAccessibilityConfiguration">
-							<string key="IBUIAccessibilityLabel">AppElem</string>
-						</object>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">Label 1</string>
-						<reference key="IBUITextColor" ref="835328643"/>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">0</int>
-						<reference key="IBUIFontDescription" ref="735206737"/>
-						<reference key="IBUIFont" ref="575235018"/>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
-					</object>
-					<object class="IBUISlider" id="373721015">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{91, 288}, {118, 23}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSNextKeyView" ref="924216972"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<object class="IBUIAccessibilityConfiguration" key="IBUIAccessibilityConfiguration">
-							<string key="IBUIAccessibilityLabel">AppElem</string>
-						</object>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<float key="IBUIValue">0.5</float>
-					</object>
-					<object class="IBUILabel" id="924216972">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{122, 318}, {56, 21}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<reference key="NSNextKeyView" ref="380300170"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<bool key="IBUIClipsSubviews">YES</bool>
-						<int key="IBUIContentMode">7</int>
-						<bool key="IBUIUserInteractionEnabled">NO</bool>
-						<object class="IBUIAccessibilityConfiguration" key="IBUIAccessibilityConfiguration">
-							<string key="IBUIAccessibilityLabel">AppElem</string>
-						</object>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">Label 2</string>
-						<reference key="IBUITextColor" ref="835328643"/>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">0</int>
-						<reference key="IBUIFontDescription" ref="735206737"/>
-						<reference key="IBUIFont" ref="575235018"/>
-						<bool key="IBUIAdjustsFontSizeToFit">NO</bool>
-					</object>
-					<object class="IBUIButton" id="380300170">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{83, 347}, {136, 44}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<bool key="IBUIEnabled">NO</bool>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">disabled button</string>
-						<reference key="IBUIHighlightedTitleColor" ref="117515812"/>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">3</int>
-							<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-						</object>
-						<reference key="IBUINormalTitleShadowColor" ref="877481141"/>
-						<reference key="IBUIFontDescription" ref="543225109"/>
-						<reference key="IBUIFont" ref="871252260"/>
-					</object>
-					<object class="IBUIButton" id="809824375">
-						<reference key="NSNextResponder" ref="191373211"/>
-						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{93, 397}, {116, 44}}</string>
-						<reference key="NSSuperview" ref="191373211"/>
-						<string key="NSReuseIdentifierKey">_NS:9</string>
-						<bool key="IBUIOpaque">NO</bool>
-						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<int key="IBUIContentHorizontalAlignment">0</int>
-						<int key="IBUIContentVerticalAlignment">0</int>
-						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Test Gesture</string>
-						<reference key="IBUIHighlightedTitleColor" ref="117515812"/>
-						<object class="NSColor" key="IBUINormalTitleColor">
-							<int key="NSColorSpace">1</int>
-							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
-						</object>
-						<reference key="IBUINormalTitleShadowColor" ref="877481141"/>
-						<reference key="IBUIFontDescription" ref="543225109"/>
-						<reference key="IBUIFont" ref="871252260"/>
-					</object>
-				</array>
-				<string key="NSFrame">{{0, 20}, {320, 460}}</string>
-				<reference key="NSSuperview"/>
-				<reference key="NSNextKeyView" ref="331326436"/>
-				<object class="NSColor" key="IBUIBackgroundColor">
-					<int key="NSColorSpace">3</int>
-					<bytes key="NSWhite">MQA</bytes>
-					<reference key="NSCustomColorSpace" ref="712793226"/>
-				</object>
-				<object class="IBUISimulatedStatusBarMetrics" key="IBUISimulatedStatusBarMetrics"/>
-				<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-			</object>
-		</array>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<array class="NSMutableArray" key="connectionRecords">
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">view</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="191373211"/>
-					</object>
-					<int key="connectionID">3</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">firstArg</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="331326436"/>
-					</object>
-					<int key="connectionID">9</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">secondArg</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="1060849759"/>
-					</object>
-					<int key="connectionID">10</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">answerLabel</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="345291070"/>
-					</object>
-					<int key="connectionID">12</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchOutletConnection" key="connection">
-						<string key="label">computeSumButton</string>
-						<reference key="source" ref="372490531"/>
-						<reference key="destination" ref="1032139202"/>
-					</object>
-					<int key="connectionID">13</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">computeAction:</string>
-						<reference key="source" ref="1032139202"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">11</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">showAlert:</string>
-						<reference key="source" ref="706685511"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">18</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBCocoaTouchEventConnection" key="connection">
-						<string key="label">testGesture:</string>
-						<reference key="source" ref="809824375"/>
-						<reference key="destination" ref="372490531"/>
-						<int key="IBEventType">7</int>
-					</object>
-					<int key="connectionID">26</int>
-				</object>
-			</array>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<array key="orderedObjects">
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<array key="object" id="0"/>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">1</int>
-						<reference key="object" ref="191373211"/>
-						<array class="NSMutableArray" key="children">
-							<reference ref="1060849759"/>
-							<reference ref="331326436"/>
-							<reference ref="345291070"/>
-							<reference ref="1032139202"/>
-							<reference ref="706685511"/>
-							<reference ref="373721015"/>
-							<reference ref="437918133"/>
-							<reference ref="924216972"/>
-							<reference ref="380300170"/>
-							<reference ref="809824375"/>
-						</array>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="372490531"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="975951072"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">4</int>
-						<reference key="object" ref="1032139202"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">5</int>
-						<reference key="object" ref="331326436"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="1060849759"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">7</int>
-						<reference key="object" ref="345291070"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">16</int>
-						<reference key="object" ref="706685511"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">19</int>
-						<reference key="object" ref="437918133"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">20</int>
-						<reference key="object" ref="373721015"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">21</int>
-						<reference key="object" ref="924216972"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">23</int>
-						<reference key="object" ref="380300170"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">25</int>
-						<reference key="object" ref="809824375"/>
-						<reference key="parent" ref="191373211"/>
-					</object>
-				</array>
-			</object>
-			<dictionary class="NSMutableDictionary" key="flattenedProperties">
-				<string key="-1.CustomClassName">MyViewControllerViewController</string>
-				<string key="-1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="-2.CustomClassName">UIResponder</string>
-				<string key="-2.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="1.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="16.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="19.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="20.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="21.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<object class="NSMutableDictionary" key="23.IBAttributePlaceholdersKey">
-					<string key="NS.key.0">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-					<object class="IBUIUserDefinedRuntimeAttributesPlaceholder" key="NS.object.0">
-						<string key="name">IBUserDefinedRuntimeAttributesPlaceholderName</string>
-						<reference key="object" ref="380300170"/>
-						<array key="userDefinedRuntimeAttributes">
-							<object class="IBUserDefinedRuntimeAttribute">
-								<string key="typeIdentifier">com.apple.InterfaceBuilder.userDefinedRuntimeAttributeType.string</string>
-								<string key="keyPath">accessibilityIdentifier</string>
-								<string key="value">DisabledButton</string>
-							</object>
-						</array>
-					</object>
-				</object>
-				<string key="23.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="25.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="5.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="7.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			</dictionary>
-			<dictionary class="NSMutableDictionary" key="unlocalizedProperties"/>
-			<nil key="activeLocalization"/>
-			<dictionary class="NSMutableDictionary" key="localizations"/>
-			<nil key="sourceID"/>
-			<int key="maxID">26</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDependencyDefaults">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaTouchPlugin.iPhoneOS</string>
-			<real value="1552" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">2083</string>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="4514" systemVersion="12F45" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none">
+    <dependencies>
+        <deployment defaultVersion="1552" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3747"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MyViewControllerViewController">
+            <connections>
+                <outlet property="answerLabel" destination="7" id="12"/>
+                <outlet property="computeSumButton" destination="4" id="13"/>
+                <outlet property="firstArg" destination="5" id="9"/>
+                <outlet property="locationStatus" destination="bMw-Gn-PAX" id="gaY-Qi-5Ut"/>
+                <outlet property="secondArg" destination="6" id="10"/>
+                <outlet property="view" destination="1" id="3"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="1">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="4">
+                    <rect key="frame" x="94" y="122" width="113" height="37"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <accessibility key="accessibilityConfiguration" label="ComputeSumButton"/>
+                    <state key="normal" title="Compute Sum">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="computeAction:" destination="-1" eventType="touchUpInside" id="11"/>
+                    </connections>
+                </button>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" id="5">
+                    <rect key="frame" x="102" y="38" width="97" height="31"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <accessibility key="accessibilityConfiguration" label="TextField1"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" id="6">
+                    <rect key="frame" x="102" y="77" width="97" height="31"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <accessibility key="accessibilityConfiguration" label="TextField2"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <textInputTraits key="textInputTraits"/>
+                </textField>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="???" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="10" id="7">
+                    <rect key="frame" x="129" y="167" width="42" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <accessibility key="accessibilityConfiguration" label="SumLabel"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="16">
+                    <rect key="frame" x="94" y="208" width="113" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="show alert">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="showAlert:" destination="-1" eventType="touchUpInside" id="18"/>
+                    </connections>
+                </button>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label 1" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="19">
+                    <rect key="frame" x="122" y="259" width="56" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <accessibility key="accessibilityConfiguration" label="AppElem"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" id="20">
+                    <rect key="frame" x="91" y="288" width="118" height="29"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <accessibility key="accessibilityConfiguration" label="AppElem"/>
+                </slider>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="Label 2" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="21">
+                    <rect key="frame" x="122" y="318" width="56" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <accessibility key="accessibilityConfiguration" label="AppElem"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="23">
+                    <rect key="frame" x="83" y="347" width="136" height="28"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="disabled button">
+                        <color key="titleColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="DisabledButton"/>
+                    </userDefinedRuntimeAttributes>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="25">
+                    <rect key="frame" x="93" y="397" width="116" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <state key="normal" title="Test Gesture">
+                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                    </state>
+                    <connections>
+                        <action selector="testGesture:" destination="-1" eventType="touchUpInside" id="26"/>
+                    </connections>
+                </button>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="4Ko-7N-LkD">
+                    <rect key="frame" x="82" y="383" width="73" height="21"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <accessibility key="accessibilityConfiguration" label="">
+                        <bool key="isElement" value="NO"/>
+                    </accessibility>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <switch opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" id="bMw-Gn-PAX">
+                    <rect key="frame" x="170" y="378" width="51" height="31"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <accessibility key="accessibilityConfiguration" label="locationStatus"/>
+                </switch>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
+        </view>
+    </objects>
+</document>

--- a/sample-code/apps/TestApp/TestApp.xcodeproj/project.pbxproj
+++ b/sample-code/apps/TestApp/TestApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1BB2B952189053DC00D0591D /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1BB2B951189053DC00D0591D /* CoreLocation.framework */; };
 		255BAFEC1790223300DE7158 /* GestureTestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 255BAFEA1790223300DE7158 /* GestureTestViewController.m */; };
 		255BAFED1790223300DE7158 /* GestureTestViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 255BAFEB1790223300DE7158 /* GestureTestViewController.xib */; };
 		255BAFEF1790249F00DE7158 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 255BAFEE1790249F00DE7158 /* MapKit.framework */; };
@@ -22,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		1BB2B951189053DC00D0591D /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		255BAFE91790223300DE7158 /* GestureTestViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GestureTestViewController.h; sourceTree = "<group>"; };
 		255BAFEA1790223300DE7158 /* GestureTestViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GestureTestViewController.m; sourceTree = "<group>"; };
 		255BAFEB1790223300DE7158 /* GestureTestViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GestureTestViewController.xib; sourceTree = "<group>"; };
@@ -47,6 +49,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1BB2B952189053DC00D0591D /* CoreLocation.framework in Frameworks */,
 				255BAFEF1790249F00DE7158 /* MapKit.framework in Frameworks */,
 				3647AE1315CA0082006F70D6 /* UIKit.framework in Frameworks */,
 				3647AE1515CA0082006F70D6 /* Foundation.framework in Frameworks */,
@@ -79,6 +82,7 @@
 		3647AE1115CA0082006F70D6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1BB2B951189053DC00D0591D /* CoreLocation.framework */,
 				3647AE1215CA0082006F70D6 /* UIKit.framework */,
 				3647AE1415CA0082006F70D6 /* Foundation.framework */,
 				3647AE1615CA0082006F70D6 /* CoreGraphics.framework */,

--- a/test/functional/ios/prefs-specs.js
+++ b/test/functional/ios/prefs-specs.js
@@ -53,6 +53,8 @@ describe("prefs @skip-ios6 @skip-ios7", function () {
       .then(function () {
         if (setting === 'fraud') {
           return driver.elementByName("Fraud Warning");
+        } else if (setting === 'popups') {
+          return driver.elementByName("Block Pop-ups");
         } else {
           return new Error("Bad setting " + setting);
         }
@@ -97,8 +99,28 @@ describe("prefs @skip-ios6 @skip-ios7", function () {
     setup(this, _.defaults({safariIgnoreFraudWarning: false}, desired))
       .then(function (d) { driver = d; });
 
-    it('should respond to cap when true', function (done) {
+    it('should respond to cap when false', function (done) {
       checkSafariSetting(driver, 'fraud', 1, done);
+    });
+  });
+
+  describe('using safariAllowPopups', function () {
+    var driver;
+    setup(this, _.defaults({safariAllowPopups: true}, desired))
+      .then(function (d) { driver = d; });
+
+    it('should respond to cap when true', function (done) {
+      checkSafariSetting(driver, 'popups', 0, done);
+    });
+  });
+
+  describe('using safariAllowPopups', function () {
+    var driver;
+    setup(this, _.defaults({safariAllowPopups: false}, desired))
+      .then(function (d) { driver = d; });
+
+    it('should respond to cap when false', function (done) {
+      checkSafariSetting(driver, 'popups', 1, done);
     });
   });
 });

--- a/test/functional/ios/prefs-specs.js
+++ b/test/functional/ios/prefs-specs.js
@@ -2,6 +2,7 @@
 
 var env = require("../../helpers/env")
   , setup = require("../common/setup-base")
+  , initSession = require('../../helpers/session').initSession
   , chai = require('chai')
   , _ = require('underscore');
 
@@ -12,7 +13,7 @@ var desired = {
 , device: 'iPhone Simulator'
 };
 
-describe("prefs @skip-ios6 @skip-ios7", function () {
+describe("prefs @skip-ios7", function () {
 
   describe('settings app', function () {
     var driver;
@@ -84,43 +85,45 @@ describe("prefs @skip-ios6 @skip-ios7", function () {
     });
   });
 
-  describe('using safariIgnoreFraudWarning', function () {
-    var driver;
-    setup(this, _.defaults({safariIgnoreFraudWarning: true}, desired))
-      .then(function (d) { driver = d; });
+  describe('safari prefs', function () {
+    describe('using safariIgnoreFraudWarning', function () {
+      var driver;
+      setup(this, _.defaults({safariIgnoreFraudWarning: true}, desired))
+        .then(function (d) { driver = d; });
 
-    it('should respond to cap when true', function (done) {
-      checkSafariSetting(driver, 'fraud', 0, done);
+      it('should respond to cap when true', function (done) {
+        checkSafariSetting(driver, 'fraud', 0, done);
+      });
     });
-  });
 
-  describe('using safariIgnoreFraudWarning', function () {
-    var driver;
-    setup(this, _.defaults({safariIgnoreFraudWarning: false}, desired))
-      .then(function (d) { driver = d; });
+    describe('using safariIgnoreFraudWarning', function () {
+      var driver;
+      setup(this, _.defaults({safariIgnoreFraudWarning: false}, desired))
+        .then(function (d) { driver = d; });
 
-    it('should respond to cap when false', function (done) {
-      checkSafariSetting(driver, 'fraud', 1, done);
+      it('should respond to cap when false', function (done) {
+        checkSafariSetting(driver, 'fraud', 1, done);
+      });
     });
-  });
 
-  describe('using safariAllowPopups', function () {
-    var driver;
-    setup(this, _.defaults({safariAllowPopups: true}, desired))
-      .then(function (d) { driver = d; });
+    describe('using safariAllowPopups', function () {
+      var driver;
+      setup(this, _.defaults({safariAllowPopups: true}, desired))
+        .then(function (d) { driver = d; });
 
-    it('should respond to cap when true', function (done) {
-      checkSafariSetting(driver, 'popups', 0, done);
+      it('should respond to cap when true', function (done) {
+        checkSafariSetting(driver, 'popups', 0, done);
+      });
     });
-  });
 
-  describe('using safariAllowPopups', function () {
-    var driver;
-    setup(this, _.defaults({safariAllowPopups: false}, desired))
-      .then(function (d) { driver = d; });
+    describe('using safariAllowPopups', function () {
+      var driver;
+      setup(this, _.defaults({safariAllowPopups: false}, desired))
+        .then(function (d) { driver = d; });
 
-    it('should respond to cap when false', function (done) {
-      checkSafariSetting(driver, 'popups', 1, done);
+      it('should respond to cap when false', function (done) {
+        checkSafariSetting(driver, 'popups', 1, done);
+      });
     });
   });
 });

--- a/test/functional/ios/prefs-specs.js
+++ b/test/functional/ios/prefs-specs.js
@@ -46,6 +46,22 @@ describe("prefs @skip-ios6 @skip-ios7", function () {
       }).nodeify(cb);
   };
 
+  var checkSafariSetting = function (driver, setting, expected, cb) {
+    driver
+      .elementsByTagName("tableCell")
+      .then(function (els) { return els[4].click(); })
+      .then(function () {
+        if (setting === 'fraud') {
+          return driver.elementByName("Fraud Warning");
+        } else {
+          return new Error("Bad setting " + setting);
+        }
+      })
+      .getValue().then(function (checked) {
+        (!!parseInt(checked, 10)).should.eql(!!expected);
+      }).nodeify(cb);
+  };
+
   describe('settings app with location services', function () {
     var driver;
     setup(this, _.defaults({locationServicesEnabled: true}, desired))
@@ -63,6 +79,26 @@ describe("prefs @skip-ios6 @skip-ios7", function () {
 
     it('should respond to negative locationServicesEnabled cap', function (done) {
       checkLocServ(driver, 0, done);
+    });
+  });
+
+  describe('using safariIgnoreFraudWarning', function () {
+    var driver;
+    setup(this, _.defaults({safariIgnoreFraudWarning: true}, desired))
+      .then(function (d) { driver = d; });
+
+    it('should respond to cap when true', function (done) {
+      checkSafariSetting(driver, 'fraud', 0, done);
+    });
+  });
+
+  describe('using safariIgnoreFraudWarning', function () {
+    var driver;
+    setup(this, _.defaults({safariIgnoreFraudWarning: false}, desired))
+      .then(function (d) { driver = d; });
+
+    it('should respond to cap when true', function (done) {
+      checkSafariSetting(driver, 'fraud', 1, done);
     });
   });
 });

--- a/test/functional/ios/prefs-specs.js
+++ b/test/functional/ios/prefs-specs.js
@@ -3,6 +3,7 @@
 var env = require("../../helpers/env")
   , setup = require("../common/setup-base")
   , initSession = require('../../helpers/session').initSession
+  , settingsPlists = require('../../../lib/devices/ios/settings.js')
   , chai = require('chai')
   , _ = require('underscore');
 
@@ -47,24 +48,6 @@ describe("prefs @skip-ios7", function () {
       }).nodeify(cb);
   };
 
-  var checkSafariSetting = function (driver, setting, expected, cb) {
-    driver
-      .elementsByTagName("tableCell")
-      .then(function (els) { return els[4].click(); })
-      .then(function () {
-        if (setting === 'fraud') {
-          return driver.elementByName("Fraud Warning");
-        } else if (setting === 'popups') {
-          return driver.elementByName("Block Pop-ups");
-        } else {
-          return new Error("Bad setting " + setting);
-        }
-      })
-      .getValue().then(function (checked) {
-        (!!parseInt(checked, 10)).should.eql(!!expected);
-      }).nodeify(cb);
-  };
-
   describe('settings app with location services', function () {
     var driver;
     setup(this, _.defaults({locationServicesEnabled: true}, desired))
@@ -84,46 +67,138 @@ describe("prefs @skip-ios7", function () {
       checkLocServ(driver, 0, done);
     });
   });
+});
 
-  describe('safari prefs', function () {
-    describe('using safariIgnoreFraudWarning', function () {
-      var driver;
-      setup(this, _.defaults({safariIgnoreFraudWarning: true}, desired))
-        .then(function (d) { driver = d; });
+describe('safari prefs @skip-ios7', function () {
+  var checkSafariSetting = function (driver, setting, expected, cb) {
+    driver
+      .elementsByTagName("tableCell")
+      .then(function (els) { return els[4].click(); })
+      .then(function () {
+        if (setting === 'fraud') {
+          return driver.elementByName("Fraud Warning");
+        } else if (setting === 'popups') {
+          return driver.elementByName("Block Pop-ups");
+        } else {
+          return new Error("Bad setting " + setting);
+        }
+      })
+      .getValue().then(function (checked) {
+        (!!parseInt(checked, 10)).should.eql(!!expected);
+      }).nodeify(cb);
+  };
 
-      it('should respond to cap when true', function (done) {
-        checkSafariSetting(driver, 'fraud', 0, done);
-      });
+  describe('using safariIgnoreFraudWarning', function () {
+    var driver;
+    setup(this, _.defaults({safariIgnoreFraudWarning: true}, desired))
+      .then(function (d) { driver = d; });
+
+    it('should respond to cap when true', function (done) {
+      checkSafariSetting(driver, 'fraud', 0, done);
     });
+  });
 
-    describe('using safariIgnoreFraudWarning', function () {
-      var driver;
-      setup(this, _.defaults({safariIgnoreFraudWarning: false}, desired))
-        .then(function (d) { driver = d; });
+  describe('using safariIgnoreFraudWarning', function () {
+    var driver;
+    setup(this, _.defaults({safariIgnoreFraudWarning: false}, desired))
+      .then(function (d) { driver = d; });
 
-      it('should respond to cap when false', function (done) {
-        checkSafariSetting(driver, 'fraud', 1, done);
-      });
+    it('should respond to cap when false', function (done) {
+      checkSafariSetting(driver, 'fraud', 1, done);
     });
+  });
 
-    describe('using safariAllowPopups', function () {
-      var driver;
-      setup(this, _.defaults({safariAllowPopups: true}, desired))
-        .then(function (d) { driver = d; });
+  describe('using safariAllowPopups', function () {
+    var driver;
+    setup(this, _.defaults({safariAllowPopups: true}, desired))
+      .then(function (d) { driver = d; });
 
-      it('should respond to cap when true', function (done) {
-        checkSafariSetting(driver, 'popups', 0, done);
-      });
+    it('should respond to cap when true', function (done) {
+      checkSafariSetting(driver, 'popups', 0, done);
     });
+  });
 
-    describe('using safariAllowPopups', function () {
-      var driver;
-      setup(this, _.defaults({safariAllowPopups: false}, desired))
-        .then(function (d) { driver = d; });
+  describe('using safariAllowPopups', function () {
+    var driver;
+    setup(this, _.defaults({safariAllowPopups: false}, desired))
+      .then(function (d) { driver = d; });
 
-      it('should respond to cap when false', function (done) {
-        checkSafariSetting(driver, 'popups', 1, done);
-      });
+    it('should respond to cap when false', function (done) {
+      checkSafariSetting(driver, 'popups', 1, done);
+    });
+  });
+});
+
+describe('safari ios7 prefs @skip-ios6', function () {
+
+  var desired = {
+    app: 'safari'
+  , device: 'iPhone Simulator'
+  };
+
+  var checkSafariSetting = function (setting, expected, cb) {
+    var settingsSets;
+    var foundSettings;
+    try {
+      settingsSets = settingsPlists.getSettings('7', 'mobileSafari');
+    } catch (e) {
+      return cb(e);
+    }
+    _.size(settingsSets).should.be.above(0);
+    for (var i = 0; i < settingsSets.length; i++) {
+      try {
+        foundSettings.push(settingsSets[i][setting]);
+      } catch (e) {
+        return cb(e);
+      }
+    }
+    if (settingsSets.length > 0) {
+      console.log("More than one safari settings set found, a failure here " +
+                  "might not be accurate");
+    }
+    for (i = 0; i < settingsSets.length; i++) {
+      foundSettings[i].should.eql(expected);
+    }
+    cb();
+  };
+
+  describe('using safariIgnoreFraudWarning', function () {
+    var driver;
+    setup(this, _.defaults({safariIgnoreFraudWarning: true}, desired))
+      .then(function (d) { driver = d; });
+
+    it('should respond to cap when true', function (done) {
+      checkSafariSetting('WarnAboutFraudulentWebsites', false, done);
+    });
+  });
+
+  describe('using safariIgnoreFraudWarning', function () {
+    var driver;
+    setup(this, _.defaults({safariIgnoreFraudWarning: false}, desired))
+      .then(function (d) { driver = d; });
+
+    it('should respond to cap when false', function (done) {
+      checkSafariSetting('WarnAboutFraudulentWebsites', true, done);
+    });
+  });
+
+  describe('using safariAllowPopups', function () {
+    var driver;
+    setup(this, _.defaults({safariAllowPopups: true}, desired))
+      .then(function (d) { driver = d; });
+
+    it('should respond to cap when true', function (done) {
+      checkSafariSetting('WebKitJavaScriptCanOpenWindowsAutomatically', true, done);
+    });
+  });
+
+  describe('using safariAllowPopups', function () {
+    var driver;
+    setup(this, _.defaults({safariAllowPopups: false}, desired))
+      .then(function (d) { driver = d; });
+
+    it('should respond to cap when false', function (done) {
+      checkSafariSetting('WebKitJavaScriptCanOpenWindowsAutomatically', false, done);
     });
   });
 });

--- a/test/functional/ios/testapp/location-specs.js
+++ b/test/functional/ios/testapp/location-specs.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var setup = require("../../common/setup-base"),
+    _ = require("underscore"),
     desired = require('./desired');
 
 describe('testapp - location -', function () {
@@ -42,6 +43,42 @@ describe('testapp - location -', function () {
     };
     driver.execute('mobile: setLocation', [locationOpts])
       .should.be.rejected
+      .nodeify(done);
+  });
+});
+
+describe('testapp - location services -', function () {
+  var driver;
+  var newDesired = _.clone(desired);
+  _.extend(newDesired, {
+    locationServicesAuthorized: true,
+    bundleId: 'io.appium.TestApp'
+  });
+  setup(this, newDesired).then(function (d) { driver = d; });
+
+  it('should be able to be turned on', function (done) {
+    driver
+      .elementByName('locationStatus').getValue().then(function (checked) {
+        checked.should.equal(1);
+      })
+      .nodeify(done);
+  });
+});
+
+describe('testapp - location services -', function () {
+  var driver;
+  var newDesired = _.clone(desired);
+  _.extend(newDesired, {
+    locationServicesAuthorized: false,
+    bundleId: 'io.appium.TestApp'
+  });
+  setup(this, newDesired).then(function (d) { driver = d; });
+
+  it('should be able to be turned off', function (done) {
+    driver
+      .elementByName('locationStatus').getValue().then(function (checked) {
+        checked.should.equal(0);
+      })
       .nodeify(done);
   });
 });


### PR DESCRIPTION
Lots of stuff here:
- allow toggling location services system wide with `locationServicesEnabled` cap
- allow toggling location services for AUT with `locationServicesEnabled` cap
- various Safari-specific capabilities:
  - `safariAllowPopups`: true/false
  - `safariIgnoreFraudWarning`: true/false
  - `safariOpenLinksInBackground`: true/false

These all involve plist hacking which assumes the simulator dirs and in some cases the app specific dirs are present. So if they're not, we briefly launch instruments and then kill it to create the dirs. Unknown whether this is enough for the app-specific dirs at this point.

I've added tests for these, but please pull and test before we merge!
