### PR TITLE
new device launching strategy needs to use correct version

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -765,9 +765,11 @@ IOS.prototype.getDeviceString = function () {
     } else if (device.indexOf("ipad") !== -1) {
       isiPhone = false;
     }
-    isTall = isiPhone && (device.indexOf("4-inch") !== -1);
-    isRetina =  (device.indexOf("retina") !== -1);
-    is64bit = (device.indexOf("64-bit") !== -1);
+    if (this.args.deviceName !== this.args.device) {
+      isTall = isiPhone && (device.indexOf("4-inch") !== -1);
+      isRetina =  (device.indexOf("retina") !== -1);
+      is64bit = (device.indexOf("64-bit") !== -1);
+    }
   }
 
   var iosDeviceString = isiPhone ? "iPhone" : "iPad";
@@ -790,7 +792,7 @@ IOS.prototype.getDeviceString = function () {
     }
   }
   if (this.iOSSDKVersion >= 7.1) {
-    iosDeviceString += " - Simulator - iOS " + this.args.version;
+    iosDeviceString += " - Simulator - iOS " + this.iOSSDKVersion;
   }
   return iosDeviceString;
 };


### PR DESCRIPTION
also, don't override retina/tall/64bit opts when user doesn't actually
pass in deviceName cap.
cc @dandoveralba
