### PR TITLE
Add error handling for invalid multi pointer gestures

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -1085,6 +1085,12 @@ androidController.parseTouch = function (gestures, cb) {
 };
 
 androidController.performMultiAction = function (elementId, actions, cb) {
+  // Android needs at least two actions to be able to perform a multi pointer gesture
+  if (actions.length === 1) {
+    return cb(new Error("Multi Pointer Gestures need at least two actions. " +
+                        "Use Touch Actions for a single action."));
+  }
+
   var states = [];
   async.eachSeries(actions, function (action, done) {
     this.parseTouch(action, function (err, val) {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -297,6 +297,11 @@ exports.performMultiAction = function (req, res) {
   var elementId = req.body.elementId;
   var actions = req.body.actions;
 
+  if (actions.length === 0) {
+    return respondError(req, res, status.codes.UnknownError.code,
+      new Error("Unable to perform Multi Pointer Gesture with no actions."));
+  }
+
   req.device.performMultiAction(elementId, actions, getResponseHandler(req, res));
 };
 


### PR DESCRIPTION
Added errors for two case:
1. No actions in the multi pointer gesture.
2. Only one action in an Android multi pointer gesture. Android does not allow such things, and we get a very unhelpful `java.lang.reflect.InvocationTargetException`.

Addresses Issue #2735
