### PR TITLE
Allow to have more than one emulator started

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -764,8 +764,33 @@ ADB.prototype.launchAVD = function (avdName, avdArgs, cb) {
         logger.error("Unable to start Emulator: " + data);
       }
     });
-    this.getRunningAVDWithRetry(avdName.replace('@', ''), 120000, cb);
+    this.getRunningAVDWithRetry(avdName.replace('@', ''), 120000, function (err) {
+      if (err) return cb(err);
+      this.waitForEmulatorReady(120000, cb);
+    }.bind(this));
   }.bind(this));
+};
+
+ADB.prototype.waitForEmulatorReady = function (timeoutMs, cb) {
+  var start = Date.now();
+  var error = new Error("Emulator is not ready.");
+  logger.info("Waiting until emulator is ready");
+  var getBootAnimStatus = function () {
+    this.shell("getprop init.svc.bootanim", function (err, stdout) {
+      if (err || stdout === null || stdout.indexOf('stopped') !== 0) {
+        if ((Date.now() - start) > timeoutMs) {
+          cb(error);
+        } else {
+          setTimeout(function () {
+            getBootAnimStatus();
+          }.bind(this), 3000);
+        }
+      } else {
+        cb();
+      }
+    }.bind(this));
+  }.bind(this);
+  getBootAnimStatus();
 };
 
 ADB.prototype.getConnectedDevices = function (cb) {

--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -716,6 +716,14 @@ ADB.prototype.launchAVD = function (avdName, avdArgs, cb) {
       logger.error("Unable to start Emulator: " + err.message);
       // actual error will get caught by getDevicesWithRetry
     });
+    proc.stderr.on('data', function (data) {
+      logger.error("Unable to start Emulator: " + data);
+    });
+    proc.stdout.on('data', function (data) {
+      if (data.toString().indexOf('ERROR') > -1) {
+        logger.error("Unable to start Emulator: " + data);
+      }
+    });
     this.getDevicesWithRetry(120000, cb);
   }.bind(this));
 };

--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -696,7 +696,7 @@ ADB.prototype.killAllEmulators = function (cb) {
   });
 };
 
-ADB.prototype.launchAVD = function (avdName, cb) {
+ADB.prototype.launchAVD = function (avdName, avdArgs, cb) {
   logger.info("Launching Emulator with AVD " + avdName);
   this.checkSdkBinaryPresent("emulator", function (err, emulatorBinaryPath) {
     if (err) return cb(err);
@@ -705,8 +705,13 @@ ADB.prototype.launchAVD = function (avdName, cb) {
       avdName = "@" + avdName;
     }
 
+    if (avdArgs === null) {
+      avdArgs = [avdName];
+    } else {
+      avdArgs = [avdName, avdArgs];
+    }
     var proc = spawn(emulatorBinaryPath.substr(1, emulatorBinaryPath.length - 2),
-      [avdName]);
+      avdArgs);
     proc.on("error", function (err) {
       logger.error("Unable to start Emulator: " + err.message);
       // actual error will get caught by getDevicesWithRetry

--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -678,9 +678,49 @@ ADB.prototype.getPortFromEmulatorString = function (emStr) {
   return false;
 };
 
-ADB.prototype.getRunningAVDName = function (cb) {
-  logger.info("Getting running AVD name");
-  this.sendTelnetCommand("avd name", cb);
+ADB.prototype.getRunningAVD = function (avdName, cb) {
+  logger.info("Trying to find " + avdName + " emulator");
+  this.getConnectedEmulators(function (err, emulators) {
+    if (err || emulators.length < 1) {
+      return cb(new Error("No emulators connected"), null);
+    } else {
+      async.forEach(emulators, function (emulator, asyncCb) {
+        this.setEmulatorPort(emulator.port);
+        this.sendTelnetCommand("avd name", function (err, runningAVDName) {
+          if (avdName === runningAVDName) {
+            logger.info("Found emulator " + avdName + " in port " + emulator.port);
+            this.setDeviceId(emulator.udid);
+            return cb(null, emulator);
+          }
+          asyncCb();
+        }.bind(this));
+      }.bind(this), function (err) {
+        logger.info("Emulator " + avdName + " not running");
+        cb(err, null);
+      });
+    }
+  }.bind(this));
+};
+
+ADB.prototype.getRunningAVDWithRetry = function (avdName, timeoutMs, cb) {
+  var start = Date.now();
+  var error = new Error("Could not find " + avdName + " emulator.");
+  var getAVD = function () {
+    this.getRunningAVD(avdName.replace('@', ''), function (err, runningAVD) {
+      if (err || runningAVD === null) {
+        if ((Date.now() - start) > timeoutMs) {
+          cb(error);
+        } else {
+          setTimeout(function () {
+            getAVD();
+          }.bind(this), 2000);
+        }
+      } else {
+        cb();
+      }
+    }.bind(this));
+  }.bind(this);
+  getAVD();
 };
 
 ADB.prototype.killAllEmulators = function (cb) {
@@ -714,7 +754,7 @@ ADB.prototype.launchAVD = function (avdName, avdArgs, cb) {
       avdArgs);
     proc.on("error", function (err) {
       logger.error("Unable to start Emulator: " + err.message);
-      // actual error will get caught by getDevicesWithRetry
+      // actual error will get caught by getRunningAVDWithRetry
     });
     proc.stderr.on('data', function (data) {
       logger.error("Unable to start Emulator: " + data);
@@ -724,7 +764,7 @@ ADB.prototype.launchAVD = function (avdName, avdArgs, cb) {
         logger.error("Unable to start Emulator: " + data);
       }
     });
-    this.getDevicesWithRetry(120000, cb);
+    this.getRunningAVDWithRetry(avdName.replace('@', ''), 120000, cb);
   }.bind(this));
 };
 
@@ -750,6 +790,23 @@ ADB.prototype.getConnectedDevices = function (cb) {
       this.debug(devices.length + " device(s) connected");
       cb(null, devices);
     }
+  }.bind(this));
+};
+
+ADB.prototype.getConnectedEmulators = function (cb) {
+  logger.debug("Getting connected emulators");
+  this.getConnectedDevices(function (err, devices) {
+    if (err) return cb(err);
+    var emulators = [];
+    _.each(devices, function (device) {
+      var port = this.getPortFromEmulatorString(device.udid);
+      if (port) {
+        device.port = port;
+        emulators.push(device);
+      }
+    }.bind(this));
+    logger.debug(emulators.length + " emulator(s) connected");
+    cb(null, emulators);
   }.bind(this));
 };
 
@@ -789,6 +846,7 @@ ADB.prototype.ping = function (cb) {
 };
 
 ADB.prototype.setDeviceId = function (deviceId) {
+  logger.info("Setting device id to " + deviceId);
   this.curDeviceId = deviceId;
   this.adbCmd = this.adb + " -s " + deviceId;
 };
@@ -886,6 +944,8 @@ ADB.prototype.stopLogcat = function (cb) {
   if (this.logcat !== null) {
     this.logcat.stopCapture(cb);
     this.logcat = null;
+  } else {
+    cb();
   }
 };
 

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -294,7 +294,7 @@ androidCommon.prepareEmulator = function (cb) {
         logger.info("Did not launch AVD because it was already running.");
         return cb();
       }
-      this.adb.launchAVD(this.args.avd, cb);
+      this.adb.launchAVD(this.args.avd, this.args.avdArgs, cb);
     }.bind(this));
   } else {
     cb();

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -288,9 +288,11 @@ androidCommon.checkAppPresent = function (cb) {
 
 androidCommon.prepareEmulator = function (cb) {
   if (this.args.avd !== null) {
-    this.adb.getRunningAVDName(function (err, runningAVDName) {
-      if (err && err.message.indexOf('No devices') === -1) return cb(err);
-      if (this.args.avd.replace('@', '') === runningAVDName) {
+    var avdName = this.args.avd.replace('@', '');
+    this.adb.getRunningAVD(avdName, function (err, runningAVD) {
+      if (err && err.message.indexOf('No devices') === -1 &&
+          err.message.indexOf('No emulators') === -1) return cb(err);
+      if (runningAVD !== null) {
         logger.info("Did not launch AVD because it was already running.");
         return cb();
       }
@@ -302,6 +304,10 @@ androidCommon.prepareEmulator = function (cb) {
 };
 
 androidCommon.prepareActiveDevice = function (cb) {
+  if (this.adb.curDeviceId) {
+    // deviceId is already setted
+    return cb();
+  }
   this.adb.getDevicesWithRetry(function (err, devices) {
     if (err) return cb(err);
     var deviceId = null;
@@ -316,7 +322,6 @@ androidCommon.prepareActiveDevice = function (cb) {
       var emPort = this.adb.getPortFromEmulatorString(deviceId);
       this.adb.setEmulatorPort(emPort);
     }
-    logger.info("Setting device id to " + deviceId);
     this.adb.setDeviceId(deviceId);
     cb();
   }.bind(this));

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -252,7 +252,15 @@ var args = [
     defaultValue: null
   , required: false
   , example: "@default"
-  , help: 'name of the avd to launch'
+  , help: "(Android-only) Name of the avd to launch"
+  }],
+
+  [['--avd-args'], {
+    dest: 'avdArgs'
+  , defaultValue: null
+  , required: false
+  , example: "-no-snapshot-load"
+  , help: "(Android-only) Additional emulator arguments to launch the avd"
   }],
 
   [['--device-ready-timeout'], {


### PR DESCRIPTION
- Starts the emulator specified in --avd option and runs tests in this emulator, even if other emulators or devices are connected
  If --avd and --udid options are used simultaneously, --avd has preference.
- Print all errors while starting emulator
  In some cases (like wrong snapshot), the emulator does not start but no error is thrown. 
  The error message is in stdout, instead of stderr.
- Added option --avd-args to allow launch avd with additional arguments
  Example: node . --avd AVD17 --avd-args="-no-snapshot-load -no-snapshot-save"
- Wait for emulator is ready after launch it
  Without this wait, UIAutomator launch fails: "error: UiAutomator quit before it successfully launched"
