### PR TITLE
Fix setWindow for Android

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -869,11 +869,13 @@ androidController.setContext = function (name, cb) {
 
 // TODO: remove in appium 1.0
 androidController.getWindowHandle = function (cb) {
+  warnDeprecated('function', 'getWindowHandle', 'getCurrentContext()');
   jwpSuccess(this.curContext, cb);
 };
 
 // TODO: remove in appium 1.0
 androidController.getWindowHandles = function (cb) {
+  warnDeprecated('function', 'getWindowHandles', 'getContexts()');
   this.listWebviews(function (err, webviews) {
     if (err) return cb(err);
     if (webviews.length) {
@@ -887,7 +889,8 @@ androidController.getWindowHandles = function (cb) {
 
 // TODO: remove in appium 1.0
 androidController.setWindow = function (name, cb) {
-  this.getContexts(function () {
+  warnDeprecated('function', 'setWindow', 'setContext(name)');
+  this.getWindowHandles(function () {
     if (!_.contains(this.contexts, name)) {
       return cb(null, {
         status: status.codes.NoSuchWindow.code

--- a/test/functional/android/webview-specs.js
+++ b/test/functional/android/webview-specs.js
@@ -3,4 +3,7 @@
 process.env.DEVICE = process.env.DEVICE || "android";
 var androidWebviewTests = require('../../helpers/android-webview');
 
-describe('android - web_view -', androidWebviewTests);
+describe('android - web_view - contexts -', androidWebviewTests.contexts);
+
+// TODO: remove in Appium 1.0
+describe('android - web_view - windows -', androidWebviewTests.windows);

--- a/test/helpers/android-webview.js
+++ b/test/helpers/android-webview.js
@@ -11,7 +11,7 @@ var desired = {
   'app-activity': '.HomeScreenActivity'
 };
 
-module.exports = function () {
+module.exports.contexts = function () {
   var driver;
   setup(this, desired).then(function (d) { driver = d; });
 
@@ -52,11 +52,79 @@ module.exports = function () {
   });
 
   // skip until Selendroid implements context methods
-  it('should raise NoSuchContext error for non-existent context @skip-selendroid-all', function (done) {
+  it('should raise NoSuchContext (status: 35) @skip-selendroid-all', function (done) {
     driver
       .context('WEBVIEW_42')
-      .should.be.rejectedWith('NoSuchContext')
+      .should.be.rejectedWith(/status: 35/)
       .nodeify(done);
+  });
+
+  it('should find and click an element', function (done) {
+    driver
+      .elementByCssSelector('input[type=submit]').click()
+      .waitForElementByXPath("//h1[contains(., 'This is my way')]")
+      .nodeify(done);
+  });
+
+  // selendroid test app is busted
+  it('should clear input @skip-selendroid-all', function (done) {
+    driver
+      .elementById('name_input').click().clear().getValue().should.become("")
+      .nodeify(done);
+  });
+
+  // selendroid test app is busted
+  it('should find and enter key sequence in input @skip-selendroid-all', function (done) {
+    driver
+      .elementById('name_input').clear()
+        .type("Mathieu").getValue().should.become("Mathieu")
+      .nodeify(done);
+  });
+
+  it('should be able to handle selendroid special keys @skip-android-all', function (done) {
+    driver.keys('\uE102').nodeify(done);
+  });
+
+  it('should get web source', function (done) {
+    driver
+      .source().should.eventually.include("<title>Say Hello Demo<")
+      .nodeify(done);
+  });
+};
+
+// TODO: remove in Appium 1.0
+module.exports.windows = function () {
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  beforeEach(function (done) {
+    driver
+      .waitForElementByName('buttonStartWebviewCD').click()
+      .sleep(500)
+      .window('WEBVIEW')
+      .nodeify(done);
+  });
+
+  if (env.FAST_TESTS) {
+    afterEach(function (done) {
+      driver
+        .window('NATIVE_APP')
+        .then(function () {
+          if (env.DEVICE === "selendroid") {
+            return driver.elementByIdOrNull('goBack');
+          } else {
+            return driver.elementByTagNameOrNull('button');
+          }
+        })
+        .then(function (el) {
+          if (el) return el.click().sleep(1000);
+        }).nodeify(done);
+    });
+  }
+
+  it('should be web view', function (done) {
+    // todo: add some sort of check here
+    done();
   });
 
   it('should find and click an element', function (done) {


### PR DESCRIPTION
Fixes issue #2210

Use `getWindowHandles` instead of `getContexts` in `androidController.setWindow()`. I've also fixed the old tests, and added deprecation warnings to the window methods.
