### PR TITLE
Fix for a bug where bundleId is converted to lower case.

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -145,7 +145,7 @@ IOS.prototype.configureApp = function (cb) {
       } else if (this.appIsPackageOrBundle(app)) {
         // we have a bundle ID
         logger.info("App is an iOS bundle, will attempt to run as pre-existing");
-        this.args.bundleId = app;
+        this.args.bundleId = this.args.app;
         this.args.app = null;
         return cb();
       }


### PR DESCRIPTION
Appium fails to start the app if a bundleId with Upper case letters is used as 'app' in the capabilities. This is because of an incorrect conversion to lower case.
