### PR TITLE
Fix iOS context switch

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1349,46 +1349,52 @@ iOSController.setContext = function (name, cb, skipReadyCheck) {
     }
   } else {
     var idx = name.replace(WEBVIEW_BASE, '');
-    if (_.contains(this.contexts, idx)) {
-      var pageIdKey = parseInt(idx, 10);
-      var next = function () {
-        this.processingRemoteCmd = true;
-        if (this.args.udid === null) {
-          this.remote.selectPage(pageIdKey, function () {
-            this.curContext = idx;
-            cb(null, {
-              status: status.codes.Success.code
-            , value: ''
-            });
-            this.processingRemoteCmd = false;
-          }.bind(this), skipReadyCheck);
-        } else {
-          if (name === this.curContext) {
-            logger.info("Remote debugger is already connected to window [" + name + "]");
-            cb(null, {
-              status: status.codes.Success.code
-            , value: name
-            });
-          } else {
-            this.remote.disconnect(function () {
-              this.curContext = idx;
-              this.remote.connect(idx, function () {
-                cb(null, {
-                  status: status.codes.Success.code
-                , value: name
-                });
-              });
-            }.bind(this));
-          }
-        }
-      }.bind(this);
-      next();
-    } else {
-      cb(null, {
-        status: status.codes.NoSuchContext.code
-      , value: "Context '" + name + "' does not exist"
-      });
+    if (idx === WEBVIEW_WIN) {
+      // allow user to pass in "WEBVIEW" without an index
+      idx = '1';
     }
+    this.getContexts(function () {
+      if (_.contains(this.contexts, idx)) {
+        var pageIdKey = parseInt(idx, 10);
+        var next = function () {
+          this.processingRemoteCmd = true;
+          if (this.args.udid === null) {
+            this.remote.selectPage(pageIdKey, function () {
+              this.curContext = idx;
+              cb(null, {
+                status: status.codes.Success.code
+              , value: ''
+              });
+              this.processingRemoteCmd = false;
+            }.bind(this), skipReadyCheck);
+          } else {
+            if (name === this.curContext) {
+              logger.info("Remote debugger is already connected to window [" + name + "]");
+              cb(null, {
+                status: status.codes.Success.code
+              , value: name
+              });
+            } else {
+              this.remote.disconnect(function () {
+                this.curContext = idx;
+                this.remote.connect(idx, function () {
+                  cb(null, {
+                    status: status.codes.Success.code
+                  , value: name
+                  });
+                });
+              }.bind(this));
+            }
+          }
+        }.bind(this);
+        next();
+      } else {
+        cb(null, {
+          status: status.codes.NoSuchContext.code
+        , value: "Context '" + name + "' does not exist"
+        });
+      }
+    }.bind(this));
   }
 };
 

--- a/test/functional/ios/webview/webview-specs.js
+++ b/test/functional/ios/webview/webview-specs.js
@@ -41,6 +41,24 @@ describe('webview - webview -', function () {
       .should.eventually.equal("Google")
       .nodeify(done);
   });
+  it('setting context to \'WEBVIEW_1\' should work without first getting contexts', function (done) {
+    driver
+      .context("WEBVIEW_1")
+      .get("http://google.com")
+      .sleep(500)
+      .title()
+      .should.eventually.equal("Google")
+      .nodeify(done);
+  });
+  it('setting context to \'WEBVIEW\' should work', function (done) {
+    driver
+      .context("WEBVIEW")
+      .get("http://google.com")
+      .sleep(500)
+      .title()
+      .should.eventually.equal("Google")
+      .nodeify(done);
+  });
   it('setting context to \'null\' should work', function (done) {
     driver.contexts().then(function (ctxs) {
       ctxs.length.should.be.above(0);


### PR DESCRIPTION
Allow switching to a new context without first calling to see what contexts there are.
