### PR TITLE
Bundle all ChromeDrivers when publishing

### DIFF
--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -27,7 +27,7 @@ fi
 
 set -e
 git pull upstream master
-./reset.sh --hardcore --real-safari
+./reset.sh --hardcore --real-safari --chromedriver-install-all --chromedriver-version 2.8
 npm publish
 version=$(cat package.json | underscore extract version | sed 's/\"//g')
 git tag -a "v$version" -m "tag appium@$version for npm publish"

--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -9,6 +9,8 @@ var Android = require('./android.js')
   , async = require('async')
   , through = require('through')
   , isWindows = require('../../helpers.js').isWindows()
+  , isMac = require('../../helpers.js').isMac()
+  , isLinux = require('../../helpers.js').isLinux()
   , ADB = require('./adb.js')
   , path = require('path')
   , fs = require('fs');
@@ -53,6 +55,15 @@ ChromeAndroid.prototype.unlock = function (cb) {
 
 ChromeAndroid.prototype.ensureChromedriverExists = function (cb) {
   logger.info("Ensuring Chromedriver exists");
+  var executable = isWindows ? "chromedriver.exe" : "chromedriver";
+  var platform = "mac";
+  if (isWindows) {
+    platform = "windows";
+  } else if (isLinux) {
+    platform = "linux";
+  }
+  this.chromedriver = path.resolve(__dirname, "..", "..", "..", "build", "chromedriver", platform, executable);
+
   fs.exists(this.chromedriver, function (exists) {
     if (!exists) return cb(new Error("Could not find chromedriver. Need to run reset script?"));
     cb();

--- a/reset.bat
+++ b/reset.bat
@@ -91,9 +91,15 @@ if %doAndroid% == 1 (
 
   :: Reset ChromeDriver
   echo =====Resetting ChromeDriver=====
+  SET "chromedriver_build_directory=.\build\chromedriver\windows"
+  echo Building directory structure
+  IF NOT EXIST .\build                      CALL :runCmd "mkdir %chromedriver_build_directory%"
+  IF NOT EXIST .\build\chromedriver         CALL :runCmd "mkdir %chromedriver_build_directory%"
+  IF NOT EXIST .\build\chromedriver\windows CALL :runCmd "mkdir %chromedriver_build_directory%"
+
   echo Removing old files
-  IF EXIST .\build\chromedriver.zip CALL :runCmd "del .\build\chromedriver.zip"
-  IF EXIST .\build\chromedriver.exe CALL :runCmd "del .\build\chromedriver.exe"
+  IF EXIST %chromedriver_build_directory%\chromedriver.zip CALL :runCmd "del %chromedriver_build_directory%\chromedriver.zip"
+  IF EXIST %chromedriver_build_directory%\chromedriver.exe CALL :runCmd "del %chromedriver_build_directory%\chromedriver.exe"
 
   IF NOT DEFINED chromedriver_version (
     echo Finding latest version
@@ -101,8 +107,8 @@ if %doAndroid% == 1 (
   )
 
   echo Downloading and installing version %chromedriver_version%
-  CALL :runCmd "curl -L http://chromedriver.storage.googleapis.com/%chromedriver_version%/chromedriver_win32.zip -o .\build\chromedriver.zip"
-  CALL :runCmd "PUSHD .\build"
+  CALL :runCmd "curl -L http://chromedriver.storage.googleapis.com/%chromedriver_version%/chromedriver_win32.zip -o %chromedriver_build_directory%\chromedriver.zip"
+  CALL :runCmd "PUSHD %chromedriver_build_directory%"
   CALL :runCmd "unzip chromedriver.zip"
   CALL :runCmd "del chromedriver.zip"
   CALL :runCmd "POPD"


### PR DESCRIPTION
Put ChromeDriver for Windows, Mac, and Linux into the build when publishing to NPM. The build is set at the moment to use ChromeDriver 2.8 (as I couldn't get the latest, 2.9, to reliably work).

Bundle will include

```
build/chromedriver/linux/chromedriver
build/chromedriver/mac/chromedriver
build/chromedriver/windows/chromedriver.exe
```

And `chrome.js` gets the correct version for the platform upon which it is run.
