### PR TITLE
Reset compressXml to false after each find by XPATH call.

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -46,6 +46,7 @@ public class Find extends CommandHandler {
   Dynamic                  dynamic          = new Dynamic();
   public static JSONObject apkStrings       = null;
   UiSelectorParser         uiSelectorParser = new UiSelectorParser();
+  public static boolean    compressed       = false;
 
   /*
    * @param command The {@link AndroidCommand} used for this handler.
@@ -66,6 +67,13 @@ public class Find extends CommandHandler {
     final Strategy strategy;
     try {
       strategy = Strategy.fromString((String) params.get("strategy"));
+      if (!compressed && strategy == Strategy.INDEX_PATHS) {
+        compressed = true;
+        setCompressed(true);
+      } else if (compressed && strategy != Strategy.INDEX_PATHS) {
+        compressed = false;
+        setCompressed(false);
+      }
     } catch (final InvalidStrategyException e) {
       return new AndroidCommandResult(WDStatus.UNKNOWN_COMMAND, e.getMessage());
     }
@@ -340,9 +348,6 @@ public class Find extends CommandHandler {
             e.getMessage());
       }
     }
-    // Reset the compression to false
-    DumpWindowHierarchy.setCompressed(false);
-    DumpWindowHierarchy.instance.execute(null);
     if (multiple) {
       return getSuccessResult(resArray);
     } else {
@@ -451,6 +456,12 @@ public class Find extends CommandHandler {
       }
     }
     return sel;
+  }
+
+  private void setCompressed(final boolean compressed) {
+    // Toggle compression
+    DumpWindowHierarchy.setCompressed(compressed);
+    DumpWindowHierarchy.instance.execute(null);
   }
 
   private UiSelector stringsXmlId(final boolean many, String text)

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -340,6 +340,9 @@ public class Find extends CommandHandler {
             e.getMessage());
       }
     }
+    // Reset the compression to false
+    DumpWindowHierarchy.setCompressed(false);
+    DumpWindowHierarchy.instance.execute(null);
     if (multiple) {
       return getSuccessResult(resArray);
     } else {


### PR DESCRIPTION
To work around bug #2517, we need to reset compressXml to False
and issue a dumpWindowHierarchy.
