### PR TITLE
Allow for different inputs to find method

### DIFF
--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -260,9 +260,8 @@ exports.performTouch = function (req, res) {
 
   // some clients, like Python, send an object in which there is an `actions`
   // property that is the array of actions
-  // if this is not an array (having a `shift` method) try to get the
-  // actions from there
-  if (typeof gestures.shift !== 'function') {
+  // get the gestures from there if we don't already have an array
+  if (gestures && !Array.isArray(gestures)) {
     gestures = gestures.actions;
   }
 
@@ -429,8 +428,16 @@ exports.mobileSource = function (req, res) {
 
 exports.find = function (req, res) {
   var strategy = "dynamic"
-    , selector = req.body
-    , all = selector && selector[0] && typeof selector[0] === "string" && selector[0].toLowerCase() === "all";
+    , selector = req.body;
+
+  // some clients send the selector as the `selector` property of an object,
+  // rather than the whole body.
+  // selector ought to be an array
+  if (selector && !Array.isArray(selector)) {
+    selector = req.body.selector;
+  }
+
+  var all = selector && selector[0] && typeof selector[0] === "string" && selector[0].toLowerCase() === "all";
 
   if (all) {
     req.device.findElements(strategy, selector, getResponseHandler(req, res));


### PR DESCRIPTION
Some clients (e.g., wd, python) send the `selector` as a property of an object, rather than the entire body. Test for it and get the selectors in that case.
