### PR TITLE
add process arguments before spawning instruments 

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -291,6 +291,7 @@ IOS.prototype.makeInstruments = function () {
   return new Instruments({
     app: this.args.app || this.args.bundleId
   , udid: this.args.udid
+  , processArguments: this.args.processArguments
   , ignoreStartupExit: this.shouldIgnoreInstrumentsExit()
   , bootstrap: uiauto.bootstrap
   , template: this.args.automationTraceTemplatePath


### PR DESCRIPTION
```
    e.g usage
```

  capability[:processArguments] = "forceLogout"
in our app, we have process arguments that we can send to instruments process before starting UI automation. 
  e.g usage in ios Code to send in processArguments 
NSArray *processArguments = [[NSProcessInfo processInfo] arguments];
