### PR TITLE
Pass quiet flag to fruitstrap when appium in quiet mode.

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1236,7 +1236,8 @@ IOS.prototype.removeApp = function (bundleId, cb) {
 
 IOS.prototype.installApp = function (unzippedAppPath, cb) {
   if (this.args.udid) {
-    var installationCommand = fruitstrap + ' install --id ' + this.args.udid + ' --bundle ' + unzippedAppPath;
+    var installQuietFlag = this.args.quiet ? ' -q' : '';
+    var installationCommand = fruitstrap + installQuietFlag + ' install --id ' + this.args.udid + ' --bundle ' + unzippedAppPath;
     deviceCommon.installApp(installationCommand, this.args.udid, unzippedAppPath, cb);
   } else {
     cb(new Error("You can not call installApp for the iOS simulator!"));


### PR DESCRIPTION
If appium is started with the quiet flag, this will now be propagated to
the fruitstrap install command.  Fruitstap can be very noisy when
installing app with a large number of resources in the bundle.
