### PR TITLE
Move reset timeout from "global before" to "session before"

### DIFF
--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -26,9 +26,6 @@ exports.getGlobalBeforeFilter = function (appium) {
     if (typeof req.body === "object") {
       logger.debug("Request received with params: " + JSON.stringify(req.body));
     }
-    if (req.appium.commandTimeout) {
-      req.appium.resetTimeout();
-    }
     if (proxy.shouldProxy(req)) {
       if (typeof req.device.translatePath !== "undefined") {
         req.device.translatePath(req);
@@ -43,6 +40,9 @@ exports.getGlobalBeforeFilter = function (appium) {
 exports.sessionBeforeFilter = function (req, res, next) {
   var match = new RegExp("([^/]+)").exec(req.params[0]);
   var sessId = match ? match[1] : null;
+  if (req.appium.commandTimeout) {
+    req.appium.resetTimeout();
+  }
   // if we don't actually have a valid session, respond with an error
   if (sessId && (!req.device || req.appium.sessionId !== sessId)) {
     res.send(404, {sessionId: null, status: status.codes.NoSuchDriver.code, value: ''});


### PR DESCRIPTION
At this moment timeout on command execution resets on every request to Appium server. So, deletion of session will never happen using Appium via Selenium Grid, because hub constantly checks Appium status and these requests eventually resets timeout. Thus reset of timeout on command makes sense only with some concrete session.
