### PR TITLE
Allow chromeOptions method

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -45,7 +45,6 @@
 |`keyAlias`| Alias for key |e.g., `androiddebugkey`|
 |`keyPassword`| Password for key |e.g., `foo`|
 |`chromedriverExecutable`| The absolute local path to webdriver executable (if Chromium embedder provides its own webdriver, it should be used instead of original chromedriver bundled with Appium) |`/abs/path/to/webdriver`|
-|`specialChromedriverSessionArgs`| Custom arguments passed directly to chromedriver in chromeOptions capability. Passed as object which properties depend on a specific webdriver. |e.g., `{'androidDeviceSocket': 'opera_beta_devtools_remote',}`|
 |`autoWebviewTimeout`| Amount of time to wait for Webview context to become active, in ms. Defaults to `2000`| e.g. `4`|
 |`intentAction`| Intent action which will be used to start activity (default `android.intent.action.MAIN`)| e.g.`android.intent.action.MAIN`, `android.intent.action.VIEW`|
 |`intentCategory`| Intent category which will be used to start activity (default `android.intent.category.LAUNCHER`)| e.g. `android.intent.category.LAUNCHER`, `android.intent.category.APP_CONTACTS`

--- a/lib/devices/android/android-hybrid.js
+++ b/lib/devices/android/android-hybrid.js
@@ -153,7 +153,18 @@ androidHybrid.startChromedriverProxy = function (context, cb) {
     // for all Chromium embedders (as their Webdrivers will derive from Chromedriver)
     if (this.args.specialChromedriverSessionArgs) {
       _.each(this.args.specialChromedriverSessionArgs, function (val, option) {
+        logger.debug("This method is being deprecated. Apply chromeOptions normally to pass along options," +
+                     "see sites.google.com/a/chromium.org/chromedriver/capabilities for more info");
         caps.chromeOptions[option] = val;
+      });
+    }
+    if (typeof this.args.chromeOptions) {
+      _.each(typeof this.args.chromeOptions, function (val, option) {
+        if (typeof caps.chromeOptions[option] === "undefined") {
+          caps.chromeOptions[option] = val;
+        } else {
+          logger.warn("Cannot pass option " + caps.chromeOptions[option] + " because Appium needs it to make chromeDriver work");
+        }
       });
     }
     this.chromedriver.createSession(caps, function (err, sessId) {

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -11,6 +11,7 @@ var okObjects = [
   'proxy'
 , 'launchTimeout'
 , 'specialChromedriverSessionArgs'
+, 'chromeOptions'
 ];
 
 var requiredCaps = [


### PR DESCRIPTION
Added a way to look for chromeOptions that will add in undefined arguments but still let us set the ones we need. Added a deprecation message to the old method and removed it from documentation.
