### PR TITLE
Handle error in md5 calculation

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -481,11 +481,16 @@ androidCommon.installRemoteWithRetry = function (remoteApk, cb) {
 };
 
 androidCommon.getAppMd5 = function (cb) {
-  md5(this.args.app, function (err, md5Hash) {
-    if (err) return cb(err);
-    logger.info("MD5 for app is " + md5Hash);
-    cb(null, md5Hash);
-  }.bind(this));
+  try {
+    md5(this.args.app, function (err, md5Hash) {
+      if (err) return cb(err);
+      logger.info("MD5 for app is " + md5Hash);
+      cb(null, md5Hash);
+    }.bind(this));
+  } catch (e) {
+    logger.error("Problem calculating md5: " + e);
+    return cb(e);
+  }
 };
 
 androidCommon.remoteTempPath = function () {


### PR DESCRIPTION
Catch error thrown by MD5 Calculator when it doesn't recognize the format (which in its mind can only be `apk` or `ipa`).

Fixes issue #2702
