### PR TITLE
Do not filter out system.log lines that do not have dates

### DIFF
--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -21,6 +21,7 @@ var IosLog = function (opts) {
   this.iosLogStarted = false;
   this.iosLogStartTime = null;
   this.calledBack = false;
+  this.loggingModeOn = true;
   this.logs = [];
   this.logRow = "";
   this.logsSinceLastRequest = [];
@@ -49,6 +50,9 @@ IosLog.prototype.startCapture = function (cb) {
     spawnEnv.PATH = process.env.PATH + ":" + limdDir;
     spawnEnv.DYLD_LIBRARY_PATH = limdDir + ":" + process.env.DYLD_LIBRARY_PATH;
     logger.info("Starting iOS device log capture via idevicesyslog");
+    // idevicesyslog retrieves many old device log lines that came before it was
+    // started so filter those out until we encounter new log lines.
+    this.loggingModeOn = false;
     this.proc = spawn("idevicesyslog", ["-u", this.udid], {env: spawnEnv});
     this.finishStartingLogCapture(cb);
   } else {
@@ -143,12 +147,20 @@ IosLog.prototype.onOutput = function (data, prefix) {
   _.each(logs, function (log) {
     log = log.trim();
     if (log) {
-      // Filter old log rows
-      var logRowParts = log.split(" ");
-      var logRowDate = new Date(
-        Date.parse(this.iosLogStartTime.getFullYear() + " " + logRowParts[0] + " " + logRowParts[1] + " " + logRowParts[2])
-      );
-      if (!this.udid || logRowDate.isAfter(this.iosLogStartTime)) {
+      // Turn logging on when the 1st row that has a new date comes through.
+      // - Some system.log lines do not have a leading date and therefore never pass the
+      //   logRowDate.isAfter(this.iosLogStartTime) check so we require a state flag here,
+      //   otherwise all the lines without dates get filtered out even if they are new.
+      if (!this.loggingModeOn) {
+        var logRowParts = log.split(" ");
+        var logRowDate = new Date(
+          Date.parse(this.iosLogStartTime.getFullYear() + " " + logRowParts[0] + " " + logRowParts[1] + " " + logRowParts[2])
+        );
+        if (logRowDate.isAfter(this.iosLogStartTime)) {
+          this.loggingModeOn = true;
+        }
+      }
+      if (this.loggingModeOn) {
         var logObj = {
           timestamp: Date.now()
         , level: 'ALL'


### PR DESCRIPTION
Adding state flag so device/simulator system.log lines that do not have dates do not always get filtered out even if they are new log lines.
