### PR TITLE
Get localized strings in Android, Selendroid and iOS

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -6,6 +6,8 @@ var logger = require('../../server/logger.js').get('appium')
   , fs = require('fs')
   , path = require('path')
   , exec = require('child_process').exec
+  , helpers = require('../../helpers.js')
+  , getTempPath = helpers.getTempPath
   , helperJarPath = path.resolve(__dirname, 'helpers')
   , md5 = require('md5calculator')
   , async = require('async')
@@ -681,7 +683,7 @@ androidCommon.getDeviceLanguage = function (cb) {
   }.bind(this));
 };
 
-androidCommon.extractLocalizedStrings = function (outputPath, cb) {
+androidCommon.extractLocalizedStrings = function (language, outputPath, cb) {
   var stringsFromApkJarPath = path.resolve(helperJarPath,
       'strings_from_apk.jar');
   if (!this.args.appPackage) {
@@ -690,9 +692,14 @@ androidCommon.extractLocalizedStrings = function (outputPath, cb) {
   var makeStrings = ['java -jar "', stringsFromApkJarPath,
                      '" "', this.args.app, '" "', outputPath, '"'].join('');
 
-  this.getDeviceLanguage(function (err, language) {
+  if (language) {
     this.extractStringsFromApk(makeStrings, language, cb);
-  }.bind(this));
+  } else {
+    // If language is not setted, use device language
+    this.getDeviceLanguage(function (err, language) {
+      this.extractStringsFromApk(makeStrings, language, cb);
+    }.bind(this));
+  }
 };
 
 androidCommon.extractStringsFromApk = function (makeStrings, language, cb) {
@@ -707,6 +714,31 @@ androidCommon.extractStringsFromApk = function (makeStrings, language, cb) {
       cb(err, stdout, stderr);
     }
   }.bind(this));
+};
+
+androidCommon.extractStrings = function (cb, language) {
+  var outputPath = path.resolve(getTempPath(), this.args.appPackage);
+  var stringsJson = 'strings.json';
+  if (!fs.existsSync(this.args.app)) {
+    logger.debug("Apk doesn't exist locally");
+    this.apkStrings = {};
+    this.language = null;
+    return cb(new Error("Apk doesn't exist locally"));
+  } else {
+    this.extractLocalizedStrings(language, outputPath, function (err, stdout, stderr) {
+      if (err) {
+        logger.warn("Error getting strings.xml from apk");
+        logger.debug(stderr);
+        this.apkStrings = {};
+        this.language = null;
+        return cb(err);
+      }
+      var file = fs.readFileSync(path.join(outputPath, stringsJson), 'utf8');
+      this.apkStrings = JSON.parse(file);
+      this.language = language;
+      cb();
+    }.bind(this));
+  }
 };
 
 module.exports = androidCommon;

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -667,4 +667,16 @@ androidCommon.getCurrentActivity = function (cb) {
   });
 };
 
+androidCommon.getDeviceLanguage = function (cb) {
+  this.adb.shell("getprop persist.sys.language", function (err, stdout) {
+    if (err) {
+      logger.warn("Error getting device language: " + err);
+      cb(err, null);
+    } else {
+      logger.debug("Current device language: " + stdout.trim());
+      cb(null, stdout.trim());
+    }
+  }.bind(this));
+};
+
 module.exports = androidCommon;

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -695,7 +695,7 @@ androidCommon.extractLocalizedStrings = function (language, outputPath, cb) {
   if (language) {
     this.extractStringsFromApk(makeStrings, language, cb);
   } else {
-    // If language is not setted, use device language
+    // If language is not set, use device language
     this.getDeviceLanguage(function (err, language) {
       this.extractStringsFromApk(makeStrings, language, cb);
     }.bind(this));

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -5,6 +5,8 @@ var logger = require('../../server/logger.js').get('appium')
   , status = require("../../server/status.js")
   , fs = require('fs')
   , path = require('path')
+  , exec = require('child_process').exec
+  , helperJarPath = path.resolve(__dirname, 'helpers')
   , md5 = require('md5calculator')
   , async = require('async')
   , errors = require('../../server/errors.js')
@@ -675,6 +677,34 @@ androidCommon.getDeviceLanguage = function (cb) {
     } else {
       logger.debug("Current device language: " + stdout.trim());
       cb(null, stdout.trim());
+    }
+  }.bind(this));
+};
+
+androidCommon.extractLocalizedStrings = function (outputPath, cb) {
+  var stringsFromApkJarPath = path.resolve(helperJarPath,
+      'strings_from_apk.jar');
+  if (!this.args.appPackage) {
+    return cb(new Error("Parameter 'appPackage' is required for launching application"));
+  }
+  var makeStrings = ['java -jar "', stringsFromApkJarPath,
+                     '" "', this.args.app, '" "', outputPath, '"'].join('');
+
+  this.getDeviceLanguage(function (err, language) {
+    this.extractStringsFromApk(makeStrings, language, cb);
+  }.bind(this));
+};
+
+androidCommon.extractStringsFromApk = function (makeStrings, language, cb) {
+  var makeLanguageStrings = makeStrings;
+  if (language !== null) makeLanguageStrings = [makeStrings, language].join(' ');
+  logger.debug(makeLanguageStrings);
+  exec(makeLanguageStrings, { maxBuffer: 524288 }, function (err, stdout, stderr) {
+    if (err && language !== null) {
+      logger.info("No strings.xml for language '" + language + "', getting default strings.xml");
+      this.extractStringsFromApk(makeStrings, null, cb);
+    } else {
+      cb(err, stdout, stderr);
     }
   }.bind(this));
 };

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -185,10 +185,6 @@ androidController.touchMove = function (elementId, x, y, cb) {
   this.proxy(["element:touchMove", opts], cb);
 };
 
-androidController.getStrings = function (cb) {
-  this.proxy(["getStrings"], cb);
-};
-
 androidController.complexTap = function (tapCount, touchCount, duration, x, y, elementId, cb) {
   this.proxy(["click", {x: x, y: y}], cb);
 };

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -320,7 +320,8 @@ Android.prototype.getStrings = function (language, cb) {
 
   // Extract, push and return strings
   return this.pushStrings(function () {
-    this.proxy(["updateStrings", {}], function () {
+    this.proxy(["updateStrings", {}], function (err, res) {
+      if (err || res.status !== status.codes.Success.code) return cb(err, res);
       cb(null, {
         status: status.codes.Success.code,
         value: this.apkStrings

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var errors = require('../../server/errors.js')
-  , exec = require('child_process').exec
   , path = require('path')
   , fs = require('fs')
   , ADB = require('./adb.js')
@@ -12,7 +11,6 @@ var errors = require('../../server/errors.js')
   , logger = require('../../server/logger.js').get('appium')
   , deviceCommon = require('../common.js')
   , status = require("../../server/status.js")
-  , helperJarPath = path.resolve(__dirname, 'helpers')
   , async = require('async')
   , androidController = require('./android-controller.js')
   , androidCommon = require('./android-common.js')
@@ -286,6 +284,7 @@ Android.prototype.processFromManifest = function (cb) {
 };
 
 Android.prototype.pushStrings = function (cb) {
+  var outputPath = path.resolve(getTempPath(), this.args.appPackage);
   var remotePath = '/data/local/tmp';
   var stringsJson = 'strings.json';
   if (!fs.existsSync(this.args.app)) {
@@ -296,46 +295,21 @@ Android.prototype.pushStrings = function (cb) {
       cb();
     });
   } else {
-    var stringsFromApkJarPath = path.resolve(helperJarPath,
-        'strings_from_apk.jar');
-    if (!this.args.appPackage) {
-      return cb(new Error("Parameter 'appPackage' is required for launching application"));
-    }
-    var outputPath = path.resolve(getTempPath(), this.args.appPackage);
-    var makeStrings = ['java -jar "', stringsFromApkJarPath,
-                       '" "', this.args.app, '" "', outputPath, '"'].join('');
-    this.getDeviceLanguage(function (err, language) {
-      this.extractStrings(makeStrings, language, function (err, stdout, stderr) {
-        if (err) {
-          // if we can't get strings, just dump an empty json and continue
-          logger.warn("Error getting strings.xml from apk");
-          logger.debug(stderr);
-          var remoteFile = path.resolve(remotePath, stringsJson);
-          return this.adb.shell("echo '{}' > " + remoteFile, cb);
-        }
-        var jsonFile = path.resolve(outputPath, stringsJson);
-        this.adb.push(jsonFile, remotePath, function (err) {
-          if (err) return cb(new Error("Could not push strings.json"));
-          cb();
-        });
-      }.bind(this));
+    this.extractLocalizedStrings(outputPath, function (err, stdout, stderr) {
+      if (err) {
+        // if we can't get strings, just dump an empty json and continue
+        logger.warn("Error getting strings.xml from apk");
+        logger.debug(stderr);
+        var remoteFile = path.resolve(remotePath, stringsJson);
+        return this.adb.shell("echo '{}' > " + remoteFile, cb);
+      }
+      var jsonFile = path.resolve(outputPath, stringsJson);
+      this.adb.push(jsonFile, remotePath, function (err) {
+        if (err) return cb(new Error("Could not push strings.json"));
+        cb();
+      });
     }.bind(this));
   }
-};
-
-Android.prototype.extractStrings = function (makeStrings, language, cb) {
-  var makeStringsLanguage = makeStrings;
-  if (language !== null) makeStringsLanguage = [makeStrings, language].join(' ');
-  logger.debug(makeStringsLanguage);
-
-  exec(makeStringsLanguage, { maxBuffer: 524288 }, function (err, stdout, stderr) {
-    if (err && language !== null) {
-      logger.info("No strings.xml for language '" + language + "', getting default strings.xml");
-      this.extractStrings(makeStrings, null, cb);
-    } else {
-      cb(err, stdout, stderr);
-    }
-  }.bind(this));
 };
 
 Android.prototype.pushAppium = function (cb) {

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -300,7 +300,7 @@ Android.prototype.pushStrings = function (cb) {
         // if we can't get strings, just dump an empty json and continue
         logger.warn("Error getting strings.xml from apk");
         logger.debug(stderr);
-        var remoteFile = path.resolve(remotePath, stringsJson);
+        var remoteFile = remotePath + '/' + stringsJson;
         return this.adb.shell("echo '{}' > " + remoteFile, cb);
       }
       var jsonFile = path.resolve(outputPath, stringsJson);

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -283,33 +283,50 @@ Android.prototype.processFromManifest = function (cb) {
   }
 };
 
-Android.prototype.pushStrings = function (cb) {
+Android.prototype.pushStrings = function (cb, language) {
   var outputPath = path.resolve(getTempPath(), this.args.appPackage);
   var remotePath = '/data/local/tmp';
   var stringsJson = 'strings.json';
-  if (!fs.existsSync(this.args.app)) {
-    // apk doesn't exist locally so remove old strings.json
-    logger.debug("Apk doesn't exist. Removing old strings.json");
-    this.adb.rimraf(remotePath + '/' + stringsJson, function (err) {
-      if (err) return cb(new Error("Could not remove old strings"));
-      cb();
-    });
-  } else {
-    this.extractLocalizedStrings(outputPath, function (err, stdout, stderr) {
-      if (err) {
+  this.extractStrings(function (err) {
+    if (err) {
+      if (!fs.existsSync(this.args.app)) {
+        // apk doesn't exist locally so remove old strings.json
+        return this.adb.rimraf(remotePath + '/' + stringsJson, function (err) {
+          if (err) return cb(new Error("Could not remove old strings"));
+          cb();
+        });
+      } else {
         // if we can't get strings, just dump an empty json and continue
-        logger.warn("Error getting strings.xml from apk");
-        logger.debug(stderr);
         var remoteFile = remotePath + '/' + stringsJson;
         return this.adb.shell("echo '{}' > " + remoteFile, cb);
       }
-      var jsonFile = path.resolve(outputPath, stringsJson);
-      this.adb.push(jsonFile, remotePath, function (err) {
-        if (err) return cb(new Error("Could not push strings.json"));
-        cb();
+    }
+    var jsonFile = path.resolve(outputPath, stringsJson);
+    this.adb.push(jsonFile, remotePath, function (err) {
+      if (err) return cb(new Error("Could not push strings.json"));
+      cb();
+    });
+  }.bind(this), language);
+};
+
+Android.prototype.getStrings = function (language, cb) {
+  if (this.language && this.language === language) {
+    // Return last strings
+    return cb(null, {
+      status: status.codes.Success.code,
+      value: this.apkStrings
+    });
+  }
+
+  // Extract, push and return strings
+  return this.pushStrings(function () {
+    this.proxy(["updateStrings", {}], function () {
+      cb(null, {
+        status: status.codes.Success.code,
+        value: this.apkStrings
       });
     }.bind(this));
-  }
+  }.bind(this), language);
 };
 
 Android.prototype.pushAppium = function (cb) {

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -304,22 +304,38 @@ Android.prototype.pushStrings = function (cb) {
     var outputPath = path.resolve(getTempPath(), this.args.appPackage);
     var makeStrings = ['java -jar "', stringsFromApkJarPath,
                        '" "', this.args.app, '" "', outputPath, '"'].join('');
-    logger.debug(makeStrings);
-    exec(makeStrings, { maxBuffer: 524288 }, function (err, stdout, stderr) {
-      if (err) {
-        // if we can't get strings, just dump an empty json and continue
-        logger.warn("Error getting strings.xml from apk");
-        logger.debug(stderr);
-        var remoteFile = path.resolve(remotePath, stringsJson);
-        return this.adb.shell("echo '{}' > " + remoteFile, cb);
-      }
-      var jsonFile = path.resolve(outputPath, stringsJson);
-      this.adb.push(jsonFile, remotePath, function (err) {
-        if (err) return cb(new Error("Could not push strings.json"));
-        cb();
-      });
+    this.getDeviceLanguage(function (err, language) {
+      this.extractStrings(makeStrings, language, function (err, stdout, stderr) {
+        if (err) {
+          // if we can't get strings, just dump an empty json and continue
+          logger.warn("Error getting strings.xml from apk");
+          logger.debug(stderr);
+          var remoteFile = path.resolve(remotePath, stringsJson);
+          return this.adb.shell("echo '{}' > " + remoteFile, cb);
+        }
+        var jsonFile = path.resolve(outputPath, stringsJson);
+        this.adb.push(jsonFile, remotePath, function (err) {
+          if (err) return cb(new Error("Could not push strings.json"));
+          cb();
+        });
+      }.bind(this));
     }.bind(this));
   }
+};
+
+Android.prototype.extractStrings = function (makeStrings, language, cb) {
+  var makeStringsLanguage = makeStrings;
+  if (language !== null) makeStringsLanguage = [makeStrings, language].join(' ');
+  logger.debug(makeStringsLanguage);
+
+  exec(makeStringsLanguage, { maxBuffer: 524288 }, function (err, stdout, stderr) {
+    if (err && language !== null) {
+      logger.info("No strings.xml for language '" + language + "', getting default strings.xml");
+      this.extractStrings(makeStrings, null, cb);
+    } else {
+      cb(err, stdout, stderr);
+    }
+  }.bind(this));
 };
 
 Android.prototype.pushAppium = function (cb) {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidCommandExecutor.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidCommandExecutor.java
@@ -13,7 +13,6 @@ import io.appium.android.bootstrap.handler.GetDeviceSize;
 import io.appium.android.bootstrap.handler.GetLocation;
 import io.appium.android.bootstrap.handler.GetName;
 import io.appium.android.bootstrap.handler.GetSize;
-import io.appium.android.bootstrap.handler.GetStrings;
 import io.appium.android.bootstrap.handler.GetText;
 import io.appium.android.bootstrap.handler.MultiPointerGesture;
 import io.appium.android.bootstrap.handler.Orientation;
@@ -28,6 +27,7 @@ import io.appium.android.bootstrap.handler.TouchDown;
 import io.appium.android.bootstrap.handler.TouchLongClick;
 import io.appium.android.bootstrap.handler.TouchMove;
 import io.appium.android.bootstrap.handler.TouchUp;
+import io.appium.android.bootstrap.handler.UpdateStrings;
 import io.appium.android.bootstrap.handler.WaitForIdle;
 import io.appium.android.bootstrap.handler.Wake;
 
@@ -71,7 +71,7 @@ class AndroidCommandExecutor {
     map.put("dumpWindowHierarchy", new DumpWindowHierarchy());
     map.put("pressKeyCode", new PressKeyCode());
     map.put("takeScreenshot", new TakeScreenshot());
-    map.put("getStrings", new GetStrings());
+    map.put("updateStrings", new UpdateStrings());
     map.put("getDataDir", new GetDataDir());
     map.put("performMultiPointerGesture", new MultiPointerGesture());
   }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
@@ -3,7 +3,7 @@ package io.appium.android.bootstrap;
 import io.appium.android.bootstrap.exceptions.AndroidCommandException;
 import io.appium.android.bootstrap.exceptions.CommandTypeException;
 import io.appium.android.bootstrap.exceptions.SocketServerException;
-import io.appium.android.bootstrap.handler.Find;
+import io.appium.android.bootstrap.handler.UpdateStrings;
 import io.appium.android.bootstrap.utils.NotImportantViews;
 import io.appium.android.bootstrap.utils.TheWatchers;
 
@@ -114,7 +114,7 @@ class SocketServer {
    */
   public void listenForever() throws SocketServerException {
     Logger.info("Appium Socket Server Ready");
-    Find.loadStringsJson();
+    UpdateStrings.loadStringsJson();
     dismissCrashAlerts();
     final TimerTask updateWatchers = new TimerTask() {
       @Override

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
@@ -8,9 +8,6 @@ import io.appium.android.bootstrap.utils.NotImportantViews;
 import io.appium.android.bootstrap.utils.TheWatchers;
 
 import java.io.BufferedReader;
-import java.io.DataInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
@@ -117,7 +114,7 @@ class SocketServer {
    */
   public void listenForever() throws SocketServerException {
     Logger.info("Appium Socket Server Ready");
-    loadStringsJson();
+    Find.loadStringsJson();
     dismissCrashAlerts();
     final TimerTask updateWatchers = new TimerTask() {
       @Override
@@ -153,29 +150,6 @@ class SocketServer {
       Logger.info("Registered crash watchers.");
     } catch (Exception e) {
       Logger.info("Unable to register crash watchers.");
-    }
-  }
-
-  public void loadStringsJson() {
-    Logger.info("Loading json...");
-    try {
-      final File jsonFile = new File("/data/local/tmp/strings.json");
-      // json will not exist for apks that are only on device
-      // because the node server can't extract the json from the apk.
-      if (!jsonFile.exists()) {
-        return;
-      }
-      final DataInputStream dataInput = new DataInputStream(
-          new FileInputStream(jsonFile));
-      final byte[] jsonBytes = new byte[(int) jsonFile.length()];
-      dataInput.readFully(jsonBytes);
-      // this closes FileInputStream
-      dataInput.close();
-      final String jsonString = new String(jsonBytes, "UTF-8");
-      Find.apkStrings = new JSONObject(jsonString);
-      Logger.info("json loading complete.");
-    } catch (final Exception e) {
-      e.printStackTrace();
     }
   }
 

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -17,6 +17,10 @@ import io.appium.android.bootstrap.exceptions.UnallowedTagNameException;
 import io.appium.android.bootstrap.selector.Strategy;
 import io.appium.android.bootstrap.utils.UiSelectorParser;
 
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Hashtable;
@@ -468,5 +472,28 @@ public class Find extends CommandHandler {
       }
     }
     return sel;
+  }
+
+  public static void loadStringsJson() {
+    Logger.info("Loading json...");
+    try {
+      final File jsonFile = new File("/data/local/tmp/strings.json");
+      // json will not exist for apks that are only on device
+      // because the node server can't extract the json from the apk.
+      if (!jsonFile.exists()) {
+        return;
+      }
+      final DataInputStream dataInput = new DataInputStream(
+          new FileInputStream(jsonFile));
+      final byte[] jsonBytes = new byte[(int) jsonFile.length()];
+      dataInput.readFully(jsonBytes);
+      // this closes FileInputStream
+      dataInput.close();
+      final String jsonString = new String(jsonBytes, "UTF-8");
+      Find.apkStrings = new JSONObject(jsonString);
+      Logger.info("json loading complete.");
+    } catch (final Exception e) {
+      e.printStackTrace();
+    }
   }
 }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -17,10 +17,6 @@ import io.appium.android.bootstrap.exceptions.UnallowedTagNameException;
 import io.appium.android.bootstrap.selector.Strategy;
 import io.appium.android.bootstrap.utils.UiSelectorParser;
 
-import java.io.DataInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Hashtable;
@@ -472,28 +468,5 @@ public class Find extends CommandHandler {
       }
     }
     return sel;
-  }
-
-  public static void loadStringsJson() {
-    Logger.info("Loading json...");
-    try {
-      final File jsonFile = new File("/data/local/tmp/strings.json");
-      // json will not exist for apks that are only on device
-      // because the node server can't extract the json from the apk.
-      if (!jsonFile.exists()) {
-        return;
-      }
-      final DataInputStream dataInput = new DataInputStream(
-          new FileInputStream(jsonFile));
-      final byte[] jsonBytes = new byte[(int) jsonFile.length()];
-      dataInput.readFully(jsonBytes);
-      // this closes FileInputStream
-      dataInput.close();
-      final String jsonString = new String(jsonBytes, "UTF-8");
-      Find.apkStrings = new JSONObject(jsonString);
-      Logger.info("json loading complete.");
-    } catch (final Exception e) {
-      e.printStackTrace();
-    }
   }
 }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/UpdateStrings.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/UpdateStrings.java
@@ -3,25 +3,25 @@ package io.appium.android.bootstrap.handler;
 import io.appium.android.bootstrap.AndroidCommand;
 import io.appium.android.bootstrap.AndroidCommandResult;
 import io.appium.android.bootstrap.CommandHandler;
+import io.appium.android.bootstrap.handler.Find;
 
 /**
- * This handler is used to get the apk strings.
- * 
+ * This handler is used to update the apk strings.
+ *
  */
-public class GetStrings extends CommandHandler {
+public class UpdateStrings extends CommandHandler {
 
   /*
    * @param command The {@link AndroidCommand} used for this handler.
-   * 
+   *
    * @return {@link AndroidCommandResult}
-   * 
-   * @throws JSONException
-   * 
+   *
    * @see io.appium.android.bootstrap.CommandHandler#execute(io.appium.android.
    * bootstrap.AndroidCommand)
    */
   @Override
   public AndroidCommandResult execute(final AndroidCommand command) {
-    return getSuccessResult(Find.apkStrings);
+    Find.loadStringsJson();
+    return getSuccessResult(true);
   }
 }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/UpdateStrings.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/UpdateStrings.java
@@ -4,6 +4,13 @@ import io.appium.android.bootstrap.AndroidCommand;
 import io.appium.android.bootstrap.AndroidCommandResult;
 import io.appium.android.bootstrap.CommandHandler;
 import io.appium.android.bootstrap.handler.Find;
+import io.appium.android.bootstrap.Logger;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+
+import org.json.JSONObject;
 
 /**
  * This handler is used to update the apk strings.
@@ -21,7 +28,35 @@ public class UpdateStrings extends CommandHandler {
    */
   @Override
   public AndroidCommandResult execute(final AndroidCommand command) {
-    Find.loadStringsJson();
+    if (!loadStringsJson()) {
+      return getErrorResult("Unable to load json file and update strings.");
+    }
     return getSuccessResult(true);
+  }
+
+  public static boolean loadStringsJson() {
+    Logger.info("Loading json...");
+    try {
+      String filePath = "/data/local/tmp/strings.json";
+      final File jsonFile = new File(filePath);
+      // json will not exist for apks that are only on device
+      // because the node server can't extract the json from the apk.
+      if (!jsonFile.exists()) {
+        return false;
+      }
+      final DataInputStream dataInput = new DataInputStream(
+          new FileInputStream(jsonFile));
+      final byte[] jsonBytes = new byte[(int) jsonFile.length()];
+      dataInput.readFully(jsonBytes);
+      // this closes FileInputStream
+      dataInput.close();
+      final String jsonString = new String(jsonBytes, "UTF-8");
+      Find.apkStrings = new JSONObject(jsonString);
+      Logger.info("json loading complete.");
+    } catch (final Exception e) {
+      Logger.error("Error loading json: " + e.getMessage());
+      return false;
+    }
+    return true;
   }
 }

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -130,7 +130,7 @@ Selendroid.prototype.start = function (cb) {
     conditionalInsertManifest,
     this.checkSelendroidCerts.bind(this),
     conditionalInstallSelendroid,
-    this.extractStrings.bind(this),
+    this.extractStringsSelendroid.bind(this),
     this.uninstallApp.bind(this),
     this.installApp.bind(this),
     this.forwardPort.bind(this),
@@ -372,34 +372,28 @@ Selendroid.prototype.translatePath = function (req) {
   req.originalUrl = path;
 };
 
-Selendroid.prototype.extractStrings = function (cb) {
-  var outputPath = path.resolve(getTempPath(), this.args.appPackage);
-  var stringsJson = 'strings.json';
-  if (!fs.existsSync(this.args.app)) {
-    // apk doesn't exist locally
-    logger.debug("Apk doesn't exist");
-    return cb();
-  } else {
-    this.extractLocalizedStrings(outputPath, function (err, stdout, stderr) {
-      if (err) {
-        // if we can't get strings, log error and continue
-        logger.warn("Error getting strings.xml from apk");
-        logger.debug(stderr);
-        this.apkStrings = {};
-        return cb();
-      }
-      var file = fs.readFileSync(path.join(outputPath, stringsJson), 'utf8');
-      this.apkStrings = JSON.parse(file);
-      cb();
-    }.bind(this));
-  }
+Selendroid.prototype.extractStringsSelendroid = function (cb) {
+  this.extractStrings(function () {
+    cb();
+  });
 };
 
-Selendroid.prototype.getStrings = function (cb) {
-  return cb(null, {
-    status: status.codes.Success.code,
-    value: this.apkStrings
-  });
+Selendroid.prototype.getStrings = function (language, cb) {
+  if (this.language && this.language === language) {
+    // Return last strings
+    return cb(null, {
+      status: status.codes.Success.code,
+      value: this.apkStrings
+    });
+  }
+
+  // Extract and return strings
+  return this.extractStrings(function () {
+    cb(null, {
+      status: status.codes.Success.code,
+      value: this.apkStrings
+    });
+  }.bind(this), language);
 };
 
 module.exports = Selendroid;

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -49,6 +49,7 @@ Selendroid.prototype.init = function () {
     , 'toggleFlightMode'
     , 'toggleWiFi'
     , 'toggleLocationServices'
+    , 'getStrings'
   ];
   this.proxyHost = 'localhost';
   this.avoidProxy = [
@@ -129,6 +130,7 @@ Selendroid.prototype.start = function (cb) {
     conditionalInsertManifest,
     this.checkSelendroidCerts.bind(this),
     conditionalInstallSelendroid,
+    this.extractStrings.bind(this),
     this.uninstallApp.bind(this),
     this.installApp.bind(this),
     this.forwardPort.bind(this),
@@ -368,6 +370,36 @@ Selendroid.prototype.translatePath = function (req) {
     path = path.replace("context", "window");
   }
   req.originalUrl = path;
+};
+
+Selendroid.prototype.extractStrings = function (cb) {
+  var outputPath = path.resolve(getTempPath(), this.args.appPackage);
+  var stringsJson = 'strings.json';
+  if (!fs.existsSync(this.args.app)) {
+    // apk doesn't exist locally
+    logger.debug("Apk doesn't exist");
+    return cb();
+  } else {
+    this.extractLocalizedStrings(outputPath, function (err, stdout, stderr) {
+      if (err) {
+        // if we can't get strings, log error and continue
+        logger.warn("Error getting strings.xml from apk");
+        logger.debug(stderr);
+        this.apkStrings = {};
+        return cb();
+      }
+      var file = fs.readFileSync(path.join(outputPath, stringsJson), 'utf8');
+      this.apkStrings = JSON.parse(file);
+      cb();
+    }.bind(this));
+  }
+};
+
+Selendroid.prototype.getStrings = function (cb) {
+  return cb(null, {
+    status: status.codes.Success.code,
+    value: this.apkStrings
+  });
 };
 
 module.exports = Selendroid;

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -466,14 +466,15 @@ iOSController.toggleLocationServices = function (cb) {
 };
 
 iOSController.getStrings = function (language, cb) {
-  if (language) logger.warn("Language parameter is not implemented in iOS");
-  var strings = this.localizableStrings;
-  if (strings && strings.length >= 1) strings = strings[0];
+  this.parseLocalizableStrings(function() {
+    var strings = this.localizableStrings;
+    if (strings && strings.length >= 1) strings = strings[0];
 
-  cb(null, {
-    status: status.codes.Success.code
-  , value: strings
-  });
+    cb(null, {
+      status: status.codes.Success.code
+    , value: strings
+    });
+  }.bind(this), language);
 };
 
 iOSController.executeAtom = function (atom, args, cb, alwaysDefaultFrame) {

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -465,7 +465,8 @@ iOSController.toggleLocationServices = function (cb) {
   cb(new NotYetImplementedError(), null);
 };
 
-iOSController.getStrings = function (cb) {
+iOSController.getStrings = function (language, cb) {
+  if (language) logger.warn("Language parameter is not implemented in iOS");
   var strings = this.localizableStrings;
   if (strings && strings.length >= 1) strings = strings[0];
 

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -956,13 +956,23 @@ IOS.prototype.setDeviceAndLaunchSimulator = function (cb) {
   }
 };
 
-IOS.prototype.parseLocalizableStrings = function (cb) {
+IOS.prototype.parseLocalizableStrings = function (cb, language) {
   if (this.args.app === null) {
     logger.info("Localizable.strings is not currently supported when using real devices.");
     cb();
   } else {
-    var strings = path.resolve(this.args.app, "Localizable.strings");
-
+    var strings = null;
+    if (language) {
+      strings = path.resolve(this.args.app, language + ".lproj", "Localizable.strings");
+      if (!fs.existsSync(strings)) {
+        logger.info("No Localizable.strings for language '" + language + "', getting default strings");
+      }
+    } else if (this.args.language) {
+      strings = path.resolve(this.args.app, this.args.language + ".lproj", "Localizable.strings");
+    }
+    if (!fs.existsSync(strings)) {
+      strings = path.resolve(this.args.app, "Localizable.strings");
+    }
     if (!fs.existsSync(strings)) {
       strings = path.resolve(this.args.app, "en.lproj", "Localizable.strings");
     }

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -962,15 +962,14 @@ IOS.prototype.parseLocalizableStrings = function (cb, language) {
     cb();
   } else {
     var strings = null;
+    language = language || this.args.language;
     if (language) {
       strings = path.resolve(this.args.app, language + ".lproj", "Localizable.strings");
-      if (!fs.existsSync(strings)) {
-        logger.info("No Localizable.strings for language '" + language + "', getting default strings");
-      }
-    } else if (this.args.language) {
-      strings = path.resolve(this.args.app, this.args.language + ".lproj", "Localizable.strings");
     }
     if (!fs.existsSync(strings)) {
+      if (language) {
+        logger.info("No Localizable.strings for language '" + language + "', getting default strings");
+      }
       strings = path.resolve(this.args.app, "Localizable.strings");
     }
     if (!fs.existsSync(strings)) {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -972,7 +972,11 @@ exports.getLogTypes = function (req, res) {
 };
 
 exports.getStrings = function (req, res) {
-  req.device.getStrings(getResponseHandler(req, res));
+  req.body = _.defaults(req.body, {
+    language: null
+  });
+  var language = req.body.language;
+  req.device.getStrings(language, getResponseHandler(req, res));
 };
 
 exports.unknownCommand = function (req, res) {

--- a/lib/server/routing.js
+++ b/lib/server/routing.js
@@ -114,7 +114,7 @@ module.exports = function (appium) {
   rest.post('/wd/hub/session/:sessionId?/appium/app/background', controller.background);
   rest.post('/wd/hub/session/:sessionId?/appium/app/end_test_coverage', controller.endCoverage);
   rest.post('/wd/hub/session/:sessionId?/appium/app/complex_find', controller.find);
-  rest.get('/wd/hub/session/:sessionId?/appium/app/strings', controller.getStrings);
+  rest.post('/wd/hub/session/:sessionId?/appium/app/strings', controller.getStrings);
 
   rest.post('/wd/hub/session/:sessionId?/appium/element/:elementId?/value', controller.setValueImmediate);
 

--- a/test/functional/android/apidemos/find-element-specs.js
+++ b/test/functional/android/apidemos/find-element-specs.js
@@ -77,7 +77,11 @@ describe("apidemo - find elements -", function () {
         .elementById("buttons_1_normal").text().should.become("Normal")
         .nodeify(done);
     });
-
+    it('should find a single element by string id', function (done) {
+      driver
+        .elementById("activity_sample_code").text().should.become("API Demos")
+        .nodeify(done);
+    });
     it('should find a single element by resource-id', function (done) {
       driver
         .elementById('android:id/home').should.eventually.exist


### PR DESCRIPTION
- Selendroid: extract strings from apk and add getStrings() method
- Bootstrap: remove unused getStrings() and add updateStrings() to read the strings file and update the strings used to find elements with ID location strategy.
- Android, Selendroid and iOS: add optional argument 'language' to 'session/:sessionId?/appium/app/strings' to get the strings for a specific language. Now it's a POST request.
  - If the app hasn't strings for that language, returns the default strings
  - In Android or Selendroid, if language isn't set, extracts strings from app corresponding to device language
  - In iOS, if language isn't set, extracts default strings
