### PR TITLE
Allow changing of ports with an environment variable

### DIFF
--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -87,7 +87,7 @@ RemoteDebugger.prototype.connect = function (cb, pageChangeCb) {
   }.bind(this));
   this.socket.on('data', this.receive.bind(this));
 
-  port = process.env.REMOTE_DEBUGGER_PORT || 27753;
+  var port = process.env.REMOTE_DEBUGGER_PORT || 27753;
   this.socket.connect(port, '::1', function () {
     this.logger.info("Debugger socket connected to " +
       this.socket.remoteAddress + ':' + this.socket.remotePort);

--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -87,7 +87,8 @@ RemoteDebugger.prototype.connect = function (cb, pageChangeCb) {
   }.bind(this));
   this.socket.on('data', this.receive.bind(this));
 
-  this.socket.connect(27753, '::1', function () {
+  port = process.env.REMOTE_DEBUGGER_PORT || 27753;
+  this.socket.connect(port, '::1', function () {
     this.logger.info("Debugger socket connected to " +
       this.socket.remoteAddress + ':' + this.socket.remotePort);
     this.setConnectionKey(cb);

--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -13,7 +13,7 @@ var _ = require('underscore')
 var WebKitRemoteDebugger = function (logColors, onDisconnect) {
   this.dataMethods = {};
   this.host = 'localhost';
-  this.port = 27753;
+  this.port = process.env.REMOTE_DEBUGGER_PORT || 27753;
   this.socketDisconnectCb = null;
   this.init(1, onDisconnect, logColors);
 };


### PR DESCRIPTION
Our use case for Appium requires that we change the default port. This PR allows for controlling the port via the environment variable REMOTE_DEBUGGER_PORT.
