### PR TITLE
Handle boolean caps sent as strings

### DIFF
--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -97,6 +97,16 @@ Capabilities.prototype.setDesired = function (caps) {
                   JSON.stringify(value));
       caps[cap] = JSON.stringify(value);
     }
+    if (typeof value === "string") {
+      // handle the case where users send in "true" or "false" as a string
+      // instead of a boolean
+      var tempValue = value.trim().toLowerCase();
+      if (tempValue === "false" || tempValue === "true") {
+        logger.warn("Converting cap " + cap + " from string to boolean. " +
+                    "This might cause unexpected behavior.");
+        caps[cap] = (tempValue === "true");
+      }
+    }
   });
   _.each(caps, function (value, cap) {
     if (_.contains(_.keys(capsConversion), cap)) {

--- a/test/unit/capabilities-specs.js
+++ b/test/unit/capabilities-specs.js
@@ -22,6 +22,18 @@ describe('capabilities', function () {
       c.platformVersion.should.equal(7.0);
       (typeof c.platformVersion).should.equal("number");
     });
+    it('should convert string booleans into actual booleans', function () {
+      var c = new Capabilities({
+        stringFalseCap: "false",
+        stringTrueCap: "true",
+        realFalseCap: false,
+        realTrueCap: true
+      });
+      c.stringFalseCap.should.equal(false);
+      c.stringTrueCap.should.equal(true);
+      c.realFalseCap.should.equal(false);
+      c.realTrueCap.should.equal(true);
+    });
     describe('with mjsonwp capabilities', function () {
       describe('deprecation warnings', function () {
         var newCapabilities = [


### PR DESCRIPTION
When users send in a boolean desired capability as a string we want to make it an actual boolean, so server logic can act on it.

With this update, capabilities such as

``` javascript
var caps = {
  app: appPath,
  autoLaunch: "false",
  // ...
};
```

will function just like

``` javascript
var caps = {
  app: appPath,
  autoLaunch: false,
  // ...
};
```

Resolves #3155
