### PR TITLE
Set log level to 'debug' for logging to file.

### DIFF
--- a/lib/server/logger.js
+++ b/lib/server/logger.js
@@ -26,13 +26,13 @@ module.exports.init = function (args) {
   , handleExceptions: true
   , exitOnError: false
   , json: false
+  , level: 'debug'
   });
 
   var winstonOptions = {
     console:
       _.extend({
         colorize: !args.logNoColors
-      , level: 'debug'
       }, options)
     };
 


### PR DESCRIPTION
Sorry, I broke this in https://github.com/appium/appium/pull/2295. I thought 'debug' means _only_ debug messages.
