### PR TITLE
Fix handling of multiple taps

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1941,7 +1941,54 @@ iOSController.getLog = function (logType, cb) {
   }
 };
 
+iOSController.handleTap = function (gesture, cb) {
+  var options = gesture.options;
+  var cmdBase;
+  if (options.element) {
+    cmdBase = ['au.getElement(\'', options.element, '\')'];
+  } else {
+    cmdBase = ['UIATarget.localTarget().frontMostApp()'];
+  }
+
+  // start by getting the size and position of the element we are tapping
+  var cmd = cmdBase.concat('.rect()').join('');
+  this.proxy(cmd, function (err, res) {
+    if (err) return cb(err);
+
+    // default to center
+    var offsetX = 0.5;
+    var offsetY = 0.5;
+
+    // there are times when there is no error but no value is returned
+    if (res.value) {
+      var rect = res.value;
+      var size = {w: rect.size.width, h: rect.size.height};
+
+      // default options x/y to center, no matter the container
+      options.x = (options.x || (size.w / 2));
+      options.y = (options.y || (size.h / 2));
+
+      offsetX = options.x / size.w;
+      offsetY = options.y / size.h;
+    }
+
+    var opts = {
+      tapOffset: {
+        x: offsetX,
+        y: offsetY
+      },
+      tapCount: options.count || 1,
+      touchCount: 1
+    };
+    cmd = cmdBase.concat(['.tapWithOptions(', JSON.stringify(opts), ')']).join('');
+    return this.proxy(cmd, cb);
+  }.bind(this));
+};
+
 iOSController.performTouch = function (gestures, cb) {
+  if (gestures.length === 1 && gestures[0].action === 'tap') {
+    return this.handleTap(gestures[0], cb);
+  }
   this.parseTouch(gestures, function (err, touchStateObjects) {
     if (err !== null) return cb(err);
     this.proxy("target.touch(" + JSON.stringify(touchStateObjects) + ")", cb);

--- a/test/functional/ios/uicatalog/touch-specs.js
+++ b/test/functional/ios/uicatalog/touch-specs.js
@@ -1,0 +1,71 @@
+"use strict";
+
+var setup = require("../../common/setup-base")
+  , desired = require('./desired')
+  , wd = require("wd")
+  , TouchAction = wd.TouchAction;
+
+describe('uicatalog - touch', function () {
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  it('should tap element with count', function (done) {
+    driver
+      .elementByXPath('//UIAStaticText[contains(@label, \'Steppers\')]')
+      .click()
+      .elementsByAccessibilityId('Increment')
+        .then(function (els) {
+          var action = new TouchAction(driver);
+          action.tap({
+            el: els[0],
+            count: 10
+          });
+          return action.perform();
+        })
+      .elementsByAccessibilityId('10')
+        .should.eventually.have.length(2)
+      .nodeify(done);
+  });
+
+  it('should tap element with offset and count', function (done) {
+    driver
+      .elementByXPath('//UIAStaticText[contains(@label, \'Steppers\')]')
+      .click()
+      .elementsByAccessibilityId('Increment')
+        .then(function (els) {
+          var action = new TouchAction(driver);
+          action.tap({
+            el: els[1],
+            x: 10,
+            y: 10,
+            count: 7
+          });
+          return action.perform();
+        })
+      .elementsByAccessibilityId('7')
+        .should.eventually.have.length(2)
+      .nodeify(done);
+  });
+
+  it('should tap offset with count', function (done) {
+    driver
+      .elementByXPath('//UIAStaticText[contains(@label, \'Steppers\')]')
+      .click()
+      .elementsByAccessibilityId('Increment')
+        .then(function (els) {
+          els[2].getLocation()
+            .then(function (loc) {
+              var action = new TouchAction(driver);
+              action.tap({
+                x: loc.x,
+                y: loc.y,
+                count: 3
+              });
+              return action.perform();
+            });
+        })
+      .elementsByAccessibilityId('3')
+        .should.eventually.have.length(2)
+      .nodeify(done);
+  });
+});


### PR DESCRIPTION
Allow for tap to be used with `count` in iOS. Resolves #3148.

Previously `count` was ignored. Now translate into a native UIAutomation `tapWithOptions` call.
