### PR TITLE
Fix iOS callback problem after finding an element by a wrong id

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -88,7 +88,7 @@ iOSController.findUIElementOrElements = function (strategy, selector, ctx, many,
   try {
     selector = this.getSelectorForStrategy(strategy, selector);
   } catch (e) {
-    cb(null, {
+    return cb(null, {
       status: status.codes.UnknownError.code
     , value: e
     });
@@ -230,7 +230,12 @@ iOSController.getSelectorForStrategy = function (strategy, selector) {
   var newSelector = selector;
   if (strategy === "id") {
     var strings = this.localizableStrings;
-    if (strings && strings.length >= 1) newSelector = strings[0][selector];
+    if (strings && strings.length >= 1) {
+      newSelector = strings[0][selector];
+      if (!newSelector) {
+        throw new TypeError("Id selector not found in Localizable.strings.");
+      }
+    }
   }
   if (strategy === 'class name') {
     if (selector.indexOf('UIA') !== 0) {

--- a/test/unit/ios-controller-specs.js
+++ b/test/unit/ios-controller-specs.js
@@ -69,6 +69,12 @@ describe('ios-controller', function () {
           var actual = controller.getSelectorForStrategy('id', 'someSelector');
           actual.should.equal('localSelector');
         });
+        it('returns an error when the selector isn\'t in localizableStrings', function () {
+          var msg = "Id selector not found in Localizable.strings.";
+          (function () {
+            controller.getSelectorForStrategy('id', 'notFoundSelector');
+          }).should.Throw(TypeError, msg);
+        });
       });
     });
   });


### PR DESCRIPTION
iOS tests hang after finding an element by id if the id selector is not in Localizable.strings
