### PR TITLE
Fixed page_source() for newer Android versions.

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -248,19 +248,38 @@ androidController.getPageSource = function (cb) {
   async.series(
     [
       function (cb) {
-        // /data/local/tmp/dump.xml
+        // On newer Android versions the dump file is stored in /data/local/tmp/local/tmp/
+        // Make sure the directory exists first.
+        exec(this.adb.adbCmd + ' shell mkdir /data/local/tmp/local');
+        exec(this.adb.adbCmd + ' shell mkdir /data/local/tmp/local/tmp');
+        cb(null);
+      }.bind(this),
+      function (cb) {
         this.proxy(["dumpWindowHierarchy"], cb);
       }.bind(this),
       function (cb) {
-        var cmd = this.adb.adbCmd + ' pull /data/local/tmp/dump.xml "' + xmlFile + '"';
-        logger.debug('transferPageSource command: ' + cmd);
-        exec(cmd, { maxBuffer: 524288 }, function (err, stdout, stderr) {
-          if (err) {
-            logger.warn(stderr);
-            return cb(err);
+        var dumpPaths = ['/data/local/tmp/local/tmp/dump.xml', '/data/local/tmp/dump.xml'];
+        var execNext = function (err) {
+          if (err) return cb(err);
+          var dumpPath = dumpPaths.pop();
+          if (dumpPath) {
+            var cmd = this.adb.adbCmd + ' pull ' + dumpPath + ' "' + xmlFile + '"';
+            logger.debug('transferPageSource command: ' + cmd);
+            exec(cmd, { maxBuffer: 524288 }, function (err, stdout, stderr) {
+              if (err) {
+                logger.warn(stderr);
+                execNext();
+              } else {
+                cb(null);
+              }
+            });
+          } else {
+            var msg = "Could not get the page source!";
+            logger.warn(msg);
+            return cb(new Error(msg));
           }
-          cb(null);
-        });
+        }.bind(this);
+        execNext();
       }.bind(this),
       function (cb) {
         var jar = path.resolve(__dirname, 'helpers', 'dump2json.jar');


### PR DESCRIPTION
Fix for https://github.com/appium/appium/issues/675.

On my Nexus 5 (4.4.2), the hierarchy file name is different from what page_source() expects.
See:
http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/4.4.2_r1/com/android/uiautomator/core/UiDevice.java?av=f#769
So the file path will be `/data/local/tmp/local/tmp/dump.xml`.

With this fix we will try to look for a list of possible dump files before giving up and returning an empty string. It also makes sure that `/data/local/tmp/local/tmp` exists otherwise dumpWindowHierarchy will fail. 
