### PR TITLE
Update python samples for --strict-caps

### DIFF
--- a/sample-code/examples/python/android_webview.py
+++ b/sample-code/examples/python/android_webview.py
@@ -13,10 +13,12 @@ class TestAndroidWebView(unittest.TestCase):
                 os.path.join(os.path.dirname(__file__),
                              '../../apps/selendroid-test-app.apk'))
         desired_caps = {
-            'device': 'selendroid',
             'app': app,
             'appPackage': 'io.selendroid.testapp',
-            'appActivity': '.HomeScreenActivity'
+            'appActivity': '.HomeScreenActivity',
+            'platformName': 'Android',
+            'platformVersion': '4.4',
+            'deviceName': 'Android Emulator'
         }
 
         self.driver = webdriver.Remote('http://localhost:4723/wd/hub',
@@ -29,6 +31,7 @@ class TestAndroidWebView(unittest.TestCase):
         self.driver.switch_to.context('WEBVIEW')
 
         input_field = self.driver.find_element_by_id('name_input')
+        sleep(1)
         input_field.clear()
         input_field.send_keys('Appium User')
         input_field.submit()

--- a/sample-code/examples/python/ios_complex.py
+++ b/sample-code/examples/python/ios_complex.py
@@ -29,7 +29,10 @@ class ComplexIOSTests(unittest.TestCase):
         self.driver = webdriver.Remote(
             command_executor='http://127.0.0.1:4723/wd/hub',
             desired_capabilities={
-                'app': app
+                'app': app,
+                'platformName': 'iOS',
+                'platformVersion': '7.0',
+                'deviceName': 'iPhone Simulator'
             })
         self._values = []
 
@@ -49,10 +52,10 @@ class ComplexIOSTests(unittest.TestCase):
 
         # is number of cells/rows inside table correct
         rows = table.find_elements_by_class_name("UIATableCell")
-        self.assertEqual(12, len(rows))
+        self.assertEqual(18, len(rows))
 
         # is first one about buttons
-        self.assertEqual(rows[0].get_attribute("name"), "Buttons, Various uses of UIButton")
+        self.assertEqual(rows[0].get_attribute("name"), "Action Sheets, AAPLActionSheetViewController")
 
         # there is nav bar inside the app
         nav_bar = self.driver.find_element_by_class_name("UIANavigationBar")
@@ -60,10 +63,7 @@ class ComplexIOSTests(unittest.TestCase):
 
     def test_frames(self):
         # go into webview frame
-        self._open_menu_position(7)
-
-        scroll = self.driver.find_element_by_class_name("UIAScrollView")
-        webview = scroll.find_element_by_class_name("UIAWebView")
+        self._open_menu_position(15)
 
         # get the contexts and switch to webview
         contexts = self.driver.contexts
@@ -101,32 +101,9 @@ class ComplexIOSTests(unittest.TestCase):
         # get rid of the file
         os.remove("foo.png")
 
-    def test_attributes(self):
-        # go to the toolbar section
-        self._open_menu_position(8)
-
-        segmented_control = self.driver.find_element_by_class_name("UIASegmentedControl")
-        # segmented_control is enabled by default
-        self.assertTrue(segmented_control.is_enabled())
-        self.assertTrue(segmented_control.is_displayed())
-
-        # row is from previous view, should not be visible
-        self.assertFalse(self._row.is_displayed())
-
-        tinted_control = self.driver.find_elements_by_class_name("UIASegmentedControl")[4]
-        tinted_buttons = tinted_control.find_elements_by_class_name("UIAButton")
-
-        #verify the control has three buttons
-        self.assertEqual(3, len(tinted_buttons))
-
-        #verify the buttons have the right text
-        self.assertEquals(tinted_buttons[0].get_attribute('name'), 'Check')
-        self.assertEquals(tinted_buttons[1].get_attribute('name'), 'Search')
-        self.assertEquals(tinted_buttons[2].get_attribute('name'), 'Tools')
-
     def test_text_field_edit(self):
         # go to the text fields section
-        self._open_menu_position(2)
+        self._open_menu_position(13)
 
         text_field = self.driver.find_elements_by_class_name("UIATextField")[0]
 
@@ -144,30 +121,25 @@ class ComplexIOSTests(unittest.TestCase):
 
     def test_alert_interaction(self):
         # go to the alerts section
-        self._open_menu_position(10)
-        elements = self.driver.find_elements_by_name("Show Simple")
+        self.driver.find_element_by_name('Alert Views, AAPLAlertViewController').click()
+        triggerOk = self.driver.find_element_by_name("Simple")
 
         # TOFIX: Looks like alert object is not proper state
         # something to do with UIActionSheet vs. UIAlertView?
-        triggerOk = elements[0]
+        # triggerOk = elements[0]
         triggerOk.click()
         alert = self.driver.switch_to_alert()
-
-        # this does not work here.
-        # 'An attempt was made to operate on a modal dialog when one was not open.'
-        # check if title of alert is correct
-        # self.assertEqual(alert.text, "UIAlertView")
 
         # dismiss alert
         alert.accept()
 
         # trigger modal alert with cancel & ok buttons
-        triggerOkCancel = elements[1]
+        triggerOkCancel = self.driver.find_element_by_name("Okay / Cancel")
         triggerOkCancel.click()
         alert = self.driver.switch_to_alert()
 
         # check if title of alert is correct
-        self.assertEqual(alert.text, "UIAlertView <Alert message>")
+        self.assertEqual(alert.text, "A Short Title Is Best A message should be a short, complete sentence.")
         alert.accept()
 
     def test_slider(self):
@@ -195,13 +167,14 @@ class ComplexIOSTests(unittest.TestCase):
         # get main view soruce
         source_main = self.driver.page_source
         self.assertIn("UIATableView", source_main)
-        self.assertIn("TextFields, Uses of UITextField", source_main)
+        self.assertIn("Text Fields, AAPLTextFieldViewController", source_main)
 
         # got to text fields section
-        self._open_menu_position(2)
+        self._open_menu_position(13)
+        sleep(10)
         source_textfields = self.driver.page_source
         self.assertIn("UIAStaticText", source_textfields)
-        self.assertIn("TextFields", source_textfields)
+        self.assertIn("Text Fields", source_textfields)
 
         self.assertNotEqual(source_main, source_textfields)
 

--- a/sample-code/examples/python/ios_simple.py
+++ b/sample-code/examples/python/ios_simple.py
@@ -18,7 +18,10 @@ class SimpleIOSTests(unittest.TestCase):
         self.driver = webdriver.Remote(
             command_executor='http://127.0.0.1:4723/wd/hub',
             desired_capabilities={
-                'app': app
+                'app': app,
+                'platformName': 'iOS',
+                'platformVersion': '7.0',
+                'deviceName': 'iPhone Simulator'
             })
 
     def tearDown(self):
@@ -58,7 +61,7 @@ class SimpleIOSTests(unittest.TestCase):
         el = self.driver.find_element_by_xpath('//UIAMapView[1]')
 
         location = el.location
-        self.driver.swipe(startx=location['x'], starty=location['y'], endx=0.5, endy=location['y'], duration=0.8)
+        self.driver.swipe(start_x=location['x'], start_y=location['y'], end_x=0.5, end_y=location['y'], duration=800)
 
 
 if __name__ == '__main__':

--- a/sample-code/examples/python/ios_webview.py
+++ b/sample-code/examples/python/ios_webview.py
@@ -22,7 +22,8 @@ class WebViewIOSTests(unittest.TestCase):
             desired_capabilities={
                 'app': app,
                 'deviceName': 'iPhone Simulator',
-                'platformName': 'iOS'
+                'platformName': 'iOS',
+                'platformVersion': '7.0'
             })
 
     def tearDown(self):

--- a/sample-code/examples/python/selendroid_simple.py
+++ b/sample-code/examples/python/selendroid_simple.py
@@ -22,8 +22,6 @@ class SimpleSalendroidTests(unittest.TestCase):
         desired_caps['app'] = PATH(
             '../../../sample-code/apps/ApiDemos/bin/ApiDemos-debug.apk'
         )
-        desired_caps['appPackage'] = 'com.example.android.apis'
-        desired_caps['appActivity'] = '.ApiDemos'
 
         self.driver = webdriver.Remote('http://localhost:4723/wd/hub', desired_caps)
 


### PR DESCRIPTION
Allow Python sample code to work with `--strict-caps` turned on on the server. Also clean up a bit and fix for changed UICatalog.app.
