### PR TITLE
Fix parsing of device log lines

### DIFF
--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -152,7 +152,7 @@ IosLog.prototype.onOutput = function (data, prefix) {
       //   logRowDate.isAfter(this.iosLogStartTime) check so we require a state flag here,
       //   otherwise all the lines without dates get filtered out even if they are new.
       if (!this.loggingModeOn) {
-        var logRowParts = log.split(" ");
+        var logRowParts = log.split(/\s+/);
         var logRowDate = new Date(
           Date.parse(this.iosLogStartTime.getFullYear() + " " + logRowParts[0] + " " + logRowParts[1] + " " + logRowParts[2])
         );


### PR DESCRIPTION
Parsing date from device log lines using regex to handle splitting on 1 or more spaces because date strings for days 1->9 look like "June  9 14:30:43" (i.e. there is 2 spaces between June and the 9) and splitting on single space was incorrect.
