### PR TITLE
Allow String keycode

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/PressKeyCode.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/PressKeyCode.java
@@ -13,7 +13,7 @@ import com.android.uiautomator.core.UiDevice;
 
 /**
  * This handler is used to PressKeyCode.
- * 
+ *
  */
 public class PressKeyCode extends CommandHandler {
   public Integer keyCode;
@@ -21,11 +21,11 @@ public class PressKeyCode extends CommandHandler {
 
   /*
    * @param command The {@link AndroidCommand} used for this handler.
-   * 
+   *
    * @return {@link AndroidCommandResult}
-   * 
+   *
    * @throws JSONException
-   * 
+   *
    * @see io.appium.android.bootstrap.CommandHandler#execute(io.appium.android.
    * bootstrap.AndroidCommand)
    */
@@ -34,7 +34,14 @@ public class PressKeyCode extends CommandHandler {
       throws JSONException {
     try {
       final Hashtable<String, Object> params = command.params();
-      keyCode = (Integer) params.get("keycode");
+      Object kc = params.get("keycode");
+      if (kc instanceof Integer) {
+        keyCode = (Integer) kc;
+      } else if (kc instanceof String) {
+        keyCode = Integer.parseInt((String) kc);
+      } else {
+        throw new IllegalArgumentException("Keycode of type " + kc.getClass() + "not supported.");
+      }
 
       if (params.get("metastate") != JSONObject.NULL) {
         metaState = (Integer) params.get("metastate");


### PR DESCRIPTION
Fix problem where keycodes sent as `String` cause casting error (related to issue appium/appium-dotnet-driver#21
