### PR TITLE
Use deviceconsole instead of idevicesyslog to capture iOS real device logs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "submodules/sample-code"]
 	path = submodules/sample-code
 	url = https://github.com/appium/sample-code
+[submodule "submodules/deviceconsole"]
+	path = submodules/deviceconsole
+	url = https://github.com/rpetrich/deviceconsole.git

--- a/docs/en/contributing-to-appium/credits.md
+++ b/docs/en/contributing-to-appium/credits.md
@@ -12,3 +12,4 @@
 * [Selenium Project](http://code.google.com/p/selenium/)
 * [ios-webkit-debug-proxy](https://github.com/google/ios-webkit-debug-proxy)
 * [instruments-without-delay](https://github.com/facebook/instruments-without-delay)
+* [deviceconsole](https://github.com/rpetrich/deviceconsole)

--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -61,7 +61,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--calendar-format`|null|(IOS-only) calendar format for the iOS simulator|`--calendar-format gregorian`|
 |`--orientation`|null|(IOS-only) use LANDSCAPE or PORTRAIT to initialize all requests to this orientation|`--orientation LANDSCAPE`|
 |`--tracetemplate`|null|(IOS-only) .tracetemplate file to use with Instruments|`--tracetemplate /Users/me/Automation.tracetemplate`|
-|`--show-sim-log`|false|(IOS-only) if set, the iOS simulator log will be written to the console||
+|`--show-ios-log`|false|(IOS-only) if set, the iOS system log will be written to the console||
 |`--nodeconfig`|null|Configuration JSON file to register appium with selenium grid|`--nodeconfig /abs/path/to/nodeconfig.json`|
 |`-ra`, `--robot-address`|0.0.0.0|IP Address of robot|`--robot-address 0.0.0.0`|
 |`-rp`, `--robot-port`|-1|port for robot|`--robot-port 4242`|

--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -38,14 +38,14 @@ IosLog.prototype.startCapture = function (cb) {
   if (this.udid) {
     var spawnEnv = _.clone(process.env);
     var limdDir = path.resolve(__dirname,
-                               "../../../build/libimobiledevice-macosx/");
+                               "../../../build/deviceconsole");
     spawnEnv.PATH = process.env.PATH + ":" + limdDir;
     spawnEnv.DYLD_LIBRARY_PATH = limdDir + ":" + process.env.DYLD_LIBRARY_PATH;
-    logger.debug("Starting iOS device log capture via idevicesyslog");
-    // idevicesyslog retrieves many old device log lines that came before it was
+    logger.debug("Starting iOS device log capture via deviceconsole");
+    // deviceconsole retrieves many old device log lines that came before it was
     // started so filter those out until we encounter new log lines.
     this.loggingModeOn = false;
-    this.proc = spawn("idevicesyslog", ["-u", this.udid], {env: spawnEnv});
+    this.proc = spawn("deviceconsole", ["-u", this.udid], {env: spawnEnv});
     this.finishStartingLogCapture(cb);
   } else {
     if (parseInt(this.xcodeVersion.split(".")[0], 10) >= 5) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1399,7 +1399,7 @@ IOS.prototype.startLogCapture = function (cb) {
   this.logs.syslog = new iOSLog({
     udid: this.args.udid
   , xcodeVersion: this.xcodeVersion
-  , showLogs: this.args.showSimulatorLog
+  , showLogs: this.args.showSimulatorLog || this.args.showIOSLog
   });
   this.logs.syslog.startCapture(function (err) {
     if (err) cb(err);

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -411,6 +411,15 @@ var args = [
   , nargs: 0
   }],
 
+  [['--show-ios-log'], {
+    defaultValue: false
+  , dest: 'showIOSLog'
+  , action: 'storeTrue'
+  , required: false
+  , help: "(IOS-only) if set, the iOS system log will be written to the console"
+  , nargs: 0
+  }],
+
   [['--nodeconfig'], {
     required: false
   , defaultValue: null

--- a/reset.sh
+++ b/reset.sh
@@ -240,6 +240,15 @@ reset_ios() {
     echo "* Copying libimobiledevice-macosx to build"
     run_cmd rm -rf build/libimobiledevice-macosx
     run_cmd cp -r submodules/libimobiledevice-macosx build/libimobiledevice-macosx
+    echo "* Cloning/updating deviceconsole"
+    run_cmd git submodule update --init submodules/deviceconsole
+    echo "* Building deviceconsole"
+    run_cmd pushd submodules/deviceconsole
+    run_cmd make
+    run_cmd popd
+    echo "* Copying deviceconsole to build"
+    run_cmd rm -rf build/deviceconsole
+    run_cmd cp -r submodules/deviceconsole build/deviceconsole
 }
 
 get_apidemos() {


### PR DESCRIPTION
idevicesyslog often misses parts of the log, or stops capturing the log until the end of the test. [deviceconsole](https://github.com/rpetrich/deviceconsole) works in the same way, but much better.

Resolves #3202 and #2855.

One further issue: The server flag is `--show-sim-log` though as far as I can tell it is how you turn on the real device logs as well. At least, it turns them on.
