### PR TITLE
Allow android multi touch actions without an element

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -1004,18 +1004,26 @@ androidController.tap = function (elementId, x, y, count, cb) {
     this.proxy(opts, loop);
   }.bind(this);
 
-  if (x !== 0 || y !== 0) {
-    this.proxy(["element:getLocation", {elementId: elementId}], function (err, res) {
-      if (err) return cb(err);
-      var value = res.value;
-      x += parseInt(value.x);
-      y += parseInt(value.y);
+  if (elementId) {
+    // we are either tapping on the default location of the element
+    // or an offset from the top left corner
+    if (x !== 0 || y !== 0) {
+      this.proxy(["element:getLocation", {elementId: elementId}], function (err, res) {
+        if (err) return cb(err);
+        var value = res.value;
+        x += parseInt(value.x);
+        y += parseInt(value.y);
 
-      opts = ["click", {x: x, y: y}];
+        opts = ["click", {x: x, y: y}];
+        loop();
+      }.bind(this));
+    } else {
+      opts = ["element:click", {elementId: elementId}];
       loop();
-    }.bind(this));
+    }
   } else {
-    opts = ["element:click", {elementId: elementId}];
+    // we have absolute coordinates
+    opts = ["click", {x: x, y: y}];
     loop();
   }
 };
@@ -1156,6 +1164,7 @@ androidController.parseTouch = function (gestures, cb) {
           x: (gesture.options.x || 0),
           y: (gesture.options.y || 0)
         };
+
         touchStateObject = {
           timeOffset: 0.005,
           touch: tapPoint
@@ -1221,11 +1230,19 @@ androidController.performMultiAction = function (elementId, actions, cb) {
   }.bind(this), function (err) {
     if (err) return cb(err);
 
-    var opts = {
-      elementId: elementId,
-      actions: states
-    };
-    return this.proxy(["element:performMultiPointerGesture", opts], cb);
+    var opts;
+    if (elementId) {
+      opts = {
+        elementId: elementId,
+        actions: states
+      };
+      return this.proxy(["element:performMultiPointerGesture", opts], cb);
+    } else {
+      opts = {
+        actions: states
+      };
+      return this.proxy(["performMultiPointerGesture", opts], cb);
+    }
   }.bind(this));
 };
 

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchEvent.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchEvent.java
@@ -23,18 +23,9 @@ import com.android.uiautomator.core.UiObjectNotFoundException;
 /**
  * This handler is and abstract class that contains all the common code for
  * touch event handlers.
- * 
+ *
  */
-public abstract class TouchEvent extends CommandHandler {
-  private static Field enableField(final Class<?> clazz, final String field)
-      throws SecurityException, NoSuchFieldException {
-    Logger.debug("Updating class \"" + clazz + "\" to enable field \"" + field
-        + "\"");
-    final Field fieldObject = clazz.getDeclaredField(field);
-    fieldObject.setAccessible(true);
-    return fieldObject;
-  }
-
+public abstract class TouchEvent extends TouchableEvent {
   protected AndroidElement            el;
 
   protected int                       clickX;
@@ -46,7 +37,7 @@ public abstract class TouchEvent extends CommandHandler {
   protected boolean                   isElement;
 
   /**
-   * 
+   *
    * @param command
    *          The {@link AndroidCommand}
    * @return {@link AndroidCommandResult}
@@ -112,32 +103,6 @@ public abstract class TouchEvent extends CommandHandler {
 
   protected abstract boolean executeTouchEvent()
       throws UiObjectNotFoundException;
-
-  /*
-   * getAutomatorBridge is private so we access the bridge via reflection to use
-   * the touchDown / touchUp / touchMove methods.
-   */
-  protected Object getController() throws IllegalArgumentException,
-      IllegalAccessException, SecurityException, NoSuchFieldException {
-    final UiDevice device = UiDevice.getInstance();
-    final Object bridge = enableField(device.getClass(), "mUiAutomationBridge")
-        .get(device);
-    final Object controller = enableField(bridge.getClass().getSuperclass(),
-        "mInteractionController").get(bridge);
-    return controller;
-
-  }
-
-  protected Method getMethod(final String name, final Object controller)
-      throws NoSuchMethodException, SecurityException {
-    final Class<?> controllerClass = controller.getClass();
-
-    Logger.debug("Finding methods on class: " + controllerClass);
-    final Method method = controllerClass.getDeclaredMethod(name, int.class,
-        int.class);
-    method.setAccessible(true);
-    return method;
-  }
 
   /**
    * Variables persist across executions. initialize must be called at the start

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchableEvent.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchableEvent.java
@@ -1,0 +1,59 @@
+package io.appium.android.bootstrap.handler;
+
+import io.appium.android.bootstrap.CommandHandler;
+import io.appium.android.bootstrap.Logger;
+
+import android.view.MotionEvent.PointerCoords;
+
+import com.android.uiautomator.core.UiDevice;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+/**
+ * This handler is and abstract class that contains all the common code for
+ * touch event handlers.
+ *
+ */
+public abstract class TouchableEvent extends CommandHandler {
+  private static Field enableField(final Class<?> clazz, final String field)
+      throws SecurityException, NoSuchFieldException {
+    Logger.debug("Updating class \"" + clazz + "\" to enable field \"" + field
+        + "\"");
+    final Field fieldObject = clazz.getDeclaredField(field);
+    fieldObject.setAccessible(true);
+    return fieldObject;
+  }
+
+  /*
+   * getAutomatorBridge is private so we access the bridge via reflection to use
+   * the touchDown / touchUp / touchMove methods.
+   */
+  protected Object getController() throws IllegalArgumentException,
+      IllegalAccessException, SecurityException, NoSuchFieldException {
+    final UiDevice device = UiDevice.getInstance();
+    final Object bridge = enableField(device.getClass(), "mUiAutomationBridge")
+        .get(device);
+    final Object controller = enableField(bridge.getClass().getSuperclass(),
+        "mInteractionController").get(bridge);
+    return controller;
+
+  }
+
+  protected Method getMethod(final String name, final Object controller)
+      throws NoSuchMethodException, SecurityException {
+    final Class<?> controllerClass = controller.getClass();
+
+    Logger.debug("Finding methods on class: " + controllerClass);
+    final Method method;
+    if (name.equals("performMultiPointerGesture")) {
+      // multi pointer gestures take a 2d array of coordinates
+      method = controllerClass.getDeclaredMethod(name, PointerCoords[][].class);
+    } else {
+      // all the other touch events send two ints
+      method = controllerClass.getDeclaredMethod(name, int.class, int.class);
+    }
+    method.setAccessible(true);
+    return method;
+  }
+}

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -266,6 +266,21 @@ exports.performTouch = function (req, res) {
     gestures = gestures.actions;
   }
 
+  // press-wait-moveTo-release is `swipe`, so use native method
+  if (gestures.length === 4) {
+    if ((gestures[0].action === 'press') && (gestures[1].action === 'wait') && (gestures[2].action === 'moveTo') && (gestures[3].action === 'release')) {
+      var body = {
+        startX: gestures[0].options.x,
+        startY: gestures[0].options.y,
+        endX: gestures[2].options.x,
+        endY: gestures[2].options.y,
+        duration: gestures[1].options.ms
+      };
+      req.body = body;
+      return exports.mobileSwipe(req, res);
+    }
+  }
+
   req.device.performTouch(gestures, getResponseHandler(req, res));
 };
 


### PR DESCRIPTION
The multi action spec does all of its actions on elements. But there is no real reason for doing it that way. Both the Android and iOS methods work on absolute coordinates, so the element is essentially ignored.

This adds elementless access to multi-actions in Android. iOS works as is.

The second commit adds a decoding of `press`-`wait`-`moveTo`-`release` action sequence into a `swipe`. Without this it is not possible to reliably use `duration` of swipe actions.
