### PR TITLE
Reset proxy status when suspending ChromeDriver

### DIFF
--- a/lib/devices/android/android-hybrid.js
+++ b/lib/devices/android/android-hybrid.js
@@ -126,7 +126,12 @@ androidHybrid.startChromedriverProxy = function (context, cb) {
   if (this.sessionChromedrivers[context]) {
     logger.debug("Found existing Chromedriver for context '" + context + "'." +
                  " Using it.");
+    this.rememberProxyState();
     this.chromedriver = this.sessionChromedrivers[context];
+    this.proxyHost = this.chromedriver.proxyHost;
+    this.proxyPort = this.chromedriver.proxyPort;
+    this.proxySessionId = this.chromedriver.chromeSessionId;
+    this.isProxy = true;
     cb();
   } else {
     var chromeArgs = {
@@ -202,6 +207,7 @@ androidHybrid.cleanupChromedriver = function (chromedriver, cb) {
 
 androidHybrid.suspendChromedriverProxy = function (cb) {
   this.chromedriver = null;
+  this.restoreProxyState();
   cb();
 };
 

--- a/test/functional/common/android-webview-base.js
+++ b/test/functional/common/android-webview-base.js
@@ -84,4 +84,24 @@ module.exports = function () {
       .source().should.eventually.include("<h1>This page is a Selenium sandbox<")
       .nodeify(done);
   });
+
+  it('should be able to move into and out of webview with proper proxying', function (done) {
+    driver
+      .elementById('i_am_a_textbox')
+        .should.not.be.rejected
+      // leave the webview
+      .context('NATIVE_APP')
+      // should not find the element in native context
+      .elementById('i_am_a_textbox')
+        .should.be.rejectedWith("status: 7")
+      // go back into the webview
+      .contexts()
+      .then(function (ctxs) {
+        return driver.context(ctxs[ctxs.length - 1]);
+      })
+      // should find the element in the web context
+      .elementById('i_am_a_textbox')
+        .should.not.be.rejected
+      .nodeify(done);
+  });
 };


### PR DESCRIPTION
Refactor of ChromeDriver handling made it so that proxying to ChromeDriver remained in effect, even after switching to native app. Added a test to make sure it works and this doesn't regress again.

Hopefully this addresses #3412.
