### PR TITLE
Fix issue - failed to pass multi params in avdArgs 

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -756,7 +756,8 @@ ADB.prototype.launchAVD = function (avdName, avdArgs, avdLaunchTimeout,
     if (avdArgs === null) {
       avdArgs = [avdName];
     } else if (typeof avdArgs === "string") {
-      avdArgs = [avdName, avdArgs];
+      avdArgs = avdArgs.split(" ");
+      avdArgs.unshift(avdName);
     }
     var proc = spawn(emulatorBinaryPath.substr(1, emulatorBinaryPath.length - 2),
       avdArgs);


### PR DESCRIPTION
when passing multiple params in avdArgs, for instance, --avd-args="-port 5564", transfer the value string into array to avoid failures when spawning a new process
