### PR TITLE
Fix error handling in installApp

### DIFF
--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -71,7 +71,7 @@ exports.installApp = function (req, res) {
   var install = function (appPath) {
     req.device.installApp(appPath, function (error, response) {
       if (error !== null) {
-        respondError(req, res, response);
+        respondError(req, res, error);
       } else {
         respondSuccess(req, res, response);
       }


### PR DESCRIPTION
Pass the `error` object to the error handler, so that we get something meaningful passed through to the client.

Previously:

```
info: Responding to client with error: {"status":1,"value":{"message":"undefined status object"},"sessionId":"0f8c271f-bdeb-4b94-8daa-453da23f3de0"}
```

Now:

```
info: Responding to client with error: {"status":1,"value":{"message":"You can not call installApp for the iOS simulator!"},"sessionId":"cfa7a214-db9a-4b2d-8949-15cb42efa37c"}
```

Deals with issue #2728
