### PR TITLE
Better app url handling

### DIFF
--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -9,7 +9,7 @@ var fs = require('fs')
   , unzipApp = helpers.unzipApp
   , downloadFile = helpers.downloadFile
   , capConversion = require('../server/capabilities.js').capabilityConversions
-  ;
+  , url = require('url');
 
 var Device = function () {
   throw new Error("Cannot instantiate Device directly");
@@ -95,10 +95,16 @@ Device.prototype.appIsPackageOrBundle = function (app) {
 
 Device.prototype.configureDownloadedApp = function (cb) {
   var origin = this.capabilities.app ? "desired caps" : "command line";
-  var appUrl = this.args.app ? this.args.app : '';
-  if (appUrl.substring(appUrl.length - 4) === ".apk") {
+  var appUrl;
+  try {
+    appUrl = url.parse(this.args.app);
+  } catch (err) {
+    cb("Invalid App URL (" + this.args.app + ")");
+  }
+  var ext = path.extname(appUrl.pathname);
+  if (ext === ".apk") {
     try {
-      downloadFile(appUrl, ".apk", function (appPath) {
+      downloadFile(url.format(appUrl), ".apk", function (appPath) {
         this.tempFiles.push(appPath);
         this.args.app = appPath;
         cb();
@@ -108,9 +114,9 @@ Device.prototype.configureDownloadedApp = function (cb) {
       logger.error("Failed downloading app from appUrl " + appUrl);
       cb(err);
     }
-  } else if (appUrl.substring(appUrl.length - 4) === ".zip") {
+  } else if (ext === ".zip") {
     try {
-      this.downloadAndUnzipApp(appUrl, function (zipErr, appPath) {
+      this.downloadAndUnzipApp(url.format(appUrl), function (zipErr, appPath) {
         if (zipErr) {
           cb(zipErr);
         } else {
@@ -126,7 +132,7 @@ Device.prototype.configureDownloadedApp = function (cb) {
       cb(err);
     }
   } else {
-    cb("App URL (" + appUrl + ") didn't seem to end in .zip or .apk");
+    cb("App URL (" + this.args.app + ") didn't seem to point to a .zip or .apk file");
   }
 };
 


### PR DESCRIPTION
With this you can download app direct from github for instance:
https://github.com/appium/appium-dotnet-driver/blob/1.0.0-beta/samples/assets/TestApp.zip?raw=true
