### PR TITLE
Try toggle discard again

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
@@ -44,7 +44,6 @@ class SocketServer {
    * @throws SocketServerException
    */
   public SocketServer(final int port) throws SocketServerException {
-    NotImportantViews.discard(true); // must be set for API 18+
     keepListening = true;
     executor = new AndroidCommandExecutor();
     try {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/DumpWindowHierarchy.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/DumpWindowHierarchy.java
@@ -3,6 +3,7 @@ package io.appium.android.bootstrap.handler;
 import io.appium.android.bootstrap.AndroidCommand;
 import io.appium.android.bootstrap.AndroidCommandResult;
 import io.appium.android.bootstrap.CommandHandler;
+import io.appium.android.bootstrap.utils.NotImportantViews;
 
 import java.io.File;
 
@@ -21,22 +22,11 @@ public class DumpWindowHierarchy extends CommandHandler {
   // Note that
   // "new File(new File(Environment.getDataDirectory(), "local/tmp"), fileName)"
   // is directly from the UiDevice.java source code.
-  private static final File    dumpFolder   = new File(Environment.getDataDirectory(), "local/tmp");
-  private static final String  dumpFileName = "dump.xml";
-  private static final File    dumpFile     = new File(dumpFolder, dumpFileName);
+  private static final File   dumpFolder   = new File(Environment.getDataDirectory(), "local/tmp");
+  private static final String dumpFileName = "dump.xml";
+  private static final File   dumpFile     = new File(dumpFolder, dumpFileName);
 
-  /*
-   * @param command The {@link AndroidCommand} used for this handler.
-   *
-   * @return {@link AndroidCommandResult}
-   *
-   * @throws JSONException
-   *
-   * @see io.appium.android.bootstrap.CommandHandler#execute(io.appium.android.
-   * bootstrap.AndroidCommand)
-   */
-  @Override
-  public AndroidCommandResult execute(final AndroidCommand command) {
+  public static boolean dump() {
     dumpFolder.mkdirs();
 
     if (dumpFile.exists()) {
@@ -56,6 +46,22 @@ public class DumpWindowHierarchy extends CommandHandler {
       }
     }
 
-    return getSuccessResult(dumpFile.exists());
+    return dumpFile.exists();
+  }
+
+  /*
+   * @param command The {@link AndroidCommand} used for this handler.
+   *
+   * @return {@link AndroidCommandResult}
+   *
+   * @throws JSONException
+   *
+   * @see io.appium.android.bootstrap.CommandHandler#execute(io.appium.android.
+   * bootstrap.AndroidCommand)
+   */
+  @Override
+  public AndroidCommandResult execute(final AndroidCommand command) {
+    NotImportantViews.discard(true);
+    return getSuccessResult(dump());
   }
 }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -15,6 +15,7 @@ import io.appium.android.bootstrap.exceptions.InvalidStrategyException;
 import io.appium.android.bootstrap.exceptions.UiSelectorSyntaxException;
 import io.appium.android.bootstrap.exceptions.UnallowedTagNameException;
 import io.appium.android.bootstrap.selector.Strategy;
+import io.appium.android.bootstrap.utils.NotImportantViews;
 import io.appium.android.bootstrap.utils.UiSelectorParser;
 
 import java.util.ArrayList;
@@ -187,7 +188,10 @@ public class Find extends CommandHandler {
         + " with the contextId: " + contextId);
 
     if (strategy == Strategy.INDEX_PATHS) {
+      NotImportantViews.discard(true);
       return findElementsByIndexPaths(text, multiple);
+    } else {
+      NotImportantViews.discard(false);
     }
 
     try {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/NotImportantViews.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/NotImportantViews.java
@@ -8,10 +8,14 @@ public abstract class NotImportantViews {
   // setCompressedLayoutHeirarchy doesn't exist on API <= 17
   // http://developer.android.com/reference/android/accessibilityservice/AccessibilityServiceInfo.html#FLAG_INCLUDE_NOT_IMPORTANT_VIEWS
   private static boolean canDiscard = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2;
+  private static boolean lastDiscard = false;
 
   public static void discard(boolean discard) {
     if (canDiscard) {
-      UiDevice.getInstance().setCompressedLayoutHeirarchy(discard);
+      if (discard != lastDiscard) {
+        UiDevice.getInstance().setCompressedLayoutHeirarchy(discard);
+        lastDiscard = discard;
+      }
     }
   }
 }


### PR DESCRIPTION
```
$ DEVICE=android mocha -t 60000 -R spec find-element-specs.js 


  apidemo - find elements -
    mobile find
      ✓ should scroll to an element by text or content desc (1900ms)
      ✓ should find a single element by content-description (932ms)
      ✓ should find a single element by text (1060ms)
    find element(s) methods
      ✓ should find a single element by content-description (4026ms)
      ✓ should find an element by class name (992ms)
      ✓ should find multiple elements by class name (1532ms)
      ✓ should not find an element that doesnt exist (5209ms)
      ✓ should not find multiple elements that doesnt exist (5161ms)
      ✓ should fail on empty locator (1400ms)
      ✓ should find a single element by id (5584ms)
      ✓ should find a single element by string id (1576ms)
      ✓ should find a single element by resource-id (1611ms)
      ✓ should find multiple elements by resource-id (2742ms)
      ✓ should find multiple elements by resource-id even when theres just one (926ms)
    find element(s) from element
      ✓ should find a single element by tag name (1273ms)
      ✓ should find multiple elements by tag name (1511ms)
      ✓ should not find an element that doesnt exist (5798ms)
      ✓ should not find multiple elements that dont exist (6201ms)
    xpath
      ✓ should find element by type (923ms)
      ✓ should find element by text (1035ms)
      ✓ should find element by partial text (381ms)
      ✓ should find the last element (1310ms)
      ✓ should find element by xpath index and child (803ms)
      ✓ should find element by index and embedded desc (5384ms)
    find elements using accessibility id locator strategy
      ✓ should find an element by name (693ms)
      ✓ should return an array of one element if the plural "elements" is used (957ms)
    find elements by -android uiautomator locator strategy
      ✓ should find elements with a boolean argument (5611ms)
      ✓ should find elements without prepending "new UiSelector()" (1851ms)
      ✓ should find elements without prepending "new UiSelector()." (278ms)
      ✓ should find elements without prepending "new " (1432ms)
      ✓ should find an element with an int argument (1243ms)
      ✓ should find an element with a string argument (403ms)
      ✓ should find an element with an overloaded method argument (1484ms)
      ✓ should find an element with a Class<T> method argument (1470ms)
      ✓ should find an element with a long chain of methods (1430ms)
      ✓ should find an element with recursive UiSelectors (1454ms)
      ✓ should not find an element with bad syntax (5157ms)
      ✓ should not find an element with a made up method (5095ms)
      ✓ should not find an element which does not exist (5187ms)
    invalid locator strategy
      ✓ should not accept -ios uiautomation locator strategy (80ms)


  40 passing (2m)
```

/cc @paymand
