### PR TITLE
Add interKeyDelay cap for iOS

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -74,3 +74,4 @@
 |`keepKeyChains`| (Sim-only) Whether to keep keychains (Library/Keychains) when appium session is started/finished|`true` or `false`|
 |`localizableStringsDir`| Where to look for localizable strings. Default `en.lproj`|`en.lproj`|
 |`processArguments`| Arguments to pass to the AUT using instruments|e.g., `-myflag`|
+|`interKeyDelay`| The delay, in ms, between keystrokes sent to an element when typing.|e.g., `100`|

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -327,7 +327,7 @@ IOS.prototype.startInstruments = function (cb) {
 IOS.prototype.makeInstruments = function (cb) {
   // at the moment all the logging in uiauto is at debug level
   // TODO: be able to use info in appium-uiauto
-  prepareBootstrap({sock: this.sock}).then(
+  prepareBootstrap({sock: this.sock, interKeyDelay: this.args.interKeyDelay}).then(
     function (bootstrapPath) {
       var instruments = new Instruments({
         app: this.args.app || this.args.bundleId

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -79,6 +79,7 @@ var iosCaps = [
 , 'safariOpenLinksInBackground'
 , 'keepKeyChains'
 , 'localizableStringsDir'
+, 'interKeyDelay'
 ];
 
 var Capabilities = function (capabilities) {


### PR DESCRIPTION
Since there are timing issues with typing on iOS, this adds a capability to set the delay, in ms, between keystrokes sent to the device. The value is passed into `uiauto`.

Hopefully this will alleviate some of the problems as in #1567, #1624, and #3336.
