### PR TITLE
Fix iOS context switching

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1356,7 +1356,7 @@ iOSController.setContext = function (name, cb, skipReadyCheck) {
       // allow user to pass in "WEBVIEW" without an index
       idx = '1';
     }
-    this.getContexts(function () {
+    var pickContext = function () {
       if (_.contains(this.contexts, idx)) {
         var pageIdKey = parseInt(idx, 10);
         var next = function () {
@@ -1397,7 +1397,16 @@ iOSController.setContext = function (name, cb, skipReadyCheck) {
         , value: "Context '" + name + "' does not exist"
         });
       }
-    }.bind(this));
+    }.bind(this);
+
+    // only get contexts if they haven't already been gotten
+    if (typeof this.contexts === 'undefined') {
+      this.getContexts(function () {
+        pickContext();
+      }.bind(this));
+    } else {
+      pickContext();
+    }
   }
 };
 


### PR DESCRIPTION
Remote debugger hangs on selecting app multiple times in Safari mode, as it tries to if we call getContexts multiple times.
