### PR TITLE
Fix Android uninstall detection

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -1146,7 +1146,8 @@ ADB.prototype.uninstallApk = function (pkg, cb) {
       cb(err);
     } else {
       stdout = stdout.trim();
-      if (stdout === "Success") {
+      // stdout may contain warnings meaning success is not on the first line.
+      if (stdout.indexOf("Success") !== -1) {
         logger.debug("App was uninstalled");
       } else {
         logger.debug("App was not uninstalled, maybe it wasn't on device?");


### PR DESCRIPTION
API 19 uses the following stdout message:

WARNING: linker: libdvm.so has text relocations. This is wasting memory and is a security risk. Please fix.
Success

That broke the simple == 'Success' check.
