### PR TITLE
Allow to start adb with --adb option in chrome tests

### DIFF
--- a/lib/devices/android/adb.js
+++ b/lib/devices/android/adb.js
@@ -106,7 +106,7 @@ ADB.prototype.checkSdkBinaryPresent = function (binary, cb) {
     exec(cmd + " " + binary, { maxBuffer: 524288 }, function (err, stdout) {
       if (stdout) {
         this.debug("Using " + binary + " from " + stdout);
-        this.binaries[binary] = stdout.trim();
+        this.binaries[binary] = '"' + stdout.trim() + '"';
         cb(null, this.binaries[binary]);
       } else {
         cb(new Error("Could not find " + binary + "; do you have the Android " +
@@ -765,7 +765,8 @@ ADB.prototype.launchAVD = function (avdName, avdArgs, language, locale, avdLaunc
       avdArgs = avdArgs.split(" ");
       launchArgs = launchArgs.concat(avdArgs);
     }
-    var proc = spawn(emulatorBinaryPath, launchArgs);
+    var proc = spawn(emulatorBinaryPath.substr(1, emulatorBinaryPath.length - 2),
+      launchArgs);
     proc.on("error", function (err) {
       logger.error("Unable to start Emulator: " + err.message);
       // actual error will get caught by getRunningAVDWithRetry

--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -51,8 +51,8 @@ ChromeAndroid.prototype.start = function (cb, onDie) {
   this.adb = new ADB(this.args);
   this.onDie = onDie;
 
-  async.waterfall([
-    this.prepareActiveDevice.bind(this),
+  async.series([
+    this.prepareDevice.bind(this),
     this.prepareChromedriver.bind(this),
     this.unlock.bind(this),
     this.createSession.bind(this)


### PR DESCRIPTION
- [Fix error launching avd] Revert change of line 762 of this commit: https://github.com/appium/appium/commit/5401b42d3ed1a4086ac969cb8d6c5bc07a98ed25#diff-d4541b272a5b0a77b423305223ffd8dfL762. The method checkSdkBinaryPresent() returns paths with quotation marks.
- [Use --adb option with chrome tests] Allow to start adb with --adb option in chrome tests. Solves this problem: https://groups.google.com/forum/#!topic/appium-discuss/MhtRoE4qj_E 
