### PR TITLE
Removed request size limit.

### DIFF
--- a/lib/server/main.js
+++ b/lib/server/main.js
@@ -100,7 +100,12 @@ var main = function (args, readyCb, doneCb) {
   rest.use(allowCrossDomain);
   rest.use(parserWrap);
   rest.use(bodyParser.urlencoded({extended: true}));
-  rest.use(bodyParser.json({limit: '50mb'}));
+  // 8/18/14: body-parser requires that we supply the limit field to ensure the server can
+  // handle requests large enough for Appium's use cases. Neither Node nor HTTP spec defines a max
+  // request size, so any hard-coded request-size limit is arbitrary. Units are in bytes (ie "gb" == "GB",
+  // not "Gb"). Using 1GB because..., well because it's arbitrary and 1GB is sufficiently large for 99.99%
+  // of testing scenarios while still providing an upperbounds to reduce the odds of squirrelliness.
+  rest.use(bodyParser.json({limit: '1gb'}));
   rest.use(morgan({format: function (tokens, req, res) {
     // morgan output is redirected straight to winston
     var data = '';


### PR DESCRIPTION
Fix for #3209 

Increased request size limit to 1GB.  We really shouldn't need to supply a limit since neither node nor the http spec specifies one, but when I tried removing the limit field altogether, tests started failing. This is a limitation in a second or third order dependency.
