### PR TITLE
Add server arguments for intent options

### DIFF
--- a/docs/en/server-args.md
+++ b/docs/en/server-args.md
@@ -40,6 +40,10 @@ All flags are optional, but some are required in conjunction with certain others
 |`--avd`|null|(Android-only) Name of the avd to launch|`--avd @default`|
 |`--avd-args`|null|(Android-only) Additional emulator arguments to launch the avd|`--avd-args -no-snapshot-load`|
 |`--device-ready-timeout`|5|(Android-only) Timeout in seconds while waiting for device to become ready|`--device-ready-timeout 5`|
+|`--intent-action`|`android.intent.action.MAIN`|(Android-only) Intent action which will be used to start activity|`android.intent.action.VIEW`|
+|`--intent-category`|`android.intent.category.LAUNCHER`|(Android-only) Intent category which will be used to start activity|`android.intent.category.APP_CONTACTS`|
+|`--intent-flags`|`0x10200000`|(Android-only) Flags that will be used to start activity|`0x10200000`|
+|`--intent-args`|null|(Android-only) Additional intent arguments that will be used to start activity. See [Intent arguments](http://developer.android.com/tools/help/adb.html#IntentSpec)|`--esn <EXTRA_KEY>`, `--ez <EXTRA_KEY> <EXTRA_BOOLEAN_VALUE>`|
 |`--safari`|false|(IOS-Only) Use the safari app||
 |`--device-name`|null|Name of the mobile device to use|`--device-name iPhone Retina (4-inch), Android Emulator`|
 |`--platform-name`|null|Name of the mobile platform: iOS, Android, or FirefoxOS|`--platform-name iOS`|

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -87,12 +87,8 @@ androidCommon.setAndroidArgs = function () {
                               this.args.appActivity;
   this.appProcess = this.args.appPackage;
   this.args.appDeviceReadyTimeout = this.args.androidDeviceReadyTimeout;
-  // TODO better way to set defaults.
   this.args.avdLaunchTimeout = this.args.avdLaunchTimeout || 120000;
   this.args.avdReadyTimeout = this.args.avdReadyTimeout || 120000;
-  this.args.intentAction = this.args.intentAction || "android.intent.action.MAIN";
-  this.args.intentCategory = this.args.intentCategory || "android.intent.category.LAUNCHER";
-  this.args.intentFlags = this.args.intentFlags || "0x10200000";
 };
 
 androidCommon.background = function (secs, cb) {

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -511,8 +511,40 @@ var args = [
   , help: 'Absolute path to directory Appium can use to manage temporary ' +
           'files, like built-in iOS apps it needs to move around. On *nix/Mac ' +
           'defaults to /tmp, on Windows defaults to C:\\Windows\\Temp'
-  }]
+  }],
 
+  [['--intent-action'], {
+    dest: 'intentAction'
+  , defaultValue: "android.intent.action.MAIN"
+  , required: false
+  , example: "android.intent.action.MAIN"
+  , help: "(Android-only) Intent action which will be used to start activity"
+  }],
+
+  [['--intent-category'], {
+    dest: 'intentCategory'
+  , defaultValue: "android.intent.category.LAUNCHER"
+  , required: false
+  , example: "android.intent.category.APP_CONTACTS"
+  , help: "(Android-only) Intent category which will be used to start activity"
+  }],
+
+  [['--intent-flags'], {
+    dest: 'intentFlags'
+  , defaultValue: "0x10200000"
+  , required: false
+  , example: "0x10200000"
+  , help: "(Android-only) Flags that will be used to start activity"
+  }],
+
+  [['--intent-args'], {
+    dest: 'optionalIntentArguments'
+  , defaultValue: null
+  , required: false
+  , example: "0x10200000"
+  , help: "(Android-only) Additional intent arguments that will be used to " +
+          "start activity"
+  }]
 ];
 
 // Setup all the command line argument parsing


### PR DESCRIPTION
Adding server arguments so that these new options can be added to Appium.app and Appium.exe.

Options introduced in https://github.com/appium/appium/pull/2875. Used the same examples, descriptions and defaults from the commit in this pull request.
