### PR TITLE
XML plist parser returns a different structure than the binary plist parser

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -59,9 +59,13 @@ var parsePlistFile = function (plist, cb) {
         }
       });
     } else {
-      logger.debug("Parsed app Info.plist (as binary)");
       binaryPlist = true;
-      cb(null, obj);
+      if (obj.length) {
+        logger.debug("Parsed app Info.plist (as binary)");
+        cb(null, obj[0]);
+      } else {
+        cb(new Error("Binary Info.plist appears to be empty"));
+      }
     }
   });
 };
@@ -940,7 +944,7 @@ IOS.prototype.getBundleIdFromApp = function (cb) {
       logger.error("Could not get the bundleId from app.");
       cb(err, null);
     } else {
-      cb(null, obj[0].CFBundleIdentifier);
+      cb(null, obj.CFBundleIdentifier);
     }
   }.bind(this));
 };


### PR DESCRIPTION
Running tests with the latest Appium source code chokes on our Info.plist file. As far as I can tell the XML parser returns just an object instead of an array.
