### PR TITLE
Android process

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -171,6 +171,8 @@ ADB.prototype.spawn = function (args) {
 
 // android:process= may be defined in AndroidManifest.xml
 // http://developer.android.com/reference/android/R.attr.html#process
+// note that the process name when used with ps must be truncated to the last 15 chars
+// ps -c com.example.android.apis becomes ps -c le.android.apis
 ADB.prototype.processFromManifest = function (localApk, cb) {
   this.checkAaptPresent(function (err) {
     if (err) return cb(err);
@@ -183,13 +185,38 @@ ADB.prototype.processFromManifest = function (localApk, cb) {
         return cb(new Error("processFromManifest failed. " + err));
       }
 
-      var process = new RegExp(/android:process\(0x01010011\)="([^"]+)"/g).exec(stdout);
-      if (process && process.length > 1) {
-        process = process[1];
-      } else {
-        process = null;
+      var result = null;
+      var lines = stdout.split("\n");
+      var applicationRegex = new RegExp(/\s+E: application \(line=\d+\).*/);
+      var applicationFound = false;
+      var attributeRegex = new RegExp(/\s+A: .+/);
+      var processRegex = new RegExp(/\s+A: android:process\(0x01010011\)="([^"]+).*"/);
+      for (var i = 0; i < lines.length; i++) {
+        var line = lines[i];
+
+        if (!applicationFound) {
+          if (applicationRegex.test(line)) {
+            applicationFound = true;
+          }
+        } else {
+          var notAttribute = !attributeRegex.test(line);
+          // process must be an attribute after application.
+          if (notAttribute) {
+            break;
+          }
+
+          var process = processRegex.exec(line);
+          // this is an application attribute process.
+          if (process && process.length > 1) {
+            result = process[1];
+            // must trim to last 15 for android's ps binary
+            if (result.length > 15) result = result.substr(result.length - 15);
+            break;
+          }
+        }
       }
-      cb(null, process);
+
+      cb(null, result);
     });
   }.bind(this));
 };

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -272,10 +272,13 @@ Android.prototype.processFromManifest = function (cb) {
     return cb();
   } else { // apk must be local to process the manifest.
     this.adb.processFromManifest(this.args.app, function (err, process) {
-      if (process) {
-        this.appProcess = process;
-        logger.debug("Set app process to: " + process);
-      }
+      var value = process || this.args.appPackage;
+      // must trim to last 15 for android's ps binary
+      if (value.length > 15) value = value.substr(value.length - 15);
+
+      this.appProcess = value;
+      logger.debug("Set app process to: " + this.appProcess);
+
       cb();
     }.bind(this));
   }


### PR DESCRIPTION
@jlipps There's an issue persisting fastReset across multiple sessions. It's an existing problem. I added an error check in this PR.

> error: Failed to start an Appium session, err was: Error: this.args.fastReset must not be undefined
> info: Error: this.args.fastReset must not be undefined
>     at Android.start (/Users/user/woven/appium/lib/devices/android/android.js:91:17)
>     at Appium.invoke (/Users/user/woven/appium/lib/appium.js:210:17)
>     at null.<anonymous> (/Users/user/woven/appium/lib/appium.js:87:14)
>     at /Users/user/woven/appium/lib/devices/device.js:64:7
>     at Object.oncomplete (fs.js:107:15)
> info: Responding to client with error: {"status":33,"value":{"message":"A new session could not be created. (Original error: this.args.fastReset must not be undefined)","origValue":"this.args.fastReset must not be undefined"},"sessionId":null}

Fix #2077

I updated the process detection logic so it's correctly selecting the application process instead of any random process that happens to be in the manifest.
