### PR TITLE
Don't send the JSON response as Error in getJSONFromUrl().

### DIFF
--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -98,7 +98,7 @@ WebKitRemoteDebugger.prototype.getJSONFromUrl = function (host, port, path, cb) 
       jsonResponse += chunk;
     });
     response.on('end', function () {
-      cb(JSON.parse(jsonResponse));
+      cb(null, JSON.parse(jsonResponse));
     });
   }).on('error', cb);
 };


### PR DESCRIPTION
This is a fix for the bug where I always get "Could not connect to WebKitRemoteDebugger server" when running `driver.contexts`.
