### PR TITLE
Remove setting sessionOverride to false

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -336,7 +336,6 @@ Appium.prototype.cleanupSession = function (err, cb) {
   this.commandTimeoutMs = this.defCommandTimeoutMs;
   var dyingSession = this.sessionId;
   this.sessionId = null;
-  this.sessionOverride = false;
   this.device = null;
   this.args = _.clone(this.serverArgs);
   this.oldDesiredCapabilities = _.clone(this.desiredCapabilities);


### PR DESCRIPTION
Remove setting sessionOverride to false when cleaning up the session.
This parameter should left as it is.
Users may specify this value to true in the args when starting Appium server. However, once a session is cleared, this parameter would be as it was, instead of setting it to false.
