### PR TITLE
bugfix: watchForUnresponsiveInstruments process run on systems without ios configured

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ sample-code/apps/ApiDemos
 org.eclipse.ltk.core.refactoring.prefs
 /selendroid
 .appiumconfig
+.appiumconfig.json
 build/
 .idea
 lib/devices/ios/uiauto/lib/status.js

--- a/grunt-helpers.js
+++ b/grunt-helpers.js
@@ -152,7 +152,7 @@ module.exports.setDeviceConfigVer = function (grunt, device, cb) {
 };
 
 module.exports.writeConfigKey = function (grunt, key, value, cb) {
-  var configPath = path.resolve(__dirname, ".appiumconfig");
+  var configPath = path.resolve(__dirname, ".appiumconfig.json");
   fs.readFile(configPath, function (err, data) {
     var writeConfig = function (config) {
       config[key] = value;

--- a/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
+++ b/lib/devices/ios/uiauto/lib/instruments_client_launcher.js
@@ -120,7 +120,7 @@ var clientPath = (function () {
 })();
 
 var nodePathAppiumConfig = function () {
-  var appiumconfig = '.appiumconfig';
+  var appiumconfig = '.appiumconfig.json';
   var module = 'node_modules/appium/';
 
   // Adding "|| echo 'file not found'" in case "cat config file" fails - this
@@ -141,7 +141,7 @@ var nodePathAppiumConfig = function () {
     }
     // This setup does not have node_bin configured in appiumconfig.
   } catch (e) {
-    console.log("WARN: JSON parse of .appiumconfig failed: " + e);
+    console.log("WARN: JSON parse of .appiumconfig.json failed: " + e);
   }
   return null;
 };
@@ -163,7 +163,7 @@ var nodePath = (function () {
   } catch (e) {
     path = nodePathAppiumConfig();
     if (path !== null) {
-      console.log("Found node through node_bin in .appiumconfig: " + path);
+      console.log("Found node through node_bin in .appiumconfig.json: " + path);
       return path;
     }
     try {

--- a/lib/doctor/ios.js
+++ b/lib/doctor/ios.js
@@ -230,15 +230,15 @@ IOSChecker.prototype.checkForNodeBinaryUsingAppleScript = function (cb) {
 };
 
 IOSChecker.prototype.checkForNodeBinaryUsingAppiumConfigFile = function (cb) {
-  var msg = 'Node binary not found in the .appiumconfig file.';
-  var appiumConfigPath = path.resolve(__dirname, "../..", ".appiumconfig");
+  var msg = 'Node binary not found in the .appiumconfig.json file.';
+  var appiumConfigPath = path.resolve(__dirname, "../..", ".appiumconfig.json");
   if (fs.existsSync(appiumConfigPath)) {
     fs.readFile(appiumConfigPath, 'utf8', function (err, data) {
       if (err === null) {
         try {
           var jsonobj = JSON.parse(data);
           if (typeof jsonobj.node_bin !== "undefined" && fs.existsSync(jsonobj.node_bin)) {
-            this.log.pass("Node binary found using .appiumconfig at " + jsonobj.node_bin, cb);
+            this.log.pass("Node binary found using .appiumconfig.json at " + jsonobj.node_bin, cb);
           } else {
             cb(msg, msg);
           }
@@ -284,7 +284,7 @@ IOSChecker.prototype.authorizeIOS = function (outerCb, innerCb) {
 };
 
 IOSChecker.prototype.setupNodeBinaryPath = function (cb) {
-  var appiumConfigPath = path.resolve(__dirname, "../../", ".appiumconfig");
+  var appiumConfigPath = path.resolve(__dirname, "../../", ".appiumconfig.json");
   if (fs.existsSync(appiumConfigPath)) {
     fs.readFile(appiumConfigPath, 'utf8', function (err, data) {
       if (!err) {
@@ -295,16 +295,16 @@ IOSChecker.prototype.setupNodeBinaryPath = function (cb) {
             this.checkForNodeBinary(cb);
           }.bind(this));
         } catch (jsonErr) {
-          this.log.error("Could not setup node binary path in .appiumconfig. Error parsing JSON: " + jsonErr);
+          this.log.error("Could not setup node binary path in .appiumconfig.json. Error parsing JSON: " + jsonErr);
           this.checkForNodeBinary(cb);
         }
       } else {
-        this.log.error("Could not setup node binary path in .appiumconfig. Error reading config: " + err);
+        this.log.error("Could not setup node binary path in .appiumconfig.json. Error reading config: " + err);
         this.checkForNodeBinary(cb);
       }
     }.bind(this));
   } else {
-    this.log.error('The .appiumconfig file was not found at ' + appiumConfigPath);
+    this.log.error('The .appiumconfig.json file was not found at ' + appiumConfigPath);
     this.exitDoctor();
   }
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -517,3 +517,27 @@ exports.getiOSSimulatorDirectories = function (cb) {
     }
   });
 };
+
+exports.getAppiumConfig = function () {
+  var configPath = path.resolve(__dirname, "..", ".appiumconfig.json");
+  var config
+    , msg;
+  try {
+    config = require(configPath);
+  } catch (e) {
+    if (e.code === "MODULE_NOT_FOUND") {
+      msg = "Could not find config file: " + configPath +
+                 "; looks like config hasn't been run." +
+                 " Please run reset.sh or appium configure.";
+      logger.error(msg);
+      throw new Error(msg);
+    } else {
+      msg = "Invalid config file at " + configPath +
+                " please re-run reset.sh or appium config";
+      logger.error(msg);
+      throw new Error(msg);
+    }
+  }
+
+  return config;
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -541,3 +541,7 @@ exports.getAppiumConfig = function () {
 
   return config;
 };
+
+exports.iosConfigured = function () {
+  return typeof exports.getAppiumConfig().ios !== "undefined";
+};

--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -3,6 +3,7 @@
 var helpers = require('../helpers.js')
   , isWindows = helpers.isWindows()
   , isMac = helpers.isMac()
+  , iosConfigured = helpers.iosConfigured
   , macVersionArray = helpers.macVersionArray
   , _ = require("underscore")
   , exec = require('child_process').exec
@@ -199,7 +200,7 @@ var startAlertSocket = function (restServer, appiumServer, logColors) {
 module.exports.startListening = function (server, args, appiumVer, appiumRev, appiumServer, cb) {
   var alreadyReturned = false;
   server.listen(args.port, args.address, function () {
-    if (isMac && !args.merciful) {
+    if (isMac && iosConfigured() && !args.merciful) {
       watchForUnresponsiveInstruments(function () {});
     }
     var welcome = "Welcome to Appium v" + appiumVer;

--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -124,44 +124,35 @@ module.exports.noColorLogger = function (tokens, req, res) {
     res.statusCode + ' ' + (new Date() - req._startTime) + 'ms' + len;
 };
 
-module.exports.configureServer = function (configFile, appiumVer, appiumServer,
+module.exports.configureServer = function (rawConfig, appiumVer, appiumServer,
     cb) {
   var appiumRev;
-  fs.readFile(configFile, function (err, data) {
-    if (err) {
-      logger.error("Could not find config file; looks like config hasn't " +
-                   "been run! Please run reset.sh or appium configure.");
-      return cb(err);
-    }
-    var rawConfig;
-    try {
-      rawConfig = JSON.parse(data.toString('utf8'));
-    } catch (e) {
-      logger.error("Error parsing configuration json, please re-run config");
-      return cb(e);
-    }
-    var versionMismatches = {};
-    var excludedKeys = ["git-sha", "node_bin", "built"];
-    _.each(rawConfig, function (deviceConfig, key) {
-      if (deviceConfig.version !== appiumVer && !_.contains(excludedKeys, key)) {
-        versionMismatches[key] = deviceConfig.version;
-      } else if (key === "git-sha") {
-        appiumRev = rawConfig['git-sha'];
-      }
-    });
-    if (_.keys(versionMismatches).length) {
-      logger.error("Got some configuration version mismatches. Appium is " +
-                   "at " + appiumVer + ".");
-      _.each(versionMismatches, function (mismatchedVer, key) {
-        logger.error(key + " configured at " + mismatchedVer);
-      });
-      logger.error("Please re-run reset.sh or config");
-      return cb(new Error("Appium / config version mismatch"));
-    } else {
-      appiumServer.registerConfig(rawConfig);
-      cb(null, appiumRev);
+
+  if (!rawConfig) {
+    return cb(new Error('config data required'));
+  }
+
+  var versionMismatches = {};
+  var excludedKeys = ["git-sha", "node_bin", "built"];
+  _.each(rawConfig, function (deviceConfig, key) {
+    if (deviceConfig.version !== appiumVer && !_.contains(excludedKeys, key)) {
+      versionMismatches[key] = deviceConfig.version;
+    } else if (key === "git-sha") {
+      appiumRev = rawConfig['git-sha'];
     }
   });
+  if (_.keys(versionMismatches).length) {
+    logger.error("Got some configuration version mismatches. Appium is " +
+                 "at " + appiumVer + ".");
+    _.each(versionMismatches, function (mismatchedVer, key) {
+      logger.error(key + " configured at " + mismatchedVer);
+    });
+    logger.error("Please re-run reset.sh or config");
+    return cb(new Error("Appium / config version mismatch"));
+  } else {
+    appiumServer.registerConfig(rawConfig);
+    cb(null, appiumRev);
+  }
 };
 
 module.exports.conditionallyPreLaunch = function (args, appiumServer, cb) {

--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -20,8 +20,8 @@ var http = require('http')
   , appiumVer = require('../../package.json').version
   , appiumRev = null
   , async = require('async')
-  , configFile = path.resolve(__dirname, "..", "..", ".appiumconfig")
-  , helpers = require('./helpers')
+  , helpers = require('./helpers.js')
+  , getConfig = require('../helpers.js').getAppiumConfig
   , allowCrossDomain = helpers.allowCrossDomain
   , catchAllHandler = helpers.catchAllHandler
   , checkArgs = helpers.checkArgs
@@ -35,13 +35,11 @@ var main = function (args, readyCb, doneCb) {
 
   if (args.showConfig) {
     try {
-      var config = fs.readFileSync(configFile);
-      console.log(config.toString('utf8'));
-      process.exit(0);
+      console.log(JSON.stringify(getConfig()));
     } catch (e) {
-      console.error("Error: Appium is not correctly configured");
       process.exit(1);
     }
+    process.exit(0);
   }
 
   checkArgs(args);
@@ -82,7 +80,7 @@ var main = function (args, readyCb, doneCb) {
 
   async.series([
     function (cb) {
-      configureServer(configFile, appiumVer, appiumServer, function (err, rev) {
+      configureServer(getConfig(), appiumVer, appiumServer, function (err, rev) {
         if (err) return cb(err);
         appiumRev = rev;
         cb();

--- a/reset.sh
+++ b/reset.sh
@@ -88,8 +88,9 @@ reset_npm() {
     if $hardcore ; then
         echo "* Removing NPM modules"
         run_cmd rm -rf node_modules
-        echo "* Clearing out old .appiumconfig"
-        run_cmd rm -rf ./.appiumconfig
+        echo "* Clearing out old .appiumconfig.json"
+        run_cmd rm -rf ./.appiumconfig      #remove legacy config file
+        run_cmd rm -rf ./.appiumconfig.json
     fi
     if $prod_deps ; then
         echo "* Installing new or updated NPM modules"


### PR DESCRIPTION
If you tried to run appium on a system without ios configured, it would fail because it would try to start the watchForUnresponsiveInstruments process. Added a check to the config file to prevent it being run is an `ios` key is not present.

I noticed that the .appiumconfig file was being read by `fs.readSync` every time it was accessed. Renaming it to .appiumconfig.json allows us to `require()` it, and `require()` automatically caches successive calls.
