### PR TITLE
Removed 'fastClear' capability.

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -328,15 +328,15 @@ androidCommon.prepareActiveDevice = function (cb) {
 };
 
 androidCommon.resetApp = function (cb) {
-  if (this.args.fastClear) {
-    logger.info("Running fastClear");
+  if (this.args.fastReset) {
+    logger.info("Running fast reset (stop and clear)");
     this.adb.stopAndClear(this.args.appPackage, cb);
   } else {
-    logger.info("Running old fashion clear (reinstall)");
+    logger.info("Running old fashion reset (reinstall)");
     this.remoteApkExists(function (err, remoteApk) {
       if (err) return cb(err);
       if (!remoteApk) {
-        return cb(new Error("Can't run clear if remote apk doesn't exist"));
+        return cb(new Error("Can't run reset if remote apk doesn't exist"));
       }
       this.adb.forceStop(this.args.appPackage, function (err) {
         if (err) return cb(err);
@@ -404,9 +404,9 @@ androidCommon.installApp = function (cb) {
   this.remoteApkExists(function (err, remoteApk) {
     // err is set if the remote apk doesn't exist so don't check it.
     this.adb.isAppInstalled(this.args.appPackage, function (err, installed) {
-      if (installed && this.args.fastReset && (this.args.fastClear || remoteApk)) {
+      if (installed && this.args.fastReset && remoteApk) {
         this.resetApp(cb);
-      } else if (!installed || (this.args.fastReset && !this.args.fastClear && !remoteApk)) {
+      } else if (!installed || (this.args.fastReset && !remoteApk)) {
         this.adb.checkAndSignApk(this.args.app, this.args.appPackage, function (err) {
           if (err) return cb(err);
           this.adb.mkdir(this.remoteTempPath(), function (err) {

--- a/test/functional/android/apidemos/basic-specs.js
+++ b/test/functional/android/apidemos/basic-specs.js
@@ -112,9 +112,9 @@ describe("apidemo - basic -", function () {
     });
   });
 
-  describe('without fastClear', function () {
+  describe('with fastReset', function () {
     var driver;
-    setup(this, _.defaults({fastClear: false}, desired))
+    setup(this, desired)
      .then(function (d) { driver = d; });
 
     it('should still be able to reset', function (done) {
@@ -223,7 +223,7 @@ describe("apidemo - basic -", function () {
 
     describe('launching new session', function () {
       var driver;
-      setup(this, _.defaults({fastClear: false}, desired))
+      setup(this, desired)
        .then(function (d) { driver = d; });
 
       it('should kill pre-existing uiautomator process', function (done) {


### PR DESCRIPTION
No need for 'fastClear' anymore. Current modes are:
1. fullReset: Reinstall the app.
2. noReset: Don't reinstall, keep app data.
3. fastReset (!fullReset && !noReset): Don't reinstall the app, but clear the app data (pm clear).
