### PR TITLE
Fixed the url for appium-adb submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,4 +45,4 @@
 	branch = published
 [submodule "submodules/appium-adb"]
 	path = submodules/appium-adb
-	url = git@github.com:appium/appium-adb.git
+	url = https://github.com/appium/appium-adb.git


### PR DESCRIPTION
Fix for this error:

```
paymand@payman:~/src/appium$ git submodule update --recursive
Cloning into 'submodules/appium-adb'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
Clone of 'git@github.com:appium/appium-adb.git' into submodule path 'submodules/appium-adb' failed
```
