### PR TITLE
Add stability test for iOS keyboard

### DIFF
--- a/test/functional/ios/testapp/keyboard-specs.js
+++ b/test/functional/ios/testapp/keyboard-specs.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var setup = require("../../common/setup-base")
+ ,  desired = require('./desired')
+ ,  _ = require('underscore');
+
+
+describe("testapp - keyboard stability @skip-ci", function () {
+  var runs = 10
+    , text = 'Delhi is New @@@ QA-BREAKFAST-FOOD-0001';
+
+  var driver;
+  setup(this, _.defaults({
+    deviceName: 'iPad Simulator',
+  }, desired)).then(function (d) { driver = d; });
+
+  var test = function () {
+    it("should send keys to a text field", function (done) {
+      driver
+        .elementByClassName('UIATextField')
+          .sendKeys(text)
+          .text().should.become(text)
+        .nodeify(done);
+    });
+  };
+
+  for (var n = 0; n < runs; n++) {
+    describe('sendKeys test ' + (n + 1), test);
+  }
+});


### PR DESCRIPTION
Handle each character in the string sent to the text field individually. Otherwise there are problems particularly with capital letters. In the event of an error on a particular key, retry once.

Tried setting `interKeyDelay` but had no success in it actually slowing things down and fixing the problem.

Resolves #1567
