### PR TITLE
Get localized strings in android and selendroid

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -5,6 +5,8 @@ var logger = require('../../server/logger.js').get('appium')
   , status = require("../../server/status.js")
   , fs = require('fs')
   , path = require('path')
+  , exec = require('child_process').exec
+  , helperJarPath = path.resolve(__dirname, 'helpers')
   , md5 = require('md5calculator')
   , async = require('async')
   , errors = require('../../server/errors.js')
@@ -664,6 +666,34 @@ androidCommon.getDeviceLocale = function (cb) {
     } else {
       logger.debug("Current device locale: " + stdout.trim());
       cb(null, stdout.trim());
+    }
+  }.bind(this));
+};
+
+androidCommon.extractLocalizedStrings = function (outputPath, cb) {
+  var stringsFromApkJarPath = path.resolve(helperJarPath,
+      'strings_from_apk.jar');
+  if (!this.args.appPackage) {
+    return cb(new Error("Parameter 'app-package' is required for launching application"));
+  }
+  var makeStrings = ['java -jar "', stringsFromApkJarPath,
+                     '" "', this.args.app, '" "', outputPath, '"'].join('');
+
+  this.getDeviceLocale(function (err, locale) {
+    this.extractStringsFromApk(makeStrings, locale, cb);
+  }.bind(this));
+};
+
+androidCommon.extractStringsFromApk = function (makeStrings, locale, cb) {
+  var makeLocaleStrings = makeStrings;
+  if (locale !== null) makeLocaleStrings = [makeStrings, locale].join(' ');
+  logger.debug(makeLocaleStrings);
+  exec(makeLocaleStrings, { maxBuffer: 524288 }, function (err, stdout, stderr) {
+    if (err && locale !== null) {
+      logger.info("No strings.xml for locale '" + locale + "', getting default strings.xml");
+      this.extractStringsFromApk(makeStrings, null, cb);
+    } else {
+      cb(err, stdout, stderr);
     }
   }.bind(this));
 };

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -656,4 +656,16 @@ androidCommon.getCurrentActivity = function (cb) {
   });
 };
 
+androidCommon.getDeviceLocale = function (cb) {
+  this.adb.shell("getprop persist.sys.language", function (err, stdout) {
+    if (err) {
+      logger.warn("Error getting device locale: " + err);
+      cb(err, null);
+    } else {
+      logger.debug("Current device locale: " + stdout.trim());
+      cb(null, stdout.trim());
+    }
+  }.bind(this));
+};
+
 module.exports = androidCommon;

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var errors = require('../../server/errors.js')
-  , exec = require('child_process').exec
   , path = require('path')
   , fs = require('fs')
   , ADB = require('./adb.js')
@@ -12,7 +11,6 @@ var errors = require('../../server/errors.js')
   , logger = require('../../server/logger.js').get('appium')
   , deviceCommon = require('../common.js')
   , status = require("../../server/status.js")
-  , helperJarPath = path.resolve(__dirname, 'helpers')
   , async = require('async')
   , androidController = require('./android-controller.js')
   , androidCommon = require('./android-common.js')
@@ -287,6 +285,7 @@ Android.prototype.processFromManifest = function (cb) {
 };
 
 Android.prototype.pushStrings = function (cb) {
+  var outputPath = path.resolve(getTempPath(), this.args.appPackage);
   var remotePath = '/data/local/tmp';
   var stringsJson = 'strings.json';
   if (!fs.existsSync(this.args.app)) {
@@ -297,46 +296,21 @@ Android.prototype.pushStrings = function (cb) {
       cb();
     });
   } else {
-    var stringsFromApkJarPath = path.resolve(helperJarPath,
-        'strings_from_apk.jar');
-    if (!this.args.appPackage) {
-      return cb(new Error("Parameter 'app-package' is required for launching application"));
-    }
-    var outputPath = path.resolve(getTempPath(), this.args.appPackage);
-    var makeStrings = ['java -jar "', stringsFromApkJarPath,
-                       '" "', this.args.app, '" "', outputPath, '"'].join('');
-    this.getDeviceLocale(function (err, locale) {
-      this.extractStrings(makeStrings, locale, function (err, stdout, stderr) {
-        if (err) {
-          // if we can't get strings, just dump an empty json and continue
-          logger.warn("Error getting strings.xml from apk");
-          logger.debug(stderr);
-          var remoteFile = path.resolve(remotePath, stringsJson);
-          return this.adb.shell("echo '{}' > " + remoteFile, cb);
-        }
-        var jsonFile = path.resolve(outputPath, stringsJson);
-        this.adb.push(jsonFile, remotePath, function (err) {
-          if (err) return cb(new Error("Could not push strings.json"));
-          cb();
-        });
-      }.bind(this));
+    this.extractLocalizedStrings(outputPath, function (err, stdout, stderr) {
+      if (err) {
+        // if we can't get strings, just dump an empty json and continue
+        logger.warn("Error getting strings.xml from apk");
+        logger.debug(stderr);
+        var remoteFile = path.resolve(remotePath, stringsJson);
+        return this.adb.shell("echo '{}' > " + remoteFile, cb);
+      }
+      var jsonFile = path.resolve(outputPath, stringsJson);
+      this.adb.push(jsonFile, remotePath, function (err) {
+        if (err) return cb(new Error("Could not push strings.json"));
+        cb();
+      });
     }.bind(this));
   }
-};
-
-Android.prototype.extractStrings = function (makeStrings, locale, cb) {
-  var makeStringsLocale = makeStrings;
-  if (locale !== null) makeStringsLocale = [makeStrings, locale].join(' ');
-  logger.debug(makeStringsLocale);
-
-  exec(makeStringsLocale, { maxBuffer: 524288 }, function (err, stdout, stderr) {
-    if (err && locale !== null) {
-      logger.info("No strings.xml for locale '" + locale + "', getting default strings.xml");
-      this.extractStrings(makeStrings, null, cb);
-    } else {
-      cb(err, stdout, stderr);
-    }
-  }.bind(this));
 };
 
 Android.prototype.pushAppium = function (cb) {

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -305,22 +305,38 @@ Android.prototype.pushStrings = function (cb) {
     var outputPath = path.resolve(getTempPath(), this.args.appPackage);
     var makeStrings = ['java -jar "', stringsFromApkJarPath,
                        '" "', this.args.app, '" "', outputPath, '"'].join('');
-    logger.debug(makeStrings);
-    exec(makeStrings, { maxBuffer: 524288 }, function (err, stdout, stderr) {
-      if (err) {
-        // if we can't get strings, just dump an empty json and continue
-        logger.warn("Error getting strings.xml from apk");
-        logger.debug(stderr);
-        var remoteFile = path.resolve(remotePath, stringsJson);
-        return this.adb.shell("echo '{}' > " + remoteFile, cb);
-      }
-      var jsonFile = path.resolve(outputPath, stringsJson);
-      this.adb.push(jsonFile, remotePath, function (err) {
-        if (err) return cb(new Error("Could not push strings.json"));
-        cb();
-      });
+    this.getDeviceLocale(function (err, locale) {
+      this.extractStrings(makeStrings, locale, function (err, stdout, stderr) {
+        if (err) {
+          // if we can't get strings, just dump an empty json and continue
+          logger.warn("Error getting strings.xml from apk");
+          logger.debug(stderr);
+          var remoteFile = path.resolve(remotePath, stringsJson);
+          return this.adb.shell("echo '{}' > " + remoteFile, cb);
+        }
+        var jsonFile = path.resolve(outputPath, stringsJson);
+        this.adb.push(jsonFile, remotePath, function (err) {
+          if (err) return cb(new Error("Could not push strings.json"));
+          cb();
+        });
+      }.bind(this));
     }.bind(this));
   }
+};
+
+Android.prototype.extractStrings = function (makeStrings, locale, cb) {
+  var makeStringsLocale = makeStrings;
+  if (locale !== null) makeStringsLocale = [makeStrings, locale].join(' ');
+  logger.debug(makeStringsLocale);
+
+  exec(makeStringsLocale, { maxBuffer: 524288 }, function (err, stdout, stderr) {
+    if (err && locale !== null) {
+      logger.info("No strings.xml for locale '" + locale + "', getting default strings.xml");
+      this.extractStrings(makeStrings, null, cb);
+    } else {
+      cb(err, stdout, stderr);
+    }
+  }.bind(this));
 };
 
 Android.prototype.pushAppium = function (cb) {

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -301,7 +301,7 @@ Android.prototype.pushStrings = function (cb) {
         // if we can't get strings, just dump an empty json and continue
         logger.warn("Error getting strings.xml from apk");
         logger.debug(stderr);
-        var remoteFile = path.resolve(remotePath, stringsJson);
+        var remoteFile = remotePath + '/' + stringsJson;
         return this.adb.shell("echo '{}' > " + remoteFile, cb);
       }
       var jsonFile = path.resolve(outputPath, stringsJson);

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -50,6 +50,7 @@ Selendroid.prototype.init = function () {
     , 'toggleFlightMode'
     , 'toggleWiFi'
     , 'toggleLocationServices'
+    , 'getStrings'
   ];
   this.proxyHost = 'localhost';
   this.avoidProxy = [
@@ -128,6 +129,7 @@ Selendroid.prototype.start = function (cb) {
     conditionalInsertManifest,
     this.checkSelendroidCerts.bind(this),
     conditionalInstallSelendroid,
+    this.extractStrings.bind(this),
     this.uninstallApp.bind(this),
     this.installApp.bind(this),
     this.forwardPort.bind(this),
@@ -367,6 +369,36 @@ Selendroid.prototype.translatePath = function (req) {
     path = path.replace("context", "window");
   }
   req.originalUrl = path;
+};
+
+Selendroid.prototype.extractStrings = function (cb) {
+  var outputPath = path.resolve(getTempPath(), this.args.appPackage);
+  var stringsJson = 'strings.json';
+  if (!fs.existsSync(this.args.app)) {
+    // apk doesn't exist locally
+    logger.debug("Apk doesn't exist");
+    return cb();
+  } else {
+    this.extractLocalizedStrings(outputPath, function (err, stdout, stderr) {
+      if (err) {
+        // if we can't get strings, log error and continue
+        logger.warn("Error getting strings.xml from apk");
+        logger.debug(stderr);
+        this.apkStrings = {};
+        return cb();
+      }
+      var file = fs.readFileSync(path.join(outputPath, stringsJson), 'utf8');
+      this.apkStrings = JSON.parse(file);
+      cb();
+    }.bind(this));
+  }
+};
+
+Selendroid.prototype.getStrings = function (cb) {
+  return cb(null, {
+    status: status.codes.Success.code,
+    value: this.apkStrings
+  });
 };
 
 module.exports = Selendroid;

--- a/test/functional/selendroid/basic-specs.js
+++ b/test/functional/selendroid/basic-specs.js
@@ -55,6 +55,12 @@ describe('selendroid - basic -', function () {
         .nodeify(done);
     });
 
+    it('should be able to get strings', function (done) {
+      driver
+        .execute("mobile: getStrings")
+        .nodeify(done);
+    });
+
     it('should error out nicely with incompatible commands', function (done) {
       driver
         .execute("mobile: flick", [{}])


### PR DESCRIPTION
- (android) Extract strings from apk corresponding to device locale instead of extract the default strings.
  Strings are used with android device in 'mobile: getStrings' and finding elements using ID location strategy.
- (selendroid) Extract strings from apk in selendroid to allow 'mobile: getStrings'.
