### PR TITLE
Fix for issue #2085. Use "mobile: reset" in beforeEach().

### DIFF
--- a/test/functional/android/apidemos/gestures-specs.js
+++ b/test/functional/android/apidemos/gestures-specs.js
@@ -12,7 +12,7 @@ describe("apidemo - gestures -", function () {
 
   if (env.FAST_TESTS) {
     beforeEach(function (done) {
-      androidReset('com.example.android.apis', '.ApiDemos')
+      driver.execute("mobile: reset")
         .then(function () { return driver.sleep(3000); })
         .nodeify(done);
     });


### PR DESCRIPTION
Fix for https://github.com/appium/appium/issues/2085.
Here's the output after this fix:

```
paymand@payman:~/src/appium$ mocha -t 60000 -R spec test/functional/android/apidemos/gestures-specs.js 


  apidemo - gestures -
    ✓ should click via x/y pixel coords (11096ms)
    ✓ should click via x/y pct (22752ms)
    ✓ should click via touch api (6987ms)
    ✓ should swipe screen by pixels @skip-android-all (8317ms)
    ✓ should swipe screen by pct @skip-android-all (7869ms)
    ✓ should flick screen by pixels @skip-android-all (7236ms)
    ✓ should flick screen by speed @skip-android-all (7437ms)
    ✓ should drag by pixels @skip-android-all (28257ms)
    ✓ should drag element to point @skip-android-all (25370ms)
    ✓ should drag element to destEl @skip-android-all (25207ms)
    ✓ should bring the element into view @skip-android-all (12873ms)
    ✓ should pinch out/in @skip-android-all (78612ms)
    ✓ should long click via element value (10572ms)
    ✓ should long click via element value with custom duration (8995ms)
    ✓ should long click via pixel value (8404ms)
    ✓ should long click via relative value (15583ms)
    ✓ should execute down/move/up via element value (11631ms)
    ✓ should execute down/move/up click via pixel value (22128ms)
    ✓ should execute down/move/up via relative value (18073ms)


  19 passing (18m)
```
