### PR TITLE
Fixed logcat capture for multiple devices.

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -758,9 +758,9 @@ ADB.prototype.startLogcat = function (cb) {
     cb(new Error("Trying to start logcat capture but it's already started!"));
     return;
   }
-  var adb = this.adb.replace(/"/g, '');
+  var adbCmd = this.adbCmd.replace(/"/g, '');
   this.logcat = new Logcat({
-    adbCmd: adb
+    adbCmd: adbCmd
   , debug: false
   , debugTrace: false
   });

--- a/lib/devices/android/logcat.js
+++ b/lib/devices/android/logcat.js
@@ -25,7 +25,9 @@ util.inherits(Logcat, EventEmitter);
 Logcat.prototype.startCapture = function (cb) {
   this.onLogcatStart = cb;
   logger.info("Starting logcat capture");
-  this.proc = spawn(this.adbCmd, ['logcat']);
+  var args = this.adbCmd.split(' ').concat(['logcat']);
+  var adbCmd = args.shift();
+  this.proc = spawn(adbCmd, args);
   this.proc.stdout.setEncoding('utf8');
   this.proc.stderr.setEncoding('utf8');
   this.proc.on('error', function (err) {


### PR DESCRIPTION
Appium fails to capture the logcat correctly when multiple devices are present. We need to specify the device serial for the logcat command.
