### PR TITLE
Fixing the breaking tests due to adb-1.0.3 auto-update. Now pointing to exact 1.0.2 instead of approximate version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "adm-zip": "~0.4.4",
-    "appium-adb": "~1.0.2",
+    "appium-adb": "1.0.2",
     "appium-atoms": "~0.0.5",
     "appium-instruments": "~1.0.0",
     "appium-uiauto": "~1.2.0-beta2",


### PR DESCRIPTION
-Tests breaking due to `"appium-adb": "1.0.2"` instead of `"appium-adb": "~1.0.2"`, currently its picking up latest submodule. 
-Related to #2026 changes in appium-adb 
