### PR TITLE
Display error message correctly when install/removeApp fails on iOS.

### DIFF
--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -115,7 +115,7 @@ exports.removeApp = function (removeCommand, udid, bundleId, cb) {
   logger.info("Removing app using cmd: " + removeCommand);
   exec(removeCommand, function (error) {
     if (error !== null) {
-      cb(error, 'Unable to un-install [' + bundleId + '] from device with id [' + udid + ']. Error [' + error + ']');
+      cb(new Error('Unable to un-install [' + bundleId + '] from device with id [' + udid + ']. Error [' + error + ']'));
     } else {
       cb(error, 'Successfully un-installed [' + bundleId + '] from device with id [' + udid + ']');
     }
@@ -126,7 +126,7 @@ exports.installApp = function (installationCommand, udid, unzippedAppPath, cb) {
   logger.info("Installing app using cmd: " + installationCommand);
   exec(installationCommand, function (error) {
     if (error !== null) {
-      cb(error, 'Unable to install [' + unzippedAppPath + '] to device with id [' + udid + ']. Error [' + error + ']');
+      cb(new Error('Unable to install [' + unzippedAppPath + '] to device with id [' + udid + ']. Error [' + error + ']'));
     } else {
       cb(error, 'Successfully unzipped and installed [' + unzippedAppPath + '] to device with id [' + udid + ']');
     }


### PR DESCRIPTION
When the install/remove commands fail, this is what I get in Appium:

```
info: Installing app using cmd: fruitstrap install --id bar --bundle foo.app
info: Cleaning up appium session
error: Failed to start an Appium session, err was: Error: Command failed: 
info: Responding to client with error: {"status":33,"value":{"message":"A new session could not be created. (Original error: Command failed: )","killed":false,"code":1,"signal":null,"origValue":"Command failed: "},"sessionId":null}
```

This is a fix for displaying the custom message (as intended) so that I can get:

```
info: Installing app using cmd: fruitstrap install --id bar --bundle foo.app
info: Cleaning up appium session
error: Failed to start an Appium session, err was: Error: Unable to install [foo.app] to device with id [bar]. Error [Error: Command failed: ]
info: Responding to client with error: {"status":33,"value":{"message":"A new session could not be created. (Original error: Unable to install [foo.app] to device with id [bar]. Error [Error: Command failed: ])","origValue":"Unable to install [foo.app] to device with id [bar]. Error [Error: Command failed: ]"},"sessionId":null}
```

Not sure if it's the best way to handle this, but 'Error: Command failed:' is a bit suboptimal.
