### PR TITLE
Add scrollIntoView

### DIFF
--- a/docs/en/uiautomator_uiselector.md
+++ b/docs/en/uiautomator_uiselector.md
@@ -1,0 +1,37 @@
+# uiautomator UiSelector
+
+Appium enables searching using [UiSelectors](http://developer.android.com/tools/help/uiautomator/UiSelector.html).
+[UiScrollable](http://developer.android.com/tools/help/uiautomator/UiScrollable.html)
+is also supported.
+
+Note that the index selector is unreliable so prefer instance instead. The
+following examples are written against the api demos apk using Ruby.
+
+
+Find the first textview.
+
+```ruby
+first_textview = find_element(:uiautomator, 'new UiSelector().className("android.widget.TextView").instance(0)');
+```
+
+Find the first element by text.
+
+```ruby
+first_text = find_element(:uiautomator, 'new UiSelector().text("Animation")')
+first_text.text # "Animation"
+```
+
+Find the first scrollable element, then find a TextView with the text "Tabs".
+The "Tabs" element will be scrolled into view.
+
+```ruby
+element = find_element(:uiautomator, 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).getChildByText(new UiSelector().className("android.widget.TextView"), "Tabs")')
+```
+
+As a special case, scrollIntoView returns the element that is scrolled into view.
+scrollIntoView allows scrolling to any UiSelector.
+
+```ruby
+element = find_element(:uiautomator, 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("WebView").instance(0));')
+element.text # "WebView"
+```

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/UiAutomatorParser.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/UiAutomatorParser.java
@@ -1,6 +1,7 @@
 package io.appium.android.bootstrap.utils;
 
 import com.android.uiautomator.core.UiSelector;
+import io.appium.android.bootstrap.Logger;
 import io.appium.android.bootstrap.exceptions.UiSelectorSyntaxException;
 
 import java.util.ArrayList;
@@ -77,8 +78,10 @@ public class UiAutomatorParser {
 
     statement = text.substring(0, index);
     if (UiScrollableParser.isUiScrollable(statement)) {
+      Logger.debug("Parsing scrollable: " + statement);
       selectors.add(scrollableParser.parse(statement));
     } else {
+      Logger.debug("Parsing selector: " + statement);
       selectors.add(selectorParser.parse(statement));
     }
 

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/UiSelectorParser.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/UiSelectorParser.java
@@ -1,6 +1,7 @@
 package io.appium.android.bootstrap.utils;
 
 import com.android.uiautomator.core.UiSelector;
+import io.appium.android.bootstrap.Logger;
 import io.appium.android.bootstrap.exceptions.UiSelectorSyntaxException;
 
 import java.lang.reflect.InvocationTargetException;
@@ -151,6 +152,7 @@ public class UiSelectorParser {
   }
 
   private Object coerceArgToType(Type type, String argument) throws UiSelectorSyntaxException {
+    Logger.debug("UiSelector coerce type: " + type + " arg: " + argument);
     if (type == boolean.class) {
       if (argument.equals("true")) {
         return true;

--- a/test/functional/android/apidemos/find/by-uiautomator-specs.js
+++ b/test/functional/android/apidemos/find/by-uiautomator-specs.js
@@ -143,6 +143,13 @@ describe("apidemo - find elements - by uiautomator", function () {
       text.should.equal("Views");
     }).nodeify(done);
   });
+  it('should allow UiScrollable scrollIntoView', function (done) {
+    driver.elementByAndroidUIAutomator('new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("Views").instance(0));')
+    .text()
+    .then(function (text) {
+      text.should.equal("Views");
+    }).nodeify(done);
+  });
   it('should error reasonably if a UiScrollable does not return a UiObject', function (done) {
     driver.elementByAndroidUIAutomator('new UiScrollable(new UiSelector().scrollable(true).instance(0)).setMaxSearchSwipes(10)')
     .should.be.rejectedWith(/status: 9/)


### PR DESCRIPTION
Once I write some tests then this will be ready. I've included a working example below. Open to feedback on the general approach.
- I added debugging logs. It was very difficult to tell where the parser failed with no logging.
- scrollIntoView returns the element that it scrolled to. In general the element not found error isn't handled properly for any of the find by uiautomator.

Fix #2935

```
Example:

 a =  find_element(:uiautomator, 'new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("WebView").instance(0));')

 a.text # WebView
```
