### PR TITLE
Update adb.js - Fix issue when iterating the entries.

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -566,7 +566,7 @@ ADB.prototype.checkApkKeystoreMatch = function (keytool, md5re, keystoreHash,
     }
   };
 
-  for (var i = 0; i < entries.length; i++) {
+  while(entries.length > 0){
     if (responded) break;
     var entry = entries.pop(); // meta-inf tends to be at the end
     entry = entry.entryName;


### PR DESCRIPTION
Every time you call entries.pop(), the entries.length minus 1.
We should check entries.length>0 as the end of loop.
