### PR TITLE
Detect architecture type on linux

### DIFF
--- a/reset.sh
+++ b/reset.sh
@@ -453,6 +453,12 @@ reset_gappium() {
 
 reset_chromedriver() {
     echo "RESETTING CHROMEDRIVER"
+    machine=$(run_cmd_output uname -m)
+    if [ "$machine" == "i686" ]; then
+        machine="32"
+    else
+        machine="64"
+    fi
     if [ -d "$appium_home"/build/chromedriver ]; then
         echo "* Clearing old ChromeDriver(s)"
         run_cmd rm -rf "$appium_home"/build/chromedriver/*
@@ -473,7 +479,7 @@ reset_chromedriver() {
             run_cmd mkdir "$appium_home"/build/chromedriver/mac
         else
             platform="linux"
-            chromedriver_file="chromedriver_linux32.zip"
+            chromedriver_file="chromedriver_linux$machine.zip"
             run_cmd mkdir "$appium_home"/build/chromedriver/linux
         fi
         install_chromedriver $platform $chromedriver_version $chromedriver_file
@@ -484,7 +490,7 @@ reset_chromedriver() {
         run_cmd mkdir "$appium_home"/build/chromedriver/windows
 
         install_chromedriver "mac" $chromedriver_version "chromedriver_mac32.zip"
-        install_chromedriver "linux" $chromedriver_version "chromedriver_linux32.zip"
+        install_chromedriver "linux" $chromedriver_version "chromedriver_linux$machine.zip"
         install_chromedriver "windows" $chromedriver_version "chromedriver_win32.zip"
     fi
 }


### PR DESCRIPTION
We should detecting architecture type because chromedriver can have problems running 32bit if the required libraries aren't available on a 64bit OS.

```
debug: Killing any old chromedrivers, running: ps -e | grep /home/testuser/dev/appium/build/chromedriver/linux/chromedriver | grep -v grep |grep -e '--port=9515$' | awk '{ print $1 }' | xargs kill -15
debug: Successfully cleaned up old chromedrivers
debug: Spawning chromedriver with: /home/testuser/dev/appium/build/chromedriver/linux/chromedriver
debug: [CHROMEDRIVER STDERR] /home/testuser/dev/appium/build/chromedriver/linux/chromedriver: error while loading shared libraries: libgobject-2.0.so.0: cannot open shared object file: No such file or directory
debug: Chromedriver exited with code 127
debug: Cleaning up appium session
error: Failed to start an Appium session, err was: Error: Chromedriver quit before it was available
debug: Error: Chromedriver quit before it was available
    at Chromedriver.onClose (/home/testuser/dev/appium/lib/devices/android/chromedriver.js:120:11)
    at ChildProcess.emit (events.js:98:17)
    at Process.ChildProcess._handle.onexit (child_process.js:809:12)
debug: Responding to client with error: {"status":33,"value":{"message":"A new session could not be created. (Original error: Chromedriver quit before it was available)","origValue":"Chromedriver quit before it was available"},"sessionId":null}
POST /wd/hub/session 500 2126.288 ms - 204
```

This occurs on a 64bit of the latest Ubuntu desktop, I also had a similar error occur on CentOS, but didn't debug it far enough to realise it was looking for 32bit libraries. This pull request will fix this. 
