### PR TITLE
Add tests for custom keystore, and fix Selendroid handling

### DIFF
--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -86,16 +86,33 @@ Selendroid.prototype.start = function (cb) {
   this.adb = new ADB(this.args);
 
   var modServerExists = false
-    , modAppPkg = null;
+    , modAppPkg = null
+    , modServerTimestamp = null;
 
   var checkModServerExists = function (cb) {
     this.selendroidServerPath = path.resolve(this.args.tmpDir,
         'selendroid.' + this.args.appPackage + '.apk');
     modAppPkg = this.args.appPackage + '.selendroid';
-    fs.stat(this.selendroidServerPath, function (err) {
+    fs.stat(this.selendroidServerPath, function (err, stat) {
       modServerExists = !err;
+      if (stat) {
+        modServerTimestamp = stat.mtime.getTime();
+      }
       cb();
     });
+  }.bind(this);
+
+  var checkServerResigned = function (cb) {
+    if (modServerExists) {
+      fs.stat(this.selendroidServerPath, function (err, stat) {
+        if (stat && stat.mtime.getTime() > modServerTimestamp) {
+          modServerExists = false;
+        }
+        cb();
+      });
+    } else {
+      cb();
+    }
   }.bind(this);
 
   var conditionalUninstallSelendroid = function (cb) {
@@ -138,9 +155,10 @@ Selendroid.prototype.start = function (cb) {
     this.prepareDevice.bind(this),
     this.packageAndLaunchActivityFromManifest.bind(this),
     checkModServerExists,
-    conditionalUninstallSelendroid,
     conditionalInsertManifest,
     this.checkSelendroidCerts.bind(this),
+    checkServerResigned,
+    conditionalUninstallSelendroid,
     conditionalInstallSelendroid,
     this.extractStringsSelendroid.bind(this),
     this.uninstallApp.bind(this),

--- a/test/functional/android/keystore-specs.js
+++ b/test/functional/android/keystore-specs.js
@@ -1,0 +1,5 @@
+"use strict";
+
+var testBase = require('../common/keystore-base');
+
+describe("android - keystore", testBase);

--- a/test/functional/common/keystore-base.js
+++ b/test/functional/common/keystore-base.js
@@ -1,0 +1,43 @@
+"use strict";
+
+var setup = require("./setup-base")
+  , env = require('../../helpers/env')
+  , exec = require('child_process').exec
+  , fs = require('fs')
+  , osType = require('os').type();
+
+
+module.exports = function () {
+  var tmp = osType === 'Windows_NT' ? 'C:\\Windows\\Temp' : '/tmp';
+  var keystorePath = tmp + '/appiumtest.keystore';
+  var keyAlias = 'appiumtest';
+  var desired = {
+    app: "sample-code/apps/selendroid-test-app.apk",
+    appPackage: 'io.selendroid.testapp',
+    appActivity: '.HomeScreenActivity',
+    useKeystore: true,
+    keystorePath: keystorePath,
+    keyAlias: keyAlias
+  };
+  this.timeout(env.MOCHA_INIT_TIMEOUT);
+
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('should be able to launch an app with custom keystore', function (done) {
+    fs.unlink(keystorePath, function (err) {
+      if (err) return done(err);
+      var cmd = 'keytool -genkey -v -keystore ' + keystorePath + ' -alias ' + keyAlias + ' -storepass android -keypass android -keyalg RSA -validity 14000';
+      var child = exec(cmd, function (err) {
+        if (err) return done(err);
+
+        driver
+          .getCurrentActivity()
+            .should.eventually.include(desired.appActivity)
+          .nodeify(done);
+      });
+      // answer the questions that `keytool` asks
+      child.stdin.write('Appium Testsuite\nAppium\nTest\nSan Francisco\nCalifornia\nUS\nyes\n');
+    });
+  });
+};

--- a/test/functional/selendroid/keystore-specs.js
+++ b/test/functional/selendroid/keystore-specs.js
@@ -1,0 +1,6 @@
+"use strict";
+
+process.env.DEVICE = process.env.DEVICE || "selendroid";
+var testBase = require('../common/keystore-base');
+
+describe("selendroid - keystore", testBase);


### PR DESCRIPTION
- Add tests for custom keystore functionality
- Fix handling of Selendroid custom keystore by checking if the instrumentation app has been resigned/modified and reinstalling

Resolves #1880.
