### PR TITLE
Allow multiple calls to get contexts in iOS

### DIFF
--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -31,6 +31,10 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
   var onDone = function (res) {
     this.processingRemoteCmd = false;
     isDone = true;
+    if (Array.isArray(res) && res.length === 0) {
+      // we have no web frames, so disconnect from the remote debugger
+      this.stopRemote();
+    }
     cb(res);
   }.bind(this);
 

--- a/test/functional/ios/testapp/context-specs.js
+++ b/test/functional/ios/testapp/context-specs.js
@@ -1,0 +1,50 @@
+"use strict";
+
+var setup = require("../../common/setup-base"),
+    desired = require('./desired'),
+    unorm = require('unorm');
+
+describe('testapp - context methods', function () {
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('getting list multiple times should not crash appium', function (done) {
+    driver
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .nodeify(done);
+  });
+  it('setting context to \'null\' should work', function (done) {
+    driver.contexts().then(function (ctxs) {
+      ctxs.length.should.be.equal(1);
+      return ctxs[0];
+    }).then(function (ctx) {
+      return driver.context(ctx);
+    })
+    .context(null)
+    .nodeify(done);
+  });
+  it('setting context to \'NATIVE_APP\' should work', function (done) {
+    driver.contexts().then(function (ctxs) {
+      ctxs.length.should.be.above(0);
+      return ctxs[0];
+    }).then(function (ctx) {
+      return driver.context(ctx);
+    })
+    .context('NATIVE_APP')
+    .nodeify(done);
+  });
+
+  it('setting context to non-existent context should return \'NoSuchContext\' (status: 35)', function (done) {
+    driver
+      .context("WEBVIEW_42")
+      .should.be.rejectedWith(/status: 35/)
+      .nodeify(done);
+  });
+});

--- a/test/functional/ios/webview/webview-specs.js
+++ b/test/functional/ios/webview/webview-specs.js
@@ -24,6 +24,17 @@ describe('webview - webview -', function () {
       .contexts().should.eventually.have.length.above(0)
       .nodeify(done);
   });
+  it('getting list multiple times should not crash appium', function (done) {
+    driver
+      .contexts().should.eventually.have.length.above(1)
+      .contexts().should.eventually.have.length.above(1)
+      .contexts().should.eventually.have.length.above(1)
+      .contexts().should.eventually.have.length.above(1)
+      .contexts().should.eventually.have.length.above(1)
+      .contexts().should.eventually.have.length.above(1)
+      .contexts().should.eventually.have.length.above(1)
+      .nodeify(done);
+  });
   it('contexts should be strings', function (done) {
     driver.contexts().then(function (ctxs) {
       ctxs.length.should.be.above(0);


### PR DESCRIPTION
When there is no webview, close remote debugger. Otherwise subsequent calls hang.

Fixes issue #2442
