### PR TITLE
Allow for whitespace in app path.

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -180,7 +180,7 @@ ADB.prototype.processFromManifest = function (localApk, cb) {
   this.checkAaptPresent(function (err) {
     if (err) return cb(err);
 
-    var extractProcess = [this.binaries.aapt, 'dump', 'xmltree', localApk, 'AndroidManifest.xml'].join(' ');
+    var extractProcess = [this.binaries.aapt, 'dump', 'xmltree', '"' + localApk + '"', 'AndroidManifest.xml'].join(' ');
     logger.debug("processFromManifest: " + extractProcess);
     exec(extractProcess, { maxBuffer: 524288 }, function (err, stdout, stderr) {
       if (err || stderr) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1275,7 +1275,7 @@ IOS.prototype.removeApp = function (bundleId, cb) {
 IOS.prototype.installApp = function (unzippedAppPath, cb) {
   if (this.args.udid) {
     var installQuietFlag = this.args.quiet ? ' -q' : '';
-    var installationCommand = fruitstrap + installQuietFlag + ' install --id ' + this.args.udid + ' --bundle ' + unzippedAppPath;
+    var installationCommand = fruitstrap + installQuietFlag + ' install --id ' + this.args.udid + ' --bundle "' + unzippedAppPath + '"';
     deviceCommon.installApp(installationCommand, this.args.udid, unzippedAppPath, cb);
   } else {
     cb(new Error("You can not call installApp for the iOS simulator!"));


### PR DESCRIPTION
Try running apps with whitespace in path on Android and iOS.
iOS: installApp() fails trying to install the app to the device using fruitstrap.
Android: processFromManifest() fails.

I tested running on device (iOS, Android), don't know if we need more fixes for running on the emulator or using the app bundle, etc.
