### PR TITLE
Make sure the app is always signed *before* getting the MD5 hash.

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -401,14 +401,14 @@ androidCommon.installApp = function (cb) {
     return cb();
   }
 
-  this.remoteApkExists(function (err, remoteApk) {
-    // err is set if the remote apk doesn't exist so don't check it.
-    this.adb.isAppInstalled(this.args.appPackage, function (err, installed) {
-      if (installed && this.args.fastReset && remoteApk) {
-        this.resetApp(cb);
-      } else if (!installed || (this.args.fastReset && !remoteApk)) {
-        this.adb.checkAndSignApk(this.args.app, this.args.appPackage, function (err) {
-          if (err) return cb(err);
+  this.adb.checkAndSignApk(this.args.app, this.args.appPackage, function (err) {
+    if (err) return cb(err);
+    this.remoteApkExists(function (err, remoteApk) {
+      // err is set if the remote apk doesn't exist so don't check it.
+      this.adb.isAppInstalled(this.args.appPackage, function (err, installed) {
+        if (installed && this.args.fastReset && remoteApk) {
+          this.resetApp(cb);
+        } else if (!installed || (this.args.fastReset && !remoteApk)) {
           this.adb.mkdir(this.remoteTempPath(), function (err) {
             if (err) return cb(err);
             this.getRemoteApk(function (err, remoteApk, md5Hash) {
@@ -427,10 +427,10 @@ androidCommon.installApp = function (cb) {
               }.bind(this));
             }.bind(this));
           }.bind(this));
-        }.bind(this));
-      } else {
-        cb();
-      }
+        } else {
+          cb();
+        }
+      }.bind(this));
     }.bind(this));
   }.bind(this));
 };


### PR DESCRIPTION
I have a Jenkins job which runs a number of tests using Appium. It excecutes a harness that runs the tests by starting/quitting an Appium session for each test and uses fastReset (reset) to clear app data between tests.

I ran into a bug with the new Appium (v0.17.6) where the second test in the batch always got a reinstall instead of reset. The strange thing was that it only happened when running the Jenkins job.

Turns out that it is because the job copies the apk from another job in the beginning. The original apk is of course unsigned. So what happens here is that we get different MD5 sums for the first test (where the app is unsigned) compared to the rest of the tests (where the app is signed).

This fix makes sure we always sign the app before checking for the MD5 hash.
