### PR TITLE
new command line option for specifying  Localizable.strings path

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -964,7 +964,7 @@ IOS.prototype.parseLocalizableStrings = function (cb) {
     var strings = path.resolve(this.args.app, "Localizable.strings");
 
     if (!fs.existsSync(strings)) {
-      strings = path.resolve(this.args.app, "en.lproj", "Localizable.strings");
+      strings = path.resolve(this.args.app, this.args.localizableStringsDir, "Localizable.strings");
     }
 
     bplistParse.parseFile(strings, function (err, obj) {

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -12,6 +12,14 @@ var args = [
   , nargs: 0
   }],
 
+  [['--localizable-strings-dir'], {
+    required: false
+  , dest: 'localizableStringsDir'
+  , defaultValue: 'en.lproj'
+  , help: 'IOS only: the relative path of the dir where Localizable.strings file resides '
+  , example: "en.lproj"
+  }],
+
   [['--app'], {
     required: false
   , defaultValue: null


### PR DESCRIPTION
Hi,
Some iOS apps do not use single Localizable.strings,but the strings are distributed in many files. 
In this case, one can collate all *.strings files into a single Localizable.strings file, which can be stored somewhere. 

This new command line option helps to specify the outside (full) path for such consolidated Localizable.strings.

Cheers,
Muthu
