### PR TITLE
Fix touch actions below API 18

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/MultiPointerGesture.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/MultiPointerGesture.java
@@ -1,5 +1,7 @@
 package io.appium.android.bootstrap.handler;
 
+import android.os.Build;
+
 import android.view.MotionEvent.PointerCoords;
 
 import com.android.uiautomator.core.UiObject;
@@ -39,12 +41,18 @@ public class MultiPointerGesture extends TouchableEvent {
         }
       } else {
         Object controller = getController();
-        final Method pmpg = getMethod("performMultiPointerGesture", controller);
-        Boolean rt = (Boolean)pmpg.invoke(controller, (Object)pcs);
-        if (rt.booleanValue()) {
-          return getSuccessResult("OK");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+          final Method pmpg = getMethod("performMultiPointerGesture", controller);
+          Boolean rt = (Boolean)pmpg.invoke(controller, (Object)pcs);
+          if (rt.booleanValue()) {
+            return getSuccessResult("OK");
+          } else {
+            return getErrorResult("Unable to perform multi pointer gesture");
+          }
         } else {
-          return getErrorResult("Unable to perform multi pointer gesture");
+          Logger.error("Device does not support API < 18!");
+          return new AndroidCommandResult(WDStatus.UNKNOWN_ERROR,
+              "Cannot perform multi pointer gesture on device below API level 18");
         }
       }
     } catch (final ElementNotInHashException e) {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchableEvent.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchableEvent.java
@@ -3,6 +3,8 @@ package io.appium.android.bootstrap.handler;
 import io.appium.android.bootstrap.CommandHandler;
 import io.appium.android.bootstrap.Logger;
 
+import android.os.Build;
+
 import android.view.MotionEvent.PointerCoords;
 
 import com.android.uiautomator.core.UiDevice;
@@ -34,8 +36,14 @@ public abstract class TouchableEvent extends CommandHandler {
     final UiDevice device = UiDevice.getInstance();
     final Object bridge = enableField(device.getClass(), "mUiAutomationBridge")
         .get(device);
-    final Object controller = enableField(bridge.getClass().getSuperclass(),
-        "mInteractionController").get(bridge);
+    Object controller = null;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+      controller = enableField(bridge.getClass().getSuperclass(),
+          "mInteractionController").get(bridge);
+    } else {
+      controller = enableField(bridge.getClass(),
+          "mInteractionController").get(bridge);
+    }
     return controller;
 
   }


### PR DESCRIPTION
Wrong bridge is accessed for Android API 17. Fixes issue #2573.

Also add handling of error for non-element based multi gesture touch actions.
