### PR TITLE
Added 2 fixes for when using the installApp, launchApp, removeApp requests seperately

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -278,9 +278,8 @@ Appium.prototype.invoke = function (cb) {
   this.sessionId = UUID.create().hex;
   logger.info('Creating new appium session ' + this.sessionId);
 
-  if (_.has(this.desiredCapabilities, 'launch') &&
-      this.desiredCapabilities.launch === false) {
-    // if user has passed in desiredCaps.launch = false
+  if (this.device.args.autoLaunch === false) {
+    // if user has passed in desiredCaps.autoLaunch = false
     // meaning they will manage app install / launching
     cb(null, this.device);
   } else {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -696,29 +696,35 @@ IOS.prototype.detectUdid = function (cb) {
 };
 
 IOS.prototype.installToRealDevice = function (cb) {
-  if (this.args.udid) {
-    if (this.args.ipa && this.args.bundleId) {
-      this.installIpa(cb);
-    } else if (this.args.ipa) {
-      var msg = "You specified a UDID and ipa but did not include the bundle " +
-                "id";
-      logger.error(msg);
-      cb(new Error(msg));
-    } else if (this.args.app) {
-      try {
-        this.realDevice = this.getIDeviceObj();
-      } catch (e) {
-        return cb(e);
+  // if user has passed in desiredCaps.autoLaunch = false
+  // meaning they will manage app install / launching
+  if (this.args.autoLaunch === false) {
+    cb();
+  } else {
+    if (this.args.udid) {
+      if (this.args.ipa && this.args.bundleId) {
+        this.installIpa(cb);
+      } else if (this.args.ipa) {
+        var msg = "You specified a UDID and ipa but did not include the bundle " +
+                  "id";
+        logger.error(msg);
+        cb(new Error(msg));
+      } else if (this.args.app) {
+        try {
+          this.realDevice = this.getIDeviceObj();
+        } catch (e) {
+          return cb(e);
+        }
+        this.installApp(this.args.app, cb);
+      } else {
+        logger.debug("Real device specified but no ipa or app path, assuming bundle ID is " +
+                     "on device");
+        cb();
       }
-      this.installApp(this.args.app, cb);
     } else {
-      logger.debug("Real device specified but no ipa or app path, assuming bundle ID is " +
-                   "on device");
+      logger.debug("No device id or app, not installing to real device.");
       cb();
     }
-  } else {
-    logger.debug("No device id or app, not installing to real device.");
-    cb();
   }
 };
 

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -5,7 +5,8 @@ var _ = require('underscore')
 
 var capsConversion = {
   'device': 'platformName',
-  'version': 'platformVersion'
+  'version': 'platformVersion',
+  'launch': 'autoLaunch'
 };
 
 var Capabilities = function (capabilities) {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -81,8 +81,8 @@ exports.installApp = function (req, res) {
         install(unpackedAppPath);
       }
     });
-  } else if (typeof req.appium.args.app !== "undefined") {
-    install(req.appium.args.app);
+  } else if (typeof req.device.args.app !== "undefined") {
+    install(req.device.args.app);
   } else {
     respondError(req, res, "No app defined (either through desired capabilities or as an argument)");
   }
@@ -121,17 +121,17 @@ exports.isAppInstalled = function (req, res) {
 
 exports.launchApp = function (req, res) {
   req.device.start(function () {
-    respondSuccess(req, res, "Successfully launched the [" + req.appium.args.app + "] app.");
+    respondSuccess(req, res, "Successfully launched the [" + req.device.args.app + "] app.");
   }, function () {
-    respondError(req, res, "Unable to launch the  [" + req.appium.args.app + "] app.");
+    respondError(req, res, "Unable to launch the  [" + req.device.args.app + "] app.");
   });
 };
 
 exports.closeApp = function (req, res) {
   req.device.stop(function () {
-    respondSuccess(req, res, "Successfully closed the [" + req.appium.args.app + "] app.");
+    respondSuccess(req, res, "Successfully closed the [" + req.device.args.app + "] app.");
   }, function () {
-    respondError(req, res, "Something whent wront whilst closing the [" + req.appium.args.app + "] app.");
+    respondError(req, res, "Something whent wront whilst closing the [" + req.device.args.app + "] app.");
   });
 };
 


### PR DESCRIPTION
1. Updated the app argument for the installApp, launchApp and closeApp to point to the <b>req.device.arg</b> rather than <b>req.appium.arg</b>. As the app argument was no longer available in req.appium.args.
2. Also added a check for the "installToRealDevice" function to check if "launch" desired capability has not been set to false (as in that instance we want to manage installation and launching ourselves).
   Should the same desired capability ("launch") be used for this? 
