### PR TITLE
Allow the ios_webkit_debug_proxy port to be configurable by specifying the port. 

### DIFF
--- a/docs/server-args.md
+++ b/docs/server-args.md
@@ -56,10 +56,11 @@ All flags are optional, but some are required in conjunction with certain others
 |`--selendroid-port`|8080|Local port used for communication with Selendroid|`--selendroid-port 8080`|
 |`--chromedriver-port`|9515|Port upon which ChromeDriver will run|`--chromedriver-port 9515`|
 |`--use-keystore`|false|(Android-only) When set the keystore will be used to sign apks.||
-|`--keystore-path`|/Users/saucelabs/.android/debug.keystore|(Android-only) Path to keystore||
+|`--keystore-path`|/Users/user/.android/debug.keystore|(Android-only) Path to keystore||
 |`--keystore-password`|android|(Android-only) Password to keystore||
 |`--key-alias`|androiddebugkey|(Android-only) Key alias||
 |`--key-password`|android|(Android-only) Key password||
 |`--show-config`|false|Show info about the appium server configuration and exit||
 |`--command-timeout`|60|The default command timeout for the server to use for all sessions. Will still be overridden by newCommandTimeout cap||
+|`--webkit-port`|27753|The port that ios_webkit_debug proxy is running on  default value is 27753||
 |`--keep-keychains`|false|(iOS) Whether to keep keychains (Library/Keychains) when reset app between sessions||

--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -45,12 +45,12 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
     }
   } else {
     if (this.args.udid !== null) {
-      this.remote = wkrd.init(!this.args.logNoColors, this.args.webkitPort, exitCb);
+      this.remote = wkrd.init(this.args.webkitPort, exitCb);
       this.remote.pageArrayFromJson(function (pageArray) {
         cb(pageArray);
       });
     } else {
-      this.remote = rd.init(!this.args.logNoColors, exitCb);
+      this.remote = rd.init(exitCb);
       this.remote.connect(function (appDict) {
         if (!_.has(appDict, this.args.bundleId)) {
           logger.error("Remote debugger did not list " + this.args.bundleId + " among " +

--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -45,12 +45,12 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
     }
   } else {
     if (this.args.udid !== null) {
-      this.remote = wkrd.init(exitCb);
+      this.remote = wkrd.init(!this.args.logNoColors, this.args.webkitPort, exitCb);
       this.remote.pageArrayFromJson(function (pageArray) {
         cb(pageArray);
       });
     } else {
-      this.remote = rd.init(exitCb);
+      this.remote = rd.init(!this.args.logNoColors, exitCb);
       this.remote.connect(function (appDict) {
         if (!_.has(appDict, this.args.bundleId)) {
           logger.error("Remote debugger did not list " + this.args.bundleId + " among " +
@@ -99,7 +99,6 @@ iOSHybrid.onPageChange = function (pageArray) {
   _.each(newIds, function (id) {
     if (!_.contains(this.contexts, id)) {
       newPages.push(id);
-      this.contexts.push(id);
     }
   }.bind(this));
   var newPage = null;

--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -10,10 +10,10 @@ var _ = require('underscore')
 // CONFIG
 // ====================================
 
-var WebKitRemoteDebugger = function (onDisconnect) {
+var WebKitRemoteDebugger = function (webkitDebugPort, onDisconnect) {
   this.dataMethods = {};
   this.host = 'localhost';
-  this.port = process.env.REMOTE_DEBUGGER_PORT || 27753;
+  this.port = webkitDebugPort;
   this.socketDisconnectCb = null;
   this.init(1, onDisconnect);
 };
@@ -168,6 +168,6 @@ WebKitRemoteDebugger.prototype.receive = function (data) {
   this.handleMessage(data, method);
 };
 
-exports.init = function (onDisconnect) {
-  return new WebKitRemoteDebugger(onDisconnect);
+exports.init = function (webkitPort, onDisconnect) {
+  return new WebKitRemoteDebugger(webkitPort, onDisconnect);
 };

--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -10,10 +10,12 @@ var _ = require('underscore')
 // CONFIG
 // ====================================
 
-var WebKitRemoteDebugger = function (onDisconnect) {
+
+var WebKitRemoteDebugger = function (webkitDebugPort, onDisconnect) {
+
   this.dataMethods = {};
   this.host = 'localhost';
-  this.port = process.env.REMOTE_DEBUGGER_PORT || 27753;
+  this.port = webkitDebugPort;
   this.socketDisconnectCb = null;
   this.init(1, onDisconnect);
 };
@@ -168,6 +170,8 @@ WebKitRemoteDebugger.prototype.receive = function (data) {
   this.handleMessage(data, method);
 };
 
-exports.init = function (onDisconnect) {
-  return new WebKitRemoteDebugger(onDisconnect);
+
+exports.init = function (webkitPort, onDisconnect) {
+  return new WebKitRemoteDebugger(webkitPort, onDisconnect);
+
 };

--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -10,16 +10,14 @@ var _ = require('underscore')
 // CONFIG
 // ====================================
 
-<<<<<<< HEAD
+
 var WebKitRemoteDebugger = function (webkitDebugPort, onDisconnect) {
-=======
-var WebKitRemoteDebugger = function (logColors, webkitDebugPort, onDisconnect) {
->>>>>>> 1e3f8cf6d0df72aa60527bc5e9e917bb89dc3e93
+
   this.dataMethods = {};
   this.host = 'localhost';
   this.port = webkitDebugPort;
   this.socketDisconnectCb = null;
-  this.init(1, onDisconnect, logColors);
+  this.init(1, onDisconnect);
 };
 
 //extend the remote debugger
@@ -172,11 +170,8 @@ WebKitRemoteDebugger.prototype.receive = function (data) {
   this.handleMessage(data, method);
 };
 
-<<<<<<< HEAD
+
 exports.init = function (webkitPort, onDisconnect) {
   return new WebKitRemoteDebugger(webkitPort, onDisconnect);
-=======
-exports.init = function (logColors, webkitPort, onDisconnect) {
-  return new WebKitRemoteDebugger(logColors, webkitPort, onDisconnect);
->>>>>>> 1e3f8cf6d0df72aa60527bc5e9e917bb89dc3e93
+
 };

--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -10,12 +10,12 @@ var _ = require('underscore')
 // CONFIG
 // ====================================
 
-var WebKitRemoteDebugger = function (onDisconnect) {
+var WebKitRemoteDebugger = function (logColors, webkitDebugPort, onDisconnect) {
   this.dataMethods = {};
   this.host = 'localhost';
-  this.port = process.env.REMOTE_DEBUGGER_PORT || 27753;
+  this.port = webkitDebugPort;
   this.socketDisconnectCb = null;
-  this.init(1, onDisconnect);
+  this.init(1, onDisconnect, logColors);
 };
 
 //extend the remote debugger
@@ -168,6 +168,6 @@ WebKitRemoteDebugger.prototype.receive = function (data) {
   this.handleMessage(data, method);
 };
 
-exports.init = function (onDisconnect) {
-  return new WebKitRemoteDebugger(onDisconnect);
+exports.init = function (logColors, webkitPort, onDisconnect) {
+  return new WebKitRemoteDebugger(logColors, webkitPort, onDisconnect);
 };

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -458,7 +458,7 @@ var args = [
           'sessions. Will still be overridden by newCommandTimeout cap'
   }],
   [['--webkit-port'], {
-    defaultValue: 27753
+    defaultValue: process.env.REMOTE_DEBUGGER_PORT || 27753
   , dest: 'webkitPort'
   , type: 'int'
   , required: false

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -457,6 +457,14 @@ var args = [
   , help: 'The default command timeout for the server to use for all ' +
           'sessions. Will still be overridden by newCommandTimeout cap'
   }],
+  [['--webkit-port'], {
+    defaultValue: 27753
+  , dest: 'webkitPort'
+  , type: 'int'
+  , required: false
+  , help: 'The port that ios_webkit_debug proxy is running on ' +
+          ' default value is 27753'
+  }],
 
   [['--keep-keychains'], {
     defaultValue: false


### PR DESCRIPTION
I have changed the code to allow the ios_webkit_debug_proxy port to be configurable by specifying the port.

If --webkit-port is set it will use the port that is passed in. If no port is set it will use the default 27753.

This is useful for when you have more than one real IOS device connected to your mac. And allows testing on both devices with mutiple instances of Appium.

Example usage would be running two appiums for two different ios devices.

ios_webkit_debug_proxy -c :27753 -d
node appium.js -a 127.0.0.1 -p 4723 -dp 4733 -U

ios_webkit_debug_proxy -c :27754 -d
node appium.js -a 127.0.0.1 -p 4723 -dp 4733 -U --webkit-port 27754
