### PR TITLE
Allow multiple calls to get contexts in iOS

### DIFF
--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -31,6 +31,10 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
   var onDone = function (res) {
     this.processingRemoteCmd = false;
     isDone = true;
+    if (Array.isArray(res) && res.length === 0) {
+      // we have no web frames, so disconnect from the remote debugger
+      this.stopRemote();
+    }
     cb(res);
   }.bind(this);
 

--- a/test/functional/ios/testapp/context-specs.js
+++ b/test/functional/ios/testapp/context-specs.js
@@ -1,0 +1,67 @@
+"use strict";
+
+var setup = require("../../common/setup-base"),
+    desired = require('./desired'),
+    unorm = require('unorm');
+
+describe('testapp - context methods', function () {
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('getting list multiple times should not crash appium', function (done) {
+    driver
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .contexts().should.eventually.have.length(1)
+      .nodeify(done);
+  });
+  it('setting context to \'null\' should work', function (done) {
+    driver.contexts().then(function (ctxs) {
+      ctxs.length.should.be.equal(1);
+      return ctxs[0];
+    }).then(function (ctx) {
+      return driver.context(ctx);
+    })
+    .context(null)
+    .nodeify(done);
+  });
+  it('setting context to \'NATIVE_APP\' should work', function (done) {
+    driver.contexts().then(function (ctxs) {
+      ctxs.length.should.be.above(0);
+      return ctxs[0];
+    }).then(function (ctx) {
+      return driver.context(ctx);
+    })
+    .context('NATIVE_APP')
+    .nodeify(done);
+  });
+
+  it('setting context to non-existent context should return \'NoSuchContext\' (status: 35)', function (done) {
+    driver
+      .context("WEBVIEW_42")
+      .should.be.rejectedWith(/status: 35/)
+      .nodeify(done);
+  });
+});
+
+describe('testapp - window methods', function () {
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('getting list multiple times should not crash appium', function (done) {
+    driver
+      .windowHandles().should.eventually.have.length(0)
+      .windowHandles().should.eventually.have.length(0)
+      .windowHandles().should.eventually.have.length(0)
+      .windowHandles().should.eventually.have.length(0)
+      .windowHandles().should.eventually.have.length(0)
+      .windowHandles().should.eventually.have.length(0)
+      .windowHandles().should.eventually.have.length(0)
+      .nodeify(done);
+  });
+});

--- a/test/functional/ios/webview/webview-specs.js
+++ b/test/functional/ios/webview/webview-specs.js
@@ -25,6 +25,17 @@ describe('webview - webview -', function () {
         .contexts().should.eventually.have.length.above(0)
         .nodeify(done);
     });
+    it('getting list multiple times should not crash appium', function (done) {
+      driver
+        .contexts().should.eventually.have.length.above(1)
+        .contexts().should.eventually.have.length.above(1)
+        .contexts().should.eventually.have.length.above(1)
+        .contexts().should.eventually.have.length.above(1)
+        .contexts().should.eventually.have.length.above(1)
+        .contexts().should.eventually.have.length.above(1)
+        .contexts().should.eventually.have.length.above(1)
+        .nodeify(done);
+    });
     it('contexts should be strings', function (done) {
       driver.contexts().then(function (ctxs) {
         ctxs.length.should.be.above(0);
@@ -46,7 +57,7 @@ describe('webview - webview -', function () {
       driver
         .context("WEBVIEW_1")
         .get("http://google.com")
-        .sleep(500)
+        .sleep(1000)
         .title()
         .should.eventually.equal("Google")
         .nodeify(done);
@@ -55,7 +66,7 @@ describe('webview - webview -', function () {
       driver
         .context("WEBVIEW")
         .get("http://google.com")
-        .sleep(500)
+        .sleep(1000)
         .title()
         .should.eventually.equal("Google")
         .nodeify(done);
@@ -99,7 +110,7 @@ describe('webview - webview -', function () {
         .context("NATIVE_APP")
         .context("WEBVIEW_1")
         .get("https://saucelabs.com/home")
-        .sleep(500)
+        .sleep(1000)
         .title()
         .should.eventually.equal("Sauce Labs: Selenium Testing, Mobile Testing, JS Unit Testing and More")
         .nodeify(done);
@@ -123,6 +134,17 @@ describe('webview - webview -', function () {
     });
     it('getting list twice should not crash appium', function (done) {
       driver
+        .windowHandles().should.eventually.have.length.above(0)
+        .windowHandles().should.eventually.have.length.above(0)
+        .nodeify(done);
+    });
+    it('getting list multiple times should not crash appium', function (done) {
+      driver
+        .windowHandles().should.eventually.have.length.above(0)
+        .windowHandles().should.eventually.have.length.above(0)
+        .windowHandles().should.eventually.have.length.above(0)
+        .windowHandles().should.eventually.have.length.above(0)
+        .windowHandles().should.eventually.have.length.above(0)
         .windowHandles().should.eventually.have.length.above(0)
         .windowHandles().should.eventually.have.length.above(0)
         .nodeify(done);


### PR DESCRIPTION
Fix problem with multiple calls to iOS `contexts` when there is no webview. Already in 1.0-beta.
