### PR TITLE
Miscellaneous doc formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,13 @@ and then run your test.
 
 The quick way to get started:
 
-    $ git clone https://github.com/appium/appium.git
-    $ cd appium
-    $ ./reset.sh
-    $ sudo grunt authorize # for ios only
-    $ node .
+<code>
+$ git clone https://github.com/appium/appium.git
+$ cd appium
+$ ./reset.sh
+$ sudo grunt authorize # for ios only
+$ node .
+</code>
 
 ## Hacking with Appium
 
@@ -30,10 +32,12 @@ From your local repo's command prompt, install the following packages using the
 following commands (if you didn't install `node` using homebrew, you might have
 to run npm with sudo privileges):
 
-    npm install -g mocha
-    npm install -g grunt-cli
-    node bin/appium-doctor.js --dev
-    ./reset.sh --dev
+<code>
+$ npm install -g mocha
+$ npm install -g grunt-cli
+$ node bin/appium-doctor.js --dev
+$ ./reset.sh --dev
+</code>
 
 The first two commands install test and build tools (`sudo` may not be
 necessary if you installed node.js via Homebrew). The third command verifies
@@ -43,14 +47,18 @@ command installs all app dependencies and builds supporting binaries and test
 apps. `reset.sh` is also the recommended command to run after pulling changes
 from master. At this point, you're able to start the Appium server:
 
-    node .
+<code>
+$ node .
+</code>
 
 There are some arguments you can pass into the Appium server from the command-line:
 
-    node . --app /absolute/path/to/app  // launch Appium server with app
-    node . --launch // pre-launch the app when appium loads
-    node . --log /my/appium.log // log to file instead of stdout
-    node . --log-level warn // don't log verbose output
+<code>
+$ node . --app /absolute/path/to/app  // launch Appium server with app
+$ node . --launch // pre-launch the app when appium loads
+$ node . --log /my/appium.log // log to file instead of stdout
+$ node . --log-level warn // don't log verbose output
+</code>
 
 See [the server documentation](docs/en/server-args.md)
 for a full list of arguments.
@@ -68,12 +76,15 @@ have to modify your `/etc/authorization` file in one of two ways:
 
 2. Run the following grunt command which automatically modifies your
    `/etc/authorization` file for you:
-
-       sudo ./bin/authorize-ios.js
+    <code>
+    $ sudo ./bin/authorize-ios.js
+    </code>
 
 At this point, run:
 
-    ./reset.sh --ios --dev
+<code>
+$ ./reset.sh --ios --dev
+</code>
 
 Now your Appium instance is ready to go. Run `node .` to kick up the Appium server.
 
@@ -81,17 +92,23 @@ Now your Appium instance is ready to go. Run `node .` to kick up the Appium serv
 
 Bootstrap running for Android by running:
 
-    ./reset.sh --android --dev
+<code>
+$ ./reset.sh --android --dev
+</code>
 
 If you want to use [Selendroid](http://github.com/DominikDary/selendroid) for support on older Android platforms like 2.3, then run:
 
-    ./reset.sh --selendroid --dev
+<code>
+$ ./reset.sh --selendroid --dev
+</code>
 
 Make sure you have one and only one Android emulator or device running, e.g.
 by running this command in another process (assuming the `emulator` command is
 on your path):
 
-    emulator -avd <MyAvdName>
+<code>
+$ emulator -avd <MyAvdName>
+</code>
 
 Now you are ready to run the Appium server via `node .`.
 
@@ -103,13 +120,17 @@ to do all this for all platforms (the `--dev` flag gets dev npm dependencies
 and test applications used in the Appium test suite). You will also need to do
 this when Appium bumps its version up:
 
-    ./reset.sh --dev
+<code>
+$ ./reset.sh --dev
+</code>
 
 Or you can run reset for individual platforms only:
 
-    ./reset.sh --ios --dev
-    ./reset.sh --android --dev
-    ./reset.sh --selendroid --dev
+<code>
+$ ./reset.sh --ios --dev
+$ ./reset.sh --android --dev
+$ ./reset.sh --selendroid --dev
+</code>
 
 ## Running Tests
 
@@ -120,38 +141,50 @@ on.
 Once your system is set up and your code is up to date, you can run unit tests
 with:
 
-    grunt unit
+<code>
+$ grunt unit
+</code>
 
 You can run functional tests for all supported platforms (after ensuring that
 Appium is running in another window with `node .`) with:
 
-    bin/test.sh
+<code>
+$ bin/test.sh
+</code>
 
 Or you can run particular platform tests with `test.sh`:
 
-    bin/test.sh --android
-    bin/test.sh --ios
-    bin/test.sh --ios7
-    bin/test.sh --ios71
+<code>
+$ bin/test.sh --android
+$ bin/test.sh --ios
+$ bin/test.sh --ios7
+$ bin/test.sh --ios71
+</code>
 
 Before committing code, please run `grunt` to execute some basic tests and check
 your changes against code quality standards:
 
-    grunt
-    > Running "lint:all" (lint) task
-    > Lint free.
-    > Done, without errors.
+<code>
+$ grunt
+> Running "lint:all" (lint) task
+> Lint free.
+> Done, without errors.
+</code>
 
 ### Running individual tests
 
 If you have an Appium server listening, you can run individual test files using
 Mocha, for example:
 
-    DEVICE=ios71 mocha -t 60000 -R spec test/functional/ios/testapp/simple.js
+<code>
+$ DEVICE=ios71 mocha -t 60000 -R spec test/functional/ios/testapp/simple.js
+</code>
 
 Or individual tests (e.g., a test with the word "alert" in the name):
 
-    DEVICE=ios6 mocha -t 60000 -R spec --grep "alert" test/functional/ios/apidemos
+<code>
+$ DEVICE=ios6 mocha -t 60000 -R spec --grep "alert" test/functional/ios/apidemos
+</code>
 
 NOTE: For Android, you will need an emulator/device with screen size of 4.0"
 (480x800). Some tests might fail on a different screen size.

--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ You can run an Appium server using node.js or using the application, see below.
 
 ### Using Node.js
 
-    $ npm install -g appium
-    $ appium &
+<code>
+$ npm install -g appium
+$ appium &
+</code>
 
 ### Using the App
 

--- a/docs/en/grid.md
+++ b/docs/en/grid.md
@@ -1,11 +1,11 @@
 # Selenium Grid
 
 You are able to register your appium server with a local grid by using the
-**"--nodeconfig"** server parameter.
+**"`--nodeconfig`"** server parameter.
 
-```bash
-> node . -V --nodeconfig /path/to/nodeconfig.json
-```
+<code>
+$ node . -V --nodeconfig /path/to/nodeconfig.json
+</code>
 
 In the node config file you have to define the **"browserName"**,
 **"version"** and **"platform"** and based on these parameters the grid

--- a/docs/en/hybrid.md
+++ b/docs/en/hybrid.md
@@ -176,11 +176,11 @@ https://gist.github.com/feelobot/7309729
 ```python
 APP_PATH = "https://dl.dropboxusercontent.com/s/123456789101112/ts_ios.zip"
 capabilities = {
-    'browserName': 'iOS 6.0',
-    'platform': 'Mac 10.8',
-    'device': 'iPhone Simulator',
+    'platformName': 'iOS',
+    'deviceName': 'iPhone Simulator',
+    'deviceVersion': '7.1'
     'app': APP_PATH,
-    'name': "Example Python Test"
+    'name': "Example Hybrid Python Test"
 }
 driver = webdriver.Remote('http://localhost:4723/wd/hub', capabilities)
 
@@ -301,4 +301,17 @@ assertEqual('My very own text', elements[0].text)
 
 driver.switch_to.context("NATIVE_APP")
 driver.quit()
+```
+
+```php
+// assuming we have an initialized object working on a hybrid app
+public function testThings()
+{
+    $this->context('WEBVIEW_1');
+
+    $els = $this->elements($this->using('css')->value('.some-class'));
+    $this->assertLessThan(0, count($els));
+
+    $this->context('NATIVE_APP');
+}
 ```

--- a/docs/en/ios-deploy.md
+++ b/docs/en/ios-deploy.md
@@ -9,19 +9,19 @@ To prepare for your Appium tests to run on a real device, you will need to:
 ## Xcodebuild with parameters:
 A newer xcodebuild now allows settings to be specified. Taken from [developer.apple.com](https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man1/xcodebuild.1.html):
 
-```
-xcodebuild [-project projectname] [-target targetname ...]
+<code>
+$ xcodebuild [-project projectname] [-target targetname ...]
              [-configuration configurationname] [-sdk [sdkfullpath | sdkname]]
              [buildaction ...] [setting=value ...] [-userdefault=value ...]
-```
+</code>
 
 This is a resource to explore the available [settings](https://developer.apple.com/library/mac/#documentation/DeveloperTools/Reference/XcodeBuildSettingRef/1-Build_Setting_Reference/build_setting_ref.html#//apple_ref/doc/uid/TP40003931-CH3-DontLinkElementID_10)
 
-```
+<code>
 CODE_SIGN_IDENTITY (Code Signing Identity)
     Description: Identifier. Specifies the name of a code signing identity.
     Example value: iPhone Developer
-```
+</code>
 
 PROVISIONING_PROFILE is missing from the index of available commands,
 but may be necessary.
@@ -29,9 +29,9 @@ but may be necessary.
 Specify "CODE_SIGN_IDENTITY" & "PROVISIONING_PROFILE" settings in the
 xcodebuild command:
 
-```
-xcodebuild -sdk <iphoneos> -target <target_name> -configuration <Debug> CODE_SIGN_IDENTITY="iPhone Developer: Mister Smith" PROVISIONING_PROFILE="XXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX"
-```
+<code>
+$ xcodebuild -sdk <iphoneos> -target <target_name> -configuration <Debug> CODE_SIGN_IDENTITY="iPhone Developer: Mister Smith" PROVISIONING_PROFILE="XXXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXX"
+</code>
 
 On success, the app will be built to your ```<app_dir>/build/<configuration>-iphoneos/<app_name>.app```
 
@@ -48,35 +48,35 @@ parent directory.
 Execute fruitstrap after a clean build by running (commands available depend
 on your fork of fruitstrap):
 
-```
-./fruitstrap -d -b <PATH_TO_APP> -i <Device_UDID>
-```
+<code>
+$ ./fruitstrap -d -b <PATH_TO_APP> -i <Device_UDID>
+<code>
 
 If you are aiming to use continuous integration in this setup,
 you may find it useful to want to log the output of fruitstrap to both
 command line and log, like so:
 
-```
-./fruitstrap -d -b <PATH_TO_APP> -i <Device_UDID> 2>&1 | tee fruit.out
-```
+<code>
+$ ./fruitstrap -d -b <PATH_TO_APP> -i <Device_UDID> 2>&1 | tee fruit.out
+</code>
 
 Since fruitstrap will need to be killed before the node server can be
 launched, an option is to scan the output of the fruitstrap launch for some
 telling sign that the app has completed launching. This may prove useful if
 you are doing this via a Rakefile and a ``go_device.sh`` script:
 
-```
-bundle exec rake ci:fruit_deploy_app | while read line ; do 
-   echo "$line" | grep "text to identify successful launch" 
-   if [ $? = 0 ] 
-   then 
-   # Actions 
-       echo "App finished launching: $line" 
-       sleep 5 
-       kill -9 `ps -aef | grep fruitstrap | grep -v grep | awk '{print $2}'` 
+<code>
+$ bundle exec rake ci:fruit_deploy_app | while read line ; do
+   echo "$line" | grep "text to identify successful launch"
+   if [ $? = 0 ]
+   then
+   # Actions
+       echo "App finished launching: $line"
+       sleep 5
+       kill -9 `ps -aef | grep fruitstrap | grep -v grep | awk '{print $2}'`
    fi
  done
-```
+<code>
 
 Once fruitstrap is killed, node server can be launched and Appium tests can run!
 

--- a/docs/en/mobile-web.md
+++ b/docs/en/mobile-web.md
@@ -51,7 +51,7 @@ public static $browsers = array(
 To be able to run your tests against mobile Safari we use the [SafariLauncher
  App](https://github.com/snevesbarros/SafariLauncher) to launch Safari. Once
  Safari has been launched the Remote Debugger automatically connects using
- the [ios-webkit-webkit-proxy](https://github.com/google/ios-webkit-debug-proxy).
+ the [ios-webkit-debug-proxy](https://github.com/google/ios-webkit-debug-proxy).
 
 **NOTE:** There is currently [a bug](https://github.com/google/ios-webkit-debug-proxy/issues/38)
 in the ios-webkit-debug-proxy. You have to trust the machine before you can
@@ -61,6 +61,7 @@ against your iOS device.
 ## Setup
 
 Before you can run your tests against Safari on a real device you will need to:
+
 * Have the **ios-webkit-debug-proxy** installed, running and listening on port 27753 (see the
 [hybrid docs](hybrid.md) for instructions)
 * Turn on **web inspector** on iOS device (**settings > safari >
@@ -68,6 +69,7 @@ advanced**, only for iOS 6.0 and up)
 * Create a **provisioning profile** that can be used to deploy the SafariLauncherApp.
 
 To create a profile for the launcher go into the **Apple Developers Member Center** and:
+
   * **Step 1:** Create a **new App Id** and select the WildCard App ID option and set it to "*"
   * **Step 2:** Create a **new Development Profile** and for App Id select the one created in step 1.
   * **Step 3:** Select your **certificate(s) and device(s)** and click next.
@@ -77,7 +79,7 @@ To create a profile for the launcher go into the **Apple Developers Member Cente
 
 Now that you have a profile open a terminal and run the following commands:
 
-```bash
+<code>
 $ git clone https://github.com/appium/appium.git
 $ cd appium
 
@@ -92,7 +94,7 @@ $ ./reset.sh --ios --real-safari --code-sign '<code signing idendity>' --profile
 
 # Once successfully configured and with the safari launcher built, start the server as per usual
 $ node /lib/server/main.js -U <UDID>
-```
+</code>
 
 ## Running your test
 

--- a/docs/en/running-tests.md
+++ b/docs/en/running-tests.md
@@ -5,7 +5,9 @@
 Test apps run on the simulator have to be compiled specifically for the
 simulator, for example by executing the following command in the Xcode project:
 
-    > xcodebuild -sdk iphonesimulator6.0
+<code>
+$ xcodebuild -sdk iphonesimulator6.0
+</code>
 
 This creates a `build/Release-iphonesimulator` directory in your Xcode project
 that contains the `.app` package that you'll need to communicate with the
@@ -84,17 +86,22 @@ or [Linux](running-on-linux.md))
 for more information). If the Android SDK tools are on your path, you can
 simply run:
 
-    emulator -avd <MyAvdName>
-
+<code>
+$ emulator -avd <MyAvdName>
+</code>
 And wait for the android emulator to finish launching. Sometimes, for various
 reasons, `adb` gets stuck. If it's not showing any connected devices or
 otherwise failing, you can restart it by running:
 
-    adb kill-server && adb devices
+<code>
+$ adb kill-server && adb devices
+<code>
 
 Now, make sure Appium is running:
 
-    node .
+<code>
+$ node .
+<code>
 
 Then script your WebDriver test, sending in the following desired capabilities:
 

--- a/docs/en/style-guide.md
+++ b/docs/en/style-guide.md
@@ -49,108 +49,122 @@ automatic linting.
 *   Use two spaces for indentation, *no tabs*
 *   Use single spaces around operators
 
-    ```js
+    <code>
     var x = 1;
-    ```
+    </code>
+
     not
-    ```js
+
+    <code>
     var x=1;
-    ```        
-    
+    </code>
+
 *   Spaces after commas and colons in lists, objects, function calls, etc...
 
-    ```js
+    <code>
     var x = myFunc("lol", {foo: bar, baz: boo});
-    ```
+    </code>
+
     not
-    ```js
+
+    <code>
     var x = myFunc("lol",{foo:bar,baz:boo});
-    ```
+    </code>
 
 *   Always end statements with semicolons
 *   Comma-first
 
-    ```js
+    <code>
     var x = {
       foo: 'bar'
-    , baz: 'boo'
-    , wuz: 'foz'
+      , baz: 'boo'
+      , wuz: 'foz'
     };
-    ```
+    </code>
 
 *   Brackets for `function`, `if`, etc... go on same line, `else` gets sandwiched
 
-    ```js
+    <code>
     if (foo === bar) {
       // do something
     } else {
       // do something else
     }
-    ```
+    </code>
 
 *   Space after `if`, `for`, and `function`:
 
-    ```js
+    <code>
     if (foo === bar) {
-    ```
-    ```js
+    </code>
+
+    <code>
     for (var i = 0; i < 10; i ++) {
-    ```
-    ```js
+    </code>
+
+    <code>
     var lol = function (foo) {
-    ```
+    </code>
+
     not
-    ```js
+
+    <code>
     if(foo === bar) {
-    ```
-    ```js
+    </code>
+
+    <code>
     for(var i = 0; i < 10; i ++) {
-    ```
-    ```js
+    </code>
+
+    <code>
     var lol = function(foo) {
-    ```
+    </code>
 
 *   Avoid bracketless `if` for one-liners:
 
-    ```js
+    <code>
     if (foo === bar) {
       foo++;
     }
-    ```
+    </code>
+
     not
-    ```js
+
+    <code>
     if (foo === bar)
       foo++;
-    ```
+    </code>
 
 *   Use `===`, not `==`, and `!==`, not `!=` for no surprises
 *   Line length shouldn't be longer than 79 characters
 *   Break up long strings like this:
 
-    ```js
+    <code>
     myFunc("This is a really long string that's longer " +
             "than 79 characters so I broke it up, woo");
-    ```
+    </code>
 
 *   Comments should line up with code
 
-    ```js
+    <code>
     if (foo === 5) {
       myFunc(foo);
       // foo++;
     }
-    ```
+    </code>
+
     not
-    ```js
+
+    <code>
     if (foo === 5) {
       myFunc(foo);
     //foo++;
     }
-    ```
+    </code>
 
 *   Subclassing by extending prototypes
 
-    ```js
+    <code>
     var _ = require('underscore');
 
     var SuperClass = function () {
@@ -162,70 +176,76 @@ automatic linting.
     };
 
     // Create a subclass
-    
+
     var SubClass = function () {
         this.init();
     };
 
     _.extend(SubClass.prototype, SuperClass.prototype);
-    ```
+    </code>
 
 *   Callbacks are always last in function definitions
 
-    ```js
+    <code>
     var foo = function (arg1, arg2, cb) {
       ...
     };
-    ```
+    </code>
 
 *   Define functions as variables
 
-    ```js
+    <code>
     var myFunc = function (a, b, c) {};
-    ```
+    </code>
+
     not
-    ```js
+
+    <code>
     function myFunc (a, b, c) {}
-    ```
-    
+    </code>
+
 *   Variable names should be camelCased:
 
-    ```js
+    <code>
     var myVariable = 42;
-    ```
+    </code>
+
     not
-    ```js
+
+    <code>
     var my_variable = 42;
-    ```
+    </code>
 
 *    Check for undefined
 
-    ```js
+    <code>
     typeof myVariable === "undefined"
-    ```
-    not
-    ```js
-    myVariable === undefined
-    ```
+    </code>
 
-## Test Style:
-    
+    not
+
+    <code>
+    myVariable === undefined
+    </code>
+
+## Test Style
+
 Keep on the same line if it makes sense semantically and length is not an issue:
 
 Examples:
 
-```js
+<code>
   driver.elementByTagName('el1').should.become("123")
     .nodeify(done);
-  
+
   driver
     .elementsByTagName('el1').should.eventually.have.length(0)
     .nodeify(done);
-```
+</code>
 
 Alternatively use extra indents to improve readability:
 
-```js
+<code>
 h.driver
   .elementById('comments')
     .clear()
@@ -241,4 +261,4 @@ h.driver
   .execute("'nan'--")
     .should.be.rejectedWith("status: 13")
   .nodeify(done);
-```
+</code>

--- a/docs/en/troubleshooting.md
+++ b/docs/en/troubleshooting.md
@@ -21,17 +21,20 @@ to github or write to the appium-discuss mailing list.
 * `git pull` to make sure you're running the latest code
 * Run the appropriate flavor of `reset.sh` based on what you're trying to
 automate:
-    
-    ./reset.sh               # all
-    ./reset.sh --ios         # ios-only
-    ./reset.sh --android     # android-only
-    ./reset.sh --selendroid  # selendroid-only
+
+<code>
+    $ ./reset.sh               # all
+    $ ./reset.sh --ios         # ios-only
+    $ ./reset.sh --android     # android-only
+    $ ./reset.sh --selendroid  # selendroid-only
+</code>
+
 * You might also want to run `reset.sh` with the `--dev` flag if you want the
   test apps downloaded and built as well.
 * You can also use `appium-doctor` to automatically verify that all
   dependencies are met. If running from source, you may have to use
   `bin/appium-doctor.js` or `node bin/appium-doctor.js`.
-* If you get this error after upgrading to Android SDK 22: 
+* If you get this error after upgrading to Android SDK 22:
   `{ANDROID_HOME}/tools/ant/uibuild.xml:155: SDK does not have any Build Tools installed.`
 In the Android SDK 22, the platform and build tools are split up into their
 own items in the SDK manager. Make sure you install the build-tools and platform-tools.
@@ -48,7 +51,7 @@ own items in the SDK manager. Make sure you install the build-tools and platform
 * Make sure Instruments.app is not open
 * If you're running the simulator, make sure your actual device is not
   plugged in
-* Make sure the accessibility helper is turned off in your Settings app 
+* Make sure the accessibility helper is turned off in your Settings app
 * Make sure the app is compiled for the version of the simulator that's being
   run
 * If you've ever run Appium with sudo, you might need to `sudo rm
@@ -64,7 +67,7 @@ own items in the SDK manager. Make sure you install the build-tools and platform
 ## Webview/Hybrid/Safari app support
 
 * Make Sure you enable the 'Web Inspector' on the real device.
-* Make Sure you enable the Safari - Advance Preferences- Developer menu for
+* Make Sure you enable the Safari - Advance Preferences - Developer menu for
   simulators.
 * If you getting this error: select_port() failed, when trying to open the
   proxy, see this [discussion](https://groups.google.com/forum/#!topic/appium-discuss/tw2GaSN8WX0)
@@ -79,9 +82,6 @@ own items in the SDK manager. Make sure you install the build-tools and platform
 Once you've tried the above steps and your issue still isn't resolved,
 here's what you can do:
 
-If you've found what you believe is a bug, go straight to the [issue tracker](https://github.com/appium/appium/issues)
-and submit an issue describing the bug and a repro case.
-
 If you're having trouble getting Appium working and the error messages Appium
 provides are not clear, join the [mailing list](https://groups.google.com/d/forum/appium-discuss)
 and send a message. Please include the following:
@@ -89,9 +89,12 @@ and send a message. Please include the following:
 * How you're running Appium (Appium.app, npm, source)
 * The client-side and server-side errors you're getting (i.e.,
 "In Python this is the exception I get in my test script,
-and here's a link to a paste of the Appium server output)
+and here's a link to a paste of the Appium server output")
 * Per above, it's very important to include a paste of the Appium server
 output when it's run in verbose mode so that we can diagnose what's going on.
+
+If you've found what you believe is a bug, go straight to the [issue tracker](https://github.com/appium/appium/issues)
+and submit an issue describing the bug and a repro case.
 
 ## Known Issues
 


### PR DESCRIPTION
- put all server arguments in backtick quotes, so they don't get turned into en-dashes
- `<code></code>` blocks on command line, so it stays in line with text

Also fixed some Python desired capabilities, and added one missed PHP sample.
