### PR TITLE
Avoiding passing LogNoColors/LogColors everywhere.

### DIFF
--- a/lib/devices/android/uiautomator.js
+++ b/lib/devices/android/uiautomator.js
@@ -20,7 +20,6 @@ var UiAutomator = function (adb, opts) {
   this.webSocket = opts.webSocket;
   this.systemPort = opts.systemPort;
   this.resendLastCommand = function () {};
-  this.logNoColors = opts.logNoColors;
 };
 
 UiAutomator.prototype.start = function (readyCb) {
@@ -199,10 +198,7 @@ UiAutomator.prototype.handleBootstrapOutput = function (output) {
           this.restartBootstrap = true;
         }
         var log = "[UIAUTOMATOR STDOUT] " + line;
-        if (!this.logNoColors) {
-          log = log.grey;
-        }
-        logger.info(log);
+        logger.info(log.grey);
       }
     }
   }.bind(this));

--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -45,12 +45,12 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
     }
   } else {
     if (this.args.udid !== null) {
-      this.remote = wkrd.init(!this.args.logNoColors, exitCb);
+      this.remote = wkrd.init(exitCb);
       this.remote.pageArrayFromJson(function (pageArray) {
         cb(pageArray);
       });
     } else {
-      this.remote = rd.init(!this.args.logNoColors, exitCb);
+      this.remote = rd.init(exitCb);
       this.remote.connect(function (appDict) {
         if (!_.has(appDict, this.args.bundleId)) {
           logger.error("Remote debugger did not list " + this.args.bundleId + " among " +

--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -24,7 +24,6 @@ var IosLog = function (opts) {
   this.logs = [];
   this.logRow = "";
   this.logsSinceLastRequest = [];
-  this.logNoColors = opts.logNoColors;
 
   if (this.xcodeVersion === null) {
     logger.warn("Xcode version passed into log capture code as null, assuming Xcode 5");
@@ -36,10 +35,7 @@ var IosLog = function (opts) {
 IosLog.prototype.debug = function (msg) {
   if (this.debugMode) {
     var log = "[IOS_SYSLOG_CAPTURE] " + msg;
-    if (!this.logNoColors) {
-      log = log.grey;
-    }
-    logger.debug(log);
+    logger.debug(log.grey);
   }
 };
 

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -310,7 +310,6 @@ IOS.prototype.makeInstruments = function () {
   , webSocket: this.args.webSocket
   , launchTimeout: this.args.launchTimeout
   , flakeyRetries: this.args.backendRetries
-  , logNoColors: this.args.logNoColors
   , simulatorSdkAndDevice: this.iOSSDKVersion >= 7.1 ? this.getDeviceString() : null
   });
 };

--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -14,18 +14,16 @@ var net = require('net')
   , noop = function () {}
   , assert = require('assert');
 
-require('colors');
-
 // ====================================
 // CONFIG
 // ====================================
 
 
-var RemoteDebugger = function (logColors, onDisconnect) {
-  this.init(2, onDisconnect, logColors);
+var RemoteDebugger = function (onDisconnect) {
+  this.init(2, onDisconnect);
 };
 
-RemoteDebugger.prototype.init = function (debuggerType, onDisconnect, logColors) {
+RemoteDebugger.prototype.init = function (debuggerType, onDisconnect) {
   this.socket = null;
   this.connId = uuid.v4();
   this.senderId = uuid.v4();
@@ -56,10 +54,7 @@ RemoteDebugger.prototype.init = function (debuggerType, onDisconnect, logColors)
     }
   , debug: function (msg) {
       msg = "[REMOTE] " + msg;
-      if (logColors) {
-        msg = msg.grey;
-      }
-      appLogger.debug(msg);
+      appLogger.debug(msg.grey);
     }
   , error: function (msg) {
       appLogger.error("[REMOTE] " + msg);
@@ -607,8 +602,8 @@ RemoteDebugger.prototype.receive = function (data) {
   }
 };
 
-exports.init = function (logColors, onDisconnect) {
-  return new RemoteDebugger(logColors, onDisconnect);
+exports.init = function (onDisconnect) {
+  return new RemoteDebugger(onDisconnect);
 };
 
 exports.RemoteDebugger = RemoteDebugger;

--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -10,12 +10,12 @@ var _ = require('underscore')
 // CONFIG
 // ====================================
 
-var WebKitRemoteDebugger = function (logColors, onDisconnect) {
+var WebKitRemoteDebugger = function (onDisconnect) {
   this.dataMethods = {};
   this.host = 'localhost';
   this.port = 27753;
   this.socketDisconnectCb = null;
-  this.init(1, onDisconnect, logColors);
+  this.init(1, onDisconnect);
 };
 
 //extend the remote debugger
@@ -168,6 +168,6 @@ WebKitRemoteDebugger.prototype.receive = function (data) {
   this.handleMessage(data, method);
 };
 
-exports.init = function (logColors, onDisconnect) {
-  return new WebKitRemoteDebugger(logColors, onDisconnect);
+exports.init = function (onDisconnect) {
+  return new WebKitRemoteDebugger(onDisconnect);
 };

--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -172,10 +172,10 @@ module.exports.conditionallyPreLaunch = function (args, appiumServer, cb) {
   }
 };
 
-var startAlertSocket = function (restServer, appiumServer, logColors) {
+var startAlertSocket = function (restServer, appiumServer) {
   var alerts = io.listen(restServer, {
     'flash policy port': -1,
-    'log colors': logColors
+    'logger': logger
   });
 
   alerts.configure(function () {
@@ -222,7 +222,7 @@ module.exports.startListening = function (server, args, parser, appiumVer, appiu
     var logMessage = "Appium REST http interface listener started on " +
                      args.address + ":" + args.port;
     logger.info(logMessage);
-    startAlertSocket(server, appiumServer, !args.logNoColors);
+    startAlertSocket(server, appiumServer);
     if (args.nodeconfig !== null) {
       gridRegister.registerNode(args.nodeconfig, args.address, args.port);
     }

--- a/lib/server/logger.js
+++ b/lib/server/logger.js
@@ -51,7 +51,7 @@ module.exports.init = function (args) {
   winston.loggers.add('appium', winstonOptions);
   logger = winston.loggers.get('appium');
   logger.setLevels(levels);
-
+  logger.stripColors = args.logNoColors;
 
   if (args.quiet) {
     logger.transports.console.level = 'warn';

--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -7,6 +7,8 @@ var parser = require('./parser.js')()
   , path = require('path')
   , isWindows = require('../helpers.js').isWindows()
   , _ = require('underscore');
+  
+require('colors');
 
 process.chdir(path.resolve(__dirname, '../..'));
 


### PR DESCRIPTION
Winston already have the feature (badly documented), all you have to do is:
`logger.stripColors = args.logNoColors;`

Winston stripping code: [here](https://github.com/flatiron/winston/blob/511b1a958be2354cfb6999b18f269377a3e59f0f/lib/winston/logger.js#L167)
