### PR TITLE
Removed request size limit. #3209 Fix.

### DIFF
--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -100,7 +100,6 @@ var main = function (args, readyCb, doneCb) {
   rest.use(allowCrossDomain);
   rest.use(parserWrap);
   rest.use(bodyParser.urlencoded({extended: true}));
-  rest.use(bodyParser.json({limit: '50mb'}));
   rest.use(morgan({format: function (tokens, req, res) {
     // morgan output is redirected straight to winston
     var data = '';


### PR DESCRIPTION
Neither Node, the HTTP spec, nor the body-parser pkg has a max request size. The latter, which we use--oddly enough--for body parsing, wraps the size "limit" functionality of the raw-body pkg, which has no default limit. All of that taken together is why I removed our hardcoded limit on request sizes.    
