### PR TITLE
ApkSigning when using custome keystore fails

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -406,12 +406,13 @@ ADB.prototype.signWithCustomCert = function (apk, cb) {
     return cb(new Error("Keystore doesn't exist. " + this.keystorePath));
   }
 
-  var sign = [jarsigner, '"' + apk + '"',
+  var sign = [jarsigner,
       '-sigalg MD5withRSA',
       '-digestalg SHA1',
       '-keystore "' + this.keystorePath + '"',
       '-storepass "' + this.keystorePassword + '"',
       '-keypass "' + this.keyPassword + '"',
+      '"' + apk + '"',
       '"' + this.keyAlias + '"'].join(' ');
   logger.debug("Unsigning apk with: " + unsign);
   exec(unsign, { maxBuffer: 524288 }, function (err, stdout, stderr) {


### PR DESCRIPTION
ApkSigning fails when using a custom keystore. Looking into the logs I realized that the options to the jarsigner command are not in the right order. Once I made this change the signing went ahead as expected.
