### PR TITLE
Ensure object isn't undefined

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -60,7 +60,7 @@ var parsePlistFile = function (plist, cb) {
       });
     } else {
       binaryPlist = true;
-      if (obj.length) {
+      if (obj && obj.length) {
         logger.debug("Parsed app Info.plist (as binary)");
         cb(null, obj[0]);
       } else {


### PR DESCRIPTION
Hopefully error is always set if object is undefined. I think it's better to have a guard anyway.
