### PR TITLE
Fix bugs in action handling

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -1031,7 +1031,9 @@ androidController.doTouchAction = function (action, opts, cb) {
     case 'moveTo':
       return this.touchMove(opts.element, opts.x, opts.y, cb);
     case 'wait':
-      return setTimeout(cb, opts.ms);
+      return setTimeout(function () {
+        cb(null, {"value": true, "status": status.codes.Success.code});
+      }, opts.ms);
     case 'longPress':
       if (typeof opts.duration === 'undefined' || !opts.duration) {
         opts.duration = 1000;

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -255,7 +255,16 @@ exports.setValue = function (req, res) {
 };
 
 exports.performTouch = function (req, res) {
+  // first, assume that we are getting and array of gestures
   var gestures = req.body;
+
+  // some clients, like Python, send an object in which there is an `actions`
+  // property that is the array of actions
+  // if this is not an array (having a `shift` method) try to get the
+  // actions from there
+  if (typeof gestures.shift !== 'function') {
+    gestures = gestures.actions;
+  }
 
   req.device.performTouch(gestures, getResponseHandler(req, res));
 };


### PR DESCRIPTION
In some cases `wait` failed for having an invalid status object.

Some language bindings, or at least Python, inserts the `sessionId` into the body of a post, which would make the controller code fail. Check for this, and get the actions appropriately.
