### PR TITLE
Use local time for timestamps.

### DIFF
--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -29,6 +29,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`-g`, `--log`|null|Also send log output to this file|`--log /path/to/appium.log`|
 |`--log-level`|debug|log level (default: debug)|`--log-level debug`|
 |`--log-timestamp`|false|Show timestamps in console output||
+|`--local-timezone`|false|Use local timezone for timestamps||
 |`--log-no-colors`|false|Don't use colors in console output||
 |`-G`, `--webhook`|null|Also send log output to this HTTP listener|`--webhook localhost:9876`|
 |`--native-instruments-lib`|false|(IOS-only) IOS has a weird built-in unavoidable delay. We patch this in appium. If you do not want it patched, pass in this flag.||

--- a/lib/server/logger.js
+++ b/lib/server/logger.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var winston = require('winston');
+require('date-utils');
 
 var levels = {
   debug: 1
@@ -17,15 +18,25 @@ var colors = {
 };
 
 var logger = null;
+var serverArgs = null;
+
+var timestamp = function () {
+  var date = new Date();
+  if (!serverArgs.localTimezone) {
+    date = new Date(date.valueOf() + date.getTimezoneOffset() * 60000);
+  }
+  return date.toFormat("YYYY-MM-DD HH24:MI:SS:LL");
+};
 
 module.exports.init = function (args) {
+  serverArgs = args;
   var loglevel = args.logLevel ? args.logLevel :
      (args.quiet ? 'warn' : 'debug');
 
   winston.addColors(colors);
   winston.loggers.add('appium', {
     console: {
-        timestamp: args.logTimestamp ? true : false
+        timestamp: args.logTimestamp ? timestamp : false
       , colorize: args.logNoColors ? false : true
       , handleExceptions: true
       , exitOnError: false
@@ -43,7 +54,7 @@ module.exports.init = function (args) {
     try {
       winston.loggers.add('appium-file', {
         file: {
-            timestamp: true
+            timestamp: timestamp
           , colorize: false
           , filename: args.log
           , maxFiles: 1

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -166,6 +166,15 @@ var args = [
   , dest: 'logTimestamp'
   }],
 
+  [['--local-timezone'], {
+    defaultValue: false
+  , required: false
+  , help: 'Use local timezone for timestamps'
+  , nargs: 0
+  , action: 'storeTrue'
+  , dest: 'localTimezone'
+  }],
+
   [['--log-no-colors'], {
     defaultValue: false
   , required: false


### PR DESCRIPTION
The current setup uses GMT timestamps, this fix will use the local time with a new format.
Example: `2014-07-04 14:52:59:768`
I hope there are no tests, etc. that rely on the previous format, i.e. `2014-07-04T11:57:04.590Z`
Haven't been able to get the timezone info using `date-utils`. Let me know if you think it's important and I'll find a way to fix it.
