### PR TITLE
Add autoWebview capability

### DIFF
--- a/docs/en/caps.md
+++ b/docs/en/caps.md
@@ -16,6 +16,7 @@
 |`locale`| (Sim/Emu-only) Locale to set for the iOS Simulator|e.g. `fr_CA`|
 |`udid`| Unique device identifier of the connected physical device|e.g. `1ae203187fc012g`|
 |`orientation`| (Sim/Emu-only) start in a certain orientation|`LANDSCAPE` or `PORTRAIT`|
+|`autoWebview`| Move directly into Webview context. Default `false`|`true`, `false`|
 
 ### Android Only
 
@@ -43,6 +44,7 @@
 |`keyPassword`| Password for key |e.g., `foo`|
 |`chromedriverExecutable`| The absolute local path to webdriver executable (if Chromium embedder provides its own webdriver, it should be used instead of original chromedriver bundled with Appium) |`/abs/path/to/webdriver`|
 |`specialChromedriverSessionArgs`| Custom arguments passed directly to chromedriver in chromeOptions capability. Passed as object which properties depend on a specific webdriver. |e.g., `{'androidDeviceSocket': 'opera_beta_devtools_remote',}`|
+|`autoWebviewTimeout`| Amount of time to wait for Webview context to become active, in ms. Defaults to `2000`| e.g. `4`|
 
 
 ### iOS Only

--- a/lib/devices/android/android-hybrid.js
+++ b/lib/devices/android/android-hybrid.js
@@ -5,7 +5,8 @@ var logger = require('../../server/logger.js').get('appium')
   , errors = require('../../server/errors.js')
   , UnknownError = errors.UnknownError
   , async = require('async')
-  , Chromedriver = require('./chromedriver.js');
+  , Chromedriver = require('./chromedriver.js')
+  , status = require("../../server/status.js");
 
 var androidHybrid = {};
 
@@ -179,6 +180,28 @@ androidHybrid.stopChromedriverProxy = function (cb) {
     this.chromedriver.deleteSession(function (err) {
       if (err) return cb(err);
       this.cleanupChromedriver(cb);
+    }.bind(this));
+  } else {
+    cb();
+  }
+};
+
+androidHybrid.defaultWebviewName = function () {
+  return this.WEBVIEW_WIN;
+};
+
+androidHybrid.initAutoWebview = function (cb) {
+  if (this.args.autoWebview) {
+    logger.debug('Setting auto webview');
+    var viewName = this.defaultWebviewName();
+    var timeout = (this.args.autoWebviewTimeout) || 2000;
+    this.setContext(viewName, function (err, res) {
+      if (err && res.status !== status.codes.NoSuchContext.code) return cb(err);
+      if (res.status === status.codes.Success.code) return cb();
+      setTimeout(function () {
+        logger.debug("Retrying context switch with timeout '" + timeout + "'");
+        this.setContext(viewName, cb);
+      }.bind(this), timeout);
     }.bind(this));
   } else {
     cb();

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -101,7 +101,8 @@ Android.prototype.start = function (cb, onDie) {
       this.wakeUp.bind(this),
       this.unlockScreen.bind(this),
       this.getDataDir.bind(this),
-      this.startApp.bind(this)
+      this.startApp.bind(this),
+      this.initAutoWebview.bind(this)
     ], function (err) {
       if (err) {
         this.shutdown(function () {
@@ -109,7 +110,7 @@ Android.prototype.start = function (cb, onDie) {
         }.bind(this));
       } else {
         this.didLaunch = true;
-        this.launchCb();
+        this.launchCb(null, this.proxySessionId);
       }
     }.bind(this));
   } else {

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -147,7 +147,14 @@ Selendroid.prototype.start = function (cb) {
     this.waitForServer.bind(this)
   ], function (err) {
     if (err) return cb(err);
-    this.createSession(cb);
+    async.series([
+      this.createSession.bind(this),
+      this.initAutoWebview.bind(this)
+    ], function (err, res) {
+      if (err) return cb(err);
+      // `createSession` returns session id, so send that along
+      cb(null, res[0]);
+    });
   }.bind(this));
 };
 
@@ -432,6 +439,10 @@ Selendroid.prototype.getContexts = function (cb) {
       cb(null, {sessionId: this.selendroidSessionId, status: status.codes.Success.code, value: this.contexts});
     }.bind(this));
   }.bind(this));
+};
+
+Selendroid.prototype.defaultWebviewName = function () {
+  return this.WEBVIEW_WIN + "_0";
 };
 
 module.exports = Selendroid;

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -279,6 +279,7 @@ IOS.prototype.start = function (cb, onDie) {
     this.setBundleId.bind(this),
     this.setBootstrapConfig.bind(this),
     this.setInitialOrientation.bind(this),
+    this.initAutoWebview.bind(this)
   ], function (err) {
     cb(err);
   });
@@ -1320,6 +1321,87 @@ IOS.prototype.startLogCapture = function (cb) {
     if (err) cb(err);
     this.logs.crashlog.startCapture(cb);
   }.bind(this));
+};
+
+IOS.prototype.initAutoWebview = function (cb) {
+  if (this.args.autoWebview) {
+    logger.debug('Setting auto webview');
+    this.navToInitialWebview(cb);
+  } else {
+    cb();
+  }
+};
+
+IOS.prototype.navToInitialWebview = function (cb) {
+  if (this.args.udid) {
+    setTimeout(function () {
+      // the latest window is the one we want.
+      this.navToLatestAvailableWebview(cb);
+    }.bind(this), 6000);
+  } else {
+    this.navToLatestAvailableWebview(cb);
+  }
+};
+
+IOS.prototype.navToLatestAvailableWebview = function (cb) {
+  if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.args.udid && this.capabilities.safari) {
+    this.navToViewThroughFavorites(cb);
+  } else {
+    this.navToView(cb);
+  }
+};
+
+IOS.prototype.navToViewThroughFavorites = function (cb) {
+  logger.debug("We're on iOS7 simulator: clicking apple button to get into " +
+              "a webview");
+  var oldImpWait = this.implicitWaitMs;
+  this.implicitWaitMs = 7000; // wait 7s for apple button to exist
+  this.findElement('xpath', '//UIAScrollView[1]/UIAButton[1]', function (err, res) {
+    this.implicitWaitMs = oldImpWait;
+    if (err || res.status !== status.codes.Success.code) {
+      var msg = "Could not find button to click to get into webview. " +
+                "Proceeding on the assumption we have a working one.";
+      logger.error(msg);
+      return this.navToView(cb);
+    }
+    this.nativeTap(res.value.ELEMENT, function (err, res) {
+      if (err || res.status !== status.codes.Success.code) {
+        var msg = "Could click button to get into webview. " +
+                  "Proceeding on the assumption we have a working one.";
+        logger.error(msg);
+      }
+      this.navToView(cb);
+    }.bind(this));
+  }.bind(this));
+};
+
+IOS.prototype.navToView = function (cb) {
+  logger.debug("Navigating to most recently opened webview");
+  var start = Date.now();
+  var spinHandles = function () {
+    this.getContexts(function (err, res) {
+      if (err || res.status && res.status !== 0) {
+        cb(new Error("Could not navigate to webview! Err: " + err));
+      } else if (res.value.length < 2) {
+        // NATIVE_WIN is always in the list of contexts, so we need at least
+        // 2 contexts to know we have an active webview
+        if ((Date.now() - start) < 6000) {
+          logger.warn("Could not find any webviews yet, retrying");
+          return setTimeout(spinHandles, 500);
+        }
+        cb(new Error("Could not navigate to webview; there aren't any!"));
+      } else {
+        var latestWindow = res.value[res.value.length - 1];
+        logger.debug("Picking webview " + latestWindow);
+        this.setContext(latestWindow, function (err) {
+          if (err) return cb(err);
+          this.remote.cancelPageLoad();
+          cb();
+        }.bind(this), true);
+      }
+    }.bind(this));
+  }.bind(this);
+  spinHandles();
 };
 
 _.extend(IOS.prototype, iOSHybrid);

--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -2,7 +2,6 @@
 
 var IOS = require('./ios.js')
   , logger = require('../../server/logger.js').get('appium')
-  , status = require("../../server/status.js")
   , path = require('path')
   , helpers = require('../../helpers.js')
   , cleanSafari = helpers.cleanSafari
@@ -91,78 +90,6 @@ Safari.prototype.start = function (cb, onDie) {
 
 Safari.prototype.shouldIgnoreInstrumentsExit = function () {
   return !!this.args.udid;
-};
-
-Safari.prototype.navToInitialWebview = function (cb) {
-  if (this.args.udid) {
-    setTimeout(function () {
-      //the latest window is the one newly created by Safari launcher.
-      this.navToLatestAvailableWebview(cb);
-    }.bind(this), 6000);
-  } else {
-    this.navToLatestAvailableWebview(cb);
-  }
-};
-
-Safari.prototype.navToLatestAvailableWebview = function (cb) {
-  if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.args.udid) {
-    this.navToViewThroughFavorites(cb);
-  } else {
-    this.navToView(cb);
-  }
-};
-
-Safari.prototype.navToViewThroughFavorites = function (cb) {
-  logger.debug("We're on iOS7 simulator: clicking apple button to get into " +
-              "a webview");
-  var oldImpWait = this.implicitWaitMs;
-  this.implicitWaitMs = 7000; // wait 7s for apple button to exist
-  this.findElement('xpath', '//UIAScrollView[1]/UIAButton[1]', function (err, res) {
-    this.implicitWaitMs = oldImpWait;
-    if (err || res.status !== status.codes.Success.code) {
-      var msg = "Could not find button to click to get into webview. " +
-                "Proceeding on the assumption we have a working one.";
-      logger.error(msg);
-      return this.navToView(cb);
-    }
-    this.nativeTap(res.value.ELEMENT, function (err, res) {
-      if (err || res.status !== status.codes.Success.code) {
-        var msg = "Could click button to get into webview. " +
-                  "Proceeding on the assumption we have a working one.";
-        logger.error(msg);
-      }
-      this.navToView(cb);
-    }.bind(this));
-  }.bind(this));
-};
-
-Safari.prototype.navToView = function (cb) {
-  logger.debug("Navigating to most recently opened webview");
-  var start = Date.now();
-  var spinHandles = function () {
-    this.getContexts(function (err, res) {
-      if (err || res.status && res.status !== 0) {
-        cb(new Error("Could not navigate to webview! Err: " + err));
-      } else if (res.value.length < 2) {
-        // NATIVE_WIN is always in the list of contexts, so we need at least
-        // 2 contexts to know we have an active webview
-        if ((Date.now() - start) < 6000) {
-          logger.warn("Could not find any webviews yet, retrying");
-          return setTimeout(spinHandles, 500);
-        }
-        cb(new Error("Could not navigate to webview; there aren't any!"));
-      } else {
-        var latestWindow = res.value[res.value.length - 1];
-        logger.debug("Picking webview " + latestWindow);
-        this.setContext(latestWindow, function (err) {
-          if (err) return cb(err);
-          this.remote.cancelPageLoad();
-          cb();
-        }.bind(this), true);
-      }
-    }.bind(this));
-  }.bind(this);
-  spinHandles();
 };
 
 Safari.prototype._click = IOS.prototype.click;

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -29,6 +29,7 @@ var generalCaps = requiredCaps.concat([
 , 'locale'
 , 'udid'
 , 'orientation'
+, 'autoWebview'
 ]);
 
 var androidCaps = [
@@ -48,6 +49,7 @@ var androidCaps = [
 , 'keystorePassword'
 , 'keyAlias'
 , 'keyPassword'
+, 'autoWebviewTimeout'
 ];
 
 var iosCaps = [

--- a/test/functional/android/webview-auto-specs.js
+++ b/test/functional/android/webview-auto-specs.js
@@ -1,0 +1,5 @@
+"use strict";
+
+var androidAutoWebviewTests = require('../common/android-auto-webview-base');
+
+describe('android - webview - auto @skip-ci', androidAutoWebviewTests);

--- a/test/functional/android/webview-specs.js
+++ b/test/functional/android/webview-specs.js
@@ -2,6 +2,4 @@
 
 var androidWebviewTests = require('../common/android-webview-base');
 
-// TODO: androidWebviewTests is using an app built by selendroid. Need to build it once
-// and save it into asset so that it can be used by android tests
-describe('android - web_view @skip-ci', androidWebviewTests);
+describe('android - webview @skip-ci', androidWebviewTests);

--- a/test/functional/common/android-auto-webview-base.js
+++ b/test/functional/common/android-auto-webview-base.js
@@ -1,0 +1,33 @@
+"use strict";
+
+var env = require('../../helpers/env')
+  , setup = require("../common/setup-base")
+  , safeClear = require('../../helpers/safe-clear');
+
+var desired = {
+  app: "sample-code/apps/selendroid-test-app.apk",
+  appPackage: 'io.selendroid.testapp',
+  appActivity: '.WebViewActivity',
+  autoWebview: true
+};
+if (env.SELENDROID) {
+  desired.automationName = 'selendroid';
+}
+
+module.exports = function () {
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('should go directly into webview', function (done) {
+    var el;
+    driver
+      .elementById('name_input')
+      .then(function (_el) { el = _el; })
+      .then(function () { return safeClear(el); })
+      .then(function () { return el.type("Appium User")
+        .getValue().should.become("Appium User"); })
+      .elementByCssSelector('input[type=submit]').click()
+      .waitForElementByXPath("//h1[contains(., 'This is my way')]")
+      .nodeify(done);
+  });
+};

--- a/test/functional/common/android-webview-base.js
+++ b/test/functional/common/android-webview-base.js
@@ -57,7 +57,7 @@ module.exports = function () {
 
   it('should list all contexts', function (done) {
     driver
-      .contexts().should.eventually.have.length(2)
+      .contexts().should.eventually.have.length.at.least(2)
       .nodeify(done);
   });
 

--- a/test/functional/ios/webview/basics-specs.js
+++ b/test/functional/ios/webview/basics-specs.js
@@ -2,7 +2,8 @@
 
 var setup = require("../../common/setup-base")
   , desired = require('./desired')
-  , _ = require('underscore');
+  , _ = require('underscore')
+  , env = require('../../../helpers/env');
 
 describe('webview - basics', function () {
 
@@ -46,28 +47,28 @@ describe('webview - basics', function () {
   it('setting context to \'WEBVIEW_1\' should work', function (done) {
     driver.contexts().should.eventually.have.length.above(0)
       .context("WEBVIEW_1")
-      .get("http://google.com")
+      .get(env.GUINEA_TEST_END_POINT)
       .sleep(500)
       .title()
-      .should.eventually.equal("Google")
+      .should.eventually.equal("I am a page title")
       .nodeify(done);
   });
   it('setting context to \'WEBVIEW_1\' should work without first getting contexts', function (done) {
     driver
       .context("WEBVIEW_1")
-      .get("http://google.com")
+      .get(env.GUINEA_TEST_END_POINT)
       .sleep(500)
       .title()
-      .should.eventually.equal("Google")
+      .should.eventually.equal("I am a page title")
       .nodeify(done);
   });
   it('setting context to \'WEBVIEW\' should work', function (done) {
     driver
       .context("WEBVIEW")
-      .get("http://google.com")
+      .get(env.GUINEA_TEST_END_POINT)
       .sleep(500)
       .title()
-      .should.eventually.equal("Google")
+      .should.eventually.equal("I am a page title")
       .nodeify(done);
   });
   it('setting context to \'null\' should work', function (done) {
@@ -102,16 +103,16 @@ describe('webview - basics', function () {
     driver
       .contexts()
       .context("WEBVIEW_1")
-      .get("http://google.com")
+      .get(env.GUINEA_TEST_END_POINT)
       .sleep(3000)
       .title()
-      .should.eventually.equal("Google")
+      .should.eventually.equal("I am a page title")
       .context("NATIVE_APP")
       .context("WEBVIEW_1")
-      .get("https://saucelabs.com/home")
+      .get(env.GUINEA_TEST_END_POINT)
       .sleep(3000)
-      .title()
-      .should.eventually.equal("Sauce Labs: Selenium Testing, Mobile Testing, JS Unit Testing and More")
+      .elementByLinkText('i am a link').click()
+      .elementById('only_on_page_2').should.eventually.exist
       .nodeify(done);
   });
 });

--- a/test/functional/ios/webview/webview-auto-spec.js
+++ b/test/functional/ios/webview/webview-auto-spec.js
@@ -1,0 +1,20 @@
+"use strict";
+
+var setup = require("../../common/setup-base")
+  , desired = require('./desired')
+  , env = require('../../../helpers/env');
+
+describe('webview - auto', function () {
+  var driver;
+  desired.autoWebview = true;
+
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('should go directly into webview', function (done) {
+    driver
+      .get(env.GUINEA_TEST_END_POINT)
+      .elementByLinkText('i am a link').click()
+      .elementById('only_on_page_2').should.eventually.exist
+      .nodeify(done);
+  });
+});

--- a/test/functional/selendroid/webview-auto-specs.js
+++ b/test/functional/selendroid/webview-auto-specs.js
@@ -1,0 +1,5 @@
+"use strict";
+
+var androidAutoWebviewTests = require('../common/android-auto-webview-base');
+
+describe('android - webview - auto @skip-ci', androidAutoWebviewTests);


### PR DESCRIPTION
Milestone 1.2 issue #2715

Allow user to enter directly into webview context. Adds universal capability `autoWebview` (`true`/`false`) and Android capability `autoWebviewTimeout` (in seconds, defaults to `2`), to set hot long to wait before checking for the webview. 

Also fixes Android/Selendroid webview tests.
