### PR TITLE
Android: Added support for 'direction' to scrollTo.

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -545,12 +545,13 @@ androidController.drag = function (startX, startY, endX, endY, duration, touchCo
   }
 };
 
-androidController.scrollTo = function (elementId, text, cb) {
+androidController.scrollTo = function (elementId, text, direction, cb) {
   // instead of the elementId as the element to be scrolled too,
   // it's the scrollable view to swipe until the uiobject that has the
   // text is found.
   var opts = {
     text: text
+  , direction: direction
   , elementId: elementId
   };
   this.proxy(["element:scrollTo", opts], cb);

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/ScrollTo.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/ScrollTo.java
@@ -44,12 +44,22 @@ public class ScrollTo extends CommandHandler {
     try {
       Boolean result;
       final Hashtable<String, Object> params = command.params();
-      String text = params.get("text").toString();
+      final String text = params.get("text").toString();
+      final String direction = params.get("direction").toString();
 
-      AndroidElement el = command.getElement();
+      final AndroidElement el = command.getElement();
+
+      if (!el.getUiObject().isScrollable()) {
+        return getErrorResult("The provided view is not scrollable.");
+      }
 
       final UiScrollable view = new UiScrollable(el.getUiObject().getSelector());
 
+      if (direction.toLowerCase().contentEquals("horizontal")
+          || view.getClassName().contentEquals(
+              "android.widget.HorizontalScrollView")) {
+        view.setAsHorizontalList();
+      }
       view.scrollToBeginning(100);
       view.setMaxSearchSwipes(100);
       result = view.scrollTextIntoView(text);

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1046,7 +1046,7 @@ iOSController.flick = function (startX, startY, endX, endY, touchCount, elId,
   this.proxyWithMinTime(command, FLICK_MS, cb);
 };
 
-iOSController.scrollTo = function (elementId, text, cb) {
+iOSController.scrollTo = function (elementId, text, direction, cb) {
   // we ignore text for iOS, as the element is the one being scrolled too
   var command = ["au.getElement('", elementId, "').scrollToVisible()"].join('');
   this.proxy(command, cb);

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -442,11 +442,13 @@ exports.mobileScrollTo = function (req, res) {
   req.body = _.defaults(req.body, {
     element: null
   , text: null
+  , direction: "vertical"
   });
   var element = req.body.element
-    , text = req.body.text;
+    , text = req.body.text
+    , direction = req.body.direction;
 
-  req.device.scrollTo(element, text, getResponseHandler(req, res));
+  req.device.scrollTo(element, text, direction, getResponseHandler(req, res));
 };
 
 exports.mobileScroll = function (req, res) {


### PR DESCRIPTION
Currently, Appium fails to scroll to text on views that scroll horizontally like HorizontalScrollView.

This fix will add a new option (direction) to 'mobile: scrollTo'. If 'horizontal' is provided (or if the view is a HorizontalScrollView), we will call setAsHorizontalList() before commencing the scroll.

I've also added a check for view's scrollability.
