### PR TITLE
Increase maxBuffer for installApp command

### DIFF
--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -124,7 +124,7 @@ exports.removeApp = function (removeCommand, udid, bundleId, cb) {
 
 exports.installApp = function (installationCommand, udid, unzippedAppPath, cb) {
   logger.info("Installing app using cmd: " + installationCommand);
-  exec(installationCommand, function (error) {
+  exec(installationCommand, { maxBuffer: 524288 }, function (error) {
     if (error !== null) {
       cb(new Error('Unable to install [' + unzippedAppPath + '] to device with id [' + udid + ']. Error [' + error + ']'));
     } else {


### PR DESCRIPTION
This fixes #1966 by increasing the exec max buffer to 50mb as is done elsewhere in Appium.  Installing an ipa using fruitstrap that contains a large number of files in the bundle quickly exhausts the default buffer allocated for stdout.
