### PR TITLE
corrected doctor error reporting

### DIFF
--- a/lib/doctor/android.js
+++ b/lib/doctor/android.js
@@ -23,7 +23,7 @@ AndroidChecker.prototype.runAllChecks = function (cb) {
 };
 
 AndroidChecker.prototype.checkAndroidHomeExported = function (cb) {
-  if (env.ANDROID_HOME === null) {
+  if (typeof env.ANDROID_HOME === "undefined") {
     this.log.fail('ANDROID_HOME is not set', cb);
   } else if (fs.existsSync(env.ANDROID_HOME)) {
     this.log.pass('ANDROID_HOME is set to "' + env.ANDROID_HOME + '"', cb);
@@ -33,7 +33,7 @@ AndroidChecker.prototype.checkAndroidHomeExported = function (cb) {
 };
 
 AndroidChecker.prototype.checkJavaHomeExported = function (cb) {
-  if (env.JAVA_HOME === null) {
+  if (typeof env.JAVA_HOME === "undefined") {
     this.log.fail('JAVA_HOME is not set', cb);
   } else if (fs.existsSync(env.JAVA_HOME)) {
     this.log.pass('JAVA_HOME is set to "' + env.JAVA_HOME + '."', cb);
@@ -55,7 +55,7 @@ AndroidChecker.prototype.checkEmulatorExists = function (cb) {
 };
 
 AndroidChecker.prototype.checkAndroidSDKBinaryExists = function (toolName, relativeToolPath, cb) {
-  if (env.ANDROID_HOME !== null) {
+  if (typeof env.ANDROID_HOME !== "undefined") {
     var adbPath = path.resolve(env.ANDROID_HOME, relativeToolPath);
     if (fs.existsSync(adbPath)) {
       this.log.pass(toolName + " exists at " + adbPath, cb);

--- a/lib/doctor/ios.js
+++ b/lib/doctor/ios.js
@@ -181,7 +181,7 @@ IOSChecker.prototype.checkForNodeBinary = function (cb) {
 };
 
 IOSChecker.prototype.checkForNodeBinaryInCommonPlaces = function (cb) {
-  if (env.NODE_BIN !== null && fs.existsSync(env.NODE_BIN)) {
+  if (typeof env.NODE_BIN !== "undefined" && fs.existsSync(env.NODE_BIN)) {
     this.log.pass("Node binary found using NODE_BIN environment variable at " + env.NODE_BIN, cb);
   } else if (fs.existsSync('/usr/local/bin/node')) {
     this.log.pass("Node binary found at /usr/local/bin/node", cb);
@@ -237,7 +237,7 @@ IOSChecker.prototype.checkForNodeBinaryUsingAppiumConfigFile = function (cb) {
       if (err === null) {
         try {
           var jsonobj = JSON.parse(data);
-          if (jsonobj.node_bin !== undefined && fs.existsSync(jsonobj.node_bin)) {
+          if (typeof jsonobj.node_bin !== "undefined" && fs.existsSync(jsonobj.node_bin)) {
             this.log.pass("Node binary found using .appiumconfig at " + jsonobj.node_bin, cb);
           } else {
             cb(msg, msg);


### PR DESCRIPTION
Calling an environment var which hasn't been set results in `undefined` not `null`
When using the identity operator, `undefined === null` is `false` so the error messages below weren't hitting the right cases.
