### PR TITLE
Set most verbose log level as default

### DIFF
--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -148,6 +148,7 @@ var args = [
 
   [['--log-level'], {
     choices: ['debug','info','warn', 'error']
+  , defaultValue: 'debug'
   , dest: 'logLevel'
   , required: false
   , example: "debug"


### PR DESCRIPTION
Fix #2798
