### PR TITLE
Allow users to pass keystore parameters from Caps

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -77,6 +77,11 @@ androidCommon.setAndroidArgs = function () {
   this.setArgFromCap("androidDeviceReadyTimeout", "device-ready-timeout");
   this.setArgFromCap("androidCoverage", "androidCoverage");
   this.setArgFromCap("compressXml", "compressXml");
+  this.setArgFromCap("useKeystore", "use-keystore");
+  this.setArgFromCap("keystorePath", "keystore-path");
+  this.setArgFromCap("keystorePassword", "keystore-password");
+  this.setArgFromCap("keyAlias", "key-alias");
+  this.setArgFromCap("keyPassword", "key-password");
   this.args.systemPort = this.args.bootstrapPort;
   this.args.appPackage = this.args.androidPackage;
   this.args.appActivity = this.args.androidActivity;


### PR DESCRIPTION
the keystore parameters(useKeystore, keystorePath, keystorePassword, keyAlias, keyPassword) are set in args. This changes allows users to pass these parameters from Caps in the testing script.
