### PR TITLE
Real XML-based XPath for Android

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -17,6 +17,7 @@ var errors = require('../../server/errors.js')
   , path = require('path')
   , XMLDom = require("xmldom")
   , helpers = require('../../helpers.js')
+  , warnDeprecatedCustom = helpers.logCustomDeprecationWarning
   , warnDeprecated = helpers.logDeprecationWarning;
 
 var androidController = {};
@@ -371,6 +372,14 @@ androidController.getPageSource = function (cb) {
     ],
     // Top level cb
     function () {
+      warnDeprecatedCustom('page source', 'json',
+        "You got the source of the app using the page source command. This " +
+        "command is undergoing a large change which will be released in " +
+        "Appium 1.0. The change will include returning an XML document " +
+        "instead of a JSON object. If you depend on the page source command " +
+        "you should try the new version, which is accessible by doing " +
+        "`driver.execute_script('mobile: source', [{type: 'xml'}])`, or " +
+        "the equivalent in your language bindings.");
       cb(null, {
         status: status.codes.Success.code
       , value: json

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -15,6 +15,7 @@ var errors = require('../../server/errors.js')
   , async = require('async')
   , mkdirp = require('mkdirp')
   , path = require('path')
+  , XMLDom = require("xmldom")
   , helpers = require('../../helpers.js')
   , warnDeprecated = helpers.logDeprecationWarning;
 
@@ -286,6 +287,48 @@ androidController.getCssProperty = function (elementId, propertyName, cb) {
   cb(new NotYetImplementedError(), null);
 };
 
+var _updateSourceXMLNodeNames = function (source) {
+  var newSource;
+  var origDom = new XMLDom.DOMParser().parseFromString(source);
+  var newDom = new XMLDom.DOMImplementation().createDocument(null);
+  _buildClassNodeFromPlainNode(newDom, newDom, origDom);
+  newSource = new XMLDom.XMLSerializer().serializeToString(newDom);
+  return newSource;
+};
+
+var _getNodeClass = function (node) {
+  var nodeClass = null;
+  _.each(node.attributes, function (attr) {
+    if (attr.name === "class") {
+      nodeClass = attr.value;
+    }
+  });
+  return nodeClass;
+};
+
+var _copyNodeAttributes = function (oldNode, newNode) {
+  _.each(oldNode.attributes, function (attr) {
+    newNode.setAttribute(attr.name, attr.value);
+  });
+};
+
+var _buildClassNodeFromPlainNode = function (newDom, newParent, oldNode) {
+  var newNode;
+  var nodeClass = _getNodeClass(oldNode);
+  if (nodeClass) {
+    newNode = newDom.createElement(nodeClass);
+    _copyNodeAttributes(oldNode, newNode);
+  } else {
+    newNode = oldNode.cloneNode(false);
+  }
+  newParent.appendChild(newNode);
+  if (oldNode.hasChildNodes()) {
+    _.each(oldNode.childNodes, function (childNode) {
+      _buildClassNodeFromPlainNode(newDom, newNode, childNode);
+    });
+  }
+};
+
 androidController.getPageSource = function (cb) {
   var xmlFile = temp.path({suffix: '.xml'});
   var jsonFile = xmlFile + '.json';
@@ -367,6 +410,11 @@ androidController.getPageSourceXML = function (cb) {
     function () {
       var xml = fs.readFileSync(xmlFile, 'utf8');
       fs.unlinkSync(xmlFile);
+      try {
+        xml = _updateSourceXMLNodeNames(xml);
+      } catch (e) {
+        return cb(e);
+      }
       cb(null, {
         status: status.codes.Success.code
       , value: xml

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -15,6 +15,7 @@ var errors = require('../../server/errors.js')
   , async = require('async')
   , mkdirp = require('mkdirp')
   , path = require('path')
+  , xpath = require("xpath")
   , XMLDom = require("xmldom")
   , helpers = require('../../helpers.js')
   , warnDeprecatedCustom = helpers.logCustomDeprecationWarning
@@ -45,6 +46,18 @@ androidController.findUIElementOrElements = function (strategy, selector, many, 
   if (!deviceCommon.checkValidLocStrat(strategy, false, cb)) {
     return;
   }
+  if (strategy === "xpath") {
+    warnDeprecatedCustom('locator strategy', 'xpath',
+        "You used the xpath locator strategy to find an element. Xpath " +
+        "support is undergoing massive change, which will become active " +
+        "in Appium 1.0. To try out the new version of xpath, use the " +
+        "'-real xpath' locator strategy instead of 'xpath'. Please take the " +
+        "time to update your tests soon.");
+  }
+  if (strategy === "-real xpath" && context) {
+    return cb(new Error("Cannot use xpath locator strategy from an element. " +
+                        "It can only be used from the root element"));
+  }
   var params = {
     strategy: strategy
   , selector: selector
@@ -71,9 +84,15 @@ androidController.findUIElementOrElements = function (strategy, selector, many, 
     helpers.logDeprecationWarning("Locator strategy", '"name"', '"accessibility id"');
   }
   var doFind = function (findCb) {
-    this.proxy(["find", params], function (err, res) {
-      this.handleFindCb(err, res, many, findCb);
-    }.bind(this));
+    if (strategy === "-real xpath") {
+      this.findUIElementsByXPath(selector, many, function (err, res) {
+        this.handleFindCb(err, res, many, findCb);
+      }.bind(this));
+    } else {
+      this.proxy(["find", params], function (err, res) {
+        this.handleFindCb(err, res, many, findCb);
+      }.bind(this));
+    }
   }.bind(this);
   if (!xpathError) {
     this.waitForCondition(this.implicitWaitMs, doFind, cb);
@@ -105,6 +124,53 @@ androidController.findElementFromElement = function (element, strategy, selector
 
 androidController.findElementsFromElement = function (element, strategy, selector, cb) {
   this.findUIElementOrElements(strategy, selector, true, element, cb);
+};
+
+var _pathFromDomNode = function (node) {
+  var path = "";
+  _.each(node.attributes, function (attrObj) {
+    if (attrObj.name === "index") {
+      path = _pathFromDomNode(node.parentNode) + "/" + attrObj.value;
+    }
+  });
+  return path;
+};
+
+androidController.findUIElementsByXPath = function (selector, many, cb) {
+  this.getPageSourceXML(function (err, res) {
+    if (err || res.status !== status.codes.Success.code) return cb(err, res);
+    var dom, nodes;
+    var xmlSource = res.value;
+    try {
+      dom = new XMLDom.DOMParser().parseFromString(xmlSource);
+      nodes = xpath.select(selector, dom);
+    } catch (e) {
+      logger.error(e);
+      return cb(e);
+    }
+    if (!many) nodes = nodes.slice(0, 1);
+    var indexPaths = _.map(nodes, _pathFromDomNode);
+    if (!many && indexPaths.length < 1) {
+      // if we don't have any matching nodes, and we wanted at least one, fail
+      return cb(null, {
+        status: status.codes.NoSuchElement.code,
+        value: null
+      });
+    } else if (indexPaths.length < 1) {
+      // and if we don't have any matching nodes, return the empty array
+      return cb(null, {
+        status: status.codes.Success.code,
+        value: []
+      });
+    }
+
+    var findParams = {
+      strategy: "index paths",
+      selector: indexPaths.join(","),
+      multiple: many
+    };
+    this.proxy(["find", findParams], cb);
+  }.bind(this));
 };
 
 androidController.setValueImmediate = function (elementId, value, cb) {
@@ -422,6 +488,7 @@ androidController.getPageSourceXML = function (cb) {
       try {
         xml = _updateSourceXMLNodeNames(xml);
       } catch (e) {
+        logger.error(e);
         return cb(e);
       }
       cb(null, {

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -17,7 +17,7 @@ var uuid = require('uuid-js')
   , deviceCommon = require('../common.js')
   , js2xml = require("js2xmlparser2")
   , xpath = require("xpath")
-  , XMLDom = require("xmldom").DOMParser
+  , XMLDom = require("xmldom")
   , errors = require('../../server/errors.js')
   , NotImplementedError = errors.NotImplementedError
   , NotYetImplementedError = errors.NotYetImplementedError;
@@ -143,7 +143,7 @@ var _xmlSourceFromJson = function (jsonSource) {
 
 var _performXpathQueryOnJson = function (selector, jsonSource) {
   var xmlSource = _xmlSourceFromJson(jsonSource);
-  var dom = new XMLDom().parseFromString(xmlSource);
+  var dom = new XMLDom.DOMParser().parseFromString(xmlSource);
   return xpath.select(selector, dom);
 };
 

--- a/test/functional/android/apidemos/find-element-specs.js
+++ b/test/functional/android/apidemos/find-element-specs.js
@@ -167,6 +167,50 @@ describe("apidemo - find elements -", function () {
     });
   });
 
+  describe('real xpath', function () {
+    var f = "android.widget.FrameLayout";
+    var l = "android.widget.ListView";
+    var t = "android.widget.TextView";
+    var v = "android.view.View";
+    it('should find element by type', function (done) {
+      driver
+        .elementByRealXPath('//' + t).text()
+          .should.become("API Demos")
+        .nodeify(done);
+    });
+    it('should find element by text', function (done) {
+      driver
+        .elementByRealXPath("//" + t + "[@text='Accessibility']").text()
+          .should.become("Accessibility")
+        .nodeify(done);
+    });
+    it('should find element by partial text', function (done) {
+      driver
+        .elementByRealXPath("//" + t + "[contains(@text, 'Accessibility')]").text()
+          .should.become("Accessibility")
+        .nodeify(done);
+    });
+    it('should find the last element', function (done) {
+      driver
+        .elementByRealXPath("//" + t + "[last()]").text()
+        .then(function (text) {
+          ["OS", "Text", "Views"].should.include(text);
+        }).nodeify(done);
+    });
+    it('should find element by xpath index and child', function (done) {
+      driver
+        .elementByRealXPath("//" + f + "[1]/" + v + "[1]/" + f + "[2]/" + l + "[1]/" + t + "[3]").text()
+          .should.become("App")
+        .nodeify(done);
+    });
+    it('should find element by index and embedded desc', function (done) {
+      driver
+        .elementByRealXPath("//" + f + "//" + t + "[4]").text()
+          .should.become("App")
+        .nodeify(done);
+    });
+  });
+
   describe('find elements using accessibility id locator strategy', function () {
     it('should find an element by name', function (done) {
       driver.element('accessibility id', 'Animation').then(function (el) {

--- a/test/functional/android/apidemos/source-specs.js
+++ b/test/functional/android/apidemos/source-specs.js
@@ -1,6 +1,8 @@
 "use strict";
 
 var setup = require("../../common/setup-base")
+  , xpath = require("xpath")
+  , XMLDom = require("xmldom").DOMParser
   , desired = require("./desired");
 
 describe("apidemos - source -", function () {
@@ -16,9 +18,19 @@ describe("apidemos - source -", function () {
         source.should.include('@class');
         var obj = JSON.parse(source);
         obj.should.exist;
-        // probably no need for so precise tests 
+        // probably no need for so precise tests
         //obj.hierarchy.node['@class'].should.equal("android.widget.FrameLayout");
         //obj.hierarchy.node.node.node[0].node['@class'].should.equal("android.widget.FrameLayout");
+      }).nodeify(done);
+  });
+  it('should return the page source as xml', function (done) {
+    driver
+      .elementByNameOrNull('Accessibility') // waiting for page to load
+      .execute("mobile: source", [{type: 'xml'}]).then(function (source) {
+        source.should.exist;
+        var dom = new XMLDom().parseFromString(source);
+        var nodes = xpath.select('//node[@content-desc="App"]', dom);
+        nodes.length.should.equal(1);
       }).nodeify(done);
   });
   it('should return the page source without crashing other commands', function (done) {
@@ -30,7 +42,7 @@ describe("apidemos - source -", function () {
         source.should.include('@class');
         var obj = JSON.parse(source);
         obj.should.exist;
-        // probably no need for so precise tests 
+        // probably no need for so precise tests
         //obj.hierarchy.node['@class'].should.equal("android.widget.FrameLayout");
         //obj.hierarchy.node.node.node[0].node['@class'].should.equal("android.widget.FrameLayout");
       }).execute("mobile: find", [[[[3, "Animation"]]]])

--- a/test/functional/android/apidemos/source-specs.js
+++ b/test/functional/android/apidemos/source-specs.js
@@ -29,7 +29,7 @@ describe("apidemos - source -", function () {
       .execute("mobile: source", [{type: 'xml'}]).then(function (source) {
         source.should.exist;
         var dom = new XMLDom().parseFromString(source);
-        var nodes = xpath.select('//node[@content-desc="App"]', dom);
+        var nodes = xpath.select('//android.widget.TextView[@content-desc="App"]', dom);
         nodes.length.should.equal(1);
       }).nodeify(done);
   });


### PR DESCRIPTION
- adds support under the '-real xpath' locator strategy
- deprecates the original xpath strategy, which will be replaced in 1.0
- because we have no way to get a dom fragment starting from an element,
  this strategy will only work for root-level queries
- this changes the xml format currently returned by `mobile: source, {type: 'xml'}`
  because that format did not include the class names as the node names, which
  is essential for using xpath properly. so if anyone is using that, it could be a
  breaking change
