### PR TITLE
Support for CHROMIUM context for embedded Chromium.

### DIFF
--- a/docs/en/caps.md
+++ b/docs/en/caps.md
@@ -31,6 +31,7 @@
 |`androidCoverage`| Fully qualified instrumentation class. Passed to -w in adb shell am instrument -e coverage true -w | `com.my.Pkg/com.my.Pkg.instrumentation.MyInstrumentation`|
 |`enablePerformanceLogging`| (Chrome and webview only) Enable Chromedriver's performance logging (default `false`)| `true`, `false`|
 |`androidDeviceReadyTimeout`|Timeout in seconds used to wait for a device to become ready after booting|e.g., `30`|
+|`androidDeviceSocket`|Devtools socket name. Needed only when tested app is a Chromium embedding browser. The socket is open by the browser and Chromedriver connects to it as a devtools client.|e.g., `chrome_devtools_remote`|
 |`avd`| Name of avd to launch|e.g., `api19`|
 |`avdLaunchTimeout`| How long to wait in milliseconds for an avd to launch and connect to ADB (default `120000`)| `300000`|
 |`avdReadyTimeout`| How long to wait in milliseconds for an avd to finish its boot animations (default `120000`)| `300000`|
@@ -40,6 +41,8 @@
 |`keystorePassword`| Password for custom keystore|e.g., `foo`|
 |`keyAlias`| Alias for key |e.g., `androiddebugkey`|
 |`keyPassword`| Password for key |e.g., `foo`|
+|`chromedriverExecutable`| The absolute local path to webdriver executable (if Chromium embedder provides its own webdriver, it should be used instead of original chromedriver bundled with Appium) |`/abs/path/to/webdriver`|
+|`specialChromedriverSessionArgs`| Custom arguments passed directly to chromedriver in chromeOptions capability. Passed as object which properties depend on a specific webdriver. |e.g., `{'androidDeviceSocket': 'opera_beta_devtools_remote',}`|
 
 
 ### iOS Only

--- a/docs/en/server-args.md
+++ b/docs/en/server-args.md
@@ -61,6 +61,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`-rp`, `--robot-port`|-1|port for robot|`--robot-port 4242`|
 |`--selendroid-port`|8080|Local port used for communication with Selendroid|`--selendroid-port 8080`|
 |`--chromedriver-port`|9515|Port upon which ChromeDriver will run|`--chromedriver-port 9515`|
+|`--chromedriver-executable`|null|ChromeDriver executable full path||
 |`--use-keystore`|false|(Android-only) When set the keystore will be used to sign apks.||
 |`--keystore-path`|/Users/user/.android/debug.keystore|(Android-only) Path to keystore||
 |`--keystore-password`|android|(Android-only) Password to keystore||

--- a/lib/devices/android/android-context-controller.js
+++ b/lib/devices/android/android-context-controller.js
@@ -1,0 +1,95 @@
+"use strict";
+
+var _ = require('underscore')
+  , logger = require('../../server/logger.js').get('appium')
+  , jwpSuccess = require('../common.js').jwpSuccess
+  , status = require('../../server/status.js')
+  , NotYetImplementedError = require('../../server/errors.js').NotYetImplementedError
+  , warnDeprecated = require('../../helpers.js').logDeprecationWarning;
+
+var androidContextController = {};
+
+androidContextController.NATIVE_WIN = "NATIVE_APP";
+androidContextController.WEBVIEW_WIN = "WEBVIEW";
+androidContextController.WEBVIEW_BASE = androidContextController.WEBVIEW_WIN + "_";
+androidContextController.CHROMIUM_WIN = "CHROMIUM";
+
+androidContextController.defaultContext = function () {
+  return this.NATIVE_WIN;
+};
+
+androidContextController.leaveWebView = function (cb) {
+  warnDeprecated('function', 'leaveWebView', 'context(null)');
+  this.setWindow(this.defaultContext(), cb);
+};
+
+androidContextController.getCurrentContext = function (cb) {
+  var response = {
+    status: status.codes.Success.code
+  , value: this.curContext || null
+  };
+  cb(null, response);
+};
+
+androidContextController.getContexts = function (cb) {
+  this.listWebviews(function (err, webviews) {
+    if (err) return cb(err);
+    this.contexts = _.union([this.NATIVE_WIN], webviews);
+    logger.info("Available contexts: " + this.contexts);
+    cb(null, {
+      status: status.codes.Success.code
+    , value: this.contexts
+    });
+  }.bind(this));
+};
+
+androidContextController.isChromedriverContext = function (viewName) {
+  return viewName.indexOf(this.WEBVIEW_WIN) !== -1 || viewName === this.CHROMIUM_WIN;
+};
+
+androidContextController.setContext = function (name, cb) {
+  if (name === null) {
+    name = this.defaultContext();
+  } else if (name === this.WEBVIEW_WIN) {
+    name = this.WEBVIEW_BASE + "1";
+  }
+  this.getContexts(function () {
+    if (!_.contains(this.contexts, name)) {
+      return cb(null, {
+        status: status.codes.NoSuchContext.code
+      , value: "Context '" + name + "' does not exist"
+      });
+    }
+    if (name === this.curContext) {
+      return jwpSuccess(cb);
+    }
+    var next = function (err) {
+      if (err) return cb(err);
+      this.curContext = name;
+      jwpSuccess(cb);
+    }.bind(this);
+
+    // current ChromeDriver doesn't handle more than a single web view
+    if (this.isChromedriverContext(name)) {
+      this.startChromedriverProxy(next);
+    } else if (this.isChromedriverContext(this.curContext)) {
+      this.stopChromedriverProxy(next);
+    } else if (this.isProxy) { // e.g. WebView context handled in Selendroid
+      this.proxyTo('wd/hub/session/' + this.proxySessionId + '/context', 'POST', {name: name}, next);
+    }
+  }.bind(this));
+};
+
+androidContextController.getWindowHandle = function (cb) {
+  cb(new NotYetImplementedError(), null);
+};
+
+androidContextController.getWindowHandles = function (cb) {
+  cb(new NotYetImplementedError(), null);
+};
+
+androidContextController.setWindow = function (name, cb) {
+  cb(new NotYetImplementedError(), null);
+};
+
+module.exports = androidContextController;

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -5,7 +5,6 @@ var errors = require('../../server/errors.js')
   , logger = require('../../server/logger.js').get('appium')
   , deviceCommon = require('../common.js')
   , helpers = require('../../helpers.js')
-  , jwpSuccess = deviceCommon.jwpSuccess
   , status = require('../../server/status.js')
   , NotYetImplementedError = errors.NotYetImplementedError
   , exec = require('child_process').exec
@@ -16,13 +15,9 @@ var errors = require('../../server/errors.js')
   , path = require('path')
   , xpath = require("xpath")
   , XMLDom = require("xmldom")
-  , helpers = require('../../helpers.js')
-  , warnDeprecated = helpers.logDeprecationWarning;
+  , helpers = require('../../helpers.js');
 
 var androidController = {};
-var NATIVE_WIN = "NATIVE_APP";
-var WEBVIEW_WIN = "WEBVIEW";
-var WEBVIEW_BASE = WEBVIEW_WIN + "_";
 
 androidController.pressKeyCode = function (keycode, metastate, cb) {
   this.proxy(["pressKeyCode", {keycode: keycode, metastate: metastate}], cb);
@@ -33,12 +28,8 @@ androidController.longPressKeyCode = function (keycode, metastate, cb) {
 };
 
 androidController.keyevent = function (keycode, metastate, cb) {
-  warnDeprecated('function', 'keyevent', 'pressKeyCode');
+  helpers.logDeprecationWarning('function', 'keyevent', 'pressKeyCode');
   this.pressKeyCode(keycode, metastate, cb);
-};
-
-androidController.defaultContext = function () {
-  return NATIVE_WIN;
 };
 
 androidController.findElement = function (strategy, selector, cb) {
@@ -254,11 +245,6 @@ androidController.keys = function (elementId, keys, cb) {
 
 androidController.frame = function (frame, cb) {
   cb(new NotYetImplementedError(), null);
-};
-
-androidController.leaveWebView = function (cb) {
-  warnDeprecated('function', 'leaveWebView', 'context(null)');
-  this.setWindow(this.defaultContext(), cb);
 };
 
 androidController.implicitWait = function (ms, cb) {
@@ -700,72 +686,6 @@ androidController.url = function (url, cb) {
 };
 
 androidController.active = function (cb) {
-  cb(new NotYetImplementedError(), null);
-};
-
-androidController.getCurrentContext = function (cb) {
-  var response = {
-    status: status.codes.Success.code
-  , value: this.curContext || null
-  };
-  cb(null, response);
-};
-
-androidController.getContexts = function (cb) {
-  this.listWebviews(function (err, webviews) {
-    if (err) return cb(err);
-    this.contexts = [NATIVE_WIN];
-    _.each(webviews, function (view, idx) {
-      this.contexts.push(WEBVIEW_BASE + (idx + 1).toString());
-    }.bind(this));
-    logger.debug("Available contexts: " + this.contexts);
-    cb(null, {
-      status: status.codes.Success.code
-    , value: this.contexts
-    });
-  }.bind(this));
-};
-
-androidController.setContext = function (name, cb) {
-  if (name === null) {
-    name = this.defaultContext();
-  } else if (name === WEBVIEW_WIN) {
-    name = WEBVIEW_BASE + "1";
-  }
-  this.getContexts(function () {
-    if (!_.contains(this.contexts, name)) {
-      return cb(null, {
-        status: status.codes.NoSuchContext.code
-      , value: "Context '" + name + "' does not exist"
-      });
-    }
-    if (name === this.curContext) {
-      return jwpSuccess(cb);
-    }
-    var next = function (err) {
-      if (err) return cb(err);
-      this.curContext = name;
-      jwpSuccess(cb);
-    }.bind(this);
-
-    // current ChromeDriver doesn't handle more than a single web view
-    if (name.indexOf(WEBVIEW_WIN) !== -1) {
-      this.startChromedriverProxy(next);
-    } else {
-      this.stopChromedriverProxy(next);
-    }
-  }.bind(this));
-};
-
-androidController.getWindowHandle = function (cb) {
-  cb(new NotYetImplementedError(), null);
-};
-
-androidController.getWindowHandles = function (cb) {
-  cb(new NotYetImplementedError(), null);
-};
-
-androidController.setWindow = function (name, cb) {
   cb(new NotYetImplementedError(), null);
 };
 

--- a/lib/devices/android/android-hybrid.js
+++ b/lib/devices/android/android-hybrid.js
@@ -8,20 +8,55 @@ var logger = require('../../server/logger.js').get('appium')
 
 var androidHybrid = {};
 
+androidHybrid.chromedriver = null;
+
 androidHybrid.listWebviews = function (cb) {
   logger.debug("Getting a list of available webviews");
   var webviews = [];
+  var definedDeviceSocket = this.args.androidDeviceSocket;
+  var androidWebViewsCount = 0; // for android.webkit.WebView
   this.adb.shell("cat /proc/net/unix", function (err, out) {
     if (err) return cb(err);
     _.each(out.split("\n"), function (line) {
-      if (line.indexOf("@webview_devtools_remote_") !== -1) {
-        webviews.push(/webview_devtools_remote_.+/.exec(line)[0]);
+      line = line.trim();
+      if (definedDeviceSocket) {
+        // check if line ends with "@"+definedDeviceSocket
+        if (line.indexOf("@" + definedDeviceSocket) ===
+            line.length - definedDeviceSocket.length - 1) {
+          if (line.indexOf("webview_devtools_remote") !== -1) {
+            webviews.push(this.WEBVIEW_BASE + androidWebViewsCount.toString());
+            androidWebViewsCount++;
+          } else {
+            webviews.push(this.CHROMIUM_WIN);
+          }
+        }
+      } else if (line.indexOf("@webview_devtools_remote") !== -1) {
+        // for multiple webviews a list of 'WEBVIEW_<index>' will be returned
+        // where <index> is zero based (same is in selendroid)
+        webviews.push(this.WEBVIEW_BASE + androidWebViewsCount.toString());
+        androidWebViewsCount++;
       }
-    });
+    }.bind(this));
     webviews = _.uniq(webviews);
     logger.debug(JSON.stringify(webviews));
     cb(null, webviews);
-  });
+  }.bind(this));
+};
+
+var previousState = {};
+
+androidHybrid.rememberProxyState = function () {
+  previousState.proxyHost = this.proxyHost;
+  previousState.proxyPort = this.proxyPort;
+  previousState.proxySessionId = this.proxySessionId;
+  previousState.isProxy = this.isProxy;
+};
+
+androidHybrid.restoreProxyState = function () {
+  this.proxyHost = previousState.proxyHost;
+  this.proxyPort = previousState.proxyPort;
+  this.proxySessionId = previousState.proxySessionId;
+  this.isProxy = previousState.isProxy;
 };
 
 androidHybrid.startChromedriverProxy = function (cb) {
@@ -31,11 +66,13 @@ androidHybrid.startChromedriverProxy = function (cb) {
   }
   var chromeArgs = {
     port: this.args.chromeDriverPort
+  , executable: this.args.chromedriverExecutable
   , deviceId: this.adb.curDeviceId
   , enablePerformanceLogging: this.args.enablePerformanceLogging
   };
   this.chromedriver = new Chromedriver(chromeArgs,
       this.onChromedriverExit.bind(this));
+  this.rememberProxyState();
   this.proxyHost = this.chromedriver.proxyHost;
   this.proxyPort = this.chromedriver.proxyPort;
   this.isProxy = true;
@@ -45,6 +82,15 @@ androidHybrid.startChromedriverProxy = function (cb) {
       androidUseRunningApp: true
     }
   };
+  // For now the only known arg passed this way is androidDeviceSocked used by Operadriver (deriving from Chromedriver)
+  // We don't know how other Chromium embedders will call this argument so for now it's name needs to be configurable
+  // When Google adds the androidDeviceSocket argument to the original Chromedriver then we will be sure about it's name
+  // for all Chromium embedders (as their Webdrivers will derive from Chromedriver)
+  if (this.args.specialChromedriverSessionArgs) {
+    _.each(this.args.specialChromedriverSessionArgs, function (val, option) {
+      caps.chromeOptions[option] = val;
+    });
+  }
   this.chromedriver.createSession(caps, function (err, sessId) {
     if (err) return cb(err);
     logger.debug("Setting proxy session id to " + sessId);
@@ -69,10 +115,7 @@ androidHybrid.cleanupChromedriver = function (cb) {
     this.chromedriver.stop(function (err) {
       if (err) logger.warn("Error stopping chromedriver: " + err.message);
       this.chromedriver = null;
-      this.proxyHost = null;
-      this.proxyPort = null;
-      this.proxySessionId = null;
-      this.isProxy = false;
+      this.restoreProxyState();
       cb();
     }.bind(this));
   } else {

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -11,6 +11,7 @@ var errors = require('../../server/errors.js')
   , status = require("../../server/status.js")
   , async = require('async')
   , androidController = require('./android-controller.js')
+  , androidContextController = require('./android-context-controller.js')
   , androidCommon = require('./android-common.js')
   , androidHybrid = require('./android-hybrid.js')
   , UiAutomator = require('./uiautomator.js')
@@ -57,7 +58,6 @@ Android.prototype.init = function () {
   this.launchCb = function () {};
   this.uiautomatorExitCb = function () {};
   this.dataDir = null;
-  this.chromedriver = null;
   this.isProxy = false;
   this.proxyHost = null;
   this.proxyPort = null;
@@ -473,6 +473,7 @@ Android.prototype.waitForActivityToStop = function (cb) {
 Android.prototype.waitForCondition = deviceCommon.waitForCondition;
 
 _.extend(Android.prototype, androidController);
+_.extend(Android.prototype, androidContextController);
 _.extend(Android.prototype, androidCommon);
 _.extend(Android.prototype, androidHybrid);
 

--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -69,6 +69,7 @@ ChromeAndroid.prototype.start = function (cb, onDie) {
 ChromeAndroid.prototype.prepareChromedriver = function (cb) {
   var chromeArgs = {
     port: this.args.proxyPort
+  , executable: this.args.chromedriverExecutable
   , deviceId: this.adb.curDeviceId
   , enablePerformanceLogging: this.args.enablePerformanceLogging
   };

--- a/lib/devices/android/chromedriver.js
+++ b/lib/devices/android/chromedriver.js
@@ -22,19 +22,27 @@ var Chromedriver = function (args, onDie) {
   this.onDie = onDie;
   this.exitCb = null;
   this.shuttingDown = false;
+
+  this.initChromedriverPath(args);
+};
+
+Chromedriver.prototype.initChromedriverPath = function (args) {
+  if (args.executable) {
+    this.chromedriver = args.executable;
+  } else {
+    var executable = isWindows ? "chromedriver.exe" : "chromedriver";
+    var platform = "mac";
+    if (isWindows) {
+      platform = "windows";
+    } else if (isLinux) {
+      platform = "linux";
+    }
+    this.chromedriver = path.resolve(__dirname, "..", "..", "..", "build", "chromedriver", platform, executable);
+  }
 };
 
 Chromedriver.prototype.ensureChromedriverExists = function (cb) {
   logger.debug("Ensuring Chromedriver exists");
-  var executable = isWindows ? "chromedriver.exe" : "chromedriver";
-  var platform = "mac";
-  if (isWindows) {
-    platform = "windows";
-  } else if (isLinux) {
-    platform = "linux";
-  }
-  this.chromedriver = path.resolve(__dirname, "..", "..", "..", "build", "chromedriver", platform, executable);
-
   fs.exists(this.chromedriver, function (exists) {
     if (!exists) return cb(new Error("Could not find chromedriver. Need to run reset script?"));
     cb();
@@ -85,7 +93,7 @@ Chromedriver.prototype.start = function (cb) {
 
   this.proc.stdout.pipe(through(function (data) {
     logger.debug('[CHROMEDRIVER] ' + data.trim());
-    if (!alreadyReturned && data.indexOf('Starting ChromeDriver') === 0) {
+    if (!alreadyReturned && data.indexOf('Starting ') === 0) {
       this.chromedriverStarted = true;
       alreadyReturned = true;
       return cb();

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -6,12 +6,15 @@ var ADB = require('./adb.js')
   , _ = require('underscore')
   , deviceCommon = require('../common.js')
   , androidController = require('./android-controller.js')
+  , androidContextController = require('./android-context-controller.js')
   , proxyTo = deviceCommon.proxyTo
+  , doRequest = deviceCommon.doRequest
   , logger = require('../../server/logger.js').get('appium')
   , status = require("../../server/status.js")
   , fs = require('fs')
   , async = require('async')
   , androidCommon = require('./android-common.js')
+  , androidHybrid = require('./android-hybrid.js')
   , path = require('path');
 
 var Selendroid = function () {
@@ -22,11 +25,13 @@ _.extend(Selendroid.prototype, Device.prototype);
 Selendroid.prototype._deviceInit = Device.prototype.init;
 Selendroid.prototype.init = function () {
   this._deviceInit();
+  this.selendroidHost = 'localhost';
+  this.selendroidPort = 8080;
+  this.selendroidSessionId = null;
   this.appExt = ".apk";
-  this.args.devicePort = 8080;
+  this.args.devicePort = this.selendroidPort;
   this.serverApk = null;
   this.onStop = function () {};
-  this.selendroidSessionId = null;
   this.adb = null;
   this.isProxy = true;
   this.mobileMethodsSupported = [
@@ -49,13 +54,16 @@ Selendroid.prototype.init = function () {
     , 'toggleLocationServices'
     , 'getStrings'
   ];
-  this.proxyHost = 'localhost';
+  this.proxyHost = this.selendroidHost;
   this.avoidProxy = [
     ['GET', new RegExp('^/wd/hub/session/[^/]+/log/types$')]
     , ['POST', new RegExp('^/wd/hub/session/[^/]+/log')]
     , ['POST', new RegExp('^/wd/hub/session/[^/]+/location')]
     , ['POST', new RegExp('^/wd/hub/session/[^/]+/appium')]
     , ['GET', new RegExp('^/wd/hub/session/[^/]+/appium')]
+    , ['POST', new RegExp('^/wd/hub/session/[^/]+/context')]
+    , ['GET', new RegExp('^/wd/hub/session/[^/]+/context')]
+    , ['GET', new RegExp('^/wd/hub/session/[^/]+/contexts')]
   ];
 };
 
@@ -289,6 +297,7 @@ Selendroid.prototype.createSession = function (cb) {
     if (res.statusCode === 301 && body.sessionId) {
       logger.debug("Successfully started selendroid session");
       this.selendroidSessionId = body.sessionId;
+      this.proxySessionId = this.selendroidSessionId;
       this.adb.waitForActivity(this.args.appWaitPackage, this.args.appWaitActivity, 1800,
           function (err) {
         if (err) {
@@ -393,6 +402,36 @@ Selendroid.prototype.getStrings = function (language, cb) {
       value: this.apkStrings
     });
   }.bind(this), language);
+};
+
+
+_.extend(Selendroid.prototype, androidHybrid);
+_.extend(Selendroid.prototype, androidContextController);
+
+
+Selendroid.prototype.isChromedriverContext = function (windowName) {
+  return windowName === this.CHROMIUM_WIN;
+};
+
+Selendroid.prototype.getContexts = function (cb) {
+  var chromiumViews = [];
+  this.listWebviews(function (err, webviews) {
+    if (err) return cb(err);
+    if (_.contains(webviews, this.CHROMIUM_WIN)) {
+      chromiumViews = [this.CHROMIUM_WIN];
+    } else {
+      chromiumViews = [];
+    }
+
+    var selendroidViews = [];
+    var reqUrl = this.selendroidHost + ':' + this.selendroidPort + '/wd/hub/session/' + this.selendroidSessionId;
+    doRequest(reqUrl + '/window_handles', 'GET', {}, null, function (err, res) {
+      if (err) return cb(err);
+      selendroidViews = JSON.parse(res.body).value;
+      this.contexts = _.union(selendroidViews, chromiumViews);
+      cb(null, {sessionId: this.selendroidSessionId, status: status.codes.Success.code, value: this.contexts});
+    }.bind(this));
+  }.bind(this));
 };
 
 module.exports = Selendroid;

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -8,8 +8,9 @@ var capsConversion = {
 };
 
 var okObjects = [
-  'proxy',
-  'launchTimeout'
+    'proxy'
+  , 'launchTimeout'
+  , 'specialChromedriverSessionArgs'
 ];
 
 var requiredCaps = [

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -434,6 +434,13 @@ var args = [
   , help: 'Port upon which ChromeDriver will run'
   }],
 
+  [['--chromedriver-executable'], {
+    defaultValue: null
+  , dest: 'chromedriverExecutable'
+  , required: false
+  , help: 'ChromeDriver executable full path'
+  }],
+
   [['--use-keystore'], {
     defaultValue: false
   , dest: 'useKeystore'


### PR DESCRIPTION
Enables switching between NATIVE_APP and CHROMIUM contexts. Works for both backends: UIAutomator and Selendroid. It's intended to work for any Chromium
embedding app under the following conditions:
- user has to make sure the devtools socket is open
- user may need to provide a webdriver working with his app (probably deriving from chromedriver)
- user needs to use some additional capabilities: 'android-device-socket', 'chromedriver-executable' (optional), 'special-chromedriver-session-args' (optional)
