### PR TITLE
Add '-real xpath' as a supported iOS strategy.

### DIFF
--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -209,6 +209,7 @@ exports.checkValidLocStrat = function (strat, includeWeb, cb) {
   ];
   var nativeStrats = [
     '-ios uiautomation',
+    '-real xpath',
     'accessibility id',
     '-android uiautomator'
   ];


### PR DESCRIPTION
Currently '-real xpath' is included as a valid strategy in [ios.js](https://github.com/appium/appium/blob/master/lib/devices/ios/ios.js#L92).  However, it's not exposed in [common.js](https://github.com/appium/appium/blob/master/lib/devices/common.js#L210).  This pull request is supposed to fix such an issue so that the client side won't run into the "Invalid locator strategy" error.
