### PR TITLE
Clear app data if using selendroid

### DIFF
--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -318,6 +318,9 @@ Selendroid.prototype.deleteSession = function (cb) {
       if (err) return cb(err);
       this.adb.stopLogcat(cb);
     }.bind(this));
+    this.adb.clear(this.args.appPackage, function (err) {
+		  if (err) return cb(err);
+	  }.bind(this));
   }.bind(this));
 };
 


### PR DESCRIPTION
I've noticed that when I invoke the --no-reset flag when starting a server, selendroid doesn't completely wipe out app data between each test case in a test suite.  My proposed change is to add a adb.clear method so that app data is completely wiped out between each test case.

I've tested this out with my selendroid test suite and it works.
