### PR TITLE
Skip keystore tests in ci

### DIFF
--- a/test/functional/android/keystore-specs.js
+++ b/test/functional/android/keystore-specs.js
@@ -2,4 +2,4 @@
 
 var testBase = require('../common/keystore-base');
 
-describe("android - keystore", testBase);
+describe("android - keystore @skip-ci", testBase);

--- a/test/functional/selendroid/keystore-specs.js
+++ b/test/functional/selendroid/keystore-specs.js
@@ -3,4 +3,4 @@
 process.env.DEVICE = process.env.DEVICE || "selendroid";
 var testBase = require('../common/keystore-base');
 
-describe("selendroid - keystore", testBase);
+describe("selendroid - keystore @skip-ci", testBase);


### PR DESCRIPTION
As it is currently designed, we cannot test the custom keystore functionality on a remote server like Sauce, since we don't send the keystore to the server at all.
