### PR TITLE
Better logging

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -99,7 +99,7 @@ Appium.prototype.start = function (desiredCaps, cb) {
   if (this.sessionId === null || this.sessionOverride) {
     this.configure(this.args, this.desiredCapabilities, function (err) {
       if (err) {
-        logger.info("Got configuration error, not starting session");
+        logger.debug("Got configuration error, not starting session");
         this.cleanupSession();
         cb(err, null);
       } else {
@@ -271,7 +271,7 @@ Appium.prototype.configure = function (args, desiredCaps, cb) {
 
 Appium.prototype.invoke = function (cb) {
   this.sessionId = UUID.create().hex;
-  logger.info('Creating new appium session ' + this.sessionId);
+  logger.debug('Creating new appium session ' + this.sessionId);
 
   if (this.device.args.autoLaunch === false) {
     // if user has passed in desiredCaps.autoLaunch = false
@@ -283,11 +283,11 @@ Appium.prototype.invoke = function (cb) {
     var onStart = function (err, sessionIdOverride) {
       if (sessionIdOverride) {
         this.sessionId = sessionIdOverride;
-        logger.info("Overriding session id with " +
+        logger.debug("Overriding session id with " +
                     JSON.stringify(sessionIdOverride));
       }
       if (err) return this.cleanupSession(err, cb);
-      logger.info("Device launched! Ready for commands");
+      logger.debug("Device launched! Ready for commands");
       this.setCommandTimeout(this.desiredCapabilities.newCommandTimeout);
       cb(null, this.device);
     }.bind(this);
@@ -320,15 +320,15 @@ Appium.prototype.getNewDevice = function (deviceType) {
 };
 
 Appium.prototype.timeoutWaitingForCommand = function () {
-  logger.info("Didn't get a new command in " + (this.commandTimeoutMs / 1000) +
+  logger.debug("Didn't get a new command in " + (this.commandTimeoutMs / 1000) +
               " secs, shutting down...");
   this.stop(function () {
-    logger.info("We shut down because no new commands came in");
+    logger.debug("We shut down because no new commands came in");
   }.bind(this));
 };
 
 Appium.prototype.cleanupSession = function (err, cb) {
-  logger.info("Cleaning up appium session");
+  logger.debug("Cleaning up appium session");
   if (this.commandTimeout) {
     clearTimeout(this.commandTimeout);
     this.commandTimeout = null;
@@ -361,9 +361,9 @@ Appium.prototype.resetTimeout = function () {
 Appium.prototype.setCommandTimeout = function (secs, cb) {
   if (typeof secs === "undefined") {
     secs = this.defCommandTimeoutMs / 1000;
-    logger.info("Setting command timeout to the default of " + secs + " secs");
+    logger.debug("Setting command timeout to the default of " + secs + " secs");
   } else {
-    logger.info("Setting command timeout to " + secs + " secs");
+    logger.debug("Setting command timeout to " + secs + " secs");
   }
   this.commandTimeoutMs = secs * 1000;
   this.resetTimeout();
@@ -374,11 +374,11 @@ Appium.prototype.setCommandTimeout = function (secs, cb) {
 
 Appium.prototype.stop = function (cb) {
   if (this.sessionId === null || this.device === null) {
-    logger.info("Trying to stop appium but there's no session, doing nothing");
+    logger.debug("Trying to stop appium but there's no session, doing nothing");
     return cb();
   }
 
-  logger.info('Shutting down appium session...');
+  logger.debug('Shutting down appium session...');
   this.device.stop(function (code) {
     var err;
     if (code && code > 0) {
@@ -389,21 +389,21 @@ Appium.prototype.stop = function (cb) {
 };
 
 Appium.prototype.reset = function (cb) {
-  logger.info("Resetting app mid-session");
+  logger.debug("Resetting app mid-session");
   if (typeof this.device.resetAndStartApp === "function") {
-    logger.info("Running device specific reset");
+    logger.debug("Running device specific reset");
     this.device.resetAndStartApp(function (err) {
       jwpResponse(err, cb);
     });
   } else {
-    logger.info("Running generic full reset");
+    logger.debug("Running generic full reset");
     var oldImpWait = this.device.implicitWaitMs
       , oldCommandTimeoutMs = this.commandTimeoutMs
       , oldId = this.sessionId;
 
     this.resetting = true;
     this.stop(function () {
-      logger.info("Restarting app");
+      logger.debug("Restarting app");
       this.start(this.oldDesiredCapabilities, function (err) {
         if (err) return cb(err);
         this.resetting = false;

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -24,11 +24,11 @@ androidCommon.configure = function (args, caps, cb) {
   this._deviceConfigure(args, caps);
   this.setAndroidArgs();
   if (!this.args.androidActivity) {
-    logger.info("No appActivity desired capability or server param. " +
+    logger.debug("No appActivity desired capability or server param. " +
                 "Parsing from apk.");
   }
   if (!this.args.androidPackage) {
-    logger.info("No appPackage desired capability or server param. " +
+    logger.debug("No appPackage desired capability or server param. " +
                 "Parsing from apk.");
   }
 
@@ -36,7 +36,7 @@ androidCommon.configure = function (args, caps, cb) {
     this.configureApp(cb);
   } else if (this.args.androidPackage) {
     this.args.app = null;
-    logger.info("Didn't get app but did get Android package, will attempt " +
+    logger.debug("Didn't get app but did get Android package, will attempt " +
                 "to launch it on the device");
     cb(null);
   } else {
@@ -64,7 +64,7 @@ androidCommon.configureApp = function (cb) {
     // we have a package instead of app
     this.args.androidPackage = this.args.app;
     this.args.app = null;
-    logger.info("App is an Android package, will attempt to run on device");
+    logger.debug("App is an Android package, will attempt to run on device");
     cb();
   } else {
     Device.prototype.configureApp.call(this, cb);
@@ -269,7 +269,7 @@ androidCommon.toggleLocationServices = function (ocb) {
 };
 
 androidCommon.prepareDevice = function (onReady) {
-  logger.info("Preparing device for session");
+  logger.debug("Preparing device for session");
   async.series([
     function (cb) { this.checkAppPresent(cb); }.bind(this),
     function (cb) { this.adb.checkAdbPresent(cb); }.bind(this),
@@ -282,11 +282,11 @@ androidCommon.prepareDevice = function (onReady) {
 
 androidCommon.checkAppPresent = function (cb) {
   if (this.args.app === null) {
-    logger.info("Not checking whether app is present since we are assuming " +
+    logger.debug("Not checking whether app is present since we are assuming " +
                 "it's already on the device");
     cb();
   } else {
-    logger.info("Checking whether app is actually present");
+    logger.debug("Checking whether app is actually present");
     fs.stat(this.args.app, function (err) {
       if (err) {
         logger.error("Could not find app apk at " + this.args.app);
@@ -305,7 +305,7 @@ androidCommon.prepareEmulator = function (cb) {
       if (err && err.message.indexOf('No devices') === -1 &&
           err.message.indexOf('No emulators') === -1) return cb(err);
       if (runningAVD !== null) {
-        logger.info("Did not launch AVD because it was already running.");
+        logger.debug("Did not launch AVD because it was already running.");
         return cb();
       }
       this.adb.launchAVD(this.args.avd, this.args.avdArgs, this.args.language, this.args.locale,
@@ -314,11 +314,11 @@ androidCommon.prepareEmulator = function (cb) {
   } else if (typeof this.args.language === "string" || typeof this.args.locale === "string") {
     var adbCmd = "";
     if (this.args.language && typeof this.args.language === "string") {
-      logger.info("Setting Android Device Language to " + this.args.language);
+      logger.debug("Setting Android Device Language to " + this.args.language);
       adbCmd += "setprop persist.sys.language " +this.args.language.toLowerCase() + ";";
     }
     if (this.args.locale && typeof this.args.locale === "string") {
-      logger.info("Setting Android Device Country to " + this.args.locale);
+      logger.debug("Setting Android Device Country to " + this.args.locale);
       adbCmd += "setprop persist.sys.country " +this.args.locale.toUpperCase() + ";";
     }
     adbCmd += " stop; sleep 5; start";
@@ -354,10 +354,10 @@ androidCommon.prepareActiveDevice = function (cb) {
 
 androidCommon.resetApp = function (cb) {
   if (this.args.fastReset) {
-    logger.info("Running fast reset (stop and clear)");
+    logger.debug("Running fast reset (stop and clear)");
     this.adb.stopAndClear(this.args.appPackage, cb);
   } else {
-    logger.info("Running old fashion reset (reinstall)");
+    logger.debug("Running old fashion reset (reinstall)");
     this.remoteApkExists(function (err, remoteApk) {
       if (err) return cb(err);
       if (!remoteApk) {
@@ -418,7 +418,7 @@ androidCommon.uninstallApp = function (cb) {
 
 androidCommon.installApp = function (cb) {
   if (this.args.app === null) {
-    logger.info("Skipping install since we launched with a package instead " +
+    logger.debug("Skipping install since we launched with a package instead " +
                 "of an app path");
     return cb();
   }
@@ -467,7 +467,7 @@ androidCommon.installRemoteWithRetry = function (remoteApk, cb) {
         this.removeTempApks([], function () {
           this.adb.push(this.args.app, remoteApk, function (err) {
             if (err) return cb(err);
-            logger.info("Attempting to install again for the last time");
+            logger.debug("Attempting to install again for the last time");
             this.adb.installRemote(remoteApk, cb);
           }.bind(this));
         }.bind(this));
@@ -482,7 +482,7 @@ androidCommon.getAppMd5 = function (cb) {
   try {
     md5(this.args.app, function (err, md5Hash) {
       if (err) return cb(err);
-      logger.info("MD5 for app is " + md5Hash);
+      logger.debug("MD5 for app is " + md5Hash);
       cb(null, md5Hash);
     }.bind(this));
   } catch (e) {
@@ -496,7 +496,7 @@ androidCommon.remoteTempPath = function () {
 };
 
 androidCommon.removeTempApks = function (exceptMd5s, cb) {
-  logger.info("Removing any old apks");
+  logger.debug("Removing any old apks");
   if (typeof exceptMd5s === "function") {
     cb = exceptMd5s;
     exceptMd5s = [];
@@ -515,7 +515,7 @@ androidCommon.removeTempApks = function (exceptMd5s, cb) {
 
   var removeApks = function (apks, cb) {
     if (apks.length < 1) {
-      logger.info("No apks to examine");
+      logger.debug("No apks to examine");
       return cb();
     }
     var matchingApkFound = false;
@@ -533,7 +533,7 @@ androidCommon.removeTempApks = function (exceptMd5s, cb) {
         if (noMd5Matched) {
           removes.push('rm "' + path + '"');
         } else {
-          logger.info("Found an apk we want to keep at " + path);
+          logger.debug("Found an apk we want to keep at " + path);
           matchingApkFound = true;
         }
       }
@@ -542,7 +542,7 @@ androidCommon.removeTempApks = function (exceptMd5s, cb) {
     // Invoking adb shell with an empty string will open a shell console
     // so return here if there's nothing to remove.
     if (removes.length < 1) {
-      logger.info("Couldn't find any apks to remove");
+      logger.debug("Couldn't find any apks to remove");
       return cb(null, matchingApkFound);
     }
 
@@ -710,7 +710,7 @@ androidCommon.extractStringsFromApk = function (makeStrings, language, cb) {
   logger.debug(makeLanguageStrings);
   exec(makeLanguageStrings, { maxBuffer: 524288 }, function (err, stdout, stderr) {
     if (err && language !== null) {
-      logger.info("No strings.xml for language '" + language + "', getting default strings.xml");
+      logger.debug("No strings.xml for language '" + language + "', getting default strings.xml");
       this.extractStringsFromApk(makeStrings, null, cb);
     } else {
       cb(err, stdout, stderr);

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -263,7 +263,7 @@ androidController.leaveWebView = function (cb) {
 
 androidController.implicitWait = function (ms, cb) {
   this.implicitWaitMs = parseInt(ms, 10);
-  logger.info("Set Android implicit wait to " + ms + "ms");
+  logger.debug("Set Android implicit wait to " + ms + "ms");
   cb(null, {
     status: status.codes.Success.code
   , value: null
@@ -718,7 +718,7 @@ androidController.getContexts = function (cb) {
     _.each(webviews, function (view, idx) {
       this.contexts.push(WEBVIEW_BASE + (idx + 1).toString());
     }.bind(this));
-    logger.info("Available contexts: " + this.contexts);
+    logger.debug("Available contexts: " + this.contexts);
     cb(null, {
       status: status.codes.Success.code
     , value: this.contexts

--- a/lib/devices/android/android-hybrid.js
+++ b/lib/devices/android/android-hybrid.js
@@ -9,7 +9,7 @@ var logger = require('../../server/logger.js').get('appium')
 var androidHybrid = {};
 
 androidHybrid.listWebviews = function (cb) {
-  logger.info("Getting a list of available webviews");
+  logger.debug("Getting a list of available webviews");
   var webviews = [];
   this.adb.shell("cat /proc/net/unix", function (err, out) {
     if (err) return cb(err);
@@ -19,13 +19,13 @@ androidHybrid.listWebviews = function (cb) {
       }
     });
     webviews = _.uniq(webviews);
-    logger.info(JSON.stringify(webviews));
+    logger.debug(JSON.stringify(webviews));
     cb(null, webviews);
   });
 };
 
 androidHybrid.startChromedriverProxy = function (cb) {
-  logger.info("Connecting to chrome-backed webview");
+  logger.debug("Connecting to chrome-backed webview");
   if (this.chromedriver !== null) {
     return cb(new Error("We already have a chromedriver instance running"));
   }
@@ -47,14 +47,14 @@ androidHybrid.startChromedriverProxy = function (cb) {
   };
   this.chromedriver.createSession(caps, function (err, sessId) {
     if (err) return cb(err);
-    logger.info("Setting proxy session id to " + sessId);
+    logger.debug("Setting proxy session id to " + sessId);
     this.proxySessionId = sessId;
     cb();
   }.bind(this));
 };
 
 androidHybrid.onChromedriverExit = function () {
-  logger.info("Chromedriver exited unexpectedly");
+  logger.debug("Chromedriver exited unexpectedly");
   if (typeof this.cbForCurrentCmd === "function") {
     var error = new UnknownError("Chromedriver quit unexpectedly during session");
     this.shutdown(function () {
@@ -65,7 +65,7 @@ androidHybrid.onChromedriverExit = function () {
 
 androidHybrid.cleanupChromedriver = function (cb) {
   if (this.chromedriver) {
-    logger.info("Cleaning up Chromedriver");
+    logger.debug("Cleaning up Chromedriver");
     this.chromedriver.stop(function (err) {
       if (err) logger.warn("Error stopping chromedriver: " + err.message);
       this.chromedriver = null;

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -80,7 +80,7 @@ Android.prototype.start = function (cb, onDie) {
 
   if (this.adb === null) {
     // Pass Android opts and Android ref to adb.
-    logger.info("Starting android appium");
+    logger.debug("Starting android appium");
     this.adb = new ADB(this.args);
     this.uiautomator = new UiAutomator(this.adb, this.args);
     this.uiautomator.setExitHandler(this.onUiautomatorExit.bind(this));
@@ -171,7 +171,7 @@ Android.prototype.wrapActionAndHandleADBDisconnect = function (action, ocb) {
 };
 
 Android.prototype.onUiautomatorExit = function () {
-  logger.info("UiAutomator exited");
+  logger.debug("UiAutomator exited");
   var respondToClient = function () {
     this.cleanupChromedriver(function () {
       this.cleanup();
@@ -192,7 +192,7 @@ Android.prototype.onUiautomatorExit = function () {
 
   if (this.adb) {
     var uninstall = function () {
-      logger.info("Attempting to uninstall app");
+      logger.debug("Attempting to uninstall app");
       this.uninstallApp(function () {
         this.shuttingDown = false;
         respondToClient();
@@ -227,7 +227,7 @@ Android.prototype.onUiautomatorExit = function () {
       this.uiautomatorIgnoreExit = false;
     }
   } else {
-    logger.info("We're in uiautomator's exit callback but adb is gone already");
+    logger.debug("We're in uiautomator's exit callback but adb is gone already");
     respondToClient();
   }
 };
@@ -366,7 +366,7 @@ Android.prototype.stop = function (cb) {
   }.bind(this);
 
   if (this.args.fullReset) {
-    logger.info("Removing app from device");
+    logger.debug("Removing app from device");
     this.uninstallApp(function (err) {
       if (err) {
         // simply warn on error here, because we don't want to stop the shutdown
@@ -383,7 +383,7 @@ Android.prototype.stop = function (cb) {
 };
 
 Android.prototype.cleanup = function () {
-  logger.info("Cleaning up android objects");
+  logger.debug("Cleaning up android objects");
   this.adb = null;
   this.uiautomator = null;
   this.shuttingDown = false;

--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -22,7 +22,7 @@ ChromeAndroid.prototype.init = function () {
 };
 
 ChromeAndroid.prototype.configure = function (args, caps, cb) {
-  logger.info("Looks like we want chrome on android");
+  logger.debug("Looks like we want chrome on android");
   this._deviceConfigure(args, caps);
   var bName = this.args.browserName || "";
   var app = this.appString().toLowerCase() ||

--- a/lib/devices/android/chromedriver.js
+++ b/lib/devices/android/chromedriver.js
@@ -25,7 +25,7 @@ var Chromedriver = function (args, onDie) {
 };
 
 Chromedriver.prototype.ensureChromedriverExists = function (cb) {
-  logger.info("Ensuring Chromedriver exists");
+  logger.debug("Ensuring Chromedriver exists");
   var executable = isWindows ? "chromedriver.exe" : "chromedriver";
   var platform = "mac";
   if (isWindows) {
@@ -54,12 +54,12 @@ Chromedriver.prototype.killOldChromedrivers = function (cb) {
       "grep -e '--port=" + this.proxyPort + "$' | awk '{ print $1 }' | " +
       "xargs kill -15";
   }
-  logger.info("Killing any old chromedrivers, running: " + cmd);
+  logger.debug("Killing any old chromedrivers, running: " + cmd);
   exec(cmd, function (err) {
     if (err) {
-      logger.info("No old chromedrivers seemed to exist");
+      logger.debug("No old chromedrivers seemed to exist");
     } else {
-      logger.info("Successfully cleaned up old chromedrivers");
+      logger.debug("Successfully cleaned up old chromedrivers");
     }
     cb();
   });
@@ -67,7 +67,7 @@ Chromedriver.prototype.killOldChromedrivers = function (cb) {
 
 Chromedriver.prototype.start = function (cb) {
   this.onChromedriverStart = cb;
-  logger.info("Spawning chromedriver with: " + this.chromedriver);
+  logger.debug("Spawning chromedriver with: " + this.chromedriver);
   var alreadyReturned = false;
   var args = ["--url-base=wd/hub", "--port=" + this.proxyPort];
   this.proc = spawn(this.chromedriver, args);
@@ -84,7 +84,7 @@ Chromedriver.prototype.start = function (cb) {
   }.bind(this));
 
   this.proc.stdout.pipe(through(function (data) {
-    logger.info('[CHROMEDRIVER] ' + data.trim());
+    logger.debug('[CHROMEDRIVER] ' + data.trim());
     if (!alreadyReturned && data.indexOf('Starting ChromeDriver') === 0) {
       this.chromedriverStarted = true;
       alreadyReturned = true;
@@ -93,7 +93,7 @@ Chromedriver.prototype.start = function (cb) {
   }.bind(this)));
 
   this.proc.stderr.pipe(through(function (data) {
-    logger.info('[CHROMEDRIVER STDERR] ' + data.trim());
+    logger.debug('[CHROMEDRIVER STDERR] ' + data.trim());
   }));
 
   this.proc.on('exit', this.onClose.bind(this));
@@ -103,9 +103,9 @@ Chromedriver.prototype.start = function (cb) {
 Chromedriver.prototype.onClose = function (code, signal) {
   if (!this.shuttingDown) {
     this.shuttingDown = true;
-    logger.info("Chromedriver exited with code " + code);
+    logger.debug("Chromedriver exited with code " + code);
     if (signal) {
-      logger.info("(killed by signal " + signal + ")");
+      logger.debug("(killed by signal " + signal + ")");
     }
     if (!this.chromedriverStarted) {
       return this.onChromedriverStart(
@@ -119,7 +119,7 @@ Chromedriver.prototype.onClose = function (code, signal) {
 };
 
 Chromedriver.prototype.createSession = function (caps, cb) {
-  logger.info("Creating Chrome session");
+  logger.debug("Creating Chrome session");
   caps.chromeOptions.androidDeviceSerial = this.deviceId;
   if (this.enablePerformanceLogging) {
     caps.loggingPrefs = {performance: 'ALL'};
@@ -144,7 +144,7 @@ Chromedriver.prototype.proxyNewSession = function (data, cb) {
     this.proxyTo('/wd/hub/session', 'POST', data, function (err, res, body) {
       if (err) {
         if (/ECONNREFUSED/.test(err.message) && curRetry < maxRetries) {
-          logger.info("Could not connect yet; retrying");
+          logger.debug("Could not connect yet; retrying");
           curRetry++;
           setTimeout(doProxy, retryInt);
           return;
@@ -156,7 +156,7 @@ Chromedriver.prototype.proxyNewSession = function (data, cb) {
       this.chromeSessionId = null;
       try {
         if (body.status === 0 && body.sessionId) {
-          logger.info("Successfully started chrome session");
+          logger.debug("Successfully started chrome session");
           this.chromeSessionId = body.sessionId;
         }
       } catch (ignore) {}
@@ -165,7 +165,7 @@ Chromedriver.prototype.proxyNewSession = function (data, cb) {
       // then check redirect success case
       try {
         if (res.statusCode === 303 && res.headers.location) {
-          logger.info("Successfully started chrome session");
+          logger.debug("Successfully started chrome session");
           var loc = res.headers.location;
           this.chromeSessionId = /\/([^\/]+)$/.exec(loc)[1];
         }
@@ -201,7 +201,7 @@ Chromedriver.prototype.proxyNewSession = function (data, cb) {
 };
 
 Chromedriver.prototype.deleteSession = function (cb) {
-  logger.info("Deleting Chrome session");
+  logger.debug("Deleting Chrome session");
   var url = '/wd/hub/session/' + this.chromeSessionId;
   this.proxyTo(url, 'DELETE', null, function (err, res) {
     if (err) return cb(err);
@@ -211,7 +211,7 @@ Chromedriver.prototype.deleteSession = function (cb) {
 };
 
 Chromedriver.prototype.stop = function (cb) {
-  logger.info('Killing chromedriver');
+  logger.debug('Killing chromedriver');
   this.exitCb = cb;
   this.proc.kill();
 };

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -69,7 +69,7 @@ Selendroid.prototype.setAndroidArgs = function () {
 };
 
 Selendroid.prototype.start = function (cb) {
-  logger.info("Starting selendroid server");
+  logger.debug("Starting selendroid server");
   this.adb = new ADB(this.args);
 
   var modServerExists = false
@@ -87,22 +87,22 @@ Selendroid.prototype.start = function (cb) {
 
   var conditionalUninstallSelendroid = function (cb) {
     if (!modServerExists) {
-      logger.info("Rebuilt selendroid apk does not exist, uninstalling " +
+      logger.debug("Rebuilt selendroid apk does not exist, uninstalling " +
                   "any instances of it on device to make way for new one");
       this.adb.uninstallApk(modAppPkg, cb);
     } else {
-      logger.info("Rebuilt selendroid apk exists, doing nothing");
+      logger.debug("Rebuilt selendroid apk exists, doing nothing");
       cb();
     }
   }.bind(this);
 
   var conditionalInsertManifest = function (cb) {
     if (!modServerExists) {
-      logger.info("Rebuilt selendroid server does not exist, inserting " +
+      logger.debug("Rebuilt selendroid server does not exist, inserting " +
                   "modified manifest");
       this.insertSelendroidManifest(this.serverApk, cb);
     } else {
-      logger.info("Rebuilt selendroid server already exists, no need to " +
+      logger.debug("Rebuilt selendroid server already exists, no need to " +
                   "rebuild it with a new manifest");
       cb();
     }
@@ -111,10 +111,10 @@ Selendroid.prototype.start = function (cb) {
   var conditionalInstallSelendroid = function (cb) {
     this.adb.isAppInstalled(modAppPkg, function (e, installed) {
       if (!installed) {
-        logger.info("Rebuilt selendroid is not installed, installing it");
+        logger.debug("Rebuilt selendroid is not installed, installing it");
         this.adb.install(this.selendroidServerPath, cb);
       } else {
-        logger.info("Rebuilt selendroid is already installed");
+        logger.debug("Rebuilt selendroid is already installed");
         cb();
       }
     }.bind(this));
@@ -163,7 +163,7 @@ Selendroid.prototype.checkSelendroidCerts = function (cb) {
   // these run in parallel
   var apks = [this.selendroidServerPath, this.args.app];
   _.each(apks, function (apk) {
-    logger.info("Checking signed status of " + apk);
+    logger.debug("Checking signed status of " + apk);
     this.adb.checkApkCert(apk, this.args.appPackage, function (err, isSigned) {
       if (err) return cb(err);
       if (isSigned) return onDoneSigning();
@@ -181,14 +181,14 @@ Selendroid.prototype.checkSelendroidCerts = function (cb) {
 Selendroid.prototype.stop = function (cb) {
 
   var completeShutdown = function (cb) {
-    logger.info("Stopping selendroid server");
+    logger.debug("Stopping selendroid server");
     this.deleteSession(function (err) {
       cb(err ? 1 : 0);
     });
   }.bind(this);
 
   if (this.args.fullReset) {
-    logger.info("Removing app from device");
+    logger.debug("Removing app from device");
     this.uninstallApp(function (err) {
       if (err) {
         // simply warn on error here, because we don't want to stop the shutdown
@@ -230,16 +230,16 @@ Selendroid.prototype.wrapActionAndHandleADBDisconnect = function (action, ocb) {
 };
 
 Selendroid.prototype.ensureServerExists = function (cb) {
-  logger.info("Checking whether selendroid is built yet");
+  logger.debug("Checking whether selendroid is built yet");
   var selBin = path.resolve(__dirname, "..", "..", "..", "build", "selendroid",
       "selendroid.apk");
   fs.stat(selBin, function (err) {
     if (err) {
-      logger.info("Selendroid needs to be built; please run ./reset.sh " +
+      logger.debug("Selendroid needs to be built; please run ./reset.sh " +
                   "--selendroid");
       return cb(err);
     }
-    logger.info("Selendroid server exists!");
+    logger.debug("Selendroid server exists!");
     this.serverApk = selBin;
     cb(null);
   }.bind(this));
@@ -260,7 +260,7 @@ Selendroid.prototype.waitForServer = function (cb) {
                        "selendroid server and it never showed up"));
         }
       } else {
-        logger.info("Selendroid server is alive!");
+        logger.debug("Selendroid server is alive!");
         cb(null);
       }
     });
@@ -270,7 +270,7 @@ Selendroid.prototype.waitForServer = function (cb) {
 };
 
 Selendroid.prototype.createSession = function (cb) {
-  logger.info("Listening for Selendroid logs");
+  logger.debug("Listening for Selendroid logs");
   this.adb.logcat.on('log', function (logObj) {
     if (/System/.test(logObj.message)) {
       var type = "";
@@ -278,21 +278,21 @@ Selendroid.prototype.createSession = function (cb) {
         type = " ERR";
       }
       var msg = logObj.message.replace(/^.+: /, '');
-      logger.info("[SELENDROID" + type + "] " + msg);
+      logger.debug("[SELENDROID" + type + "] " + msg);
     }
   }.bind(this));
-  logger.info("Creating Selendroid session");
+  logger.debug("Creating Selendroid session");
   var data = {desiredCapabilities: this.capabilities};
   this.proxyTo('/wd/hub/session', 'POST', data, function (err, res, body) {
     if (err) return cb(err);
 
     if (res.statusCode === 301 && body.sessionId) {
-      logger.info("Successfully started selendroid session");
+      logger.debug("Successfully started selendroid session");
       this.selendroidSessionId = body.sessionId;
       this.adb.waitForActivity(this.args.appWaitPackage, this.args.appWaitActivity, 1800,
           function (err) {
         if (err) {
-          logger.info("Selendroid hasn't started app yet, let's do it " +
+          logger.debug("Selendroid hasn't started app yet, let's do it " +
                       "manually with adb.startApp");
           return this.adb.startApp(this.args.appPackage, this.args.appActivity,
               this.args.appWaitPackage, this.args.appWaitActivity, false, function (err) {
@@ -325,7 +325,7 @@ Selendroid.prototype.deleteSession = function (cb) {
 Selendroid.prototype.proxyTo = proxyTo;
 
 Selendroid.prototype.insertSelendroidManifest = function (serverPath, cb) {
-  logger.info("Inserting selendroid manifest");
+  logger.debug("Inserting selendroid manifest");
   var newServerPath = this.selendroidServerPath
     , newPackage = this.args.appPackage + '.selendroid'
     , srcManifest = path.resolve(__dirname, '..', '..', '..', 'build',
@@ -362,10 +362,10 @@ Selendroid.prototype.unpackApp = androidController.unpackApp;
 Selendroid.prototype.translatePath = function (req) {
   var path = req.originalUrl;
   if (path.indexOf("contexts") !== -1) {
-    logger.info("Temporarily translating 'contexts' to 'window_handles");
+    logger.debug("Temporarily translating 'contexts' to 'window_handles");
     path = path.replace("contexts", "window_handles");
   } else if (path.indexOf("context") !== -1) {
-    logger.info("Temporarily translating 'context' to 'window'");
+    logger.debug("Temporarily translating 'context' to 'window'");
     path = path.replace("context", "window");
   }
   req.originalUrl = path;

--- a/lib/devices/android/uiautomator.js
+++ b/lib/devices/android/uiautomator.js
@@ -25,7 +25,7 @@ var UiAutomator = function (adb, opts) {
 UiAutomator.prototype.start = function (readyCb) {
   this.adb.killProcessesByName('uiautomator', function (err) {
     if (err) return readyCb(err);
-    logger.info("Running bootstrap");
+    logger.debug("Running bootstrap");
     var args = ["shell", "uiautomator", "runtest", "AppiumBootstrap.jar", "-c",
         "io.appium.android.bootstrap.Bootstrap"];
 
@@ -62,7 +62,7 @@ UiAutomator.prototype.exitHandler = function (code) {
   if (!this.alreadyExited) {
     this.alreadyExited = true;
     if (this.shuttingDown) {
-      logger.info("UiAutomator shut down normally");
+      logger.debug("UiAutomator shut down normally");
     }
     this.onExit(code);
   }
@@ -82,7 +82,7 @@ UiAutomator.prototype.checkForSocketReady = function (output) {
         data = JSON.parse(oldData + data);
         oldData = '';
       } catch (e) {
-        logger.info("Stream still not complete, waiting");
+        logger.debug("Stream still not complete, waiting");
         oldData += data;
         return;
       }
@@ -155,7 +155,7 @@ UiAutomator.prototype.shutdown = function (cb) {
   this.onExit = cb;
   this.shuttingDown = true;
   this.sendCommand('shutdown', null, function () {
-    logger.info("Sent shutdown command, waiting for UiAutomator to stop...");
+    logger.debug("Sent shutdown command, waiting for UiAutomator to stop...");
     setTimeout(function () {
       if (!this.alreadyExited) {
         logger.warn("UiAutomator did not shut down fast enough, calling it gone");
@@ -184,11 +184,11 @@ UiAutomator.prototype.handleBootstrapOutput = function (output) {
     if (line !== '') {
       match = re.exec(line);
       if (match) {
-        logger.info("[BOOTSTRAP] " + match[1]);
+        logger.debug("[BOOTSTRAP] " + match[1]);
 
         var alertRe = /Emitting system alert message/;
         if (alertRe.test(line)) {
-          logger.info("Emitting alert message...");
+          logger.debug("Emitting alert message...");
           this.webSocket.sockets.emit('alert', {message: line});
         }
       } else {
@@ -198,7 +198,7 @@ UiAutomator.prototype.handleBootstrapOutput = function (output) {
           this.restartBootstrap = true;
         }
         var log = "[UIAUTOMATOR STDOUT] " + line;
-        logger.info(log.grey);
+        logger.debug(log.grey);
       }
     }
   }.bind(this));
@@ -207,13 +207,13 @@ UiAutomator.prototype.handleBootstrapOutput = function (output) {
 UiAutomator.prototype.errorStreamHandler = function (output) {
   var lines = output.toString().split("\n");
   _.each(lines, function (line) {
-    logger.info(("[UIAUTOMATOR STDERR] " + line).yellow);
+    logger.debug(("[UIAUTOMATOR STDERR] " + line).yellow);
   });
 };
 
 UiAutomator.prototype.debug = function (msg) {
   if (this.debugMode) {
-    logger.info("[UIAUTOMATOR] " + msg);
+    logger.debug("[UIAUTOMATOR] " + msg);
   }
 };
 

--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -33,14 +33,14 @@ exports.respond = function (response, cb) {
 
 exports.proxy = function (command, cb) {
   // was thinking we should use a queue for commands instead of writing to a file
-  logger.info('Pushing command to appium work queue: ' + JSON.stringify(command));
+  logger.debug('Pushing command to appium work queue: ' + JSON.stringify(command));
   this.push([command, cb]);
 };
 
 exports.proxyWithMinTime = function (command, ms, cb) {
   // was thinking we should use a queue for commands instead of writing to a file
   var start = Date.now();
-  logger.info('Pushing command to appium work queue: ' + JSON.stringify(command));
+  logger.debug('Pushing command to appium work queue: ' + JSON.stringify(command));
   this.push([command, function () {
     var args = Array.prototype.slice.call(arguments, 0);
     var waitNeeded = ms - (Date.now() - start);
@@ -99,21 +99,21 @@ exports.doRequest = function (url, method, body, contentType, cb) {
   }
   // explicitly set these headers with correct capitalization to work around
   // an issue in node/requests
-  logger.info("Making http request with opts: " + JSON.stringify(opts));
+  logger.debug("Making http request with opts: " + JSON.stringify(opts));
   request(opts, function (err, res, body) {
     cb(err, res, body);
   });
 };
 
 exports.isAppInstalled = function (isInstalledCommand, cb) {
-  logger.info("Checking app install status using: " + isInstalledCommand);
+  logger.debug("Checking app install status using: " + isInstalledCommand);
   exec(isInstalledCommand, function (error, stdout) {
     cb(error, stdout);
   });
 };
 
 exports.removeApp = function (removeCommand, udid, bundleId, cb) {
-  logger.info("Removing app using cmd: " + removeCommand);
+  logger.debug("Removing app using cmd: " + removeCommand);
   exec(removeCommand, function (error) {
     if (error !== null) {
       cb(new Error('Unable to un-install [' + bundleId + '] from device with id [' + udid + ']. Error [' + error + ']'));
@@ -124,7 +124,7 @@ exports.removeApp = function (removeCommand, udid, bundleId, cb) {
 };
 
 exports.installApp = function (installationCommand, udid, unzippedAppPath, cb) {
-  logger.info("Installing app using cmd: " + installationCommand);
+  logger.debug("Installing app using cmd: " + installationCommand);
   exec(installationCommand, { maxBuffer: 524288 }, function (error) {
     if (error !== null) {
       cb(new Error('Unable to install [' + unzippedAppPath + '] to device with id [' + udid + ']. Error [' + error + ']'));
@@ -230,7 +230,7 @@ exports.checkValidLocStrat = function (strat, includeWeb, cb) {
     deprecations = nativeDeprecations;
   }
   if (!_.contains(validStrats, strat)) {
-    logger.info("Invalid locator strategy: " + strat);
+    logger.debug("Invalid locator strategy: " + strat);
     cb(null, {
       status: status.codes.UnknownCommand.code,
       value: {message: "Invalid locator strategy: " + strat}
@@ -266,7 +266,7 @@ exports.getAtomsElement = function (wdId) {
 
 exports.useAtomsElement = function (elementId, failCb, cb) {
   if (parseInt(elementId, 10) < 5000) {
-    logger.info("Element with id " + elementId + " passed in for use with " +
+    logger.debug("Element with id " + elementId + " passed in for use with " +
                 "atoms, but it's out of our internal scope. Adding 5000");
     elementId = (parseInt(elementId, 10) + 5000).toString();
   }

--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -67,7 +67,7 @@ Device.prototype.configureLocalApp = function (cb) {
   var ext = appPath.substring(appPath.length - 4).toLowerCase();
   if (ext === this.appExt) {
     this.args.app = appPath;
-    logger.info("Using local app from " + origin + ": " + appPath);
+    logger.debug("Using local app from " + origin + ": " + appPath);
     fs.stat(appPath, function (err) {
       if (err) {
         return cb(new Error("Error locating the app: " + err.message));
@@ -75,11 +75,11 @@ Device.prototype.configureLocalApp = function (cb) {
       cb();
     });
   } else if (ext === ".zip" || ext === ".ipa") {
-    logger.info("Using local " + ext + " from " + origin + ": " + appPath);
+    logger.debug("Using local " + ext + " from " + origin + ": " + appPath);
     this.unzipLocalApp(appPath, function (zipErr, newAppPath) {
       if (zipErr) return cb(zipErr);
       this.args.app = newAppPath;
-      logger.info("Using locally extracted app: " + this.args.app);
+      logger.debug("Using locally extracted app: " + this.args.app);
       cb();
     }.bind(this));
   } else {
@@ -115,11 +115,11 @@ Device.prototype.configureDownloadedApp = function (cb) {
           cb(zipErr);
         } else {
           this.args.app = appPath;
-          logger.info("Using extracted app: " + this.args.app);
+          logger.debug("Using extracted app: " + this.args.app);
           cb();
         }
       }.bind(this));
-      logger.info("Using downloadable app from " + origin + ": " + appUrl);
+      logger.debug("Using downloadable app from " + origin + ": " + appUrl);
     } catch (e) {
       var err = e.toString();
       logger.error("Failed downloading app from appUrl " + appUrl);

--- a/lib/devices/firefoxos/firefoxos.js
+++ b/lib/devices/firefoxos/firefoxos.js
@@ -64,7 +64,7 @@ Firefox.prototype.start = function (cb, onDie) {
 
 
   this.onConnect = function () {
-    logger.info("Firefox OS socket connected");
+    logger.debug("Firefox OS socket connected");
     var mainCb = cb;
     async.waterfall([
       function (cb) { this.getMarionetteId(cb); }.bind(this),
@@ -77,7 +77,7 @@ Firefox.prototype.start = function (cb, onDie) {
 };
 
 Firefox.prototype.stop = function (cb) {
-  logger.info("Stopping firefoxOs connection");
+  logger.debug("Stopping firefoxOs connection");
   this.proxy({type: 'deleteSession'}, function (err) {
     if (err) return cb(err);
     this.socket.destroy();
@@ -86,7 +86,7 @@ Firefox.prototype.stop = function (cb) {
 };
 
 Firefox.prototype.getMarionetteId = function (cb) {
-  logger.info("Getting marionette id");
+  logger.debug("Getting marionette id");
   this.proxy({type: 'getMarionetteID'}, function (err, res) {
     if (err) return cb(err);
     this.fromActor = res.id;
@@ -95,7 +95,7 @@ Firefox.prototype.getMarionetteId = function (cb) {
 };
 
 Firefox.prototype.createSession = function (cb) {
-  logger.info("Creating firefox os session");
+  logger.debug("Creating firefox os session");
   this.proxy({type: 'newSession'}, function (err, res) {
     if (err) return cb(err);
     this.sessionId = res.value;
@@ -104,7 +104,7 @@ Firefox.prototype.createSession = function (cb) {
 };
 
 Firefox.prototype.launchAppByName = function (cb) {
-  logger.info("Launching our app by its name");
+  logger.debug("Launching our app by its name");
   var atomSrc = getAtomSrc('gaia_apps');
   var wrappedScript = atomSrc +
     ";GaiaApps.launchWithName('" + this.args.app + "');";
@@ -125,23 +125,23 @@ Firefox.prototype.receive = function (data) {
   var parts, bytes, jsonData;
   if (this.receiveStream) {
     this.receiveStream += data.toString();
-    logger.info(data.length + " b more data received, adding to stream (" + this.receiveStream.length + " b)");
+    logger.debug(data.length + " b more data received, adding to stream (" + this.receiveStream.length + " b)");
     try {
       data = JSON.parse(this.receiveStream);
       this.receiveStream = null;
     } catch (e) {
-      logger.info("Stream still not complete, waiting");
+      logger.debug("Stream still not complete, waiting");
       return;
     }
   } else {
     parts = data.toString().split(":");
     bytes = parseInt(parts[0], 10);
-    logger.info("Data received, looking for " + bytes + " bytes");
+    logger.debug("Data received, looking for " + bytes + " bytes");
     jsonData = parts.slice(1).join(":");
     try {
       data = JSON.parse(jsonData);
     } catch (e) {
-      logger.info("Data did not parse, waiting for more");
+      logger.debug("Data did not parse, waiting for more");
       this.receiveStream = jsonData;
       return;
     }

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -219,7 +219,7 @@ iOSController.findUIElementsByXpath = function (selector, ctx, many, curRetry,
       // by the path we mentioned
       if (res.status !== status.codes.Success.code &&
           curRetry < 3) {
-        logger.info("Got a warning from uiauto that some index paths " +
+        logger.debug("Got a warning from uiauto that some index paths " +
                     "could not be resolved, trying again");
         return setTimeout(function () {
           this.findUIElementsByXpath(selector, ctx, many, curRetry + 1, cb);
@@ -247,7 +247,7 @@ iOSController.getLocalizedStringForSelector = function (selector) {
     if (localizedSelector) {
       newSelector = localizedSelector;
     } else {
-      logger.info("Id selector, '" + selector + "', not found in " +
+      logger.debug("Id selector, '" + selector + "', not found in " +
                   "Localizable.strings.");
     }
   }
@@ -401,7 +401,7 @@ iOSController.pushFile = function (base64Data, remotePath, cb) {
 };
 
 iOSController.pullFile = function (remotePath, cb) {
-  logger.info("Pulling " + remotePath + " from sim");
+  logger.debug("Pulling " + remotePath + " from sim");
   if (this.realDevice) {
     return cb(new NotYetImplementedError(), null);
   }
@@ -418,7 +418,7 @@ iOSController.pullFile = function (remotePath, cb) {
   var basePath = simRoots[0];
 
   var readAndReturnFile = function () {
-    logger.info("Attempting to read " + fullPath);
+    logger.debug("Attempting to read " + fullPath);
     fs.readFile(fullPath, {encoding: 'base64'}, function (err, data) {
       if (err) return cb(err);
       cb(null, {status: status.codes.Success.code, value: data});
@@ -436,7 +436,7 @@ iOSController.pullFile = function (remotePath, cb) {
   }
 
   if (remotePath.indexOf(appName) === 1) {
-    logger.info("We want an app-relative file");
+    logger.debug("We want an app-relative file");
     var findPath = basePath.replace(/\s/g, '\\ ');
     var findCmd = 'find ' + findPath + ' -name "' + appName + '"';
     exec(findCmd, function (err, stdout) {
@@ -447,7 +447,7 @@ iOSController.pullFile = function (remotePath, cb) {
       readAndReturnFile();
     }.bind(this));
   } else {
-    logger.info("We want a sim-relative file");
+    logger.debug("We want a sim-relative file");
     fullPath = path.resolve(basePath, remotePath);
     readAndReturnFile();
   }
@@ -554,7 +554,7 @@ iOSController.lookForAlert = function (cb, counter, looks, timeout) {
     }
     if (this.instruments !== null) {
       if (!this.returnedFromExecuteAtom[counter] && looks < 11 && !this.selectingNewPage) {
-        logger.info("atom did not return yet, checking to see if " +
+        logger.debug("atom did not return yet, checking to see if " +
           "we are blocked by an alert");
         // temporarily act like we're not processing a remote command
         // so we can proxy the alert detection functionality
@@ -562,7 +562,7 @@ iOSController.lookForAlert = function (cb, counter, looks, timeout) {
         this.proxy("au.alertIsPresent()", function (err, res) {
           if (res !== null) {
             if (res.value === true) {
-              logger.info("Found an alert, returning control to client");
+              logger.debug("Found an alert, returning control to client");
               this.returnedFromExecuteAtom[counter] = true;
               cb(null, {
                 status: status.codes.Success.code
@@ -665,7 +665,7 @@ iOSController.clickWebCoords = function (cb) {
           x: wvPos.x + (xRatio * coords.x)
         , y: wvPos.y + yOffset + (yRatio * coords.y) - serviceBarHeight
         };
-        logger.info("Converted web coords " + JSON.stringify(this.curWebCoords) +
+        logger.debug("Converted web coords " + JSON.stringify(this.curWebCoords) +
                     "into real coords " + JSON.stringify(coords));
         this.clickCoords(coords, cb);
       }
@@ -881,7 +881,7 @@ iOSController.frame = function (frame, cb) {
     var atom;
     if (frame === null) {
       this.curWebFrames = [];
-      logger.info("Leaving web frame and going back to default content");
+      logger.debug("Leaving web frame and going back to default content");
       cb(null, {
         status: status.codes.Success.code
       , value: ''
@@ -891,7 +891,7 @@ iOSController.frame = function (frame, cb) {
         this.useAtomsElement(frame.ELEMENT, cb, function (atomsElement) {
           this.executeAtom('get_frame_window', [atomsElement], function (err, res) {
             if (this.checkSuccess(err, res, cb)) {
-              logger.info("Entering new web frame: " + res.value.WINDOW);
+              logger.debug("Entering new web frame: " + res.value.WINDOW);
               this.curWebFrames.unshift(res.value.WINDOW);
               cb(err, res);
             }
@@ -910,7 +910,7 @@ iOSController.frame = function (frame, cb) {
               , value: ''
               });
             } else {
-              logger.info("Entering new web frame: " + res.value.WINDOW);
+              logger.debug("Entering new web frame: " + res.value.WINDOW);
               this.curWebFrames.unshift(res.value.WINDOW);
               cb(err, res);
             }
@@ -927,7 +927,7 @@ iOSController.frame = function (frame, cb) {
 
 iOSController.implicitWait = function (ms, cb) {
   this.implicitWaitMs = parseInt(ms, 10);
-  logger.info("Set iOS implicit wait to " + ms + "ms");
+  logger.debug("Set iOS implicit wait to " + ms + "ms");
   cb(null, {
     status: status.codes.Success.code
   , value: null
@@ -936,7 +936,7 @@ iOSController.implicitWait = function (ms, cb) {
 
 iOSController.asyncScriptTimeout = function (ms, cb) {
   this.asyncWaitMs = parseInt(ms, 10);
-  logger.info("Set iOS async script timeout to " + ms + "ms");
+  logger.debug("Set iOS async script timeout to " + ms + "ms");
   cb(null, {
     status: status.codes.Success.code
   , value: null
@@ -1101,7 +1101,7 @@ iOSController.getScreenshot = function (cb) {
       // rotate if necessary
       if (this.curOrientation === "LANDSCAPE") {
         // need to rotate 90 deg CC
-        logger.info("Rotating landscape screenshot");
+        logger.debug("Rotating landscape screenshot");
         rotateImage(shotPath, -90, function (err) {
           if (err) return cb(new Error("Could not rotate screenshot appropriately"), null);
           fs.readFile(shotPath, function read(err, _data) {
@@ -1431,7 +1431,7 @@ iOSController.setContext = function (name, cb, skipReadyCheck) {
             }.bind(this), skipReadyCheck);
           } else {
             if (name === this.curContext) {
-              logger.info("Remote debugger is already connected to window [" + name + "]");
+              logger.debug("Remote debugger is already connected to window [" + name + "]");
               cb(null, {
                 status: status.codes.Success.code
               , value: name
@@ -1532,7 +1532,7 @@ iOSController.setWindow = function (name, cb, skipReadyCheck) {
         }.bind(this), skipReadyCheck);
       } else {
         if (name === this.curWindowHandle) {
-          logger.info("Remote debugger is already connected to window [" + name + "]");
+          logger.debug("Remote debugger is already connected to window [" + name + "]");
           cb(null, {
             status: status.codes.Success.code
           , value: name

--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -11,9 +11,9 @@ var iOSHybrid = {};
 iOSHybrid.closeAlertBeforeTest = function (cb) {
   this.proxy("au.alertIsPresent()", function (err, res) {
     if (!err && res !== null && typeof res.value !== "undefined" && res.value === true) {
-      logger.info("Alert present before starting test, let's banish it");
+      logger.debug("Alert present before starting test, let's banish it");
       this.proxy("au.dismissAlert()", function () {
-        logger.info("Alert banished!");
+        logger.debug("Alert banished!");
         cb(true);
       });
     } else {
@@ -56,7 +56,7 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
           logger.error("Remote debugger did not list " + this.args.bundleId +
                        " among its available apps");
           if (_.has(appDict, "com.apple.mobilesafari")) {
-            logger.info("Using mobile safari instead");
+            logger.debug("Using mobile safari instead");
             this.remote.selectApp("com.apple.mobilesafari", onDone);
           } else {
             onDone([]);
@@ -82,9 +82,9 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
 };
 
 iOSHybrid.onPageChange = function (pageArray) {
-  logger.info("Remote debugger notified us of a new page listing");
+  logger.debug("Remote debugger notified us of a new page listing");
   if (this.selectingNewPage) {
-    logger.info("We're in the middle of selecting a page, ignoring");
+    logger.debug("We're in the middle of selecting a page, ignoring");
     return;
   }
   var newIds = []
@@ -104,15 +104,15 @@ iOSHybrid.onPageChange = function (pageArray) {
   }.bind(this));
   var newPage = null;
   if (this.curContext === null) {
-    logger.info("We don't appear to have window set yet, ignoring");
+    logger.debug("We don't appear to have window set yet, ignoring");
   } else if (newPages.length) {
-    logger.info("We have new pages, going to select page " + newPages[0]);
+    logger.debug("We have new pages, going to select page " + newPages[0]);
     newPage = newPages[0];
   } else if (!_.contains(newIds, this.curContext.toString())) {
-    logger.info("New page listing from remote debugger doesn't contain " +
+    logger.debug("New page listing from remote debugger doesn't contain " +
                  "current window, let's assume it's closed");
     if (keyId !== null) {
-      logger.info("Debugger already selected page " + keyId + ", " +
+      logger.debug("Debugger already selected page " + keyId + ", " +
                   "confirming that choice.");
     } else {
       logger.error("Don't have our current window anymore, and there " +
@@ -137,7 +137,7 @@ iOSHybrid.onPageChange = function (pageArray) {
       this.remote.pageLoad();
     }
 
-    logger.info("New page listing is same as old, doing nothing");
+    logger.debug("New page listing is same as old, doing nothing");
   }
 
   if (newPage !== null) {

--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -49,7 +49,7 @@ IosLog.prototype.startCapture = function (cb) {
                                "../../../build/libimobiledevice-macosx/");
     spawnEnv.PATH = process.env.PATH + ":" + limdDir;
     spawnEnv.DYLD_LIBRARY_PATH = limdDir + ":" + process.env.DYLD_LIBRARY_PATH;
-    logger.info("Starting iOS device log capture via idevicesyslog");
+    logger.debug("Starting iOS device log capture via idevicesyslog");
     // idevicesyslog retrieves many old device log lines that came before it was
     // started so filter those out until we encounter new log lines.
     this.loggingModeOn = false;
@@ -57,7 +57,7 @@ IosLog.prototype.startCapture = function (cb) {
     this.finishStartingLogCapture(cb);
   } else {
     if (parseInt(this.xcodeVersion.split(".")[0], 10) >= 5) {
-      logger.info("Starting iOS 7.* simulator log capture");
+      logger.debug("Starting iOS 7.* simulator log capture");
       var sim7LogsPath = path.resolve(process.env.HOME, "Library", "Logs", "iOS Simulator");
       glob(sim7LogsPath + "/7.*/system.log", function (err, files) {
         if (err || files.length < 1) {
@@ -82,7 +82,7 @@ IosLog.prototype.startCapture = function (cb) {
         }
       }.bind(this));
     } else {
-      logger.info("Starting iOS 6.* simulator log capture");
+      logger.debug("Starting iOS 6.* simulator log capture");
       this.proc = spawn("tail", ["-f", "-n", "1", "/var/log/system.log"]);
       this.finishStartingLogCapture(cb);
     }
@@ -104,7 +104,7 @@ IosLog.prototype.finishStartingLogCapture = function (cb) {
 };
 
 IosLog.prototype.stopCapture = function () {
-  logger.info("Stopping iOS log capture");
+  logger.debug("Stopping iOS log capture");
   this.proc.kill();
   this.proc = null;
 };

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -152,7 +152,7 @@ IOS.prototype.configureApp = function (cb) {
     this.configurePreferences(cb);
   } else if (this.appIsPackageOrBundle(app)) {
     // we have a bundle ID
-    logger.info("App is an iOS bundle, will attempt to run as pre-existing");
+    logger.debug("App is an iOS bundle, will attempt to run as pre-existing");
     this.args.bundleId = app;
     this.args.app = null;
     cb();
@@ -162,7 +162,7 @@ IOS.prototype.configureApp = function (cb) {
 };
 
 IOS.prototype.configurePreferences = function (cb) {
-  logger.info("Configuring settings app");
+  logger.debug("Configuring settings app");
   var prefsVer = null;
   if (typeof this.args.platformVersion !== "undefined" &&
       this.args.platformVersion) {
@@ -170,14 +170,14 @@ IOS.prototype.configurePreferences = function (cb) {
   }
 
   var sdkNext = function (prefsVer) {
-    logger.info("Trying to use settings app, version " + prefsVer);
+    logger.debug("Trying to use settings app, version " + prefsVer);
     checkPreferencesApp(prefsVer, this.args.tmpDir, function (err, attemptedApp, origApp) {
       if (err) {
         logger.error("Could not prepare settings app with version '" +
                      prefsVer + "': " + err);
         return cb(err);
       }
-      logger.info("Using settings app at " + attemptedApp);
+      logger.debug("Using settings app at " + attemptedApp);
       this.args.app = attemptedApp;
       this.args.origAppPath = origApp;
       cb();
@@ -197,7 +197,7 @@ IOS.prototype.configurePreferences = function (cb) {
 IOS.prototype.preCleanup = function (cb) {
   var removeTracedirs = function (innerCb) {
     if (this.args.removeTraceDir) {
-      logger.info("Cleaning up any tracedirs");
+      logger.debug("Cleaning up any tracedirs");
       glob("*.trace", {}, function (err, files) {
         if (err) {
           logger.error("Could not glob for tracedirs: " + err.message);
@@ -217,13 +217,13 @@ IOS.prototype.preCleanup = function (cb) {
                 if (err) {
                   logger.warn("Problem cleaning up file: " + err.message);
                 } else {
-                  logger.info("Cleaned up " + file);
+                  logger.debug("Cleaned up " + file);
                 }
                 onDelete();
               });
             });
           } else {
-            logger.info("No tracedirs to clean up");
+            logger.debug("No tracedirs to clean up");
             innerCb();
           }
         }
@@ -234,10 +234,10 @@ IOS.prototype.preCleanup = function (cb) {
   }.bind(this);
 
   var removeSocket = function (innerCb) {
-    logger.info("Removing any remaining instruments sockets");
+    logger.debug("Removing any remaining instruments sockets");
     rimraf(sock, function (err) {
       if (err) return innerCb(err);
-      logger.info("Cleaned up instruments socket " + sock);
+      logger.debug("Cleaned up instruments socket " + sock);
       innerCb();
     });
   }.bind(this);
@@ -340,10 +340,10 @@ IOS.prototype.shouldIgnoreInstrumentsExit = function () {
 };
 
 IOS.prototype.onInstrumentsLaunch = function (cb) {
-  logger.info('Instruments launched. Starting poll loop for new commands.');
+  logger.debug('Instruments launched. Starting poll loop for new commands.');
   this.instruments.setDebug(true);
   if (this.args.origAppPath) {
-    logger.info("Copying app back to its original place");
+    logger.debug("Copying app back to its original place");
     return ncp(this.args.app, this.args.origAppPath, cb);
   }
 
@@ -356,7 +356,7 @@ IOS.prototype.setBundleId = function (cb) {
   } else {
     this.proxy('au.bundleId()', function (err, bId) {
       if (err) return cb(err);
-      logger.info('Bundle ID for open app is ' + bId.value);
+      logger.debug('Bundle ID for open app is ' + bId.value);
       this.args.bundleId = bId.value;
       cb();
     }.bind(this));
@@ -368,7 +368,7 @@ IOS.prototype.setInitialOrientation = function (cb) {
       _.contains(["LANDSCAPE", "PORTRAIT"],
                  this.args.initialOrientation.toUpperCase())
       ) {
-    logger.info("Setting initial orientation to " + this.args.initialOrientation);
+    logger.debug("Setting initial orientation to " + this.args.initialOrientation);
     var command = ["au.setScreenOrientation('",
       this.args.initialOrientation.toUpperCase(), "')"].join('');
     this.proxy(command, function (err, res) {
@@ -385,7 +385,7 @@ IOS.prototype.setInitialOrientation = function (cb) {
 };
 
 IOS.prototype.setBootstrapConfig = function (cb) {
-  logger.info("Setting bootstrap config keys/values");
+  logger.debug("Setting bootstrap config keys/values");
   var autoAcceptAlerts = !(!this.args.autoAcceptAlerts || this.args.autoAcceptAlerts === 'false');
   var cmd = "setBootstrapConfig: autoAcceptAlerts=" + autoAcceptAlerts;
   this.proxy(cmd, function (err) {
@@ -394,7 +394,7 @@ IOS.prototype.setBootstrapConfig = function (cb) {
 };
 
 IOS.prototype.onUnexpectedInstrumentsExit = function (code, traceDir) {
-  logger.info("Instruments exited unexpectedly");
+  logger.debug("Instruments exited unexpectedly");
   if (typeof this.cbForCurrentCmd === "function") {
     // we were in the middle of waiting for a command when it died
     // so let's actually respond with something
@@ -409,7 +409,7 @@ IOS.prototype.onUnexpectedInstrumentsExit = function (code, traceDir) {
 };
 
 IOS.prototype.setXcodeFolder = function (cb) {
-  logger.info("Setting Xcode folder");
+  logger.debug("Setting Xcode folder");
   helpers.getXcodeFolder(function (err, xcodeFolder) {
     if (err) {
       logger.error("Could not determine Xcode folder");
@@ -420,7 +420,7 @@ IOS.prototype.setXcodeFolder = function (cb) {
 };
 
 IOS.prototype.setXcodeVersion = function (cb) {
-  logger.info("Setting Xcode version");
+  logger.debug("Setting Xcode version");
   helpers.getXcodeVersion(function (err, versionNumber) {
     if (err) {
       logger.error("Could not determine Xcode version");
@@ -436,13 +436,13 @@ IOS.prototype.setXcodeVersion = function (cb) {
 };
 
 IOS.prototype.setiOSSDKVersion = function (cb) {
-  logger.info("Setting iOS SDK Version");
+  logger.debug("Setting iOS SDK Version");
   helpers.getiOSSDKVersion(function (err, versionNumber) {
     if (err) {
       logger.error("Could not determine iOS SDK version");
     }
     this.iOSSDKVersion = versionNumber;
-    logger.info("iOS SDK Version set to " + this.iOSSDKVersion);
+    logger.debug("iOS SDK Version set to " + this.iOSSDKVersion);
     cb();
   }.bind(this));
 };
@@ -469,7 +469,7 @@ IOS.prototype.setLocale = function (cb) {
           var setLanguageForPath = function (pathIndex) {
             if (pathIndex >= pathList.length) {
               if (localeInfoWasSet) {
-                logger.info("Locale was set");
+                logger.debug("Locale was set");
                 cb();
               } else {
                 msg = "Appium was unable to set locale info.";
@@ -482,7 +482,7 @@ IOS.prototype.setLocale = function (cb) {
               cmd = (this.args.language) ? cmd + ' -language ' + this.args.language : cmd;
               cmd = (this.args.locale) ? cmd + ' -locale ' + this.args.locale : cmd;
               cmd = (this.args.calendarFormat) ? cmd + ' -calendar ' + this.args.calendarFormat : cmd;
-              logger.info("Setting locale with command " + cmd);
+              logger.debug("Setting locale with command " + cmd);
               exec(cmd, { maxBuffer: 524288 }, function (err) {
                 if (err === null) {
                   localeInfoWasSet = true;
@@ -508,17 +508,17 @@ IOS.prototype.setLocale = function (cb) {
       setLoc();
     }
   } else if (this.args.udid) {
-    logger.info("Not setting locale because we're using a real device");
+    logger.debug("Not setting locale because we're using a real device");
     cb();
   } else {
-    logger.info("Not setting locale");
+    logger.debug("Not setting locale");
     cb();
   }
 };
 
 IOS.prototype.setPreferences = function (cb) {
   if (this.args.udid !== null) {
-    logger.info("Not setting iOS and app preferences since we're on a real " +
+    logger.debug("Not setting iOS and app preferences since we're on a real " +
                 "device");
     return cb();
   }
@@ -544,11 +544,11 @@ IOS.prototype.setPreferences = function (cb) {
   }.bind(this));
 
   if (!needToSet) {
-    logger.info("No iOS / app preferences to set");
+    logger.debug("No iOS / app preferences to set");
     return cb();
   } else if (this.args.fullReset) {
     var msg = "Cannot set preferences because a full-reset was requested";
-    logger.info(msg);
+    logger.debug(msg);
     logger.error(msg);
     return cb(new Error(msg));
   }
@@ -572,7 +572,7 @@ IOS.prototype.setPreferences = function (cb) {
     cb();
   }.bind(this);
 
-  logger.info("Setting iOS and app preferences");
+  logger.debug("Setting iOS and app preferences");
   if (!settings.simDirsExist(this.iOSSDKVersion) ||
       (needToSetSafari && !settings.safari7DirsExist(this.iOSSDKVersion))) {
     this.instantLaunchAndQuit(setPrefs);
@@ -582,7 +582,7 @@ IOS.prototype.setPreferences = function (cb) {
 };
 
 IOS.prototype.instantLaunchAndQuit = function (cb) {
-  logger.info("Sim files for the " + this.iOSSDKVersion + " SDK do not yet exist, launching the sim " +
+  logger.debug("Sim files for the " + this.iOSSDKVersion + " SDK do not yet exist, launching the sim " +
       "to populate the applications and preference dirs");
   this.setDeviceAndLaunchSimulator(function (err) {
     if (err) return cb(err);
@@ -601,7 +601,7 @@ IOS.prototype.setLocServicesPrefs = function () {
     var locServ = this.capabilities.locationServicesEnabled;
     locServ = locServ || this.capabilities.locationServicesAuthorized;
     locServ = locServ ? 1 : 0;
-    logger.info("Setting location services to " + locServ);
+    logger.debug("Setting location services to " + locServ);
     settings.updateSettings(this.iOSSDKVersion, 'locationServices', {
       LocationServicesEnabled: locServ,
       'LocationServicesEnabledIn7.0': locServ
@@ -615,9 +615,9 @@ IOS.prototype.setLocServicesPrefs = function () {
     }
     var locAuth = !!this.capabilities.locationServicesAuthorized;
     if (locAuth) {
-      logger.info("Authorizing location services for app");
+      logger.debug("Authorizing location services for app");
     } else {
-      logger.info("De-authorizing location services for app");
+      logger.debug("De-authorizing location services for app");
     }
     settings.updateLocationSettings(this.iOSSDKVersion, this.args.bundleId, locAuth);
     this.keepAppToRetainPrefs = true;
@@ -630,17 +630,17 @@ IOS.prototype.setSafariPrefs = function () {
   var val;
   if (_.has(this.capabilities, 'safariAllowPopups')) {
     val = !!this.capabilities.safariAllowPopups;
-    logger.info("Setting javascript window opening to " + val);
+    logger.debug("Setting javascript window opening to " + val);
     safariSettings.WebKitJavaScriptCanOpenWindowsAutomatically = val;
   }
   if (_.has(this.capabilities, 'safariIgnoreFraudWarning')) {
     val = !this.capabilities.safariIgnoreFraudWarning;
-    logger.info("Setting fraudulent website warning to " + val);
+    logger.debug("Setting fraudulent website warning to " + val);
     safariSettings.WarnAboutFraudulentWebsites = val;
   }
   if (_.has(this.capabilities, 'safariOpenLinksInBackground')) {
     val = this.capabilities.safariOpenLinksInBackground ? 1 : 0;
-    logger.info("Setting opening links in background to " + !!val);
+    logger.debug("Setting opening links in background to " + !!val);
     safariSettings.OpenLinksInBackground = val;
   }
   if (_.size(safariSettings) > 0) {
@@ -650,7 +650,7 @@ IOS.prototype.setSafariPrefs = function () {
 };
 
 IOS.prototype.detectTraceTemplate = function (cb) {
-  logger.info("Detecting automation tracetemplate");
+  logger.debug("Detecting automation tracetemplate");
   var msg;
   if (!this.args.automationTraceTemplatePath) {
     helpers.getXcodeFolder(function (err, xcodeFolderPath) {
@@ -683,12 +683,12 @@ IOS.prototype.detectTraceTemplate = function (cb) {
 
 IOS.prototype.detectUdid = function (cb) {
   if (this.args.udid !== null && this.args.udid === "auto") {
-    logger.info("Auto-detecting iOS udid...");
+    logger.debug("Auto-detecting iOS udid...");
     var udidetectPath = path.resolve(__dirname, "../../../build/udidetect/udidetect");
     var udiddetectProc = exec(udidetectPath, { maxBuffer: 524288, timeout: 3000 }, function (err, stdout) {
       if (stdout && stdout.length > 2) {
         this.args.udid = stdout.replace("\n", "");
-        logger.info("Detected udid as " + this.args.udid);
+        logger.debug("Detected udid as " + this.args.udid);
         cb();
       } else {
         logger.error("Could not detect udid.");
@@ -700,7 +700,7 @@ IOS.prototype.detectUdid = function (cb) {
       cb(new Error("Timed out trying to detect udid."));
     });
   } else {
-    logger.info("Not auto-detecting udid, running on sim");
+    logger.debug("Not auto-detecting udid, running on sim");
     cb();
   }
 };
@@ -741,11 +741,11 @@ IOS.prototype.installToRealDevice = function (cb) {
 IOS.prototype.getIDeviceObj = function () {
   var idiPath = path.resolve(__dirname, "../../../build/",
                              "libimobiledevice-macosx/ideviceinstaller");
-  logger.info("Creating iDevice object with udid " + this.args.udid);
+  logger.debug("Creating iDevice object with udid " + this.args.udid);
   try {
     return iDevice(this.args.udid);
   } catch (e1) {
-    logger.info("Couldn't find ideviceinstaller, trying built-in at " +
+    logger.debug("Couldn't find ideviceinstaller, trying built-in at " +
                 idiPath);
     try {
       return iDevice(this.args.udid, {cmd: idiPath});
@@ -759,14 +759,14 @@ IOS.prototype.getIDeviceObj = function () {
 };
 
 IOS.prototype.installIpa = function (cb) {
-  logger.info("Installing ipa found at " + this.args.ipa);
+  logger.debug("Installing ipa found at " + this.args.ipa);
   this.realDevice = this.getIDeviceObj();
   var d = this.realDevice;
   async.waterfall([
     function (cb) { d.isInstalled(this.args.bundleId, cb); }.bind(this),
     function (installed, cb) {
       if (installed) {
-        logger.info("Bundle found on device, removing before reinstalling.");
+        logger.debug("Bundle found on device, removing before reinstalling.");
         d.remove(this.args.bundleId, cb);
       } else {
         logger.debug("Nothing found on device, going ahead and installing.");
@@ -833,13 +833,13 @@ IOS.prototype.setDeviceTypeInInfoPlist = function (deviceTypeCode, cb) {
           cb(err);
           return;
         } else {
-          logger.info("Parsed app Info.plist");
+          logger.debug("Parsed app Info.plist");
           obj.UIDeviceFamily = [deviceTypeCode];
           newPlist = xmlplist.build(obj);
         }
       });
     } else {
-      logger.info("Parsed app Info.plist");
+      logger.debug("Parsed app Info.plist");
       obj[0].UIDeviceFamily = [deviceTypeCode];
       newPlist = bplistCreate(obj);
     }
@@ -848,7 +848,7 @@ IOS.prototype.setDeviceTypeInInfoPlist = function (deviceTypeCode, cb) {
         logger.error("Could not save new Info.plist");
         cb(err);
       } else {
-        logger.info("Wrote new app Info.plist with device type");
+        logger.debug("Wrote new app Info.plist with device type");
         cb();
       }
     });
@@ -879,17 +879,17 @@ IOS.prototype.checkDeviceAvailable = function (cb) {
 IOS.prototype.setDeviceAndLaunchSimulator = function (cb) {
   var msg;
   if (this.args.udid) {
-    logger.info("Not setting device type since we're connected to a device");
+    logger.debug("Not setting device type since we're connected to a device");
     cb();
   } else if (!this.args.app && this.args.bundleId) {
-    logger.info("Not setting device type since we're using bundle ID and " +
+    logger.debug("Not setting device type since we're using bundle ID and " +
                 "assuming app is already installed");
     cb(null);
   } else if (!this.args.deviceName && this.args.forceIphone === null && this.args.forceIpad === null) {
-    logger.info("No device specified, current device in the iOS simulator will be used.");
+    logger.debug("No device specified, current device in the iOS simulator will be used.");
     cb(null);
   } else if (this.args.defaultDevice) {
-    logger.info("User specified default device, letting instruments launch it");
+    logger.debug("User specified default device, letting instruments launch it");
     this.checkDeviceAvailable(function (err) {
       if (err) return cb(err);
       var iosDeviceString = this.getDeviceString();
@@ -907,7 +907,7 @@ IOS.prototype.setDeviceAndLaunchSimulator = function (cb) {
 
       var cleanup = function (cb) {
         if ((this.args.fullReset || this.args.reset) && this.dontDeleteSimApps) {
-          logger.info("Not deleting simulator apps since we need to update " +
+          logger.debug("Not deleting simulator apps since we need to update " +
                       "their plists before launch");
           return cb();
         }
@@ -932,7 +932,7 @@ IOS.prototype.setDeviceAndLaunchSimulator = function (cb) {
         var waitForSimulatorLogs = function (countdown) {
           if (countdown <= 0 || (this.logs.syslog && (this.logs.syslog.getAllLogs().length > 0 ||
             (this.logs.crashlog && this.logs.crashlog.getAllLogs().length > 0)))) {
-            logger.info(countdown > 0 ? "Simulator is now ready." : "Waited 10 seconds for simulator to start.");
+            logger.debug(countdown > 0 ? "Simulator is now ready." : "Waited 10 seconds for simulator to start.");
             cb();
           } else {
             setTimeout(function () {
@@ -967,7 +967,7 @@ IOS.prototype.setDeviceAndLaunchSimulator = function (cb) {
 
 IOS.prototype.parseLocalizableStrings = function (cb, language) {
   if (this.args.app === null) {
-    logger.info("Localizable.strings is not currently supported when using real devices.");
+    logger.debug("Localizable.strings is not currently supported when using real devices.");
     cb();
   } else {
     var strings = null;
@@ -977,7 +977,7 @@ IOS.prototype.parseLocalizableStrings = function (cb, language) {
     }
     if (!fs.existsSync(strings)) {
       if (language) {
-        logger.info("No Localizable.strings for language '" + language + "', getting default strings");
+        logger.debug("No Localizable.strings for language '" + language + "', getting default strings");
       }
       strings = path.resolve(this.args.app, "Localizable.strings");
     }
@@ -991,13 +991,13 @@ IOS.prototype.parseLocalizableStrings = function (cb, language) {
           if (err) {
             logger.warn("Could not parse plist file at " + strings);
           } else {
-            logger.info("Parsed app Localizable.strings");
+            logger.debug("Parsed app Localizable.strings");
             this.localizableStrings = obj;
           }
           cb();
         }.bind(this));
       } else {
-        logger.info("Parsed app Localizable.strings");
+        logger.debug("Parsed app Localizable.strings");
         this.localizableStrings = obj;
         cb();
       }
@@ -1025,14 +1025,14 @@ IOS.prototype.getSimulatorApplications = function (cb) {
 
 IOS.prototype.deleteSim = function (cb) {
   var simRoot = getSimRoot();
-  logger.info("Deleting simulator folder: " + simRoot);
+  logger.debug("Deleting simulator folder: " + simRoot);
   if (fs.existsSync(simRoot)) {
     rimraf(simRoot, cb);
   } else cb();
 };
 
 IOS.prototype.cleanupAppState = function (cb) {
-  logger.info("Cleaning app state.");
+  logger.debug("Cleaning app state.");
   this.getSimulatorApplications(function (err, files) {
     if (err) {
       logger.error("Could not remove: " + err.message);
@@ -1043,7 +1043,7 @@ IOS.prototype.cleanupAppState = function (cb) {
           _(files).each(function (file, i) {
             if (!this.keepAppToRetainPrefs) {
               rimraf.sync(file);
-              logger.info("Deleted " + file);
+              logger.debug("Deleted " + file);
               if (i === 0 && this.args.keepKeyChains) {
                 mkdirp.sync(file);
               }
@@ -1052,25 +1052,25 @@ IOS.prototype.cleanupAppState = function (cb) {
             var tcc = path.join(root, 'Library/TCC');
             if (fs.existsSync(tcc)) {
               rimraf.sync(tcc);
-              logger.info("Deleted " + tcc);
+              logger.debug("Deleted " + tcc);
             }
 
             var caches = path.join(root, 'Library/Caches/locationd');
             if (!this.keepAppToRetainPrefs && fs.existsSync(caches)) {
               rimraf.sync(caches);
-              logger.info("Deleted " + caches);
+              logger.debug("Deleted " + caches);
             }
 
             var media = path.join(root, 'Media');
             if (fs.existsSync(media)) {
               rimraf.sync(media);
-              logger.info("Deleted " + media);
+              logger.debug("Deleted " + media);
             }
 
             var keychain = path.join(root, 'Library/Keychains');
             if (!this.args.keepKeyChains && fs.existsSync(keychain)) {
               rimraf.sync(keychain);
-              logger.info("Deleted " + keychain);
+              logger.debug("Deleted " + keychain);
             }
           }, this);
           cb();
@@ -1078,7 +1078,7 @@ IOS.prototype.cleanupAppState = function (cb) {
           cb(err);
         }
       } else {
-        logger.info("No folders found to remove");
+        logger.debug("No folders found to remove");
         if (this.realDevice && this.args.bundleId) {
           var bundleId = this.args.bundleId;
           this.realDevice.remove(bundleId, function (err) {
@@ -1088,12 +1088,12 @@ IOS.prototype.cleanupAppState = function (cb) {
                   logger.error("Could not remove " + bundleId + " from device");
                   cb(err);
                 } else {
-                  logger.info("Removed " + bundleId);
+                  logger.debug("Removed " + bundleId);
                   cb();
                 }
               }.bind(this));
             } else {
-              logger.info("Removed " + bundleId);
+              logger.debug("Removed " + bundleId);
               cb();
             }
           }.bind(this));
@@ -1138,14 +1138,14 @@ IOS.prototype.postCleanup = function (cb) {
       }.bind(this),
     ], cb);
   } else {
-    logger.info("Reset set to false, not ending sim or cleaning up app state");
+    logger.debug("Reset set to false, not ending sim or cleaning up app state");
     cb();
   }
 
 };
 
 IOS.prototype.endSimulator = function (cb) {
-  logger.info("Killing the simulator process");
+  logger.debug("Killing the simulator process");
   if (this.iosSimProcess) {
     this.iosSimProcess.kill("SIGHUP");
     this.iosSimProcess = null;
@@ -1164,7 +1164,7 @@ IOS.prototype.endSimulator = function (cb) {
 };
 
 IOS.prototype.endSimulatorDaemons = function (cb) {
-  logger.info("Killing any other simulator daemons");
+  logger.debug("Killing any other simulator daemons");
   var stopCmd = 'launchctl list | grep com.apple.iphonesimulator.launchd | cut -f 3 | xargs -n 1 launchctl stop';
   exec(stopCmd, { maxBuffer: 524288 }, function () {
     var removeCmd = 'launchctl list | grep com.apple.iphonesimulator.launchd | cut -f 3 | xargs -n 1 launchctl remove';
@@ -1175,9 +1175,9 @@ IOS.prototype.endSimulatorDaemons = function (cb) {
 };
 
 IOS.prototype.stop = function (cb) {
-  logger.info("Stopping ios");
+  logger.debug("Stopping ios");
   if (this.instruments === null) {
-    logger.info("Trying to stop instruments but it already exited");
+    logger.debug("Trying to stop instruments but it already exited");
     this.postCleanup(cb);
   } else {
     this.instruments.shutdown(function (code, traceDir) {
@@ -1193,7 +1193,7 @@ IOS.prototype.shutdown = function (code, traceDir, cb) {
     if (this.args.removeTraceDir && traceDir) {
       rimraf(traceDir, function (err) {
         if (err) return cb(err);
-        logger.info("Deleted tracedir we heard about from instruments (" +
+        logger.debug("Deleted tracedir we heard about from instruments (" +
                     traceDir + ")");
         cb();
       });
@@ -1225,7 +1225,7 @@ IOS.prototype.initQueue = function () {
         async.whilst(
           function () { return this.selectingNewPage && this.curContext; }.bind(this),
           function (cb) {
-            logger.info("We're in the middle of selecting a new page, " +
+            logger.debug("We're in the middle of selecting a new page, " +
                         "waiting to run next command until done");
             setTimeout(cb, 100);
           },
@@ -1245,7 +1245,7 @@ IOS.prototype.initQueue = function () {
         async.whilst(
           function () { return !matched && this.curContext && this.processingRemoteCmd; }.bind(this),
           function (cb) {
-            logger.info("We're in the middle of processing a remote debugger " +
+            logger.debug("We're in the middle of processing a remote debugger " +
                         "command, waiting to run next command until done");
             setTimeout(cb, 100);
           },

--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -76,7 +76,7 @@ RemoteDebugger.prototype.connect = function (cb, pageChangeCb) {
   this.pageChangeCb = pageChangeCb;
   this.socket = new net.Socket({type: 'tcp6'});
   this.socket.on('close', function () {
-    this.logger.info('Debugger socket disconnected');
+    this.logger.debug('Debugger socket disconnected');
     this.socketGone = true;
     this.onAppDisconnect();
   }.bind(this));
@@ -84,14 +84,14 @@ RemoteDebugger.prototype.connect = function (cb, pageChangeCb) {
 
   var port = process.env.REMOTE_DEBUGGER_PORT || 27753;
   this.socket.connect(port, '::1', function () {
-    this.logger.info("Debugger socket connected to " +
+    this.logger.debug("Debugger socket connected to " +
       this.socket.remoteAddress + ':' + this.socket.remotePort);
     this.setConnectionKey(cb);
   }.bind(this));
 };
 
 RemoteDebugger.prototype.disconnect = function () {
-  this.logger.info("Disconnecting from remote debugger");
+  this.logger.debug("Disconnecting from remote debugger");
   this.socketGone = true;
   this.socket.destroy();
 };
@@ -99,7 +99,7 @@ RemoteDebugger.prototype.disconnect = function () {
 RemoteDebugger.prototype.setConnectionKey = function (cb) {
   try { assert.ok(this.connId); } catch (err) { return cb(err); }
   var setConnKey = messages.setConnectionKey(this.connId);
-  this.logger.info("Sending connection key");
+  this.logger.debug("Sending connection key");
   this.send(setConnKey, function (simNameKey, simBuildKey) {
     this.logger.debug("Sim name: " + simNameKey);
     this.logger.debug("Sim build: " + simBuildKey);
@@ -116,7 +116,7 @@ RemoteDebugger.prototype.selectApp = function (appIdKey, cb) {
   try { assert.ok(this.connId); } catch (err) { return cb(err); }
   this.appIdKey = appIdKey;
   var connectToApp = messages.connectToApp(this.connId, this.appIdKey);
-  this.logger.info("Selecting app");
+  this.logger.debug("Selecting app");
   this.send(connectToApp, function (pageDict) {
     cb(this.pageArrayFromDict(pageDict));
     this.specialCbs['_rpc_forwardGetListing:'] = this.onPageChange.bind(this);
@@ -149,13 +149,13 @@ RemoteDebugger.prototype.selectPage = function (pageIdKey, cb, skipReadyCheck) {
   this.pageIdKey = pageIdKey;
   var setSenderKey = messages.setSenderKey(this.connId, this.appIdKey,
                                            this.senderId, this.pageIdKey);
-  this.logger.info("Selecting page " + pageIdKey + " and forwarding socket setup");
+  this.logger.debug("Selecting page " + pageIdKey + " and forwarding socket setup");
   this.send(setSenderKey, function () {
-    this.logger.info("Set sender key");
+    this.logger.debug("Set sender key");
     var enablePage = messages.enablePage(this.appIdKey, this.connId,
                                          this.senderId, this.pageIdKey, this.debuggerType);
     this.send(enablePage, function () {
-      this.logger.info("Enabled activity on page");
+      this.logger.debug("Enabled activity on page");
       if (skipReadyCheck) {
         cb();
       } else {
@@ -191,7 +191,7 @@ RemoteDebugger.prototype.onPageChange = function (pageDict) {
 RemoteDebugger.prototype.wrapScriptForFrame = function (script, frame) {
   var elFromCache = getAtom('get_element_from_cache')
     , wrapper = "";
-  this.logger.info("Wrapping script for frame " + frame);
+  this.logger.debug("Wrapping script for frame " + frame);
   frame = JSON.stringify(frame);
   wrapper += "(function (window) { var document = window.document; ";
   wrapper += "return (" + script + ");";
@@ -210,7 +210,7 @@ RemoteDebugger.prototype.executeAtom = function (atom, args, frames, cb) {
     }
     script += "(" + args.join(',') + ")";
   } else {
-    this.logger.info("Executing '" + atom + "' atom in default context");
+    this.logger.debug("Executing '" + atom + "' atom in default context");
     script += "(" + atomSrc + ")(" + args.join(',') + ")";
   }
   this.execute(script, function (err, res) {
@@ -251,7 +251,7 @@ RemoteDebugger.prototype.executeAtomAsync = function (atom, args, frames, respon
     }
     script += "(" + args.join(',') + ", " + asyncCallBack + ", true )";
   } else {
-    this.logger.info("Executing atom in default context");
+    this.logger.debug("Executing atom in default context");
     script += "(" + atomSrc + ")(" + args.join(',') + ", " + asyncCallBack + ", true )";
   }
   this.execute(script, function (err, res) {
@@ -266,7 +266,7 @@ RemoteDebugger.prototype.executeAtomAsync = function (atom, args, frames, respon
 
 RemoteDebugger.prototype.execute = function (command, cb, override) {
   if (this.pageLoading && !override) {
-    this.logger.info("Trying to execute but page is not loaded. Waiting for dom");
+    this.logger.debug("Trying to execute but page is not loaded. Waiting for dom");
     this.waitForDom(function () {
       this.execute(command, cb);
     }.bind(this));
@@ -279,7 +279,7 @@ RemoteDebugger.prototype.execute = function (command, cb, override) {
         assert.ok(this.pageIdKey);
       } catch (err) { return cb(err); }
     }
-    this.logger.info("Sending javascript command");
+    this.logger.debug("Sending javascript command");
     var sendJSCommand = messages.sendJSCommand(command, this.appIdKey,
         this.connId, this.senderId, this.pageIdKey, this.debuggerType);
     this.send(sendJSCommand, cb);
@@ -294,7 +294,7 @@ RemoteDebugger.prototype.callFunction = function (objId, fn, args, cb) {
     assert.ok(this.pageIdKey);
   } catch (err) { return cb(err); }
 
-  this.logger.info("Calling javascript function");
+  this.logger.debug("Calling javascript function");
   var callJSFunction = messages.callJSfunction(objId, fn, args, this.appIdKey,
       this.connId, this.senderId, this.pageIdKey, this.debuggerType);
   this.send(callJSFunction, cb);
@@ -309,7 +309,7 @@ RemoteDebugger.prototype.navToUrl = function (url, cb) {
       assert.ok(this.pageIdKey);
     } catch (err) { return cb(err); }
   }
-  this.logger.info("Navigating to new URL: " + url);
+  this.logger.debug("Navigating to new URL: " + url);
   var navToUrl = messages.setUrl(url, this.appIdKey, this.connId,
       this.senderId, this.pageIdKey, this.debuggerType);
   this.send(navToUrl, noop);
@@ -352,7 +352,7 @@ RemoteDebugger.prototype.cancelPageLoad = function () {
 };
 
 RemoteDebugger.prototype.frameNavigated = function () {
-  this.logger.info("Frame navigated, calling cbs");
+  this.logger.debug("Frame navigated, calling cbs");
   clearTimeout(this.navigatingTimeout);
   var cbs = this.frameNavigatedCbs;
   this.frameNavigatedCbs = [];
@@ -395,7 +395,7 @@ RemoteDebugger.prototype.handleMessage = function (plist) {
   if (_.has(this.handlers, handlerFor)) {
     this.handlers[handlerFor](plist);
   } else {
-    this.logger.info("Debugger got a message for '" + handlerFor + "' and have no " +
+    this.logger.debug("Debugger got a message for '" + handlerFor + "' and have no " +
                 "handler, doing nothing.");
   }
 };
@@ -435,15 +435,15 @@ RemoteDebugger.prototype.setHandlers = function () {
         msgId = msgId.toString();
       }
       if (dataKey.method === "Profiler.resetProfiles") {
-        this.logger.info("Device is telling us to reset profiles. Should probably " +
+        this.logger.debug("Device is telling us to reset profiles. Should probably " +
                     "do some kind of callback here");
         //me.onPageChange();
       } else if (dataKey.method === "Page.frameNavigated") {
         if (!this.willNavigateWithoutReload && !this.pageLoading) {
-          this.logger.info("Frame navigated, unloading page");
+          this.logger.debug("Frame navigated, unloading page");
           this.frameNavigated();
         } else {
-          this.logger.info("Frame navigated but we were warned about it, not " +
+          this.logger.debug("Frame navigated but we were warned about it, not " +
                       "considering page state unloaded");
           this.willNavigateWithoutReload = false;
         }
@@ -457,7 +457,7 @@ RemoteDebugger.prototype.setHandlers = function () {
                      "but we already ran that callback! WTF??");
       } else {
         if (!msgId && !result && !error) {
-          this.logger.info("Got a blank data response from debugger");
+          this.logger.debug("Got a blank data response from debugger");
         } else {
           this.logger.error("Debugger returned data for message " + msgId +
                       " but we weren't waiting for that message! " +
@@ -505,7 +505,7 @@ RemoteDebugger.prototype.send = function (data, cb, cb2) {
     plist = bplistCreate(data);
   } catch (e) {
     this.logger.error("Could not create binary plist from data");
-    return this.logger.info(e);
+    return this.logger.debug(e);
   }
 
   if (!this.socketGone) {
@@ -538,7 +538,7 @@ RemoteDebugger.prototype.receive = function (data) {
       msgLength = bufferpack.unpack('L', prefix)[0];
     } catch (e) {
       this.logger.error("Butter could not unpack");
-      return this.logger.info(e);
+      return this.logger.debug(e);
     }
 
     // Jump forward 4 bytes
@@ -559,7 +559,7 @@ RemoteDebugger.prototype.receive = function (data) {
       plist = bplistParse.parseBuffer(body);
     } catch (e) {
       this.logger.error("Error parsing binary plist");
-      this.logger.info(e);
+      this.logger.debug(e);
     }
 
     // bplistParse.parseBuffer returns an array

--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -18,7 +18,7 @@ var Safari = function () {
 _.extend(Safari.prototype, IOS.prototype);
 
 Safari.prototype.configure = function (args, caps, cb) {
-  logger.info("Configuring Safari session");
+  logger.debug("Configuring Safari session");
   this._deviceConfigure(args, caps);
   this.setIOSArgs();
   this.capabilities.safari = true;
@@ -38,11 +38,11 @@ Safari.prototype.configureSafari = function (cb) {
       this.args.platformVersion) {
     safariVer = this.args.platformVersion;
   }
-  logger.info("Trying to use mobile safari, version " + safariVer);
+  logger.debug("Trying to use mobile safari, version " + safariVer);
   var checkNext = function (attemptedApp, origApp, safariVer) {
-    logger.info("Using mobile safari app at " + attemptedApp);
+    logger.debug("Using mobile safari app at " + attemptedApp);
     this.args.app = attemptedApp;
-    logger.info("Cleaning mobile safari data files");
+    logger.debug("Cleaning mobile safari data files");
     cleanSafari(safariVer, function (err) {
       if (err) {
         logger.error(err.message);
@@ -113,7 +113,7 @@ Safari.prototype.navToLatestAvailableWebview = function (cb) {
 };
 
 Safari.prototype.navToViewThroughFavorites = function (cb) {
-  logger.info("We're on iOS7 simulator: clicking apple button to get into " +
+  logger.debug("We're on iOS7 simulator: clicking apple button to get into " +
               "a webview");
   var oldImpWait = this.implicitWaitMs;
   this.implicitWaitMs = 7000; // wait 7s for apple button to exist
@@ -137,7 +137,7 @@ Safari.prototype.navToViewThroughFavorites = function (cb) {
 };
 
 Safari.prototype.navToView = function (cb) {
-  logger.info("Navigating to most recently opened webview");
+  logger.debug("Navigating to most recently opened webview");
   var start = Date.now();
   var spinHandles = function () {
     this.getContexts(function (err, res) {
@@ -153,7 +153,7 @@ Safari.prototype.navToView = function (cb) {
         cb(new Error("Could not navigate to webview; there aren't any!"));
       } else {
         var latestWindow = res.value[res.value.length - 1];
-        logger.info("Picking webview " + latestWindow);
+        logger.debug("Picking webview " + latestWindow);
         this.setContext(latestWindow, function (err) {
           if (err) return cb(err);
           this.remote.cancelPageLoad();
@@ -183,7 +183,7 @@ Safari.prototype.setBundleId = function (cb) {
 Safari.prototype._setInitialOrientation = IOS.prototype.setInitialOrientation;
 Safari.prototype.setInitialOrientation = function (cb) {
   if (this.args.udid) {
-    logger.info("Not setting initial orientation because we're on " +
+    logger.debug("Not setting initial orientation because we're on " +
                 "SafariLauncher");
     return cb();
   }
@@ -193,7 +193,7 @@ Safari.prototype.setInitialOrientation = function (cb) {
 Safari.prototype._setBootstrapConfig = IOS.prototype.setBootstrapConfig;
 Safari.prototype.setBootstrapConfig = function (cb) {
   if (this.args.udid) {
-    logger.info("Not setting bootstrap config because we're on " +
+    logger.debug("Not setting bootstrap config because we're on " +
                 "SafariLauncher");
     return cb();
   }
@@ -210,7 +210,7 @@ Safari.prototype.installToRealDevice = function (cb) {
       }
     }.bind(this));
   } else {
-    logger.info("Not installing to real device since we're on sim");
+    logger.debug("Not installing to real device since we're on sim");
     cb();
   }
 };
@@ -223,7 +223,7 @@ Safari.prototype.stopRemote = function () {
 Safari.prototype._stop = IOS.prototype.stop;
 Safari.prototype.stop = function (cb) {
   if (this.args.udid) {
-    logger.info("Stopping safariLauncher");
+    logger.debug("Stopping safariLauncher");
     this.shutdown(null, null, cb);
   } else {
     this._stop(cb);

--- a/lib/devices/ios/settings.js
+++ b/lib/devices/ios/settings.js
@@ -179,8 +179,8 @@ settings.writeSettings = function (forPlist, prefSetPerFile, bypassCheck,
   }
   var filesWritten = 0;
   _.each(prefSetPerFile, function (prefSet, plistPath) {
-    logger.info("Writing settings for " + forPlist + " to " + plistPath + ":");
-    logger.info(JSON.stringify(prefSet));
+    logger.debug("Writing settings for " + forPlist + " to " + plistPath + ":");
+    logger.debug(JSON.stringify(prefSet));
     if (!bypassCheck) {
       checkValidSettings(forPlist, prefSet);
     }
@@ -207,7 +207,7 @@ settings.writeSettings = function (forPlist, prefSetPerFile, bypassCheck,
 };
 
 settings.updateSettings = function (sdk, forPlist, prefSet) {
-  logger.info("Updating settings for " + forPlist);
+  logger.debug("Updating settings for " + forPlist);
   checkValidSettings(forPlist, prefSet);
   var prefSetPerFile = {};
   var curSettings = settings.getSettings(sdk, forPlist);
@@ -284,7 +284,7 @@ settings.updateSafariUserSettings = function (sdk, settingSet) {
     newUserSettings.safariForceFraudWarning = !settingSet.WarnAboutFraudulentWebsites;
   }
   if (_.size(newUserSettings) > 0) {
-    logger.info("Updating UserSettings.plist and friends");
+    logger.debug("Updating UserSettings.plist and friends");
     var userSettingsPerFile = {};
     var curUserSettings = settings.getSettings(sdk, 'userSettings');
     _.each(curUserSettings, function (settingSet, file) {
@@ -303,7 +303,7 @@ var getPlistData = function (file) {
       data = bplistParse.parseBuffer(fileData)[0];
     } catch (err) {
       if (err.message.indexOf("Invalid binary plist") !== -1) {
-        logger.info("Plist was not binary format, retrying with xml");
+        logger.debug("Plist was not binary format, retrying with xml");
         data = xmlplist(file)[0];
       } else {
         throw err;
@@ -319,7 +319,7 @@ settings.getSettings = function (sdk, forPlist) {
   var files = getPlistPaths(forPlist, sdk);
   var bplists = {};
   _.each(files, function (file) {
-    logger.info("Getting current settings for " + forPlist + " from " + file);
+    logger.debug("Getting current settings for " + forPlist + " from " + file);
     try {
       bplists[file] = getPlistData(file);
     } catch (err) {

--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -32,11 +32,11 @@ WebKitRemoteDebugger.prototype.connect = function (pageId, cb, pageChangeCb) {
   this.pageIdKey = pageId;
   this.socket = new WebSocket(url);
   this.socket.on('open', function () {
-    this.logger.info('Debugger web socket connected to url [' + url + ']');
+    this.logger.debug('Debugger web socket connected to url [' + url + ']');
     cb();
   }.bind(this));
   this.socket.on('close', function () {
-    this.logger.info("Disconnecting from remote debugger");
+    this.logger.debug("Disconnecting from remote debugger");
     this.socket = null;
     if (this.socketDisconnectCb) {
       this.socketDisconnectCb();
@@ -66,7 +66,7 @@ WebKitRemoteDebugger.prototype.isConnected = function () {
 };
 
 WebKitRemoteDebugger.prototype.pageArrayFromJson = function (cb) {
-  this.logger.info("Getting WebKitRemoteDebugger pageArray");
+  this.logger.debug("Getting WebKitRemoteDebugger pageArray");
   this.getJSONFromUrl(this.host, this.port, '/json', function (err, returnValue) {
     if (err) {
       this.logger.error("Could not connect to WebKitRemoteDebugger server");
@@ -121,7 +121,7 @@ WebKitRemoteDebugger.prototype.handleMessage = function (data, method) {
   if (_.has(this.handlers, handlerFor)) {
     this.handlers[handlerFor](data);
   } else {
-    this.logger.info("Debugger got a message for '" + handlerFor +
+    this.logger.debug("Debugger got a message for '" + handlerFor +
         "' and have no handler, doing nothing.");
   }
 };
@@ -136,7 +136,7 @@ WebKitRemoteDebugger.prototype.setHandlers = function () {
       this.dataCbs[msgId] = null;
     }.bind(this),
     'Profiler.resetProfiles': function () {
-      this.logger.info("Device is telling us to reset profiles. Should probably " +
+      this.logger.debug("Device is telling us to reset profiles. Should probably " +
             "do some kind of callback here");
     }.bind(this)
   };
@@ -155,11 +155,11 @@ WebKitRemoteDebugger.prototype.send = function (data, cb) {
   this.dataCbs[this.curMsgId.toString()] = cb;
   this.dataMethods[this.curMsgId.toString()] = data.method;
   //send the data
-  this.logger.info('Remote debugger data sent [' + JSON.stringify(data) + ']');
+  this.logger.debug('Remote debugger data sent [' + JSON.stringify(data) + ']');
   data = JSON.stringify(data);
   this.socket.send(data, function (error) {
     if (error !== null && typeof error !== "undefined") {
-      this.logger.info(error);
+      this.logger.debug(error);
     }
   }.bind(this));
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -20,21 +20,21 @@ exports.downloadFile = function (fileUrl, suffix, cb) {
   tempdir.open({prefix: 'appium-app', suffix: suffix}, function (err, info) {
     var file = fs.createWriteStream(info.path);
     request(fileUrl).pipe(file).on('close', function () {
-      logger.info(fileUrl + ' downloaded to ' + info.path);
+      logger.debug(fileUrl + ' downloaded to ' + info.path);
       cb(info.path);
     });
   });
 };
 
 exports.copyLocalZip = function (localZipPath, cb) {
-  logger.info("Copying local zip to tmp dir");
+  logger.debug("Copying local zip to tmp dir");
   fs.stat(localZipPath, function (err) {
     if (err) return cb(err);
     tempdir.open({prefix: 'appium-app', suffix: '.zip'}, function (err, info) {
       var infile = fs.createReadStream(localZipPath);
       var outfile = fs.createWriteStream(info.path);
       infile.pipe(outfile).on('close', function () {
-        logger.info(localZipPath + ' copied to ' + info.path);
+        logger.debug(localZipPath + ' copied to ' + info.path);
         cb(null, info.path);
       });
     });
@@ -42,19 +42,19 @@ exports.copyLocalZip = function (localZipPath, cb) {
 };
 
 exports.unzipFile = function (zipPath, cb) {
-  logger.info("Unzipping " + zipPath);
+  logger.debug("Unzipping " + zipPath);
   exports.testZipArchive(zipPath, function (err, valid) {
     if (valid) {
       if (exports.isWindows()) {
         var zip = new AdmZip(zipPath);
         zip.extractAllTo(path.dirname(zipPath), true);
-        logger.info("Unzip successful");
+        logger.debug("Unzip successful");
         cb(null, null);
       } else {
         var execOpts = {cwd: path.dirname(zipPath), maxBuffer: 524288};
         exec('unzip -o ' + zipPath, execOpts, function (err, stderr, stdout) {
           if (!err) {
-            logger.info("Unzip successful");
+            logger.debug("Unzip successful");
             cb(null, stderr);
           } else {
             logger.error("Unzip threw error " + err);
@@ -71,10 +71,10 @@ exports.unzipFile = function (zipPath, cb) {
 };
 
 exports.testZipArchive = function (zipPath, cb) {
-  logger.info("Testing zip archive: " + zipPath);
+  logger.debug("Testing zip archive: " + zipPath);
   if (exports.isWindows()) {
     if (fs.existsSync(zipPath)) {
-      logger.info("Zip archive tested clean");
+      logger.debug("Zip archive tested clean");
       cb(null, true);
     } else {
       cb("Zip archive was not found.", false);
@@ -84,7 +84,7 @@ exports.testZipArchive = function (zipPath, cb) {
     exec("unzip -tq " + zipPath, execOpts, function (err, stderr, stdout) {
       if (!err) {
         if (/No errors detected/.exec(stderr)) {
-          logger.info("Zip archive tested clean");
+          logger.debug("Zip archive tested clean");
           cb(null, true);
         } else {
           logger.error("Zip file " + zipPath + " was not valid");
@@ -124,7 +124,7 @@ exports.unzipApp = function (zipPath, appExt, cb) {
           if (strictMatch) {
             cb(null, getAppPath(strictMatch));
           } else if (relaxedMatch) {
-            logger.info("Got a relaxed match for app in zip, be careful for app match errors");
+            logger.debug("Got a relaxed match for app in zip, be careful for app match errors");
             cb(null, getAppPath(relaxedMatch));
           } else {
             cb("App zip unzipped OK, but we couldn't find a .app bundle in it. " +
@@ -142,7 +142,7 @@ exports.unzipApp = function (zipPath, appExt, cb) {
 };
 
 exports.checkBuiltInApp = function (appName, version, tmpDir, cb) {
-  logger.info("Looking for built in app " + appName);
+  logger.debug("Looking for built in app " + appName);
   var newAppDir = path.resolve(tmpDir, 'Appium-' + appName + '.app');
   var checkApp = function (s, appPath, cb) {
     if (!s.isDirectory()) {
@@ -156,7 +156,7 @@ exports.checkBuiltInApp = function (appName, version, tmpDir, cb) {
     var appPath = path.resolve(appDir, appName + ".app");
     fs.stat(appPath, function (err, s) {
       if (err && err.message.indexOf("ENOENT") !== -1) {
-        logger.info("App is not at " + appPath);
+        logger.debug("App is not at " + appPath);
         fs.stat(newAppDir, function (err, s) {
           if (err) {
             logger.warn("App is also not at " + newAppDir);
@@ -164,7 +164,7 @@ exports.checkBuiltInApp = function (appName, version, tmpDir, cb) {
                                 "or temp dir!"));
           }
           if (checkApp(s, appPath, cb)) {
-            logger.info("Couldn't find original app, but found the temp " +
+            logger.debug("Couldn't find original app, but found the temp " +
                         "Appium one so using that");
             cb(null, newAppDir, appPath);
           }
@@ -175,14 +175,14 @@ exports.checkBuiltInApp = function (appName, version, tmpDir, cb) {
       }
       if (checkApp(s, appPath, cb)) {
         if (parseInt(version, 10) < 7) {
-          logger.info("Got app, trying to copy " + appPath + " to tmp dir");
+          logger.debug("Got app, trying to copy " + appPath + " to tmp dir");
           ncp(appPath, newAppDir, function (err) {
             if (err) return cb(err);
-            logger.info("Copied " + appName);
+            logger.debug("Copied " + appName);
             cb(null, newAppDir, null);
           });
         } else {
-          logger.info("Got app, trying to move " + appPath + " to tmp dir");
+          logger.debug("Got app, trying to move " + appPath + " to tmp dir");
           exports.moveBuiltInApp(appPath, appName, newAppDir, cb);
         }
       }
@@ -220,7 +220,7 @@ exports.getBuiltInAppDir = function (version, cb) {
 exports.moveBuiltInApp = function (appPath, appName, newAppDir, cb) {
   ncp(appPath, newAppDir, function (err) {
     if (err) return cb(err);
-    logger.info("Copied " + appName + " to " + newAppDir);
+    logger.debug("Copied " + appName + " to " + newAppDir);
     rimraf(appPath, function (err) {
       if (err) {
         if (err.message.indexOf("EACCES") !== -1) {
@@ -229,7 +229,7 @@ exports.moveBuiltInApp = function (appPath, appName, newAppDir, cb) {
         }
         return cb(err);
       }
-      logger.info("Temporarily deleted original app at " + appPath);
+      logger.debug("Temporarily deleted original app at " + appPath);
       cb(null, newAppDir, appPath);
     });
   });
@@ -247,7 +247,7 @@ exports.cleanSafari = function (safariVer, cb) {
       glob(baseSupportDirs, function (err, pathList) {
         if (err) return cb(err);
         if (pathList.length === 0) {
-          logger.info("Couldn't find Safari support directories in order " +
+          logger.debug("Couldn't find Safari support directories in order " +
                       "to clear out old data");
           return cb();
         }
@@ -284,7 +284,7 @@ exports.cleanSafari = function (safariVer, cb) {
           _.each(toDeletes, function (del) {
             var toDelete = path.resolve(baseSupportDir, del);
             toDelete = toDelete.replace(/ /g, "\\ ");
-            logger.info("Deleting " + toDelete);
+            logger.debug("Deleting " + toDelete);
             var cmd = "rm -rf " + toDelete;
             exec(cmd, function (err) {
               finishOne(err);
@@ -297,13 +297,13 @@ exports.cleanSafari = function (safariVer, cb) {
 };
 
 exports.getUser = function (cb) {
-  logger.info("Determining current user");
+  logger.debug("Determining current user");
   exec("whoami", { maxBuffer: 524288 }, function (err, stdout) {
     if (err) {
       logger.error(err);
       cb(err);
     } else {
-      logger.info("User is " + stdout.trim());
+      logger.debug("User is " + stdout.trim());
       cb(null, stdout.trim());
     }
   });
@@ -425,7 +425,7 @@ exports.clearWarnings = function () {
 };
 
 exports.rotateImage = function (imgPath, deg, cb) {
-  logger.info("Rotating image " + imgPath + " " + deg + " degrees");
+  logger.debug("Rotating image " + imgPath + " " + deg + " degrees");
   var scriptPath = require('appium-uiauto').rotate;
   var cmd = "osascript " + scriptPath + " " + JSON.stringify(imgPath) +
             " " + deg;

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -97,12 +97,12 @@ Capabilities.prototype.setDesired = function (caps) {
 
 Capabilities.prototype.checkStrictValidity = function (deviceType) {
   if (_.contains(["firefoxos", "selendroid"], deviceType)) {
-    logger.info("Not checking cap validity because we're proxying all caps " +
+    logger.debug("Not checking cap validity because we're proxying all caps " +
                 "to " + deviceType);
     return;
   }
 
-  logger.info("Checking caps according to strict mode");
+  logger.debug("Checking caps according to strict mode");
 
   var e = function (msg) { throw new Error(msg); };
 

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -155,11 +155,11 @@ exports.createSession = function (req, res) {
     req.appium.start(req.body.desiredCapabilities, function (err, instance) {
       if (err) {
         logger.error("Failed to start an Appium session, err was: " + err);
-        logger.info(err.stack);
+        logger.debug(err.stack);
         delete err.stack;
         respondError(req, res, status.codes.SessionNotCreatedException, err);
       } else {
-        logger.info("Appium session started with sessionId " + req.appium.sessionId);
+        logger.debug("Appium session started with sessionId " + req.appium.sessionId);
         next(req.headers.host, req.appium.sessionId, instance);
       }
     });
@@ -867,7 +867,7 @@ exports.executeMobileMethod = function (req, res, cmd) {
     req.body = params;
     mobileCmdMap[cmd](req, res);
   } else {
-    logger.info("Tried to execute non-existent mobile command '" + cmd + "'" +
+    logger.debug("Tried to execute non-existent mobile command '" + cmd + "'" +
                 ". Most mobile commands have been ported to official client " +
                 "library methods. Please check your Appium library for more " +
                 "information and documentation");
@@ -1008,7 +1008,7 @@ exports.getStrings = function (req, res) {
 };
 
 exports.unknownCommand = function (req, res) {
-  logger.info("Responding to client that we did not find a valid resource");
+  logger.debug("Responding to client that we did not find a valid resource");
   res.set('Content-Type', 'text/plain');
   res.send(404, "That URL did not map to a valid JSONWP resource");
 };

--- a/lib/server/grid-register.js
+++ b/lib/server/grid-register.js
@@ -24,7 +24,7 @@ function registerToGrid(options_post, jsonObject) {
       logger.error("Request to register with grid was Unsuccessful...");
     } else {
       var logMessage = "Appium successfully registered with the grid on " + jsonObject.configuration.hubHost + ":" + jsonObject.configuration.hubPort;
-      logger.info(logMessage);
+      logger.debug(logMessage);
     }
   });
 }
@@ -66,13 +66,13 @@ function postRequest(data, addr, port) {
   };
 
   if (jsonObject.configuration.register !== true) {
-    logger.info("no registration sent ( " + jsonObject.configuration.register + " = false )");
+    logger.debug("no registration sent ( " + jsonObject.configuration.register + " = false )");
   } else {
     var registerCycleTime = jsonObject.configuration.registerCycle;
     if (registerCycleTime !== null && registerCycleTime > 0) {
       //initiate a new Thread
       var first = true;
-      logger.info("starting auto register thread for grid. Will try to register every " + registerCycleTime + " ms.");
+      logger.debug("starting auto register thread for grid. Will try to register every " + registerCycleTime + " ms.");
       setInterval(function () {
         if (first !== true) {
           isAlreadyRegistered(jsonObject, function (isRegistered) {
@@ -101,7 +101,7 @@ function isAlreadyRegistered(jsonObject, cb) {
   , timeout : 10000
   }, function (error, response /*, body*/) {
     if (error !== null || response === undefined || response.statusCode !== 200) {
-      logger.info("hub down or not responding.");
+      logger.debug("hub down or not responding.");
       return cb(null);
     }
     var responseData = JSON.parse(response.body);

--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -32,17 +32,17 @@ var watchForUnresponsiveInstruments = function (cb) {
   };
 
   var startNewprocess = function (cb) {
-    logger.info("Spawning instruments force-quitting watcher process");
+    logger.debug("Spawning instruments force-quitting watcher process");
     var process = spawn(endInstrumentsPath);
     process.stdout.setEncoding('utf8');
     process.stderr.setEncoding('utf8');
 
     process.stderr.pipe(through(function (data) {
-      logger.info('[FQInstruments STDERR] ' + cleanLogs(data.trim()));
+      logger.debug('[FQInstruments STDERR] ' + cleanLogs(data.trim()));
     }));
 
     process.stdout.pipe(through(function (data) {
-      logger.info('[FQInstruments] ' + cleanLogs(data.trim()));
+      logger.debug('[FQInstruments] ' + cleanLogs(data.trim()));
     }));
 
     cb();
@@ -56,7 +56,7 @@ var watchForUnresponsiveInstruments = function (cb) {
         startNewprocess
       ], cb);
     } else {
-      logger.info("Not spawning instruments force-quit watcher since it " +
+      logger.debug("Not spawning instruments force-quit watcher since it " +
                   "only works on 10.9 and you have " + versions.join("."));
       cb();
     }
@@ -158,7 +158,7 @@ module.exports.configureServer = function (rawConfig, appiumVer, appiumServer,
 
 module.exports.conditionallyPreLaunch = function (args, appiumServer, cb) {
   if (args.launch) {
-    logger.info("Starting Appium in pre-launch mode");
+    logger.debug("Starting Appium in pre-launch mode");
     appiumServer.preLaunch(function (err) {
       if (err) {
         logger.error("Could not pre-launch appium: " + err);
@@ -194,10 +194,10 @@ var startAlertSocket = function (restServer, appiumServer) {
 
   alerts.sockets.on("connection", function (socket) {
     socket.set('log level', 1);
-    logger.info("Client connected: " + (socket.id).toString());
+    logger.debug("Client connected: " + (socket.id).toString());
 
     socket.on('disconnect', function (data) {
-      logger.info("Client disconnected: " + data);
+      logger.debug("Client disconnected: " + data);
     });
   });
 
@@ -226,17 +226,17 @@ module.exports.startListening = function (server, args, parser, appiumVer, appiu
     if (appiumRev) {
       welcome += " (REV " + appiumRev + ")";
     }
-    logger.warn(welcome);
+    logger.info(welcome);
     var logMessage = "Appium REST http interface listener started on " +
                      args.address + ":" + args.port;
-    logger.warn(logMessage);
+    logger.info(logMessage);
     startAlertSocket(server, appiumServer);
     if (args.nodeconfig !== null) {
       gridRegister.registerNode(args.nodeconfig, args.address, args.port);
     }
     var showArgs = getNonDefaultArgs(parser, args);
     if (_.size(showArgs)) {
-      logger.warn("Non-default server args: " + JSON.stringify(showArgs));
+      logger.info("Non-default server args: " + JSON.stringify(showArgs));
     }
   });
   server.on('error', function (err) {

--- a/lib/server/logger.js
+++ b/lib/server/logger.js
@@ -42,12 +42,8 @@ module.exports.init = function (args) {
   logger.setLevels(levels);
   logger.stripColors = args.logNoColors;
 
-  if (args.quiet) {
-    logger.transports.console.level = 'warn';
-  } else {
-    //TODO: pass loglevel in server args
-    logger.transports.console.level = process.env.APPIUM_LOGLEVEL || 'info';
-  }
+  logger.transports.console.level = args.logLevel ||
+    (args.quiet ? 'warn' : null) || 'info';
 
   if (args.log) {
     winstonOptions.file = _.extend({
@@ -59,7 +55,7 @@ module.exports.init = function (args) {
     try {
       logger.add(winston.transports.File, winstonOptions.file);
     } catch (e) {
-      logger.info("Tried to attach logging to file " + args.log +
+      logger.debug("Tried to attach logging to file " + args.log +
                   " but an error occurred");
     }
   }
@@ -81,7 +77,7 @@ module.exports.init = function (args) {
       logger.add(winston.transports.Webhook, { 'host': host, 'port': port,
         'path': '/' });
     } catch (e) {
-      logger.info("Tried to attach logging to webhook at " + host +
+      logger.debug("Tried to attach logging to webhook at " + host +
                   " but an error occurred");
     }
   }

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -38,7 +38,7 @@ var args = [
     required: false
   , defaultValue: false
   , action: 'storeTrue'
-  , help: "Don't use verbose logging output"
+  , help: "Don't use verbose logging output (deprecated, use --log-level instead)"
   , nargs: 0
   }],
 
@@ -144,6 +144,14 @@ var args = [
   , required: false
   , example: "/path/to/appium.log"
   , help: 'Also send log output to this file'
+  }],
+
+  [['--log-level'], {
+  choices: ['debug','info','warn', 'error']
+  , dest: 'logLevel'
+  , required: false
+  , example: "debug"
+  , help: 'log level (default: infozw)'
   }],
 
   [['--log-timestamp'], {

--- a/lib/server/responses.js
+++ b/lib/server/responses.js
@@ -20,7 +20,7 @@ var getSessionId = function (req, response) {
 };
 
 var notImplementedInThisContext = function (req, res) {
-  logger.info("Responding to client that a method is not implemented " +
+  logger.debug("Responding to client that a method is not implemented " +
               "in this context");
   res.send(501, {
     status: status.codes.UnknownError.code
@@ -61,7 +61,7 @@ var respondError = exports.respondError = function (req, res, statusObj, value) 
   }
   var response = {status: code, value: newValue};
   response.sessionId = getSessionId(req, response);
-  logger.info("Responding to client with error: " + JSON.stringify(response));
+  logger.debug("Responding to client with error: " + JSON.stringify(response));
   res.send(500, response);
 };
 
@@ -78,7 +78,7 @@ var respondSuccess = exports.respondSuccess = function (req, res, value, sid) {
       printResponse.value.length > maxLen) {
     printResponse.value = printResponse.value.slice(0, maxLen) + "...";
   }
-  logger.info("Responding to client with success: " + JSON.stringify(printResponse));
+  logger.debug("Responding to client with success: " + JSON.stringify(printResponse));
   res.send(response);
 };
 
@@ -129,7 +129,7 @@ exports.checkMissingParams = function (res, params, strict) {
   });
   if (missingParamNames.length > 0) {
     var missingList = JSON.stringify(missingParamNames);
-    logger.info("Missing params for request: " + missingList);
+    logger.debug("Missing params for request: " + missingList);
     res.send(400, "Missing parameters: " + missingList);
     return false;
   } else {
@@ -138,7 +138,7 @@ exports.checkMissingParams = function (res, params, strict) {
 };
 
 var notYetImplemented = exports.notYetImplemented = function (req, res) {
-  logger.info("Responding to client that a method is not implemented");
+  logger.debug("Responding to client that a method is not implemented");
   res.send(501, {
     status: status.codes.UnknownError.code
   , sessionId: getSessionId(req)


### PR DESCRIPTION
Currently I don't think the way we use logging is optimal. It feels like we are using `info` as `debug`, and `warn` as `info`, and we have a quiet mode which shows only warning, so it's skip essential things like the Welcome message (or we must make it a warning.)

So in this PR I did the following:
- changed all the `info` messages to `debug`
- changed `warn` which were not really warnings to `info`.
- make 'info' the default log level. This should be pretty quiet, so long term we should remove --quiet. 
- added --log-level startup argument.
  
  Note: This is the beginning of a process, the same changes will need to be propagated to sub-packages, and we probably want to move some messages to `info` when it makes sense.
