### PR TITLE
Fix the broken -g/--log and --log-no-colors.

### DIFF
--- a/lib/server/logger.js
+++ b/lib/server/logger.js
@@ -22,30 +22,19 @@ var logger = null;
 
 module.exports.init = function (args) {
   var options = _.extend(defaults, {
-    colorize: !args.logNoColors
-  , timestamp: args.logTimestamp
+    timestamp: args.logTimestamp
+  , handleExceptions: true
+  , exitOnError: false
+  , json: false
   });
 
   var winstonOptions = {
     console:
       _.extend({
-        handleExceptions: true
-      , json: false
+        colorize: !args.logNoColors
       , level: 'debug'
-      , exitOnError: false
       }, options)
     };
-
-  if (args.log) {
-    winstonOptions.file = {
-      filename: args.log
-    , colorize: false
-    , level: 'debug'
-    , maxsize: 10000000
-    , maxFiles: 1
-    , json: false
-    };
-  }
 
   winston.addColors(colors);
   winston.loggers.add('appium', winstonOptions);
@@ -55,6 +44,21 @@ module.exports.init = function (args) {
 
   if (args.quiet) {
     logger.transports.console.level = 'warn';
+  }
+
+  if (args.log) {
+    winstonOptions.file = _.extend({
+      filename: args.log
+    , colorize: false
+    , maxFiles: 1
+    }, options);
+
+    try {
+      logger.add(winston.transports.File, winstonOptions.file);
+    } catch (e) {
+      logger.info("Tried to attach logging to file " + args.log +
+                  " but an error occurred");
+    }
   }
 
   if (args.webhook) {

--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -6,9 +6,8 @@ var parser = require('./parser.js')()
   , fs = require('fs')
   , path = require('path')
   , isWindows = require('../helpers.js').isWindows()
-  , _ = require('underscore');
-  
-require('colors');
+  , _ = require('underscore')
+  , colors = require('colors');
 
 process.chdir(path.resolve(__dirname, '../..'));
 
@@ -86,6 +85,9 @@ var main = function (args, readyCb, doneCb) {
     }
     if (args.log || args.webhook) {
       rest.use(express.logger({stream: winstonStream}));
+    }
+    if (args.logNoColors || args.log) {
+      colors.mode = "none";
     }
     rest.use(parserWrap);
     rest.use(express.urlencoded());

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -144,7 +144,7 @@ var args = [
     defaultValue: null
   , required: false
   , example: "/path/to/appium.log"
-  , help: 'Log output to this file instead of stdout'
+  , help: 'Also send log output to this file'
   }],
 
   [['--log-timestamp'], {


### PR DESCRIPTION
Fix for these issues:
1.  -g/--log does not actually log to file.
2. --log-no-colors still uses colors for the actual debug levels (e.g. 'warn', 'info', etc.).
