### PR TITLE
Overriding UiAutomator method clear with custom implementation using correctLongTap and longer time intervals

### DIFF
--- a/lib/devices/android/bootstrap/README.md
+++ b/lib/devices/android/bootstrap/README.md
@@ -6,6 +6,7 @@ To install the Android Maven dependencies in your local environment, run the fol
 * Clone https://github.com/mosabua/maven-android-sdk-deployer into your workstation
 * Set the ANDROID_HOME environment to the location of the Android SDK, eg. `export ANDROID_HOME=/Developer/adt-bundle-mac-x86_64-20130219/sdk/`
 * Run `mvn install -P 4.3` from the `maven-android-sdk-deployer` directory. The build will fail if API 18 and some extra packages are not installed.
+* Please install all sdk and api versions of android for building `maven-android-sdk-deployer`.
 
 You can then compile the bootstrap project by running
 

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
@@ -3,22 +3,35 @@ package io.appium.android.bootstrap.handler;
 import com.android.uiautomator.core.UiObjectNotFoundException;
 import io.appium.android.bootstrap.*;
 import org.json.JSONException;
+import android.os.SystemClock;
+import android.view.KeyEvent;
+import java.lang.reflect.Method;
+import android.graphics.Rect;
+import com.android.uiautomator.common.ReflectionUtils;
+import com.android.uiautomator.core.UiObject;
+import com.android.uiautomator.core.UiSelector;
+
+
 
 /**
  * This handler is used to clear elements in the Android UI.
- * 
+ *
  * Based on the element Id, clear that element.
- * 
+ *
+ * UiAutomator method clearText is flaky hence overriding it with custom implementation.
  */
 public class Clear extends CommandHandler {
 
   /*
+   * Trying to select entire text with correctLongClick and increasing time intervals.
+   * Checking if element still has text in them and and if true falling back on UiAutomator clearText
+   *
    * @param command The {@link AndroidCommand}
-   * 
+   *
    * @return {@link AndroidCommandResult}
-   * 
+   *
    * @throws JSONException
-   * 
+   *
    * @see io.appium.android.bootstrap.CommandHandler#execute(io.appium.android.
    * bootstrap.AndroidCommand)
    */
@@ -28,8 +41,25 @@ public class Clear extends CommandHandler {
     if (command.isElementCommand()) {
       try {
         final AndroidElement el = command.getElement();
-        el.clearText();
-        return getSuccessResult(true);
+        final ReflectionUtils utils = new ReflectionUtils();
+        Rect rect = el.getVisibleBounds();
+        // Trying to select entire text.
+        TouchLongClick.correctLongClick(rect.left + 20, rect.centerY(),2000);
+        UiObject selectAll = new UiObject(new UiSelector().descriptionContains("Select all"));
+        if (selectAll.waitForExists(2000)) {
+            selectAll.click();
+        }
+        // wait for the selection
+        SystemClock.sleep(500);
+        // delete it
+        final Method sendKey = utils.getControllerMethod("sendKey", int.class,int.class);
+        sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_DEL, 0);
+        // If still text exist falling back on UIautomator clearText.
+        if (!el.getText().isEmpty()) {
+           Logger.debug("Clearing text not successful falling back to UiAutomator method clear");
+           el.clearText();
+        }
+        return getSuccessResult(el.getText().isEmpty());
       } catch (final UiObjectNotFoundException e) {
         return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
             e.getMessage());

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchLongClick.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchLongClick.java
@@ -16,7 +16,7 @@ public class TouchLongClick extends TouchEvent {
    * UiAutomator has a broken longClick, so we'll try to implement it using the
    * touchDown / touchUp events.
    */
-  private boolean correctLongClick(final int x, final int y, final int duration) {
+  protected static boolean correctLongClick(final int x, final int y, final int duration) {
     try {
       /*
        * bridge.getClass() returns ShellUiAutomatorBridge on API 18/19 so use


### PR DESCRIPTION
- Overriding clear with custom clear implementation
- Trying to select text with correctLongClick and waiting for more time 
- Falling back to UiAutomator method if element is not cleared.
- Added one more instruction for readme as i had to install all sdks and versions of android for building maven-android-sdk-deployer
- #1228
