### PR TITLE
Add network connection endpoint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,6 @@
 [submodule "submodules/io.appium.android.ime"]
 	path = submodules/io.appium.android.ime
 	url = https://github.com/appium/io.appium.android.ime.git
+[submodule "submodules/io.appium.settings"]
+	path = submodules/io.appium.settings
+	url = https://github.com/appium/io.appium.settings.git

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -588,6 +588,21 @@ androidCommon.pushUnicodeIME = function (cb) {
   }.bind(this));
 };
 
+androidCommon.pushSettingsApp = function (cb) {
+  logger.debug("Pushing settings apk to device...");
+  var settingsPath = path.resolve(__dirname, "..", "..", "..", "build",
+      "settings_apk", "settings_apk-debug.apk");
+
+  fs.stat(settingsPath, function (err) {
+    if (err) {
+      cb(new Error("Could not find settings apk; please run " +
+                   "'reset.sh --android' to build it."));
+    } else {
+      this.adb.install(settingsPath, false, cb);
+    }
+  }.bind(this));
+};
+
 androidCommon.pushUnlock = function (cb) {
   logger.debug("Pushing unlock helper app to device...");
   var unlockPath = path.resolve(__dirname, "..", "..", "..", "build",
@@ -799,6 +814,72 @@ androidCommon.initUnicode = function (cb) {
   } else {
     cb();
   }
+};
+
+androidCommon.getNetworkConnection = function (cb) {
+  logger.info('Getting network connection');
+  this.adb.isAirplaneModeOn(function (err, airplaneModeOn) {
+    if (err) return cb(err);
+    var connection = airplaneModeOn ? 1 : 0;
+    if (airplaneModeOn) {
+      // airplane mode on implies wifi and data off
+      return cb(null, {
+        status: status.codes.Success.code,
+        value: connection
+      });
+    }
+    this.adb.isWifiOn(function (err, wifiOn) {
+      if (err) return cb(err);
+      connection += (wifiOn ? 2 : 0);
+      this.adb.isDataOn(function (err, dataOn) {
+        if (err) return cb(err);
+        connection += (dataOn ? 4 : 0);
+        cb(null, {
+          status: status.codes.Success.code,
+          value: connection
+        });
+      }.bind(this));
+    }.bind(this));
+  }.bind(this));
+};
+
+androidCommon.setNetworkConnection = function (type, ocb) {
+  logger.info('Setting network connection');
+  // decode the input
+  var airplaneMode = type % 2;
+  type >>= 1;
+  var wifi = type % 2;
+  type >>= 1;
+  var data = type % 2;
+
+  var series = [];
+  // do airplane mode stuff first, since it will change the other statuses
+  series.push(function (cb) {
+    this.wrapActionAndHandleADBDisconnect(function (ncb) {
+      this.adb.setAirplaneMode(airplaneMode, ncb);
+    }.bind(this), cb);
+  }.bind(this));
+  series.push(function (cb) {
+    this.wrapActionAndHandleADBDisconnect(function (ncb) {
+      this.adb.broadcastAirplaneMode(airplaneMode, ncb);
+    }.bind(this), cb);
+  }.bind(this));
+  // no need to do anything else if we are in or going into airplane mode
+  if (airplaneMode === 0) {
+    series.push(function (cb) {
+      this.wrapActionAndHandleADBDisconnect(function (ncb) {
+        this.adb.setWifiAndData({
+          wifi: wifi,
+          data: data
+        }, ncb);
+      }.bind(this), cb);
+    }.bind(this));
+  }
+
+  async.series(series, function (err) {
+    if (err) return ocb(err);
+    return this.getNetworkConnection(ocb);
+  }.bind(this));
 };
 
 module.exports = androidCommon;

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -99,6 +99,7 @@ Android.prototype.start = function (cb, onDie) {
       this.forwardPort.bind(this),
       this.pushAppium.bind(this),
       this.initUnicode.bind(this),
+      this.pushSettingsApp.bind(this),
       this.pushUnlock.bind(this),
       this.uiautomator.start.bind(this.uiautomator),
       this.wakeUp.bind(this),

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -66,6 +66,8 @@ Selendroid.prototype.init = function () {
     , ['GET', new RegExp('^/wd/hub/session/[^/]+/context')]
     , ['GET', new RegExp('^/wd/hub/session/[^/]+/contexts')]
     , ['POST', new RegExp('^/wd/hub/session/[^/]+/element/[^/]+/value')]
+    , ['GET', new RegExp('^/wd/hub/session/[^/]+/network_connection')]
+    , ['POST', new RegExp('^/wd/hub/session/[^/]+/network_connection')]
   ];
 };
 
@@ -144,6 +146,7 @@ Selendroid.prototype.start = function (cb) {
     this.installApp.bind(this),
     this.forwardPort.bind(this),
     this.initUnicode.bind(this),
+    this.pushSettingsApp.bind(this),
     this.pushUnlock.bind(this),
     this.unlockScreen.bind(this),
     this.pushSelendroid.bind(this),

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -1136,3 +1136,12 @@ exports.activateIMEEngine = function (req, res) {
 exports.deactivateIMEEngine = function (req, res) {
   req.device.deactivateIMEEngine(getResponseHandler(req, res));
 };
+
+exports.getNetworkConnection = function (req, res) {
+  req.device.getNetworkConnection(getResponseHandler(req, res));
+};
+
+exports.setNetworkConnection = function (req, res) {
+  var type = req.body.type || req.body.parameters.type;
+  req.device.setNetworkConnection(type, getResponseHandler(req, res));
+};

--- a/lib/server/routing.js
+++ b/lib/server/routing.js
@@ -79,6 +79,8 @@ module.exports = function (appium) {
   rest.post('/wd/hub/session/:sessionId?/log', controller.getLog);
   rest.get('/wd/hub/session/:sessionId?/log/types', controller.getLogTypes);
   rest.post('/wd/hub/session/:sessionId?/timeouts', controller.timeouts);
+  rest.get('/wd/hub/session/:sessionId?/network_connection', controller.getNetworkConnection);
+  rest.post('/wd/hub/session/:sessionId?/network_connection', controller.setNetworkConnection);
 
   // touch gesture endpoints
   rest.post('/wd/hub/session/:sessionId?/touch/perform', controller.performTouch);

--- a/reset.bat
+++ b/reset.bat
@@ -94,6 +94,21 @@ if %doAndroid% == 1 (
   ECHO.
   ECHO =====Reset UnicodeIME.apk Complete=====
 
+  ECHO.
+  ECHO =====Resetting Settings.apk=====
+  ECHO.
+  CALL :runCmd "RD /S /Q build\settings_apk | VER > NUL"
+  CALL :runCmd "MKDIR build\settings_apk"
+  ECHO Building Settings.apk
+  CALL :runCmd "git submodule update --init submodules\io.appium.settings"
+  CALL :runCmd "PUSHD submodules\io.appium.settings"
+  CALL :runCmd "ant clean"
+  CALL :runCmd "ant debug"
+  CALL :runCmd "POPD"
+  CALL :runCmd "COPY submodules\io.appium.settings\bin\settings_apk-debug.apk build\settings_apk\settings_apk-debug.apk"
+  ECHO.
+  ECHO =====Reset Settings.apk Complete=====
+
   :: Reset Android Dev
   IF %doDev% == 1 (
     ECHO.

--- a/reset.sh
+++ b/reset.sh
@@ -20,6 +20,7 @@ appium_home=$(pwd)
 reset_successful=false
 has_reset_unlock_apk=false
 has_reset_ime_apk=false
+has_reset_settings_apk=false
 apidemos_reset=false
 toggletest_reset=false
 hardcore=false
@@ -332,6 +333,22 @@ reset_unicode_ime() {
     fi
 }
 
+reset_settings_apk() {
+    if ! $has_reset_settings_apk; then
+        run_cmd rm -rf build/settings_apk
+        run_cmd mkdir -p build/settings_apk
+        echo "* Building Settings.apk"
+        settings_base="submodules/io.appium.settings"
+        run_cmd git submodule update --init $settings_base
+        run_cmd pushd $settings_base
+        run_cmd ant clean && run_cmd ant debug
+        run_cmd popd
+        run_cmd cp $settings_base/bin/settings_apk-debug.apk build/settings_apk
+        uninstall_android_app "io.appium.settings"
+        has_reset_settings_apk=true
+    fi
+}
+
 reset_android() {
     echo "RESETTING ANDROID"
     require_java
@@ -342,6 +359,7 @@ reset_android() {
     run_cmd "$grunt" buildAndroidBootstrap
     reset_unlock_apk
     reset_unicode_ime
+    reset_settings_apk
     if $include_dev ; then
         reset_apidemos
         reset_toggle_test

--- a/sample-code/apps/ToggleTest/AndroidManifest.xml
+++ b/sample-code/apps/ToggleTest/AndroidManifest.xml
@@ -26,5 +26,7 @@
             </intent-filter>
         </activity>
     </application>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 
 </manifest>

--- a/sample-code/apps/ToggleTest/src/com/example/toggletest/MainActivity.java
+++ b/sample-code/apps/ToggleTest/src/com/example/toggletest/MainActivity.java
@@ -1,49 +1,103 @@
 package com.example.toggletest;
 
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.location.LocationManager;
 import android.net.wifi.WifiManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.provider.Settings;
+import android.provider.Settings.SettingNotFoundException;
 import android.telephony.TelephonyManager;
+import android.util.Log;
 import android.widget.ToggleButton;
-import android.annotation.TargetApi;
-import android.app.Activity;
-import android.content.Context;
+
 
 public class MainActivity extends Activity {
+	private static final String TAG = "Toggle Test";
 	private ToggleButton mWifiToggle;
 	private ToggleButton mDataToggle;
 	private ToggleButton mFlightModeToggle;
 	private ToggleButton mGPSToggle;
-	private WifiManager mWifiManager;
 	private TelephonyManager mTelephonyManager;
 	private LocationManager mLocationManager;
+	private NetworkReceiver receiver;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_main);
-		
-		mWifiManager = (WifiManager)getSystemService(Context.WIFI_SERVICE);
+
 		mTelephonyManager = (TelephonyManager)getSystemService(Context.TELEPHONY_SERVICE);
 		mLocationManager = (LocationManager)getSystemService(Context.LOCATION_SERVICE);
-		
+
 		mWifiToggle = (ToggleButton)findViewById(R.id.wifi_toggle);
 		mDataToggle = (ToggleButton)findViewById(R.id.data_toggle);
 		mFlightModeToggle = (ToggleButton)findViewById(R.id.flight_toggle);
-		mGPSToggle = (ToggleButton)findViewById(R.id.gps_toggle);	
+		mGPSToggle = (ToggleButton)findViewById(R.id.gps_toggle);
+	}
+
+	@Override
+	protected void onPause() {
+		super.onPause();
+		this.unregisterReceiver(receiver);
 	}
 
 	@Override
 	protected void onResume() {
 		super.onResume();
+		this.addReceiver();
+		this.refresh();
+	}
 
-		mWifiToggle.setChecked(mWifiManager.isWifiEnabled());
+	private void addReceiver() {
+		IntentFilter filters = new IntentFilter();
+    filters.addAction(WifiManager.WIFI_STATE_CHANGED_ACTION);
+    filters.addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION);
+    filters.addAction("android.intent.action.ANY_DATA_STATE");
+    filters.addAction(Intent.ACTION_AIRPLANE_MODE_CHANGED);
+
+    this.receiver = new NetworkReceiver(this);
+    registerReceiver(this.receiver, filters);
+	}
+
+	protected void refresh() {
+		try {
+			// the WifiManager is flakey on emulators
+			// it is faster and more reliable to get the read-only setting for wifi_on
+			int wifiOn = Settings.Global.getInt(getContentResolver(), Settings.Global.WIFI_ON);
+			mWifiToggle.setChecked(wifiOn != 0);
+		} catch (SettingNotFoundException e) {
+			// fall through
+			Log.d(TAG, "Unable to find Setting 'wifi_on': " + e.getMessage());
+		}
 		mDataToggle.setChecked(mTelephonyManager.getDataState() == TelephonyManager.DATA_CONNECTED);
-		mFlightModeToggle.setChecked(FlightMode.getInstance().isEnabled(this));
+		boolean fMode = FlightMode.getInstance().isEnabled(this);
+		mFlightModeToggle.setChecked(fMode);
+		if (fMode) {
+			// data in particular sometimes still says it's on when there is airplane mode
+			mWifiToggle.setChecked(false);
+			mDataToggle.setChecked(false);
+		}
 		mGPSToggle.setChecked(mLocationManager.isProviderEnabled(LocationManager.GPS_PROVIDER)
 				|| mLocationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER));
+	}
+
+	static class NetworkReceiver extends BroadcastReceiver {
+		private MainActivity activity;
+
+		public NetworkReceiver(MainActivity activity) {
+			this.activity = activity;
+		}
+
+		@Override
+		public void onReceive(Context context, Intent intent) {
+			activity.refresh();
+		}
 	}
 
 	static class FlightMode {
@@ -54,13 +108,13 @@ public class MainActivity extends Activity {
 				return new FlightModeJBMR1();
 			}
 		}
-		
+
 		public boolean isEnabled(Context context) {
 			return Settings.System.getInt(context.getContentResolver(),
 					Settings.System.AIRPLANE_MODE_ON, 0) != 0;
 		}
 	}
-	
+
 	@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
 	static class FlightModeJBMR1 extends FlightMode {
 		@Override

--- a/test/functional/android/toggle/network-connection-specs.js
+++ b/test/functional/android/toggle/network-connection-specs.js
@@ -1,0 +1,37 @@
+"use strict";
+
+var setup = require("../../common/setup-base"),
+    desired = require('./desired');
+
+describe('network connection details', function () {
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('should get airplane mode', function (done) {
+    driver
+      .setNetworkConnection(1)
+      .getNetworkConnection().should.eventually.become(1)
+      .nodeify(done);
+  });
+
+  it('should get wifi alone', function (done) {
+    driver
+      .setNetworkConnection(2)
+      .getNetworkConnection().should.eventually.become(2)
+      .nodeify(done);
+  });
+
+  it('should get data alone', function (done) {
+    driver
+      .setNetworkConnection(4)
+      .getNetworkConnection().should.eventually.become(4)
+      .nodeify(done);
+  });
+
+  it('should get wifi and data', function (done) {
+    driver
+      .setNetworkConnection(6)
+      .getNetworkConnection().should.eventually.become(6)
+      .nodeify(done);
+  });
+});


### PR DESCRIPTION
Add ability to set `airplane_mode`, `wifi`, and `data` in Android. 

At the moment there are problems with keeping `adb` alive. Twiddling the network settings tends to kill the adb connection, so the calls are wrapped in calls to `wrapActionAndHandleADBDisconnect`. However, periodically there is a problem where `adb shell echo 'ready'` fails with 

``` shell
error: Error running shell echo: Error: Command failed: error: protocol fault (no status)
```

This might be a case where retrying might work. But my brain is fried. I wanted to put this out there to see if there were any ideas.

Depends on https://github.com/appium/appium-adb/pull/20
