### PR TITLE
Fixed issue #1708: delete cookie inconsitency in Safari

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1934,14 +1934,15 @@ iOSController.deleteCookies = function (cb) {
       var SUCCESS = status.codes.Success.code;
       var delResponse = { status: SUCCESS, value: res.value.length > 0 };
       var delErr = null;
+      var delCallback = function (e, r) {
+                            delResponse = r;
+                            delErr = e;
+                          };
 
       if (res.value.length) {
         // loop through and delete all cookies unless an error is returned
         for(var i = 0; i < res.value.length && !delErr && delResponse.status === SUCCESS; i++) {
-          this.deleteCookie(res.value[i].name, function (e, r) {
-            delResponse = r;
-            delErr = e;
-          });
+          this.deleteCookie(res.value[i].name, delCallback);
         }
       }
       cb(delErr, delResponse);

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1886,7 +1886,7 @@ iOSController.setCookie = function (cookie, cb) {
   var webCookie = encodeURIComponent(cookie.name) + "=" +
                   encodeURIComponent(cookie.value);
 
-  var expiry = (cookie.expiry) ? cookie.expiry : null;
+  var expiry = cookie.expiry || null;
 
   if (!expiry && cookie.value === "") {
     expiry = (new Date(0)).toUTCString();
@@ -1929,23 +1929,37 @@ iOSController.deleteCookies = function (cb) {
     return cb(new NotImplementedError(), null);
   }
   this.getCookies(function (err, res) {
-
     if (this.checkSuccess(err, res, cb)) {
-      var SUCCESS = status.codes.Success.code;
-      var delResponse = { status: SUCCESS, value: res.value.length > 0 };
-      var delErr = null;
-      var delCallback = function (e, r) {
-                            delResponse = r;
-                            delErr = e;
-                          };
-
-      if (res.value.length) {
-        // loop through and delete all cookies unless an error is returned
-        for(var i = 0; i < res.value.length && !delErr && delResponse.status === SUCCESS; i++) {
-          this.deleteCookie(res.value[i].name, delCallback);
-        }
+      var numCookies = res.value.length;
+      var cookies = res.value;
+      if (numCookies) {
+        var returned = false;
+        var deleteNextCookie = function (cookieIndex) {
+          if (!returned) {
+            var cookie = cookies[cookieIndex];
+            this.deleteCookie(cookie.name, function (err, res) {
+              if (err || res.status !== status.codes.Success.code) {
+                returned = true;
+                cb(err, res);
+              } else if (cookieIndex < cookies.length - 1) {
+                deleteNextCookie(cookieIndex + 1);
+              } else {
+                returned = true;
+                cb(null, {
+                  status: status.codes.Success.code
+                  , value: true
+                });
+              }
+            });
+          }
+        }.bind(this);
+        deleteNextCookie(0);
+      } else {
+        cb(null, {
+          status: status.codes.Success.code
+          , value: false
+        });
       }
-      cb(delErr, delResponse);
     }
   }.bind(this));
 };

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1895,11 +1895,11 @@ iOSController.setCookie = function (cookie, cb) {
   }
 
   if (expiry) {
-    webCookie += ";expires=" + expiry;
+    webCookie += "; expires=" + expiry;
   }
 
   // if 'Path' field is not specified, Safari will not update cookies as expected; eg issue #1708
-  if(!cookie.path) {
+  if (!cookie.path) {
     cookie.path = "/";
   }
 

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1879,20 +1879,32 @@ iOSController.getCookies = function (cb) {
 };
 
 iOSController.setCookie = function (cookie, cb) {
-  var expiry = null;
   if (!this.isWebContext()) {
     return cb(new NotImplementedError(), null);
   }
+
   var webCookie = encodeURIComponent(cookie.name) + "=" +
                   encodeURIComponent(cookie.value);
-  if (cookie.value !== "" && typeof cookie.expiry === "number") {
-    expiry = (new Date(cookie.expiry * 1000)).toGMTString();
-  } else if (cookie.value === "") {
-    expiry = (new Date(0)).toGMTString();
+
+  var expiry = (cookie.expiry) ? cookie.expiry : null;
+
+  if (!expiry && cookie.value === "") {
+    expiry = (new Date(0)).toUTCString();
+  } else if (expiry && typeof expiry === "number") {
+    expiry = (new Date(expiry * 1000)).toUTCString();
   }
+
   if (expiry) {
-    webCookie += "; expires=" + expiry;
+    webCookie += ";expires=" + expiry;
   }
+
+  // if 'Path' field is not specified, Safari will not update cookies as expected; eg issue #1708
+  if(!cookie.path) {
+    cookie.path = "/";
+  }
+
+  webCookie += ";path=" + cookie.path;
+
   var script = "document.cookie = " + JSON.stringify(webCookie);
   this.executeAtom('execute_script', [script, []], function (err, res) {
     if (this.checkSuccess(err, res, cb)) {
@@ -1917,37 +1929,22 @@ iOSController.deleteCookies = function (cb) {
     return cb(new NotImplementedError(), null);
   }
   this.getCookies(function (err, res) {
+
     if (this.checkSuccess(err, res, cb)) {
-      var numCookies = res.value.length;
-      var cookies = res.value;
-      if (numCookies) {
-        var returned = false;
-        var deleteNextCookie = function (cookieIndex) {
-          if (!returned) {
-            var cookie = cookies[cookieIndex];
-            this.deleteCookie(cookie.name, function (err, res) {
-              if (err || res.status !== status.codes.Success.code) {
-                returned = true;
-                cb(err, res);
-              } else if (cookieIndex < cookies.length - 1) {
-                deleteNextCookie(cookieIndex + 1);
-              } else {
-                returned = true;
-                cb(null, {
-                  status: status.codes.Success.code
-                , value: true
-                });
-              }
-            });
-          }
-        }.bind(this);
-        deleteNextCookie(0);
-      } else {
-        cb(null, {
-          status: status.codes.Success.code
-        , value: false
-        });
+      var SUCCESS = status.codes.Success.code;
+      var delResponse = { status: SUCCESS, value: res.value.length > 0 };
+      var delErr = null;
+
+      if (res.value.length) {
+        // loop through and delete all cookies unless an error is returned
+        for(var i = 0; i < res.value.length && !delErr && delResponse.status === SUCCESS; i++) {
+          this.deleteCookie(res.value[i].name, function (e, r) {
+            delResponse = r;
+            delErr = e;
+          });
+        }
       }
+      cb(delErr, delResponse);
     }
   }.bind(this));
 };

--- a/test/functional/common/webview/cookies-base.js
+++ b/test/functional/common/webview/cookies-base.js
@@ -2,7 +2,6 @@
 
 var setup = require("../setup-base"),
     webviewHelper = require("../../../helpers/webview"),
-    assert = require('assert'),
     loadWebView = webviewHelper.loadWebView,
     isChrome = webviewHelper.isChrome,
     testEndpoint = webviewHelper.testEndpoint,
@@ -134,11 +133,9 @@ module.exports = function (desired) {
               .deleteAllCookies()
               .allCookies();
           }).then(function (cookies) {
-            assert(cookies.length === 0);
+            cookies.length.should.equal(0);
           }).nodeify(done);
       });
-
-
     });
   });
 };

--- a/test/functional/common/webview/cookies-base.js
+++ b/test/functional/common/webview/cookies-base.js
@@ -2,6 +2,7 @@
 
 var setup = require("../setup-base"),
     webviewHelper = require("../../../helpers/webview"),
+    assert = require('assert'),
     loadWebView = webviewHelper.loadWebView,
     isChrome = webviewHelper.isChrome,
     testEndpoint = webviewHelper.testEndpoint,
@@ -133,10 +134,11 @@ module.exports = function (desired) {
               .deleteAllCookies()
               .allCookies();
           }).then(function (cookies) {
-            _.pluck(cookies, 'name').should.not.include(newCookie.name);
-            _.pluck(cookies, 'value').should.not.include(newCookie.value);
+            assert(cookies.length === 0);
           }).nodeify(done);
       });
+
+
     });
   });
 };


### PR DESCRIPTION
Fixed the issue preventing Appium from deleting some cookies on Safari.  The problem was that Appium was not setting the "Path" field which caused Safari to act as though it could not locate cookies created in previous sessions.  Changes include:

*) Updated ios-controller::setCookie to preserve the invoker's expiry value even when cookie.value is empty. I made this change because backdating the expiry field is the correct way to delete a cookie. We shouldn't force invocations with empty values to delete cookies if the invoker has specified an expiry date. This change shouldn't affect any existing code.
*) ios-controller::setCookie now allows invokers to set the path field and defaults the field to "/" if path is undefined.
*) replaced deprecated toGMTString calls with toUTCString in ios-controller::setCookie.  Afaik, the output strings are the same.
*) Refactored ios-controller::deleteCookies. Replaced the recursive logic and nested conditions with a simple for loop. This makes it much easier to understand, debug, and maintain. It also makes it more performant. I made the change because it was difficult for me to debug.
*) The "deleteAllCookies" test in cookies-base.js will now fail if all cookies are not deleted.
