### PR TITLE
Convert `device` to `platformName` when turning caps into arguments.

### DIFF
--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -33,7 +33,7 @@ Android.prototype.init = function () {
   this.capabilities = {
     platform: 'LINUX'
   , browserName: 'Android'
-  , version: '4.1'
+  , platformVersion: '4.1'
   , webStorageEnabled: false
   , takesScreenshot: true
   , javascriptEnabled: true

--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -8,6 +8,7 @@ var fs = require('fs')
   , copyLocalZip = helpers.copyLocalZip
   , unzipApp = helpers.unzipApp
   , downloadFile = helpers.downloadFile
+  , capConversion = require('../server/capabilities.js').capabilityConversions
   ;
 
 var Device = function () {
@@ -31,7 +32,12 @@ Device.prototype.configure = function (args, caps) {
 
 Device.prototype.setArgFromCap = function (arg, cap) {
   if (typeof this.capabilities[cap] !== "undefined") {
-    this.args[arg] = this.capabilities[cap];
+    if (_.has(capConversion, cap)) {
+      var key = capConversion[cap];
+      this.args[key] = this.capabilities[cap];
+    } else {
+      this.args[arg] = this.capabilities[cap];
+    }
   }
 };
 

--- a/lib/devices/firefoxos/firefoxos.js
+++ b/lib/devices/firefoxos/firefoxos.js
@@ -22,7 +22,7 @@ Firefox.prototype.init = function () {
   this.capabilities = {
     platform: 'LINUX'
   , browserName: 'FirefoxOS'
-  , version: '18.0'
+  , platformVersion: '18.0'
   , webStorageEnabled: false
   , takesScreenshot: true
   , javascriptEnabled: true

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -120,7 +120,7 @@ IOS.prototype.setIOSArgs = function () {
   this.args.withoutDelay = !this.args.nativeInstrumentsLib;
   this.args.reset = !this.args.noReset;
   this.args.removeTraceDir = !this.args.keepArtifacts;
-  this.args.deviceName = this.args.deviceName || this.args.device;
+  this.args.deviceName = this.args.deviceName || this.args.platformName;
   this.args.initialOrientation = this.capabilities.deviceOrientation ||
                                  this.args.orientation ||
                                  "PORTRAIT";
@@ -160,8 +160,8 @@ IOS.prototype.configurePreferences = function (cb) {
   logger.info("Configuring settings app");
   var prefsVer = null;
   var caps = this.capabilities;
-  if (typeof caps.version !== "undefined" && caps.version) {
-    prefsVer = caps.version;
+  if (typeof caps.platformVersion !== "undefined" && caps.platformVersion) {
+    prefsVer = caps.platformVersion;
   }
 
   var sdkNext = function (prefsVer) {
@@ -241,7 +241,7 @@ IOS.prototype.preCleanup = function (cb) {
 };
 
 IOS.prototype.getNumericVersion = function () {
-  return parseFloat(this.capabilities.version);
+  return parseFloat(this.capabilities.platformVersion);
 };
 
 IOS.prototype.start = function (cb, onDie) {
@@ -428,7 +428,7 @@ IOS.prototype.setiOSSDKVersion = function (cb) {
       logger.error("Could not determine iOS SDK version");
     }
     this.iOSSDKVersion = versionNumber;
-    this.capabilities.version = versionNumber;
+    this.capabilities.platformVersion = versionNumber;
     logger.info("iOS SDK Version set to " + this.iOSSDKVersion);
     cb();
   }.bind(this));
@@ -769,7 +769,7 @@ IOS.prototype.getDeviceString = function () {
     } else if (device.indexOf("ipad") !== -1) {
       isiPhone = false;
     }
-    if (this.args.deviceName !== this.args.device) {
+    if (this.args.deviceName !== this.args.platformName) {
       isTall = isiPhone && (device.indexOf("4-inch") !== -1);
       isRetina =  (device.indexOf("retina") !== -1);
       is64bit = (device.indexOf("64-bit") !== -1);
@@ -797,7 +797,7 @@ IOS.prototype.getDeviceString = function () {
   }
   if (this.iOSSDKVersion >= 7.1) {
     iosDeviceString += " - Simulator - iOS " +
-                       (this.args.version || this.iOSSDKVersion);
+                       (this.args.platformVersion || this.iOSSDKVersion);
   }
   return iosDeviceString;
 };

--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -34,8 +34,8 @@ Safari.prototype.configure = function (args, caps, cb) {
 Safari.prototype.configureSafari = function (cb) {
   var safariVer = null;
   var caps = this.capabilities;
-  if (typeof caps.version !== "undefined" && caps.version) {
-    safariVer = caps.version;
+  if (typeof caps.platformVersion !== "undefined" && caps.platformVersion) {
+    safariVer = caps.platformVersion;
   }
   logger.info("Trying to use mobile safari, version " + safariVer);
   var checkNext = function (attemptedApp, origApp, safariVer) {

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -16,10 +16,6 @@ var Capabilities = function (capabilities) {
     if (_.contains(_.keys(capsConversion), cap)) {
       warnDeprecated('capability', cap, capsConversion[cap]);
     }
-    // Hacky alias for version
-    if (cap.indexOf('platformVersion') !== -1) {
-      this.version = value;
-    }
     this[cap] = value;
   }, this);
 };
@@ -35,5 +31,7 @@ Capabilities.prototype.setDesired = function (caps) {
   });
   this.desired = caps;
 };
+
+Capabilities.capabilityConversions = capsConversion;
 
 module.exports = Capabilities;

--- a/test/unit/capabilities-specs.js
+++ b/test/unit/capabilities-specs.js
@@ -74,13 +74,6 @@ describe('capabilities', function () {
           });
         });
       });
-
-      describe('platformVersion', function () {
-        it('is accessible from #version', function () {
-          var capabilities = new Capabilities({platformVersion: 32});
-          capabilities.version.should.equal(32);
-        });
-      });
     });
   });
 });

--- a/test/unit/device-specs.js
+++ b/test/unit/device-specs.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var Device = require('../../lib/devices/device.js')
+  , capConversion = require('../../lib/server/capabilities.js').capabilityConversions
+  , chai = require('chai')
+  , should = chai.should()
+  , _ = require('underscore');
+
+var Test = function () {
+  this.init();
+};
+
+_.extend(Test.prototype, Device.prototype);
+
+describe("device.js", function () {
+  describe("#configure", function () {
+    _.each(capConversion, function (newCap, cap) {
+      var name = "should store the " + cap + " capability as the " + newCap + " arg";
+      it(name, function () {
+        var caps = {};
+        caps[cap] = 'iOS';
+        var testDevice = new Test();
+        testDevice.configure({}, caps);
+        testDevice.args[newCap].should.equal('iOS');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Altered `Device.setArgFromCap` to turn `device` into `platformName`.
Updated `IOS` device to use platformName instead of device.
Added test for `Device.setArgFromCap`.

I think this is the right place for these;  rather then converting in IOS we should do it on the prototype object.

Closes #2149
