### PR TITLE
Fix handling of ime activation

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -1112,11 +1112,9 @@ androidController.getActiveIMEEngine = function (cb) {
 
 androidController.activateIMEEngine = function (imeId, cb) {
   logger.debug('Attempting to activate IME \'' + imeId + '\'');
-  var pkg = imeId.split('/')[0];
-  logger.debug('Checking if package \'' + pkg + '\' is installed');
-  this.adb.isAppInstalled(pkg, function (err, installed) {
+  this.adb.availableIMEs(function (err, engines) {
     if (err) return cb(err);
-    if (installed) {
+    if (engines.indexOf(imeId) !== -1) {
       logger.debug('Found installed IME, attempting to activate.');
       this.adb.enableIME(imeId, function (err) {
         if (err) return cb(err);


### PR DESCRIPTION
Some of the built-in IMEs don't show up as installed packages. So change to check for available IMEs.
