### PR TITLE
Fix DumpWindowHierarchy NullPointerException

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -380,6 +380,14 @@ androidController.getPageSource = function (cb) {
         xml = fs.readFileSync(xmlFile, 'utf8');
         fs.unlinkSync(xmlFile);
       }
+
+      // xml file may not exist or it could be empty.
+      if (xml === '') {
+        var error = "dumpWindowHierarchy failed";
+        logger.error(error);
+        return cb(error);
+      }
+
       try {
         xml = _updateSourceXMLNodeNames(xml);
       } catch (e) {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/DumpWindowHierarchy.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/DumpWindowHierarchy.java
@@ -1,16 +1,13 @@
 package io.appium.android.bootstrap.handler;
 
+import android.os.Environment;
+import com.android.uiautomator.core.UiDevice;
 import io.appium.android.bootstrap.AndroidCommand;
 import io.appium.android.bootstrap.AndroidCommandResult;
 import io.appium.android.bootstrap.CommandHandler;
 import io.appium.android.bootstrap.utils.NotImportantViews;
 
 import java.io.File;
-
-import android.os.Environment;
-import android.os.SystemClock;
-
-import com.android.uiautomator.core.UiDevice;
 
 /**
  * This handler is used to dumpWindowHierarchy.
@@ -22,28 +19,28 @@ public class DumpWindowHierarchy extends CommandHandler {
   // Note that
   // "new File(new File(Environment.getDataDirectory(), "local/tmp"), fileName)"
   // is directly from the UiDevice.java source code.
-  private static final File   dumpFolder   = new File(Environment.getDataDirectory(), "local/tmp");
+  private static final File dumpFolder = new File(Environment.getDataDirectory(), "local/tmp");
   private static final String dumpFileName = "dump.xml";
-  private static final File   dumpFile     = new File(dumpFolder, dumpFileName);
+  private static final File dumpFile = new File(dumpFolder, dumpFileName);
+
+  private static void deleteDumpFile() {
+    if (dumpFile.exists()) {
+      dumpFile.delete();
+    }
+  }
 
   public static boolean dump() {
     dumpFolder.mkdirs();
 
-    if (dumpFile.exists()) {
-      dumpFile.delete();
-    }
+    deleteDumpFile();
 
-    UiDevice.getInstance().dumpWindowHierarchy(dumpFileName);
-
-    if (!dumpFile.exists()) {
-      for (int count = 0; count < 30; count++) {
-        SystemClock.sleep(1000);
-        UiDevice.getInstance().dumpWindowHierarchy(dumpFileName);
-
-        if (dumpFile.exists()) {
-          break;
-        }
-      }
+    try {
+      // dumpWindowHierarchy often has a NullPointerException
+      UiDevice.getInstance().dumpWindowHierarchy(dumpFileName);
+    } catch (Exception e) {
+      e.printStackTrace();
+      // If there's an error then the dumpfile may exist and be empty.
+      deleteDumpFile();
     }
 
     return dumpFile.exists();


### PR DESCRIPTION
Fix #2655. It doesn't crash however this appears in the logs:

```
info: Pushing command to appium work queue: ["dumpWindowHierarchy"]
info: [BOOTSTRAP] [info] Got data from client: {"cmd":"action","action":"dumpWindowHierarchy","params":{}}
info: [BOOTSTRAP] [info] Got command of type ACTION
info: [BOOTSTRAP] [debug] Got command action: dumpWindowHierarchy
info: [UIAUTOMATOR STDOUT] java.lang.NullPointerException
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.core.AccessibilityNodeInfoDumper.childNafCheck(AccessibilityNodeInfoDumper.java:200)
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.core.AccessibilityNodeInfoDumper.nafCheck(AccessibilityNodeInfoDumper.java:180)
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.core.AccessibilityNodeInfoDumper.dumpNodeRec(AccessibilityNodeInfoDumper.java:104)
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.core.AccessibilityNodeInfoDumper.dumpNodeRec(AccessibilityNodeInfoDumper.java:129)
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.core.AccessibilityNodeInfoDumper.dumpNodeRec(AccessibilityNodeInfoDumper.java:129)
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.core.AccessibilityNodeInfoDumper.dumpNodeRec(AccessibilityNodeInfoDumper.java:129)
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.core.AccessibilityNodeInfoDumper.dumpWindowToFile(AccessibilityNodeInfoDumper.java:89)
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.core.UiDevice.dumpWindowHierarchy(UiDevice.java:768)
info: [UIAUTOMATOR STDOUT] at io.appium.android.bootstrap.handler.DumpWindowHierarchy.dump(DumpWindowHierarchy.java:36)
info: [UIAUTOMATOR STDOUT] at io.appium.android.bootstrap.handler.DumpWindowHierarchy.execute(DumpWindowHierarchy.java:71)
info: [UIAUTOMATOR STDOUT] at io.appium.android.bootstrap.AndroidCommandExecutor.execute(AndroidCommandExecutor.java:94)
info: [UIAUTOMATOR STDOUT] at io.appium.android.bootstrap.SocketServer.runCommand(SocketServer.java:170)
info: [UIAUTOMATOR STDOUT] at io.appium.android.bootstrap.SocketServer.handleClientData(SocketServer.java:91)
info: [UIAUTOMATOR STDOUT] at io.appium.android.bootstrap.SocketServer.listenForever(SocketServer.java:135)
info: [UIAUTOMATOR STDOUT] at io.appium.android.bootstrap.Bootstrap.testRunServer(Bootstrap.java:17)
info: [UIAUTOMATOR STDOUT] at java.lang.reflect.Method.invokeNative(Native Method)
info: [UIAUTOMATOR STDOUT] at java.lang.reflect.Method.invoke(Method.java:515)
info: [UIAUTOMATOR STDOUT] at junit.framework.TestCase.runTest(TestCase.java:168)
info: [UIAUTOMATOR STDOUT] at junit.framework.TestCase.runBare(TestCase.java:134)
info: [UIAUTOMATOR STDOUT] at junit.framework.TestResult$1.protect(TestResult.java:115)
info: [UIAUTOMATOR STDOUT] at junit.framework.TestResult.runProtected(TestResult.java:133)
info: [UIAUTOMATOR STDOUT] at junit.framework.TestResult.run(TestResult.java:118)
info: [UIAUTOMATOR STDOUT] at junit.framework.TestCase.run(TestCase.java:124)
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.testrunner.UiAutomatorTestRunner.start(UiAutomatorTestRunner.java:160)
info: [UIAUTOMATOR STDOUT] at com.android.uiautomator.testrunner.UiAutomatorTestRunner.run(UiAutomatorTestRunner.java:96)
info: [UIAUTOMATOR STDOUT] at com.android.commands.uiautomator.RunTestCommand.run(RunTestCommand.java:91)
info: [UIAUTOMATOR STDOUT] at com.android.commands.uiautomator.Launcher.main(Launcher.java:83)
info: [UIAUTOMATOR STDOUT] at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
info: [UIAUTOMATOR STDOUT] at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:243)
info: [UIAUTOMATOR STDOUT] at dalvik.system.NativeStart.main(Native Method)
info: [BOOTSTRAP] [info] Returning result: {"value":true,"status":0}
debug: transferPageSourceXML command: "/Users/user/woven/android-sdk-macosx/platform-tools/adb" -s emulator-5554 pull /data/local/tmp/dump.xml "/var/folders/w7/c1yh5bps5dnc0frz0tbj_dmh0000gn/T/114423-52462-h6wajo.xml"
invalid document source 
@#[line:0,col:undefined]
error: 
```

I'm not sure where this comes from:

```
invalid document source 
@#[line:0,col:undefined]
error: 
```
