### PR TITLE
Fix Appium crash when fails getting source page in Android

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -377,7 +377,8 @@ androidController.getPageSource = function (cb) {
 
     ],
     // Top level cb
-    function () {
+    function (err) {
+      if (err) return cb(err);
       var xml = fs.readFileSync(xmlFile, 'utf8');
       fs.unlinkSync(xmlFile);
       try {


### PR DESCRIPTION
If you use xpath to find an element and the app is still loading, the pull command fails, the error is not catched and Appium dies.

info: [BOOTSTRAP] [debug] Got command action: dumpWindowHierarchy
info: [BOOTSTRAP] [info] Returning result: {"value":true,"status":0}
debug: transferPageSourceXML command: "D:\android-sdk\platform-tools\adb.exe" -s emulator-5554 pull /data/local/tmp/dump.xml "C:\Users\username\AppData\Local\Temp\114322-11496-8ey6c4.xml"
warn: remote object '/data/local/tmp/dump.xml' does not exist
error: uncaughtException: ENOENT, no such file or directory 'C:\Users\username\AppData\Local\Temp\114322-11496-8ey6c4.xml' [...]
