### PR TITLE
Added hack force debug messages to stdout. Fix for #3194

### DIFF
--- a/lib/server/logger.js
+++ b/lib/server/logger.js
@@ -49,6 +49,12 @@ module.exports.init = function (args) {
   logger.stripColors = args.logNoColors;
   logger.appiumLoglevel = loglevel;
 
+  // 8/19/14 this is a hack to force Winston to print debug messages to stdout rather than stderr.
+  // TODO: remove this if winston provides an API for directing streams.
+  if (levels[loglevel] === levels.debug) {
+    logger.debug = function (msg) { logger.info('[debug] ' + msg); };
+  }
+
   var fileLogger = null;
   if (args.log) {
     try {


### PR DESCRIPTION
Added a small hack that prints debug messages as "info" messages when the logging level is set to "debug". I came up with a monkey patch that worked fine, but went with this because it's far less invasive.
