### PR TITLE
Fix defaults for swipe duration

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -953,7 +953,10 @@ androidController.performTouch = function (gestures, cb) {
     var gesture = gestures.shift();
     if (typeof gesture === "undefined") return cb(null, res);
 
-    this.doTouchAction(gesture.action, gesture.options, cycleThroughGestures);
+    var action = gesture.action;
+    var options = gesture.options || {};
+
+    this.doTouchAction(action, options, cycleThroughGestures);
   }.bind(this);
   cycleThroughGestures();
 };

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -268,7 +268,16 @@ exports.performTouch = function (req, res) {
   if (gestures.length === 4) {
     if ((gestures[0].action === 'press') && (gestures[1].action === 'wait') && (gestures[2].action === 'moveTo') && (gestures[3].action === 'release')) {
       // the touch action api uses ms, we want seconds
-      var duration = gestures[1].options.ms / 1000;
+      // 0.8 is the default time for the operation
+      var duration = 0.8;
+      if (typeof gestures[1].options.ms !== 'undefined' && gestures[1].options.ms) {
+        duration = gestures[1].options.ms / 1000;
+        if (duration === 0) {
+          // set to a very low number, since they wanted it fast
+          // but below 0.1 becomes 0 steps, which causes errors
+          duration = 0.1;
+        }
+      }
       var body = {
         startX: gestures[0].options.x,
         startY: gestures[0].options.y,


### PR DESCRIPTION
Add a default duration for swipe action. If not given, `steps` becomes 0, which gets interpreted as "don't do anything", or sometimes "tap at origin". Neither is wanted. Deals with issue #2488.
