### PR TITLE
Android longClick x, y, and duration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,7 @@ sample-code/apps/ApiDemos
 *~
 org.eclipse.ltk.core.refactoring.prefs
 /selendroid
-.appiumconfig
-.appiumconfig.json
+.appiumconfig*
 build/
 .idea
 lib/devices/ios/uiauto/lib/status.js

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -113,8 +113,13 @@ androidController.click = function (elementId, cb) {
   this.proxy(["element:click", {elementId: elementId}], cb);
 };
 
-androidController.touchLongClick = function (elementId, cb) {
-  this.proxy(["element:touchLongClick", {elementId: elementId}], cb);
+androidController.touchLongClick = function (elementId, x, y, duration, cb) {
+  var opts = {};
+  if (elementId) opts.elementId = elementId;
+  if (x) opts.x = x;
+  if (y) opts.y = y;
+  if (duration) opts.duration = duration;
+  this.proxy(["element:touchLongClick", opts], cb);
 };
 
 androidController.fireEvent = function (evt, elementId, value, cb) {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -256,8 +256,14 @@ exports.doClick = function (req, res) {
 
 exports.touchLongClick = function (req, res) {
   var element = req.body.element;
-  if (checkMissingParams(res, {element: element}, true)) {
-    req.device.touchLongClick(element, getResponseHandler(req, res));
+  var x = req.body.x;
+  var y = req.body.y;
+  var duration = req.body.duration;
+
+  if (element && checkMissingParams(res, {element: element}, true)) {
+    req.device.touchLongClick(element, x, y, duration, getResponseHandler(req, res));
+  } else if (checkMissingParams(res, {x: x, y: y}, true)) {
+    req.device.touchLongClick(element, x, y, duration, getResponseHandler(req, res));
   }
 };
 

--- a/test/functional/android/apidemos/gestures-specs.js
+++ b/test/functional/android/apidemos/gestures-specs.js
@@ -27,7 +27,7 @@ describe("apidemo - gestures -", function () {
       .nodeify(done);
   });
   //todo: not working in nexus 7  
-  it(' should click via x/y pct', function (done) {
+  it('should click via x/y pct', function (done) {
     // this test depends on having a certain size screen, obviously
     // I use a nexus something or other phone style thingo
     driver
@@ -232,4 +232,73 @@ describe("apidemo - gestures -", function () {
       }).nodeify(done);
   });
 
+  it('should long click via element value', function (done) {
+    var element;
+
+    driver
+      .elementsByTagName("text").then(function (els) { element = els[1]; })
+      .then(function () { driver.execute("mobile: longClick", [{element: element.value}]); })
+      .sleep(3000)
+      .elementsByTagName("text").then(function (els) { return els[1]; }).text()
+      .then(function (text) {
+        ["Accessibility Node Provider"].should.include(text);
+      }).nodeify(done);
+  });
+
+  it('should long click via element value with custom duration', function (done) {
+    var element;
+
+    driver
+      .elementsByTagName("text").then(function (els) { element = els[1]; })
+      .then(function () { driver.execute("mobile: longClick", [{element: element.value, duration: 1000}]); })
+      .sleep(3000)
+      .elementsByTagName("text").then(function (els) { return els[1]; }).text()
+      .then(function (text) {
+        ["Accessibility Node Provider"].should.include(text);
+      }).nodeify(done);
+  });
+
+  it('should long click via pixel value', function (done) {
+    var element, location, elSize;
+
+    driver
+      .elementsByTagName("text").then(function (els) { element = els[1]; })
+      .then(function () { return element.getLocation(); })
+      .then(function (loc) { location = loc; })
+      .then(function () { return element.getSize(); })
+      .then(function (size) { elSize = size; })
+      .then(function () {
+        var centerX = location.x + (elSize.width / 2);
+        var centerY = location.y + (elSize.height / 2);
+        driver.execute("mobile: longClick", [{x: centerX, y: centerY}]);
+      })
+      .sleep(3000)
+      .elementsByTagName("text").then(function (els) { return els[1]; }).text()
+      .then(function (text) {
+        ["Accessibility Node Provider"].should.include(text);
+      }).nodeify(done);
+  });
+
+  it('should long click via relative value', function (done) {
+    var element, location, elSize, windowSize;
+
+    driver
+      .elementsByTagName("text").then(function (els) { element = els[1]; })
+      .then(function () { return element.getLocation(); })
+      .then(function (loc) { location = loc; })
+      .then(function () { return element.getSize(); })
+      .then(function (size) { elSize = size; })
+      .then(function () { return driver.getWindowSize(); })
+      .then(function (size) { windowSize = size; })
+      .then(function () {
+        var relX = (location.x + (elSize.width / 2)) / windowSize.width;
+        var relY = (location.y + (elSize.height / 2)) / windowSize.height;
+        driver.execute("mobile: longClick", [{x: relX, y: relY}]);
+      })
+      .sleep(3000)
+      .elementsByTagName("text").then(function (els) { return els[1]; }).text()
+      .then(function (text) {
+        ["Accessibility Node Provider"].should.include(text);
+      }).nodeify(done);
+  });
 });


### PR DESCRIPTION
Fix #1838 

Ruby examples:

``` ruby
mobile :longClick, element: el.ref

mobile :longClick, element: el.ref, duration: 3000

mobile :longClick, x: 400, y: 297, duration: 3000

mobile :longClick, x: 0.5, y: 0.244
```

I verified each of the above cases with my app. This should probably have some JS tests before merging though so it doesn't break in the future.
