### PR TITLE
download all linux chromedriver architectures

### DIFF
--- a/lib/devices/android/chromedriver.js
+++ b/lib/devices/android/chromedriver.js
@@ -22,22 +22,37 @@ var Chromedriver = function (args, onDie) {
   this.onDie = onDie;
   this.exitCb = null;
   this.shuttingDown = false;
-
-  this.initChromedriverPath(args);
+  this.executable = args.executable;
 };
 
-Chromedriver.prototype.initChromedriverPath = function (args) {
-  if (args.executable) {
-    this.chromedriver = args.executable;
+Chromedriver.prototype.initChromedriverPath = function (cb) {
+  if (this.executable) {
+    this.chromedriver = this.executable;
   } else {
-    var executable = isWindows ? "chromedriver.exe" : "chromedriver";
-    var platform = "mac";
-    if (isWindows) {
-      platform = "windows";
-    } else if (isLinux) {
-      platform = "linux";
+    var setPath = function (platform, executable) {
+      this.chromedriver = path.resolve(__dirname, "..", "..", "..", "build",
+                                       "chromedriver", platform, executable);
+      logger.debug("Set chromedriver binary as: " + this.chromedriver);
+    }.bind(this);
+    if (isLinux) {
+      logger.debug("Determining linux architecture");
+      exec("uname -m", function (err, stdout) {
+        var executable;
+        if (err) return cb(err);
+        if (stdout.trim() === "i686") {
+          executable = "chromedriver32";
+        } else {
+          executable = "chromedriver64";
+        }
+        setPath("linux", executable);
+        cb();
+      });
+    } else {
+      var executable = isWindows ? "chromedriver.exe" : "chromedriver";
+      var platform = isWindows ? "windows" : "mac";
+      setPath(platform, executable);
+      cb();
     }
-    this.chromedriver = path.resolve(__dirname, "..", "..", "..", "build", "chromedriver", platform, executable);
   }
 };
 
@@ -137,6 +152,7 @@ Chromedriver.prototype.createSession = function (caps, cb) {
     desiredCapabilities: caps
   };
   async.waterfall([
+    this.initChromedriverPath.bind(this),
     this.ensureChromedriverExists.bind(this),
     this.killOldChromedrivers.bind(this),
     this.start.bind(this),

--- a/reset.sh
+++ b/reset.sh
@@ -507,12 +507,14 @@ reset_chromedriver() {
             platform="mac"
             chromedriver_file="chromedriver_mac32.zip"
             run_cmd mkdir "$appium_home"/build/chromedriver/mac
+            install_chromedriver $platform $chromedriver_version $chromedriver_file
         else
             platform="linux"
             chromedriver_file="chromedriver_linux$machine.zip"
+            binary="chromedriver$machine"
             run_cmd mkdir "$appium_home"/build/chromedriver/linux
+            install_chromedriver $platform $chromedriver_version $chromedriver_file $binary
         fi
-        install_chromedriver $platform $chromedriver_version $chromedriver_file
     else
         echo "* Building directory structure"
         run_cmd mkdir "$appium_home"/build/chromedriver/mac
@@ -520,7 +522,8 @@ reset_chromedriver() {
         run_cmd mkdir "$appium_home"/build/chromedriver/windows
 
         install_chromedriver "mac" $chromedriver_version "chromedriver_mac32.zip"
-        install_chromedriver "linux" $chromedriver_version "chromedriver_linux$machine.zip"
+        install_chromedriver "linux" $chromedriver_version "chromedriver_linux32.zip" "chromedriver32"
+        install_chromedriver "linux" $chromedriver_version "chromedriver_linux64.zip" "chromedriver64"
         install_chromedriver "windows" $chromedriver_version "chromedriver_win32.zip"
     fi
 }
@@ -529,6 +532,7 @@ install_chromedriver() {
     platform=$1
     version=$2
     file=$3
+    binary=$4
 
     echo "* Downloading ChromeDriver version $version for $platform"
     run_cmd curl -L http://chromedriver.storage.googleapis.com/$version/$file -o "$appium_home"/build/chromedriver/$platform/chromedriver.zip
@@ -537,6 +541,9 @@ install_chromedriver() {
     echo "* Unzipping ChromeDriver"
     run_cmd unzip chromedriver.zip
     run_cmd rm chromedriver.zip
+    if [[ $binary != "" ]]; then
+        run_cmd mv chromedriver $binary
+    fi
     run_cmd popd
 }
 


### PR DESCRIPTION
using the --chromedriver-install-all flag now downloads 32 and 64 bit archs
without the flag, the machine will download the one appropriate to its arch
fix #3368
