### PR TITLE
Fix Android tests for real device

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -233,28 +233,58 @@ androidCommon.toggleSetting = function (setting, preKeySeq, ocb) {
   }.bind(this));
 };
 
-androidCommon.toggleData = function (ocb) {
-  // up, up, down
-  this.toggleSetting('DATA_ROAMING_SETTINGS', [19, 19, 20], ocb);
-};
+androidCommon.toggleData = function (cb) {
+  this.adb.isDataOn(function (err, dataOn) {
+    if (err) return cb(err);
 
-androidCommon.toggleFlightMode = function (ocb) {
-  this.adb.getApiLevel(function (err, api) {
-    var seq = [19, 19]; // up, up
-    /*
-     * On Android 4.0 there's no "parent" button in the action bar, so we don't
-     * need to go down, the cursor is already at the top of the list
-     */
-    if (api > 15) {
-      seq.push(20);     // down
-    }
-    this.toggleSetting('AIRPLANE_MODE_SETTINGS', seq, ocb);
+    this.wrapActionAndHandleADBDisconnect(function (ncb) {
+      this.adb.setData(dataOn ? 0 : 1, ncb);
+    }.bind(this), function (err) {
+      if (err) return cb(err);
+      cb(null, {
+        status: status.codes.Success.code
+      });
+    });
   }.bind(this));
 };
 
-androidCommon.toggleWiFi = function (ocb) {
-  // right, right
-  this.toggleSetting('WIFI_SETTINGS', [22, 22], ocb);
+androidCommon.toggleFlightMode = function (ocb) {
+  this.adb.isAirplaneModeOn(function (err, airplaneModeOn) {
+    if (err) return ocb(err);
+
+    async.series([
+      function (cb) {
+        this.wrapActionAndHandleADBDisconnect(function (ncb) {
+          this.adb.setAirplaneMode(airplaneModeOn ? 0 : 1, ncb);
+        }.bind(this), cb);
+      }.bind(this),
+      function (cb) {
+        this.wrapActionAndHandleADBDisconnect(function (ncb) {
+          this.adb.broadcastAirplaneMode(airplaneModeOn ? 0 : 1, ncb);
+        }.bind(this), cb);
+      }.bind(this)
+    ], function (err) {
+      if (err) return ocb(err);
+      ocb(null, {
+        status: status.codes.Success.code
+      });
+    }.bind(this));
+  }.bind(this));
+};
+
+androidCommon.toggleWiFi = function (cb) {
+  this.adb.isWifiOn(function (err, dataOn) {
+    if (err) return cb(err);
+
+    this.wrapActionAndHandleADBDisconnect(function (ncb) {
+      this.adb.setWifi(dataOn ? 0 : 1, ncb);
+    }.bind(this), function (err) {
+      if (err) return cb(err);
+      cb(null, {
+        status: status.codes.Success.code
+      });
+    });
+  }.bind(this));
 };
 
 androidCommon.toggleLocationServices = function (ocb) {
@@ -266,7 +296,7 @@ androidCommon.toggleLocationServices = function (ocb) {
         seq.push(20);       // down
       } else if (api >= 19) {
         // Newer versions of Android have the toggle in the Action bar
-        seq = [22, 22];     // right, right
+        seq = [22, 22, 19];     // right, right, up
         /*
          * Once the Location services switch is OFF, it won't receive focus
          * when going back to the Location Services settings screen unless we

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -831,19 +831,11 @@ androidController.tap = function (elementId, x, y, count, cb) {
     // we are either tapping on the default location of the element
     // or an offset from the top left corner
     if (x !== 0 || y !== 0) {
-      this.proxy(["element:getLocation", {elementId: elementId}], function (err, res) {
-        if (err) return cb(err);
-        var value = res.value;
-        x += parseInt(value.x);
-        y += parseInt(value.y);
-
-        opts = ["click", {x: x, y: y}];
-        loop();
-      }.bind(this));
+      opts = ["element:click", {elementId: elementId, x: x, y: y}];
     } else {
       opts = ["element:click", {elementId: elementId}];
-      loop();
     }
+    loop();
   } else {
     // we have absolute coordinates
     opts = ["click", {x: x, y: y}];

--- a/sample-code/apps/ToggleTest/src/com/example/toggletest/MainActivity.java
+++ b/sample-code/apps/ToggleTest/src/com/example/toggletest/MainActivity.java
@@ -75,7 +75,12 @@ public class MainActivity extends Activity {
 			// fall through
 			Log.d(TAG, "Unable to find Setting 'wifi_on': " + e.getMessage());
 		}
-		mDataToggle.setChecked(mTelephonyManager.getDataState() == TelephonyManager.DATA_CONNECTED);
+		try {
+			int dataOn = Settings.Global.getInt(getContentResolver(), "mobile_data");
+			mDataToggle.setChecked(dataOn != 0);
+		} catch (SettingNotFoundException e) {
+			Log.d(TAG, "Unable to find Setting 'mobile_data': " + e.getMessage());
+		}
 		boolean fMode = FlightMode.getInstance().isEnabled(this);
 		mFlightModeToggle.setChecked(fMode);
 		if (fMode) {

--- a/test/functional/android/apidemos/find/by-uiautomator-specs.js
+++ b/test/functional/android/apidemos/find/by-uiautomator-specs.js
@@ -140,14 +140,14 @@ describe("apidemo - find elements - by uiautomator", function () {
     }).nodeify(done);
   });
   it('should scroll to, and return elements using UiScrollable', function (done) {
-    driver.elementByAndroidUIAutomator('new UiScrollable(new UiSelector().scrollable(true).instance(0)).getChildByText(new UiSelector().className("android.widget.TextView"), "Views")')
+    driver.elementByAndroidUIAutomator('new UiScrollable(new UiSelector().scrollable(true).instance(0)).scrollIntoView(new UiSelector().text("Views").instance(0))')
     .text()
     .then(function (text) {
       text.should.equal("Views");
     }).nodeify(done);
   });
   it('should allow chaining UiScrollable methods', function (done) {
-    driver.elementByAndroidUIAutomator('new UiScrollable(new UiSelector().scrollable(true).instance(0)).setMaxSearchSwipes(10).getChildByText(new UiSelector().className("android.widget.TextView"), "Views")')
+    driver.elementByAndroidUIAutomator('new UiScrollable(new UiSelector().scrollable(true).instance(0)).setMaxSearchSwipes(10).scrollIntoView(new UiSelector().text("Views").instance(0))')
     .text()
     .then(function (text) {
       text.should.equal("Views");

--- a/test/functional/android/apidemos/gestures/click-specs.js
+++ b/test/functional/android/apidemos/gestures/click-specs.js
@@ -21,7 +21,10 @@ describe("apidemo - gestures - click", function () {
       .execute("mobile: tap", [{x: 100, y: 300}])
       .sleep(3000)
       .elementsByClassName(droidText).then(function (els) { return els[1]; })
-        .text().should.become("Action Bar")
+        .text()
+        .then(function (text) {
+          ['Accessibility Node Provider', 'Bouncing Balls', 'Action Bar'].should.include(text);
+        })
       .nodeify(done);
   });
   //todo: not working in nexus 7
@@ -33,7 +36,7 @@ describe("apidemo - gestures - click", function () {
       .sleep(3000)
       .elementsByClassName(droidText).then(function (els) { return els[1]; }).text()
       .then(function (text) {
-        ["ForegroundDispatch", "Morse Code"].should.include(text);
+        ["ForegroundDispatch", "Morse Code", "1. Preferences from XML"].should.include(text);
       }).nodeify(done);
   });
   it('should click via touch api', function (done) {

--- a/test/functional/android/apidemos/ime-specs.js
+++ b/test/functional/android/apidemos/ime-specs.js
@@ -1,27 +1,21 @@
 "use strict";
 
 var setup = require("../../common/setup-base")
-  , _ = require('underscore');
-
-// running batched will pull `unicodeKeyboard` into all tests
-var getAppPath = require('../../../helpers/app').getAppPath;
-var ucDesired = {
-  app: getAppPath('ApiDemos'),
-  device: 'Android',
-  unicodeKeyboard: true,
-  resetKeyboard: true
-};
+  , _ = require('underscore')
+  , desired = require("./desired");
 
 describe("apidemo - ime", function () {
   var unicodeImeId = 'io.appium.android.ime/.UnicodeIME'
-    , latinImeId = 'com.android.inputmethod.latin/.LatinIME'
     , driver;
 
-  setup(this, _.defaults({appActivity: "view.Controls1" }, ucDesired))
-    .then(function (d) { driver = d; });
+  setup(this, _.defaults({
+    appActivity: "view.Controls1",
+    unicodeKeyboard: true,
+    resetKeyboard: true
+  }, desired)).then(function (d) { driver = d; });
 
   beforeEach(function (done) {
-      driver.resetApp().nodeify(done);
+    driver.resetApp().nodeify(done);
   });
 
   it('should get the default (enabled) input method', function (done) {
@@ -58,7 +52,7 @@ describe("apidemo - ime", function () {
       .activateIMEEngine(unicodeImeId)
       .activeIMEEngine().should.eventually.equal(unicodeImeId)
       .deactivateIMEEngine()
-      .activeIMEEngine().should.eventually.equal(latinImeId)
+      .activeIMEEngine().should.eventually.not.equal(unicodeImeId)
       .nodeify(done);
   });
 });

--- a/test/functional/android/apidemos/keyboard-specs.js
+++ b/test/functional/android/apidemos/keyboard-specs.js
@@ -2,16 +2,8 @@
 
 var setup = require("../../common/setup-base")
   , safeClear = require('../../../helpers/safe-clear')
-  , _ = require('underscore');
-
-// running batched will pull `unicodeKeyboard` into all tests
-var getAppPath = require('../../../helpers/app').getAppPath;
-var ucDesired = {
-  app: getAppPath('ApiDemos'),
-  device: 'Android',
-  unicodeKeyboard: true,
-  resetKeyboard: true
-};
+  , _ = require('underscore')
+  , desired = require("./desired");
 
 // TODO: fix clear logic
 describe("apidemo - keyboard @skip-ci", function () {
@@ -28,8 +20,11 @@ describe("apidemo - keyboard @skip-ci", function () {
       .nodeify(done);
   };
 
-  setup(this,  _.defaults({appActivity: ".view.Controls1" }, ucDesired))
-    .then(function (d) { driver = d; });
+  setup(this,  _.defaults({
+    appActivity: ".view.Controls1",
+    unicodeKeyboard: true,
+    resetKeyboard: true
+  }, desired)).then(function (d) { driver = d; });
 
   it('should be able to edit a text field', function (done) {
     var testText = "Life, the Universe and Everything.";

--- a/test/functional/android/apidemos/localization/language-specs.js
+++ b/test/functional/android/apidemos/localization/language-specs.js
@@ -8,7 +8,7 @@ var env = require('../../../../helpers/env')
   , _ = require('underscore');
 
 // cannot use adb on sauce
-describe("apidemos - localization- language @skip-ci", function () {
+describe("apidemos - localization- language @skip-ci @skip-real-device", function () {
   this.timeout(env.MOCHA_INIT_TIMEOUT);
   var driver;
   var adb = new ADB({}),

--- a/test/functional/android/apidemos/localization/locale-specs.js
+++ b/test/functional/android/apidemos/localization/locale-specs.js
@@ -8,7 +8,7 @@ var env = require('../../../../helpers/env')
   , _ = require('underscore');
 
 // cannot use adb on sauce
-describe("apidemos - localization- locale @skip-ci", function () {
+describe("apidemos - localization- locale @skip-ci @skip-real-device", function () {
   this.timeout(env.MOCHA_INIT_TIMEOUT);
   var driver;
   var adb = new ADB({}),

--- a/test/functional/android/apidemos/location-specs.js
+++ b/test/functional/android/apidemos/location-specs.js
@@ -8,7 +8,7 @@ var desired = {
 };
 
 // TODO: bring back when new wd is published with setGeoLocation
-describe("apidemo - location", function () {
+describe("apidemo - location @skip-real-device", function () {
   var driver;
   setup(this, desired).then(function (d) { driver = d; });
 

--- a/test/functional/android/apidemos/notifications-specs.js
+++ b/test/functional/android/apidemos/notifications-specs.js
@@ -1,38 +1,32 @@
 "use strict";
 
-var env = require('../../../helpers/env')
-  , setup = require("../../common/setup-base")
+var setup = require("../../common/setup-base")
   , desired = require("./desired")
-  , reset = require("./reset");
+  , _ = require('underscore')
+  , Q = require('q');
 
 describe("apidemo - notifications", function () {
 
   var driver;
-  setup(this, desired).then(function (d) { driver = d; });
-
-  if (env.FAST_TESTS) {
-    beforeEach(function () {
-      return reset(driver);
-    });
-  }
+  setup(this, _.defaults({
+    appActivity: '.app.StatusBarNotifications'
+  }, desired)).then(function (d) { driver = d; });
 
   it('should open the notification shade', function (done) {
     driver
-      // get to the notification page
-      .elementByName("App").click()
-      .elementByName("Notification").click()
-      .elementByName("Status Bar").click()
       // create a notification
       .elementByName(":-|").click()
       .openNotifications()
       .sleep(500)
-      // shouldn't see the elements behind shade
-      .elementByName(":-|").should.be.rejectedWith(/status: 7/)
       // should see the notification
       .elementsByClassName('android.widget.TextView').then(function (els) {
-        return els[2].text();
+        var texts = [];
+        _.each(els, function (el) {
+          texts.push(el.text());
+        });
+        return Q.all(texts);
       })
-      .should.eventually.become('Mood ring')
+      .should.eventually.include('Mood ring')
       // return to app
       .deviceKeyEvent(4)
       // should be able to see elements from app

--- a/test/functional/android/apidemos/touch/drag-specs.js
+++ b/test/functional/android/apidemos/touch/drag-specs.js
@@ -1,49 +1,21 @@
 "use strict";
 
-var env = require('../../../../helpers/env')
-  , setup = require("../../../common/setup-base")
+var setup = require("../../../common/setup-base")
   , desired = require("../desired")
-  , reset = require("../reset")
   , wd = require("wd")
-  , TouchAction = wd.TouchAction;
+  , TouchAction = wd.TouchAction
+  , _ = require('underscore');
 
 
 describe("apidemo - touch - drag", function () {
   var driver;
-  setup(this, desired).then(function (d) { driver = d; });
-
-  if (env.FAST_TESTS) {
-    beforeEach(function () {
-      return reset(driver);
-    });
-  }
+  setup(this, _.defaults({
+    appActivity: '.view.DragAndDropDemo'
+  }, desired)).then(function (d) { driver = d; });
 
   describe('drag', function () {
-    it('should drag by pixels', function (done) {
+    it('should drag by element', function (done) {
       driver
-        .elementByName("Content")
-        .then(function (el) {
-          return driver
-            .elementByName("Animation")
-            .then(function (el2) {
-              var action = new TouchAction(driver);
-              action.press({el: el}).moveTo({ el: el2}).release();
-              return action.perform();
-            });
-        })
-        .sleep(500)
-        .elementByName("Views")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.tap({el: el}).perform();
-        })
-        .sleep(500)
-        .elementByName("Drag and Drop")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.tap({el: el}).perform();
-        })
-        .sleep(500)
         .elementById("io.appium.android.apis:id/drag_dot_3")
         .then(function (dd3) {
           return driver
@@ -53,10 +25,9 @@ describe("apidemo - touch - drag", function () {
               return action.longPress({el: dd3}).moveTo({ el: dd2 }).release().perform();
             });
         })
-        .sleep(1500)
+        .sleep(500)
         .elementById("io.appium.android.apis:id/drag_result_text").text()
           .should.become("Dropped!")
-        .sleep(5000)
         .nodeify(done);
     });
   });

--- a/test/functional/android/apidemos/touch/multi-actions-specs.js
+++ b/test/functional/android/apidemos/touch/multi-actions-specs.js
@@ -4,15 +4,17 @@ var env = require('../../../../helpers/env')
   , setup = require("../../../common/setup-base")
   , desired = require("../desired")
   , wd = require("wd")
-  , droidText = 'android.widget.TextView'
   , droidList = 'android.widget.ListView'
   , TouchAction = wd.TouchAction
-  , MultiAction = wd.MultiAction;
+  , MultiAction = wd.MultiAction
+  , _ = require('underscore');
 
 
 describe("apidemo - touch - multi-actions", function () {
   var driver;
-  setup(this, desired).then(function (d) { driver = d; });
+  setup(this, _.defaults({
+    appActivity: '.view.SplitTouchView'
+  }, desired)).then(function (d) { driver = d; });
 
   if (env.FAST_TESTS) {
     beforeEach(function () {
@@ -21,26 +23,7 @@ describe("apidemo - touch - multi-actions", function () {
   }
 
   it('should scroll two different lists', function (done) {
-    var scrollOpts = {};
     driver
-      .elementByClassName(droidList)
-      .then(function (el) {
-        scrollOpts = {
-          element: el.value
-        , text: 'Views'
-        };
-        return driver.execute("mobile: scrollTo", [scrollOpts]);
-      }).elementByXPath("//" + droidText + "[@text='Views']")
-      .then(function (el) {
-        return new TouchAction(driver).tap({el: el}).perform();
-      })
-      .then(function () {
-        scrollOpts.text = 'Splitting Touches across Views';
-        return driver.execute("mobile: scrollTo", [scrollOpts]);
-      }).elementByXPath("//" + droidText + "[@text='Splitting Touches across Views']")
-      .then(function (el) {
-        return new TouchAction(driver).tap({el: el}).perform();
-      })
       .elementsByClassName(droidList)
       .then(function (els) {
         // scroll slowly on the left

--- a/test/functional/android/apidemos/touch/multi-actions-with-wait-specs.js
+++ b/test/functional/android/apidemos/touch/multi-actions-with-wait-specs.js
@@ -3,39 +3,20 @@
 var setup = require("../../../common/setup-base")
   , desired = require("../desired")
   , wd = require("wd")
-  , droidText = 'android.widget.TextView'
   , droidList = 'android.widget.ListView'
   , TouchAction = wd.TouchAction
-  , MultiAction = wd.MultiAction;
+  , MultiAction = wd.MultiAction
+  , _ = require('underscore');
 
 
 describe("apidemo - touch - multi-actions with wait", function () {
   var driver;
-  setup(this, desired).then(function (d) { driver = d; });
+  setup(this, _.defaults({
+    appActivity: '.view.SplitTouchView'
+  }, desired)).then(function (d) { driver = d; });
 
   it('should scroll two different lists with waits', function (done) {
-    var scrollOpts = {};
     driver
-      .elementByClassName(droidList)
-      .then(function (el) {
-        scrollOpts = {
-          element: el.value
-        , text: 'Views'
-        };
-        return driver.execute("mobile: scrollTo", [scrollOpts]);
-      })
-      .elementByXPath("//" + droidText + "[@text='Views']")
-      .then(function (el) {
-        return new TouchAction(driver).tap({el: el}).perform();
-      })
-      .then(function () {
-        scrollOpts.text = 'Splitting Touches across Views';
-        return driver.execute("mobile: scrollTo", [scrollOpts]);
-      })
-      .elementByXPath("//" + droidText + "[@text='Splitting Touches across Views']")
-      .then(function (el) {
-        return new TouchAction(driver).tap({el: el}).perform();
-      })
       .elementsByClassName(droidList)
       .then(function (els) {
         // scroll slowly on the left

--- a/test/functional/android/apidemos/touch/press-specs.js
+++ b/test/functional/android/apidemos/touch/press-specs.js
@@ -4,12 +4,15 @@ var env = require('../../../../helpers/env')
   , setup = require("../../../common/setup-base")
   , desired = require("../desired")
   , wd = require("wd")
-  , TouchAction = wd.TouchAction;
+  , TouchAction = wd.TouchAction
+  , _ = require('underscore');
 
 
 describe("apidemo - touch - press", function () {
   var driver;
-  setup(this, desired).then(function (d) { driver = d; });
+  setup(this, _.defaults({
+    appActivity: '.view.ExpandableList1'
+  }, desired)).then(function (d) { driver = d; });
 
   if (env.FAST_TESTS) {
     beforeEach(function () {
@@ -19,36 +22,8 @@ describe("apidemo - touch - press", function () {
 
   describe('press', function () {
     it('should work like `tap` when immediately released', function (done) {
-      driver.elementByName("Content")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          action.press({el: el});
-          driver
-            .elementByName("Animation")
-            .then(function (el2) {
-              return action.moveTo({ el: el2 }).release().perform();
-            });
-        })
-        .sleep(500)
-        .elementByName("Views")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.press({el: el}).release().perform();
-        })
-        .sleep(500)
-        .elementByName("Expandable Lists")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.press({el: el}).release().perform();
-        })
-        .sleep(500)
-        .elementByName("1. Custom Adapter")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.press({el: el}).release().perform();
-        })
-        .sleep(500)
-        .elementByName("People Names") //.should.eventually.exist
+      driver
+        .elementByName("People Names")
         .then(function (el) {
           var action = new TouchAction(driver);
           return action.press({el: el}).release().perform();
@@ -58,36 +33,8 @@ describe("apidemo - touch - press", function () {
     });
 
     it('should work like `longPress` when released after a pause', function (done) {
-      driver.elementByName("Content")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          action.press({el: el});
-          driver
-            .elementByName("Animation")
-            .then(function (el2) {
-              return action.moveTo({el: el2}).release().perform();
-            });
-        })
-        .sleep(500)
-        .elementByName("Views")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.press({el: el}).release().perform();
-        })
-        .sleep(500)
-        .elementByName("Expandable Lists")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.press({el: el}).release().perform();
-        })
-        .sleep(500)
-        .elementByName("1. Custom Adapter")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.press({el: el}).release().perform();
-        })
-        .sleep(500)
-        .elementByName("People Names") //.should.eventually.exist
+      driver
+        .elementByName("People Names")
         .then(function (el) {
           var action = new TouchAction(driver);
           return action.press({el: el}).wait(1000).release().perform();
@@ -99,35 +46,7 @@ describe("apidemo - touch - press", function () {
 
   describe('longPress', function () {
     it('should open a context menu', function (done) {
-      driver.elementByName("Content")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          action.press({el: el});
-          driver
-            .elementByName("Animation")
-            .then(function (el2) {
-              return action.moveTo({el: el2}).release().perform();
-            });
-        })
-        .sleep(500)
-        .elementByName("Views")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.tap({el: el}).perform();
-        })
-        .sleep(500)
-        .elementByName("Expandable Lists")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.tap({el: el}).perform();
-        })
-        .sleep(500)
-        .elementByName("1. Custom Adapter")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.tap({el: el}).perform();
-        })
-        .sleep(500)
+      driver
         .elementByName("People Names")
         .then(function (el) {
           var action = new TouchAction(driver);

--- a/test/functional/android/apidemos/touch/tap-specs.js
+++ b/test/functional/android/apidemos/touch/tap-specs.js
@@ -5,12 +5,15 @@ var env = require('../../../../helpers/env')
   , desired = require("../desired")
   , wd = require("wd")
   , droidText = 'android.widget.TextView'
-  , TouchAction = wd.TouchAction;
+  , TouchAction = wd.TouchAction
+  , _ = require('underscore');
 
 
 describe("apidemo - touch - tap", function () {
   var driver;
-  setup(this, desired).then(function (d) { driver = d; });
+  setup(this, _.defaults({
+    appActivity: '.text.LogTextBox1'
+  }, desired)).then(function (d) { driver = d; });
 
   if (env.FAST_TESTS) {
     beforeEach(function () {
@@ -20,38 +23,39 @@ describe("apidemo - touch - tap", function () {
 
   describe('tap visible element', function () {
     it('should tap an element', function (done) {
-      driver.elementByName("Animation")
+      driver
+        .elementByName("Add")
         .then(function (el) {
-          return (new TouchAction(driver)).tap({el: el}).perform();
+          var action = new TouchAction(driver);
+          return action.tap({el: el }).perform();
         })
-        .elementsByClassName(droidText).then(function (els) { return els[1]; })
-          .text().should.become("Bouncing Balls")
+        .elementsByClassName(droidText)
+        .then(function (els) {
+          return els[1];
+        })
+        .text()
+        .should.become("This is a test\n")
         .nodeify(done);
     });
 
     it('should tap an element from an offset', function (done) {
-      driver.elementByName("Animation")
+      driver
+        .elementByName("Add")
         .then(function (el) {
           var action = new TouchAction(driver);
           return action.tap({el: el, x: 1, y: 1 }).perform();
         })
-        .elementsByClassName(droidText).then(function (els) { return els[1]; })
-          .text().should.become("Bouncing Balls")
+        .elementsByClassName(droidText)
+        .then(function (els) {
+          return els[1];
+        })
+        .text()
+        .should.become("This is a test\n")
         .nodeify(done);
     });
 
     it('should tap an element twice', function (done) {
       driver
-        .elementByName("Text")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.tap({el: el}).perform();
-        })
-        .elementByName("LogTextBox")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.tap({el: el}).perform();
-        })
         .elementByName("Add")
         .then(function (el) {
           var action = new TouchAction(driver);
@@ -68,21 +72,12 @@ describe("apidemo - touch - tap", function () {
 
     it('should tap an element from an offset twice', function (done) {
       driver
-        .elementByName("Text")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.tap({el: el}).perform();
-        })
-        .elementByName("LogTextBox")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          return action.tap({el: el}).perform();
-        })
         .elementByName("Add")
         .then(function (el) {
           var action = new TouchAction(driver);
-          return action.tap({el: el, count: 2 }).perform();
+          return action.tap({el: el, x:1, y: 1, count: 2 }).perform();
         })
+        .sleep(2000)
         .elementsByClassName(droidText)
         .then(function (els) {
           return els[1];

--- a/test/functional/android/toggle/network-connection-specs.js
+++ b/test/functional/android/toggle/network-connection-specs.js
@@ -1,11 +1,14 @@
 "use strict";
 
 var setup = require("../../common/setup-base"),
-    desired = require('./desired');
+    desired = require('./desired'),
+    _ = require('underscore');
 
 describe('network connection details', function () {
   var driver;
-  setup(this, desired).then(function (d) { driver = d; });
+  setup(this, _.defaults({
+    fullReset: true
+  }, desired)).then(function (d) { driver = d; });
 
   it('should get airplane mode', function (done) {
     driver

--- a/test/functional/common/android-auto-webview-base.js
+++ b/test/functional/common/android-auto-webview-base.js
@@ -2,12 +2,11 @@
 
 var env = require('../../helpers/env')
   , setup = require("../common/setup-base")
-  , safeClear = require('../../helpers/safe-clear');
+  , getAppPath = require('../../helpers/app').getAppPath;
 
 var desired = {
-  app: "sample-code/apps/selendroid-test-app.apk",
-  appPackage: 'io.selendroid.testapp',
-  appActivity: '.WebViewActivity',
+  app: getAppPath('ApiDemos'),
+  appActivity: '.view.WebView1',
   autoWebview: true
 };
 if (env.SELENDROID) {
@@ -19,15 +18,11 @@ module.exports = function () {
   setup(this, desired).then(function (d) { driver = d; });
 
   it('should go directly into webview', function (done) {
-    var el;
     driver
-      .elementById('name_input')
-      .then(function (_el) { el = _el; })
-      .then(function () { return safeClear(el); })
-      .then(function () { return el.type("Appium User")
-        .getValue().should.become("Appium User"); })
-      .elementByCssSelector('input[type=submit]').click()
-      .waitForElementByXPath("//h1[contains(., 'This is my way')]")
+      .currentContext()
+      .then(function (ctx) {
+        ctx.indexOf('WEBVIEW').should.not.equal(-1);
+      })
       .nodeify(done);
   });
 };

--- a/test/functional/common/android-webview-base.js
+++ b/test/functional/common/android-webview-base.js
@@ -1,59 +1,32 @@
-/*global beforeEach:true */
 "use strict";
 
 var env = require('../../helpers/env')
   , setup = require("./setup-base")
-  , safeClear = require('../../helpers/safe-clear');
+  , safeClear = require('../../helpers/safe-clear')
+  , getAppPath = require('../../helpers/app').getAppPath;
 
 var desired = {
-  app: "sample-code/apps/selendroid-test-app.apk",
-  appPackage: 'io.selendroid.testapp',
-  appActivity: '.HomeScreenActivity'
+  app: getAppPath('ApiDemos'),
+  appActivity: '.view.WebView1',
+  newCommandTimeout: 90
 };
+if (env.SELENDROID) {
+  desired.automationName = 'selendroid';
+}
 
 module.exports = function () {
   var driver;
   setup(this, desired).then(function (d) { driver = d; });
 
-  beforeEach(function (done) {
+  before(function (done) {
     driver
-      .sleep(3000)
-      .setImplicitWaitTimeout(0)
-      .waitForElementByName('buttonStartWebviewCD')
-      .then(function (el) {
-        if (el) return;
-        else return driver.back();
-      })
-      .setImplicitWaitTimeout(env.IMPLICIT_WAIT_TIMEOUT)
-      .elementByName('buttonStartWebviewCD').click()
-      .then(function () {
-        if (env.SELENDROID) return driver.waitForElementById('mainWebView');
-        else return driver.waitForElementByXPath(
-          "//android.widget.TextView[@text='Web View Interaction']");
-      })
+      .sleep(1000)
       .contexts()
       .then(function (ctxs) {
         return driver.context(ctxs[ctxs.length - 1]);
       })
       .nodeify(done);
   });
-
-  if (env.FAST_TESTS) {
-    afterEach(function (done) {
-      driver
-        .context('NATIVE_APP')
-        .then(function () {
-          if (env.DEVICE === "selendroid") {
-            return driver.elementByIdOrNull('goBack');
-          } else {
-            return driver.elementByClassNameOrNull('android.widget.Button');
-          }
-        })
-        .then(function (el) {
-          if (el) return el.click().sleep(1000);
-        }).nodeify(done);
-    });
-  }
 
   it('should list all contexts', function (done) {
     driver
@@ -71,8 +44,9 @@ module.exports = function () {
 
   it('should find and click an element', function (done) {
     driver
-      .elementByCssSelector('input[type=submit]').click()
-      .waitForElementByXPath("//h1[contains(., 'This is my way')]")
+      .elementById('i am a link').click()
+      .source().should.eventually.include("I am some other page content")
+      .back()
       .nodeify(done);
   });
 
@@ -80,8 +54,9 @@ module.exports = function () {
   it('should clear input @skip-selendroid-all', function (done) {
     var el;
     driver
-      .waitForElementById('name_input', 10000, 500)
+      .waitForElementById('i_am_a_textbox', 10000, 500)
       .then(function (_el) { el = _el; })
+      .then(function () { return el.getValue().should.not.become(""); })
       .then(function () { return safeClear(el); })
       .then(function () { return el.getValue().should.become(""); })
       .nodeify(done);
@@ -91,7 +66,7 @@ module.exports = function () {
   it('should find and enter key sequence in input @skip-selendroid-all', function (done) {
     var el;
     driver
-      .elementById('name_input')
+      .elementById('i_am_a_textbox')
       .then(function (_el) { el = _el; })
       .then(function () { return safeClear(el); })
       .then(function () { return el.type("Mathieu")
@@ -105,8 +80,8 @@ module.exports = function () {
 
   it('should get web source', function (done) {
     driver
-      .waitForElementById('name_input') // making sure webview has been loaded
-      .source().should.eventually.include("<title>Say Hello Demo<")
+      .waitForElementById('i_am_a_textbox') // making sure webview has been loaded
+      .source().should.eventually.include("<h1>This page is a Selenium sandbox<")
       .nodeify(done);
   });
 };

--- a/test/helpers/app.js
+++ b/test/helpers/app.js
@@ -7,7 +7,7 @@ module.exports.getAppPath = function (app) {
     return "sample-code/apps/" + app +
       "/build/Release-iphonesimulator/" + app + ".app";
   }
-  if (env.ANDROID) {
+  if (env.ANDROID || env.SELENDROID) {
     return "sample-code/apps/" + app +
       "/bin/" + app + "-debug.apk";
   }

--- a/test/helpers/env.js
+++ b/test/helpers/env.js
@@ -1,6 +1,8 @@
 "use strict";
 
-var path = require('path');
+var path = require('path')
+  , _ = require('underscore')
+  , os = require('os');
 
 var env = {};
 
@@ -173,10 +175,25 @@ if (env.SAUCE && env.TARBALL) {
 }
 
 // rest enf points
+env.localIP = function () {
+  var ip = _.chain(os.networkInterfaces())
+    .flatten()
+    .filter(function (val) {
+      return (val.family === 'IPv4' && val.internal === false);
+    })
+    .pluck('address')
+    .first().value();
+  return ip;
+};
+
 env.LOCAL_APPIUM_PORT = env.SAUCE? 4443 : env.APPIUM_PORT;
 env.TEST_END_POINT = 'http://localhost:' + env.LOCAL_APPIUM_PORT + '/test/';
 env.GUINEA_TEST_END_POINT = env.TEST_END_POINT + 'guinea-pig';
-env.CHROME_TEST_END_POINT = 'http://10.0.2.2:' + env.LOCAL_APPIUM_PORT + '/test/';
+if (env.REAL_DEVICE) {
+  env.CHROME_TEST_END_POINT = 'http://' + env.localIP() + ':' + env.LOCAL_APPIUM_PORT + '/test/';
+} else {
+  env.CHROME_TEST_END_POINT = 'http://10.0.2.2:' + env.LOCAL_APPIUM_PORT + '/test/';
+}
 env.CHROME_GUINEA_TEST_END_POINT = env.CHROME_TEST_END_POINT + 'guinea-pig';
 env.PHISHING_END_POINT = env.TEST_END_POINT.replace('http://', 'http://foo:bar@');
 


### PR DESCRIPTION
This makes the tests runnable against a Samsung S4. 
- add `--real-device` flag to `bin/test.sh`, and corresponding `@skip-real-device` flag to the three tests that don't work on a real device (geo location, locale, language). 
- remove some navigation from tests.
- make toggle flight mode, wifi, and data use network connection adb methods rather than navigating the settings panes.
- fix tapping an element with an offset.
- soften expectations for tapping at specific positions, using arrays of possible values.
