### PR TITLE
Add deprecation warnings for server args

### DIFF
--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -197,6 +197,16 @@ var getNonDefaultArgs = function (parser, args) {
   return nonDefaults;
 };
 
+var getDeprecatedArgs = function (parser) {
+  var deprecated = {};
+  _.each(parser.rawArgs, function (rawArg) {
+    if (rawArg[1].deprecatedFor) {
+      deprecated[rawArg[0]] = "use instead: " + rawArg[1].deprecatedFor;
+    }
+  });
+  return deprecated;
+};
+
 module.exports.startListening = function (server, args, parser, appiumVer, appiumRev, appiumServer, cb) {
   var alreadyReturned = false;
   server.listen(args.port, args.address, function () {
@@ -215,6 +225,10 @@ module.exports.startListening = function (server, args, parser, appiumVer, appiu
     var showArgs = getNonDefaultArgs(parser, args);
     if (_.size(showArgs)) {
       logger.debug("Non-default server args: " + JSON.stringify(showArgs));
+    }
+    var deprecatedArgs = getDeprecatedArgs(parser);
+    if (_.size(deprecatedArgs)) {
+      logger.warn("Deprecated server args: " + JSON.stringify(deprecatedArgs));
     }
     logger.info('LogLevel:', logger.appiumLoglevel);
   });

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -407,6 +407,7 @@ var args = [
   , dest: 'showSimulatorLog'
   , action: 'storeTrue'
   , required: false
+  , deprecatedFor: '--show-ios-log'
   , help: "(IOS-only) if set, the iOS simulator log will be written to the console"
   , nargs: 0
   }],


### PR DESCRIPTION
Allow server arguments to be deprecated in favour of other arguments. I'm open to suggestions on the message to be displayed.
