### PR TITLE
Add option --keep-keychains to save Library/Keychains between appium session restarts

### DIFF
--- a/docs/caps.md
+++ b/docs/caps.md
@@ -42,3 +42,4 @@ Appium server capabilities
 |`safariAllowPopups`| (Sim-only) Allow javascript to open new windows in Safari. Default keeps current sim setting|`true` or `false`|
 |`safariIgnoreFraudWarning`| (Sim-only) Prevent Safari from showing a fraudulent website warning. Default keeps current sim setting.|`true` or `false`|
 |`safariOpenLinksInBackground`| (Sim-only) Whether Safari should allow links to open in new windows. Default keeps current sim setting.|`true` or `false`|
+|`keepKeyChains`| (Sim-only) Whether to keep keychains (Library/Keychains) when appium session is started/finished|`true` or `false`|

--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -58,3 +58,4 @@ All flags are optional, but some are required in conjunction with certain others
 |`--key-alias`|androiddebugkey|(Android-only) Key alias||
 |`--key-password`|android|(Android-only) Key password||
 |`--show-config`|false|Show info about the appium server configuration and exit||
+|`--keep-keychains`|false|(iOS) Whether to keep keychains (Library/Keychains) when appium session is started/finished||

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -582,6 +582,7 @@ Appium.prototype.initDevice = function () {
     , flakeyRetries: this.args.backendRetries
     , origAppPath: this.origAppPath
     , autoAcceptAlerts: this.desiredCapabilities.autoAcceptAlerts
+    , keepKeyChains: this.args.keepKeyChains || this.desiredCapabilities.keepKeyChains
     };
     if (this.desiredCapabilities.safari || this.desiredCapabilities.iwebview) {
       this.device = new Safari(iosOpts);

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -24,6 +24,7 @@ var path = require('path')
   , iOSController = require('./ios-controller.js')
   , iOSHybrid = require('./ios-hybrid.js')
   , settings = require('./settings.js')
+  , mkdirp = require('mkdirp')
   , getSimRoot = settings.getSimRoot
   , fruitstrap = path.resolve(__dirname, '../../../build/fruitstrap/fruitstrap')
   , UnknownError = errors.UnknownError;
@@ -62,6 +63,7 @@ IOS.prototype.init = function (args) {
   this.xcodeVersion = null;
   this.iOSSDKVersion = null;
   this.reset = args.reset;
+  this.keepKeyChains = args.keepKeyChains;
   this.fullReset = args.fullReset;
   this.automationTraceTemplatePath = args.automationTraceTemplatePath;
   this.removeTraceDir = args.removeTraceDir;
@@ -892,16 +894,21 @@ IOS.prototype.cleanupAppState = function (cb) {
       var filesExamined = 0;
       var maybeNext = function () {
         if (filesExamined === files.length) {
+          if (this.keepKeyChains) {
+            // files[0] is always the Applications dir
+            // we want to keep it around so --keep-keychains logic will work
+            mkdirp.sync(files[0]);
+          }
           cb();
         }
-      };
+      }.bind(this);
       if (files.length) {
         _.each(files, function (file) {
           rimraf(file, function () {
             logger.info("Deleted " + file);
             filesExamined++;
             maybeNext();
-          });
+          }.bind(this));
 
           var root = path.dirname(file);
           var tcc = path.join(root, 'Library/TCC');
@@ -927,7 +934,7 @@ IOS.prototype.cleanupAppState = function (cb) {
           }
 
           var keychain = path.join(root, 'Library/Keychains');
-          if (fs.existsSync(keychain)) {
+          if (!this.keepKeyChains && fs.existsSync(keychain)) {
             rimraf.sync(keychain);
             logger.info("Deleted " + keychain);
           }

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -420,6 +420,15 @@ var args = [
   , action: 'storeTrue'
   , required: false
   , help: 'Show info about the appium server configuration and exit'
+  }],
+
+  [['--keep-keychains'], {
+    defaultValue: false
+  , dest: 'keepKeyChains'
+  , action: 'storeTrue'
+  , required: false
+  , help: "(iOS) Whether to keep keychains (Library/Keychains) when reset app between sessions"
+  , nargs: 0
   }]
 ];
 


### PR DESCRIPTION
Use case for using this option: you need the simulator to keep ssl certificate installed even after restarting appium server and have possibility to reuse it without installing again. 
