### PR TITLE
Bundle chromedriver into build, for Windows

### DIFF
--- a/docs/mobile-web.md
+++ b/docs/mobile-web.md
@@ -84,8 +84,7 @@ remoteWebDriver.quit();
 Pre-requisites:
 
 *  Make sure Chrome (an app with the package `com.android.chrome`) is installed on your device or emulator. Getting Chrome for the x86 version of the emulator is not currently possible without building Chromium, so you may want to run an ARM emulator and then copy a Chrome APK from a real device to get Chrome on an emulator.
-*  For Windows, make sure [ChromeDriver](http://chromedriver.storage.googleapis.com/index.html), version &gt;= 2.0 is on your system and that the `chromedriver` binary is on your `$PATH`.
-*  For Mac, if downloaded from [NPM](https://www.npmjs.org/package/appium), or running from the [.app](https://github.com/appium/appium-dot-app), nothing needs to be done. If running from source, `reset.sh` will download ChromeDriver and put it in `build`. A particular version can be specified by passing the `--chromedriver-version` option (e.g., `./reset.sh --android --chromedriver-version 2.8`), otherwise the most recent one will be retrieved.
+*  If downloaded from [NPM](https://www.npmjs.org/package/appium), or running from the [.app](https://github.com/appium/appium-dot-app), nothing needs to be done. If running from source, the `reset` script will download ChromeDriver and put it in `build`. A particular version can be specified by passing the `--chromedriver-version` option (e.g., `./reset.sh --android --chromedriver-version 2.8`), otherwise the most recent one will be retrieved.
 
 Then, use desired capabilities like these to run your test in Chrome:
 

--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -10,7 +10,8 @@ var Android = require('./android.js')
   , through = require('through')
   , isWindows = require('../../helpers.js').isWindows()
   , ADB = require('./adb.js')
-  , path = require('path');
+  , path = require('path')
+  , fs = require('fs');
 
 var ChromeAndroid = function (opts) {
   this.initialize(opts);
@@ -52,16 +53,10 @@ ChromeAndroid.prototype.unlock = function (cb) {
 
 ChromeAndroid.prototype.ensureChromedriverExists = function (cb) {
   logger.info("Ensuring Chromedriver exists");
-  if (isWindows) {
-    exec("where chromedriver.exe", function (err, stdout) {
-      if (err) return cb(new Error("Could not find chromedriver, is it on PATH?"));
-      this.chromedriver = stdout.trim();
-      cb();
-    }.bind(this));
-  } else {
-    // use Appium's Chromedriver
+  fs.exists(this.chromedriver, function (exists) {
+    if (!exists) return cb(new Error("Could not find chromedriver. Need to run reset script?"));
     cb();
-  }
+  });
 };
 
 ChromeAndroid.prototype.killOldChromedrivers = function (cb) {


### PR DESCRIPTION
Download ChromeDriver into `build`, and use that copy for running Chrome tests.

Allows a particular version to be installed by passing `--chromedriver-version` and the version number to `reset.bat`.
