### PR TITLE
Separate android emulator specific calls into an interface. Added genymotion and ADK emulator implementation files.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,9 +28,6 @@
 [submodule "submodules/libimobiledevice-macosx"]
 	path = submodules/libimobiledevice-macosx
 	url = https://github.com/benvium/libimobiledevice-macosx.git
-[submodule "submodules/ForceQuitUnresponsiveApps"]
-	path = submodules/ForceQuitUnresponsiveApps
-	url = https://github.com/appium/ForceQuitUnresponsiveApps.git
 [submodule "submodules/appium-atoms"]
 	path = submodules/appium-atoms
 	url = https://github.com/appium/appium-atoms.git

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -324,8 +324,12 @@ androidCommon.prepareEmulator = function (cb) {
         logger.debug("Did not launch AVD because it was already running.");
         return cb();
       }
-      this.adb.launchAVD(this.args.avd, this.args.avdArgs, this.args.language, this.args.locale,
-        this.args.avdLaunchTimeout, this.args.avdReadyTimeout, cb);
+      // this will return a function pointer in launchAVD
+      this.adb.autoDetectEmulatorType(this.args.avd, function (err, model) {
+        if (err) return cb(err);
+        model.launchAVD(this.args.avd, this.args.avdArgs,
+          this.args.avdLaunchTimeout, this.args.avdReadyTimeout, cb);
+      }.bind(this));
     }.bind(this));
   } else if (typeof this.args.language === "string" || typeof this.args.locale === "string") {
     var adbCmd = "";
@@ -358,13 +362,31 @@ androidCommon.prepareActiveDevice = function (cb) {
                             "of connected devices"));
       }
       deviceId = this.adb.udid;
+      logger.info("Setting device id to " + deviceId);
+      this.adb.setDeviceId(deviceId);
+      cb();
     } else {
-      deviceId = devices[0].udid;
-      var emPort = this.adb.getPortFromEmulatorString(deviceId);
-      this.adb.setEmulatorPort(emPort);
+      deviceId = devices[0].udid; // first one is default
+      // need to find the active device if --avd is set
+      var getEmulatorId = function (deviceId) {
+        if (this.args.avd !== null) {
+          var avdName = this.args.avd.replace('@', '');
+          this.adb.getRunningAVD(avdName, function (err, emulator) {
+            if (!err && emulator !== null) {
+              deviceId = emulator.udid;
+            }
+            logger.info("Setting device id to " + deviceId);
+            this.adb.setDeviceId(deviceId);
+            cb();
+          }.bind(this));
+        } else {
+          logger.info("Setting device id to " + deviceId);
+          this.adb.setDeviceId(deviceId);
+          cb();
+        }
+      }.bind(this);
+      getEmulatorId(deviceId);
     }
-    this.adb.setDeviceId(deviceId);
-    cb();
   }.bind(this));
 };
 


### PR DESCRIPTION
Added genymotion.js and adk.js as the initial supported android emulators.  Emulators auto detect type of avds.  Moved adk specific code in adb.js to adk.js.
