### PR TITLE
Fixes #2131.

### DIFF
--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -24,7 +24,7 @@ ChromeAndroid.prototype.init = function () {
 ChromeAndroid.prototype.configure = function (args, caps, cb) {
   logger.info("Looks like we want chrome on android");
   this._deviceConfigure(args, caps);
-  var app = this.appString();
+  var app = this.appString().toLowerCase();
   if (app === "chromium") {
     this.args.androidPackage = "org.chromium.chrome.testshell";
     this.args.androidActivity = "org.chromium.chrome.testshell.Main";

--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -36,7 +36,7 @@ Device.prototype.setArgFromCap = function (arg, cap) {
 };
 
 Device.prototype.appString = function () {
-  return this.args.app ? this.args.app.toString().toLowerCase() : '';
+  return this.args.app ? this.args.app.toString() : '';
 };
 
 Device.prototype.configureApp = function (cb) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -136,12 +136,12 @@ IOS.prototype.configureApp = function (cb) {
   this._deviceConfigureApp(function (err) {
     var app = this.appString();
     if (err) {
-      if (app === "iwebview") {
+      if (app.toLowerCase() === "iwebview") {
         this.capabilities.iwebview = true;
         this.args.app = path.resolve(__dirname,
           "../../../build/WebViewApp/WebViewApp.app");
         return this.configureLocalApp(cb);
-      } else if (app === "settings") {
+      } else if (app.toLowerCase() === "settings") {
         return this.configurePreferences(cb);
       } else if (this.appIsPackageOrBundle(app)) {
         // we have a bundle ID


### PR DESCRIPTION
Squashed commits:
[fba9410] Making sure toLowerCase() is still used for chrome.js
[0cbfa68] We don't need toLowerCas() for app argument, as it is used for passing CFBundleIdentifier, fixes #2131
