### PR TITLE
Added pullFile support for iOS simulator.

### DIFF
--- a/docs/mobile_methods.md
+++ b/docs/mobile_methods.md
@@ -14,6 +14,25 @@ Ruby without the gem
 @driver.execute_script 'mobile: reset'
 ```
 
+##### pullFile
+
+Fetch a file from the device's filesystem, returning it base64 encoded.
+
+Takes a single argument, `path`.  On Android and iOS, this is either the path to the file (relative to the root of the app's file system).  On iOS only, if path starts with `/AppName.app`, which will be replaced with the application's .app directory
+
+```
+# Android and iOS
+'mobile: pullFile', {path: '/Library/AddressBook/AddressBook.sqlitedb'} #=> /Library/AddressBook/AddressBook.sqlitedb
+
+#iOS only
+'mobile: pullFile, {path: '/UICatalog.app/logfile.log'} #=> /Applications/12323-452262-24241-23-124124/UICatalog.app/logfile.log
+```
+
+Ruby
+```ruby
+@driver.execute_script('mobile: pullFile', {path: '/Library/AddressBook/AddressBook.sqlitedb'})
+```
+
 #### Android mobile methods
 
 ##### KeyEvent

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -3,7 +3,9 @@ var uuid = require('uuid-js')
   , path = require('path')
   , fs = require('fs')
   , async = require('async')
+  , path = require('path')
   , _ = require('underscore')
+  , exec = require('child_process').exec
   , status = require("../../server/status.js")
   , logger = require('../../server/logger.js').get('appium')
   , helpers = require('../../helpers.js')
@@ -18,6 +20,8 @@ var uuid = require('uuid-js')
   , js2xml = require("js2xmlparser2")
   , xpath = require("xpath")
   , XMLDom = require("xmldom")
+  , settings = require('./settings.js')
+  , getSimRoot = settings.getSimRoot
   , errors = require('../../server/errors.js')
   , NotImplementedError = errors.NotImplementedError
   , NotYetImplementedError = errors.NotYetImplementedError;
@@ -436,7 +440,44 @@ iOSController.pushFile = function (base64Data, remotePath, cb) {
 };
 
 iOSController.pullFile = function (remotePath, cb) {
-  cb(new NotYetImplementedError(), null);
+  if (this.realDevice) {
+    return cb(new NotYetImplementedError(), null);
+  }
+  var fullPath = "";
+  var v = (this.args.platformVersion || this.iOSSDKVersion);
+  var basePath = path.resolve(getSimRoot(), v);
+
+  var readAndReturnFile = function () {
+    fs.readFile(fullPath, {encoding: 'base64'}, function (err, data) {
+      if (err) return cb(err);
+      cb(null, {status: status.codes.Success.code, value: data});
+    });
+  };
+
+  var appName = null;
+  
+  if (this.args.app) {
+    var appNameRegex = new RegExp("\\" + path.sep + "(\\w+\\.app)");
+    var appNameMatches = appNameRegex.exec(this.args.app);
+    if (appNameMatches) {
+      appName = appNameMatches[1];
+    }
+  }
+
+  if (remotePath.indexOf(appName) === 1) {
+    var findPath = basePath.replace(/\s/g, '\\ ');
+    var findCmd = 'find ' + findPath + ' -name "' + appName + '"';
+    exec(findCmd, function (err, stdout) {
+      if (err) return cb(err);
+      var appRoot = stdout.replace(/\n$/, '');
+      var subPath = remotePath.substring(appName.length + 2);
+      fullPath = path.resolve(appRoot, subPath);
+      readAndReturnFile();
+    }.bind(this));
+  } else {
+    fullPath = path.resolve(basePath, remotePath);
+    readAndReturnFile();
+  }
 };
 
 iOSController.touchLongClick = function (elementId, cb) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -970,10 +970,7 @@ IOS.prototype.parseLocalizableStrings = function (cb) {
 
 
 IOS.prototype.getSimulatorApplications = function (cb) {
-  var user = process.env.USER;
-  var simDir = "/Users/" + user + "/Library/Application\\ " +
-               "Support/iPhone\\ Simulator";
-  var findCmd = 'find ' + simDir + ' -name "Applications"';
+  var findCmd = 'find ' + getSimRoot() + ' -name "Applications"';
   exec(findCmd, function (err, stdout) {
     // Return empty array on error otherwise
     // "No such file or directory" will crash appium.

--- a/package.json
+++ b/package.json
@@ -84,7 +84,8 @@
     "mv": "~2.0.0",
     "js2xmlparser2": "~0.2.0",
     "xpath": "~0.0.6",
-    "xmldom": "~0.1.19"
+    "xmldom": "~0.1.19",
+    "sandboxed-module": "~0.3.0"
   },
   "scripts": {
     "test": "grunt travis"

--- a/test/functional/ios/file-movement-specs.js
+++ b/test/functional/ios/file-movement-specs.js
@@ -1,0 +1,66 @@
+"use strict";
+
+var setup = require("../common/setup-base")
+  , env = require('../../helpers/env')
+  , getAppPath = require('../../helpers/app').getAppPath
+  , fs = require('fs')
+  , path = require('path')
+  , exec = require('child_process').exec;
+
+describe('pullFile', function () {
+  var driver;
+  var desired = {
+      app: getAppPath('testapp')
+    , platformName: 'iPhone Simulator'
+    };
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('should be able to fetch the Address book', function (done) {
+    var args = {path: 'Library/AddressBook/AddressBook.sqlitedb'};
+    driver
+      .execute('mobile: pullFile', [args]).then(function (data) {
+        var stringData = new Buffer(data, 'base64').toString();
+        return stringData.indexOf('SQLite').should.not.equal(-1);
+      })
+    .nodeify(done);
+  });
+  describe('for a .app', function () {
+    var fileContent = "IAmTheVeryModelOfAModernMajorTestingTool";
+    var fileName = "someFile.tmp";
+    var fullPath = "";
+    before(function (done) {
+      var u = process.env.USER;
+      var pv = env.CAPS.version || '7.1';
+      var basePath = path.resolve('/Users', u, 'Library/Application\\ Support',
+                                  'iPhone\\ Simulator', pv, 'Applications');
+
+      var findCmd = 'find ' + basePath + ' -name "testapp.app"';
+      exec(findCmd, function (err, stdout) {
+        if (err) throw (err);
+        var appRoot = stdout.replace(/\n$/, '');
+        fullPath = path.resolve(appRoot, fileName);
+        fs.writeFile(fullPath, fileContent, function (err) {
+          if (err) throw (err);
+        });
+        done();
+      });
+    });
+    after(function (done) {
+      if (fullPath) {
+        fs.unlink(fullPath, function (err) {
+          if (err) throw err;
+          done();
+        });
+      }
+    });
+    it('should be able to fetch a file from the app directory', function (done) {
+      var args = {path: path.resolve('/testapp.app', fileName)};
+      driver
+        .execute('mobile: pullFile', [args]).then(function (data) {
+          var stringData = new Buffer(data, 'base64').toString();
+          return stringData.should.equal(fileContent);
+        })
+      .nodeify(done);
+    });
+  });
+});

--- a/test/unit/ios-controller-specs.js
+++ b/test/unit/ios-controller-specs.js
@@ -1,12 +1,22 @@
 "use strict";
 
 var chai = require('chai')
-  , should = chai.should
-  , controller = require('../../lib/devices/ios/ios-controller.js')
+  , should = chai.should()
+  , sinon = require('sinon')
+  , SandboxedModule = require('sandboxed-module')
+  , fs = require('fs')
+  , path = require('path')
+  , controller_path = '../../lib/devices/ios/ios-controller.js'
+  , controller = require(controller_path)
+  , child_process = require('child_process')
   , createGetElementCommand = controller.createGetElementCommand
-  , getSelectorForStrategy = controller.getSelectorForStrategy;
+  , getSelectorForStrategy = controller.getSelectorForStrategy
+  , errors = require('../../lib/server/errors.js')
+  , NotYetImplementedError = errors.NotYetImplementedError
+  , status = require('../../lib/server/status.js');
 
 describe('ios-controller', function () {
+
   describe('#createGetElementCommand', function () {
     it('should return \'GetType\' for name selection', function () {
       var actual = createGetElementCommand('name', 'UIAKey', null, false);
@@ -35,7 +45,6 @@ describe('ios-controller', function () {
       actual.should.equal("au.getElementByType('UIAKey')");
     });
   });
-
   describe('#getSelectorForStrategy', function () {
     describe('given a class name', function () {
       it('should allow UIA names', function () {
@@ -70,6 +79,104 @@ describe('ios-controller', function () {
         it('returns the localized string', function () {
           var actual = controller.getSelectorForStrategy('id', 'someSelector');
           actual.should.equal('localSelector');
+        });
+      });
+    });
+  });
+  describe('#pullFile', function () {
+    describe('on a real device', function () {
+      before(function () {
+        controller.realDevice = true;
+      });
+      after(function () {
+        controller.realDevice = false;
+      });
+      it('returns a NotYetImplementedError', function () {
+        var cb = sinon.spy();
+        controller.pullFile("somefile", cb);
+        cb.args[0][0].should.be.an.instanceOf(NotYetImplementedError);
+      });
+    });
+    describe('on the simulator', function () {
+      before(function () {
+        controller.args = {platformVersion: '7.1'};
+      });
+      describe('with an invalid file', function () {
+        beforeEach(function () {
+          var stubbedFs = sinon.stub(fs, 'readFile');
+          stubbedFs.yields("someErr");
+        });
+        afterEach(function () {
+          fs.readFile.restore();
+        });
+        it('should return an error', function () {
+          var cb = sinon.spy();
+          controller.pullFile("", cb);
+          cb.args[0][0].should.equal("someErr");
+        });
+      });
+      describe('with a valid file', function () {
+        beforeEach(function () {
+          var stubbedFs = sinon.stub(fs, 'readFile');
+          var data = 'somedata';
+          stubbedFs.yields(null, data);
+        });
+        afterEach(function () {
+          fs.readFile.restore();
+        });
+        it('fetches data from the full path', function () {
+          var cb = sinon.spy();
+          var user = process.env.USER;
+          var expected = path.resolve("/Users", user, "Library", "Application Support",
+                                      "iPhone Simulator", "7.1", "Documents", "somefile");
+          controller.pullFile('Documents/somefile', cb);
+          fs.readFile.args[0][0].should.equal(expected);
+        });
+        it('returns the data and a success Code', function () {
+          var cb = sinon.spy();
+          controller.pullFile('somefile', cb);
+          cb.args[0][1].should.have.property('status', status.codes.Success.code);
+          cb.args[0][1].should.have.property('value', 'somedata');
+        });
+      });
+      describe('inside an application directory', function () {
+        var guid = "234234234445795432";
+        var user = process.env.USER;
+        var rootPath = path.resolve("/Users", user, "Library",
+                                    "Application Support", "iPhone Simulator",
+                                    "7.1", "Applications");
+        var appPath = path.resolve(rootPath, guid, 'greatApp.app');
+        var data = 'somedata';
+
+        beforeEach(function () {
+          var stubbedFs = sinon.stub(fs, 'readFile');
+
+          stubbedFs.yieldsAsync(null, data);
+          var stubbed_child_process = sinon.stub(child_process,
+                                                 'exec').yieldsAsync(null, appPath);
+
+          this.controller = SandboxedModule.require(controller_path, {
+            locals: {
+              "exec": stubbed_child_process.exec
+            }
+          });
+
+          this.controller.args = {platformVersion: '7.1'};
+
+          return this.controller;
+        });
+        afterEach(function () {
+          fs.readFile.restore();
+          child_process.exec.restore();
+        });
+        it('pulls from that directory, adding a GUID', function (done) {
+          var expectedPath = path.resolve(appPath, 'somefile');
+          this.controller.args.app = '/some/location/to/a/greatApp.app';
+          this.controller.pullFile('/greatApp.app/somefile', function (err, data) {
+            data.value.should.equal('somedata');
+            fs.readFile.args[0][0].should.equal(expectedPath);
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
`mobile: pullFile {:path => '/Some/Path'}` fetches a file relative to
the root of the device's filesystem.

`mobile: pullFile {:path => '/Applications/Some.app'}` fetches a file
relative to the root of that Application's .app directory, adding in the
GUID.

Fixes #2010, #1807
