### PR TITLE
Update android-hax-emulator.md

### DIFF
--- a/docs/android-hax-emulator.md
+++ b/docs/android-hax-emulator.md
@@ -5,6 +5,7 @@ If you find the android emulator a slow and your system runs on an Intel® cpu, 
 * To install HAXM open the Android SDK Manager, you will find the package under Extras.
 * You can find all relevent documentation on [Intel's website][1]
 * This will require an x86 emulator image
+* Use Intel's package to install HAXM; The Android SDK Manager appears to not do so successfully.
 
 [1]: http://software.intel.com/en-us/articles/intel-hardware-accelerated-execution-manager/ "Hax" 
 [2]: http://software.intel.com/en-us/search/site/language/en?query=Intel%20Hardware%20Accelerated%20Execution%20Manager%20%28HAXM%29 "Hax all"


### PR DESCRIPTION
Ask people to use Intel's package as the Android SDK manager package successfully installs, then misbehaves.
