### PR TITLE
Fixup for #2085. set isElement to false if getElement() throws.

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchEvent.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchEvent.java
@@ -66,6 +66,7 @@ public abstract class TouchEvent extends CommandHandler {
           isElement = true;
         }
       } catch (final Exception e) {
+        isElement = false;
       }
 
       if (isElement) {


### PR DESCRIPTION
@bootstraponline, @jlipps: The tests now pass with this fix.
