### PR TITLE
[fix] gesture parameters not being set when args is an object instead of an array

### DIFF
--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -807,6 +807,10 @@ exports.executeMobileMethod = function (req, res, cmd) {
     }
   }
 
+  if (!_.isEmpty(args)) {
+    params = req.body.args;
+  }
+
   if (_.has(mobileCmdMap, cmd)) {
     req.body = params;
     mobileCmdMap[cmd](req, res);


### PR DESCRIPTION
Issue was found when trying to run 

``` javascript
       var tapOpts = {
          x: 600,
          y: 600
        };
        return this.device.execute('mobile: tap', tapOpts);
```

Realized that the command would be called with the default values of `{x:0.5, y:0.5}` even though the arguments are being passed properly. After debugging for a bit I came up with the fix attached which made it work, but probably isn't a very elegant solution.

![](https://i.cloudup.com/pcuqfDCahx.png)

After the fix:
![](https://i.cloudup.com/eBjBB3JaLI.png)

I'm just getting started with Appium so I'm not exactly aware of how this specific part is supposed to work, I tried really hard in getting the tests to run but failed miserably with messages of failed to install application and all sort of things.

Please let me know if there is anything else I should take into account, or if I should approach this in a different manner. Below is more info on the environment I was running this.
- Appium v0.17.6
- Node v0.10.24
- iOS Simulator v7.1
