### PR TITLE
Fix uiautomator test

### DIFF
--- a/test/functional/android/apidemos/find/by-uiautomator-specs.js
+++ b/test/functional/android/apidemos/find/by-uiautomator-specs.js
@@ -21,8 +21,8 @@ describe("apidemo - find elements - by uiautomator", function () {
           .then(function (els) {
             els.length.should.be.above(0);
             els.length.should.be.below(3);
-        }).nodeify(done);
-      });
+        });
+      }).nodeify(done);
   });
   it('should find elements without prepending "new UiSelector()"', function (done) {
     driver.elementsByAndroidUIAutomator('.clickable(true)').then(function (els) {


### PR DESCRIPTION
Move call to `nodeify(done)` so if the element is not found (as in Android 'L') the test fails instead of timing out and breaking the rest of the suite.
