### PR TITLE
Fix scroll into view

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/UiScrollableParser.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/UiScrollableParser.java
@@ -229,6 +229,11 @@ public class UiScrollableParser {
             UiSelector arg = (UiSelector) convertedArgs.get(0);
             returnedUiObject = true;
             uiObject = new UiObject(arg);
+            // scrollIntoView must return the object if it's already in view.
+            // without the exists check, the parser will error because there's no scrollable.
+            if (uiObject.exists()) {
+              return;
+            }
             Logger.debug("Invoking method: " + method + " with: " + uiObject);
             method.invoke(scrollable, uiObject);
             Logger.debug("Invoke complete.");


### PR DESCRIPTION
If the desired object already exists on screen, then avoid scrolling to it.
Without this check, the server will error because there may not be a scrollable.

Scrollable existance depends on screen size. For testing, it's better to have
code that works regardless if scrolling is required or not. This matches the
complex_find behavior.
