### PR TITLE
Android Chromedriver caching

### DIFF
--- a/lib/devices/android/android-context-controller.js
+++ b/lib/devices/android/android-context-controller.js
@@ -72,9 +72,9 @@ androidContextController.setContext = function (name, cb) {
 
     // current ChromeDriver doesn't handle more than a single web view
     if (this.isChromedriverContext(name)) {
-      this.startChromedriverProxy(next);
+      this.startChromedriverProxy(name, next);
     } else if (this.isChromedriverContext(this.curContext)) {
-      this.stopChromedriverProxy(next);
+      this.suspendChromedriverProxy(next);
     } else if (this.isProxy) { // e.g. WebView context handled in Selendroid
       this.proxyTo('wd/hub/session/' + this.proxySessionId + '/context', 'POST', {name: name}, next);
     }

--- a/lib/devices/android/android-hybrid.js
+++ b/lib/devices/android/android-hybrid.js
@@ -11,6 +11,7 @@ var logger = require('../../server/logger.js').get('appium')
 var androidHybrid = {};
 
 androidHybrid.chromedriver = null;
+androidHybrid.sessionChromedrivers = {};
 
 androidHybrid.listWebviews = function (cb) {
   logger.debug("Getting a list of available webviews");
@@ -116,44 +117,53 @@ androidHybrid.getProcessNameFromWebview = function (webview, cb) {
   });
 };
 
-androidHybrid.startChromedriverProxy = function (cb) {
+androidHybrid.startChromedriverProxy = function (context, cb) {
   logger.debug("Connecting to chrome-backed webview");
   if (this.chromedriver !== null) {
     return cb(new Error("We already have a chromedriver instance running"));
   }
-  var chromeArgs = {
-    port: this.args.chromeDriverPort
-  , executable: this.args.chromedriverExecutable
-  , deviceId: this.adb.curDeviceId
-  , enablePerformanceLogging: this.args.enablePerformanceLogging
-  };
-  this.chromedriver = new Chromedriver(chromeArgs,
-      this.onChromedriverExit.bind(this));
-  this.rememberProxyState();
-  this.proxyHost = this.chromedriver.proxyHost;
-  this.proxyPort = this.chromedriver.proxyPort;
-  this.isProxy = true;
-  var caps = {
-    chromeOptions: {
-      androidPackage: this.args.appPackage,
-      androidUseRunningApp: true
-    }
-  };
-  // For now the only known arg passed this way is androidDeviceSocked used by Operadriver (deriving from Chromedriver)
-  // We don't know how other Chromium embedders will call this argument so for now it's name needs to be configurable
-  // When Google adds the androidDeviceSocket argument to the original Chromedriver then we will be sure about it's name
-  // for all Chromium embedders (as their Webdrivers will derive from Chromedriver)
-  if (this.args.specialChromedriverSessionArgs) {
-    _.each(this.args.specialChromedriverSessionArgs, function (val, option) {
-      caps.chromeOptions[option] = val;
-    });
-  }
-  this.chromedriver.createSession(caps, function (err, sessId) {
-    if (err) return cb(err);
-    logger.debug("Setting proxy session id to " + sessId);
-    this.proxySessionId = sessId;
+
+  if (this.sessionChromedrivers[context]) {
+    logger.debug("Found existing Chromedriver for context '" + context + "'." +
+                 " Using it.");
+    this.chromedriver = this.sessionChromedrivers[context];
     cb();
-  }.bind(this));
+  } else {
+    var chromeArgs = {
+      port: this.args.chromeDriverPort
+    , executable: this.args.chromedriverExecutable
+    , deviceId: this.adb.curDeviceId
+    , enablePerformanceLogging: this.args.enablePerformanceLogging
+    };
+    this.chromedriver = new Chromedriver(chromeArgs,
+        this.onChromedriverExit.bind(this));
+    this.rememberProxyState();
+    this.proxyHost = this.chromedriver.proxyHost;
+    this.proxyPort = this.chromedriver.proxyPort;
+    this.isProxy = true;
+    var caps = {
+      chromeOptions: {
+        androidPackage: this.args.appPackage,
+        androidUseRunningApp: true
+      }
+    };
+    // For now the only known arg passed this way is androidDeviceSocked used by Operadriver (deriving from Chromedriver)
+    // We don't know how other Chromium embedders will call this argument so for now it's name needs to be configurable
+    // When Google adds the androidDeviceSocket argument to the original Chromedriver then we will be sure about it's name
+    // for all Chromium embedders (as their Webdrivers will derive from Chromedriver)
+    if (this.args.specialChromedriverSessionArgs) {
+      _.each(this.args.specialChromedriverSessionArgs, function (val, option) {
+        caps.chromeOptions[option] = val;
+      });
+    }
+    this.chromedriver.createSession(caps, function (err, sessId) {
+      if (err) return cb(err);
+      logger.debug("Setting proxy session id to " + sessId);
+      this.proxySessionId = sessId;
+      this.sessionChromedrivers[context] = this.chromedriver;
+      cb();
+    }.bind(this));
+  }
 };
 
 androidHybrid.onChromedriverExit = function () {
@@ -166,12 +176,11 @@ androidHybrid.onChromedriverExit = function () {
   }
 };
 
-androidHybrid.cleanupChromedriver = function (cb) {
-  if (this.chromedriver) {
+androidHybrid.cleanupChromedriver = function (chromedriver, cb) {
+  if (chromedriver) {
     logger.debug("Cleaning up Chromedriver");
-    this.chromedriver.stop(function (err) {
+    chromedriver.stop(function (err) {
       if (err) logger.warn("Error stopping chromedriver: " + err.message);
-      this.chromedriver = null;
       this.restoreProxyState();
       cb();
     }.bind(this));
@@ -180,15 +189,20 @@ androidHybrid.cleanupChromedriver = function (cb) {
   }
 };
 
-androidHybrid.stopChromedriverProxy = function (cb) {
-  if (this.chromedriver !== null) {
-    this.chromedriver.deleteSession(function (err) {
+androidHybrid.suspendChromedriverProxy = function (cb) {
+  this.chromedriver = null;
+  cb();
+};
+
+androidHybrid.stopChromedriverProxies = function (ocb) {
+  async.eachSeries(Object.keys(this.sessionChromedrivers), function (context, cb) {
+    var chromedriver = this.sessionChromedrivers[context];
+    chromedriver.deleteSession(function (err) {
       if (err) return cb(err);
-      this.cleanupChromedriver(cb);
+      this.cleanupChromedriver(chromedriver, cb);
+      delete this.sessionChromedrivers[context];
     }.bind(this));
-  } else {
-    cb();
-  }
+  }.bind(this), ocb);
 };
 
 androidHybrid.defaultWebviewName = function () {

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -411,7 +411,7 @@ Android.prototype.cleanup = function () {
 
 Android.prototype.shutdown = function (cb) {
   var next = function () {
-    this.cleanupChromedriver(function () {
+    this.stopChromedriverProxies(function () {
       if (this.uiautomator) {
         this.uiautomator.shutdown(function () {
           this.cleanup();


### PR DESCRIPTION
Keeps track of the Chromedriver existing for a particular webview, and reuses it if the session returns to it. All are destroyed at the end. 

I am unsure at the moment how to test this other than visually inspecting the log output.

As per #3191, and in concert with #3339.
