### PR TITLE
Resolve iOS Simulator directory

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -472,6 +472,17 @@ iOSController._getFullPath = function (remotePath, cb) {
     logger.warn("There were multiple simulator roots for version " + v + ". " +
                 "We may be pulling the file from the one you're not using!");
   }
+
+  if (simRoots.length > 1) {
+    var filteredSimRoots = simRoots.filter(function (root) {
+      return fs.existsSync(root + "/Applications");
+    });
+
+    if (filteredSimRoots.length > 0) {
+      simRoots = filteredSimRoots;
+    }
+  }
+
   var basePath = simRoots[0];
 
   var appName = null;


### PR DESCRIPTION
If we have more than one iOS Simulator directory then this will try to filter out any that doesn't have an Applications folder. I suppose this still isn't fool proof, but it increases the odds of picking the right one significantly.
