### PR TITLE
Clean up

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -62,10 +62,6 @@ public class Find extends CommandHandler {
       throws JSONException {
     final Hashtable<String, Object> params = command.params();
 
-    if (((String) params.get("strategy")).equals("index paths")) {
-
-    }
-
     // only makes sense on a device
     final Strategy strategy;
     try {


### PR DESCRIPTION
findElementsByIndexPaths is called later so this if statement isn't required.
