### PR TITLE
Add 'Scroll To' to code examples

### DIFF
--- a/docs/en/appium-bindings.md
+++ b/docs/en/appium-bindings.md
@@ -597,6 +597,38 @@ todo: php
 driver.Zoom(100, 200);
 ```
 
+## Scroll To
+
+Scroll to an element.
+
+```ruby
+element = find_element :name, 'Element Name'
+execute_script "mobile: scrollTo", :element => element.ref
+```
+
+```python
+todo: python
+```
+
+```java
+WebElement element = driver.findElement(By.name("Element Name"));
+HashMap<String, String> arguments = new HashMap<String, String>();
+arguments.put("element", element.getId());
+(JavascriptExecutor)driver.executeScript("mobile: scrollTo", arguments);
+```
+
+```javascript
+todo: javascript
+```
+
+```php
+todo: php
+```
+
+```csharp
+todo: csharp
+```
+
 ## Pull file
 
 Pulls a file from the device.


### PR DESCRIPTION
Added examples for Ruby, Python and Java. I could not figure out fully how to get the element identifier as a string in the other languages.

Also, I have used other examples to write this code. I do not have any of these languages setup on my machine, but they look to use the exact same as others. If someone could quickly check these then that would be great.

This is a partial fix for https://github.com/appium/appium.io/issues/32.
