### PR TITLE
Update ApiDemos submodule; update reset to use io.appium.android.api package

### DIFF
--- a/reset.bat
+++ b/reset.bat
@@ -179,7 +179,7 @@ IF %doSelendroid% == 1 (
     CALL :runCmd "RD /S /Q sample-code\apps\WebViewDemo | VER > NUL"
     CALL :runCmd "MKDIR sample-code\apps\WebViewDemo"
     CALL :runCmd "XCOPY submodules\selendroid\selendroid-test-app sample-code\apps\WebViewDemo /E /Q"
-    CALL :uninstallAndroidApp com.example.android.apis.selendroid
+    CALL :uninstallAndroidApp io.appium.android.apis.selendroid
     CALL :uninstallAndroidApp io.selendroid.testapp
     CALL :uninstallAndroidApp io.selendroid.testapp.selendroid
     CALL :uninstallAndroidApp org.openqa.selendroid.testapp

--- a/reset.sh
+++ b/reset.sh
@@ -274,7 +274,7 @@ reset_apidemos() {
     echo "* Configuring and cleaning/building Android test app: ApiDemos"
     run_cmd "$grunt" configAndroidApp:ApiDemos
     run_cmd "$grunt" buildAndroidApp:ApiDemos
-    uninstall_android_app com.example.android.apis
+    uninstall_android_app io.appium.android.apis
     apidemos_reset=true
 }
 
@@ -395,11 +395,11 @@ reset_selendroid_quick() {
     if $include_dev ; then
         if ! $apidemos_reset; then
             reset_apidemos
-            uninstall_android_app com.example.android.apis.selendroid
+            uninstall_android_app io.appium.android.apis.selendroid
         fi
         if ! $toggletest_reset; then
             reset_toggle_test
-            uninstall_android_app com.example.toggletest.selendroid
+            uninstall_android_app io.appium.toggletest.selendroid
         fi
         run_cmd pushd /tmp/appium/selendroid
         echo "* Downloading selendroid test app"
@@ -438,11 +438,11 @@ reset_selendroid() {
     if $include_dev ; then
         if ! $apidemos_reset; then
             reset_apidemos
-            uninstall_android_app com.example.android.apis.selendroid
+            uninstall_android_app io.appium.android.apis.selendroid
         fi
         if ! $toggletest_reset; then
             reset_toggle_test
-            uninstall_android_app com.example.toggletest.selendroid
+            uninstall_android_app io.appium.toggletest.selendroid
         fi
         echo "* Linking selendroid test app"
         run_cmd rm -rf "$appium_home"/sample-code/apps/selendroid-test-app.apk


### PR DESCRIPTION
Use newest update to ApiDemos. Also, the package was [changed](https://github.com/appium/android-apidemos/commit/ececd47764e984baf388611e905ef685a33799a9) but `reset.sh`/`reset.bat` still try to uninstall the old package.
