### PR TITLE
Fix #2133

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -504,13 +504,6 @@ IOS.prototype.setPreferences = function (cb) {
     return cb();
   }
 
-  if (this.args.fullReset) {
-    var msg = "Cannot set preferences because a full-reset was requested";
-    logger.info(msg);
-    logger.error(msg);
-    return cb(new Error(msg));
-  }
-
   var settingsCaps = [
     'locationServicesEnabled',
     'locationServicesAuthorized',
@@ -534,6 +527,11 @@ IOS.prototype.setPreferences = function (cb) {
   if (!needToSet) {
     logger.info("No iOS / app preferences to set");
     return cb();
+  } else if (this.args.fullReset) {
+    var msg = "Cannot set preferences because a full-reset was requested";
+    logger.info(msg);
+    logger.error(msg);
+    return cb(new Error(msg));
   }
 
   var setPrefs = function (err) {


### PR DESCRIPTION
If no preferences are set, don't error out even if full-reset is set
