### PR TITLE
Fix deprecated server args

### DIFF
--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -197,10 +197,11 @@ var getNonDefaultArgs = function (parser, args) {
   return nonDefaults;
 };
 
-var getDeprecatedArgs = function (parser) {
+var getDeprecatedArgs = function (parser, args) {
   var deprecated = {};
   _.each(parser.rawArgs, function (rawArg) {
-    if (rawArg[1].deprecatedFor) {
+    var arg = rawArg[1].dest;
+    if (args[arg] && rawArg[1].deprecatedFor) {
       deprecated[rawArg[0]] = "use instead: " + rawArg[1].deprecatedFor;
     }
   });
@@ -226,7 +227,7 @@ module.exports.startListening = function (server, args, parser, appiumVer, appiu
     if (_.size(showArgs)) {
       logger.debug("Non-default server args: " + JSON.stringify(showArgs));
     }
-    var deprecatedArgs = getDeprecatedArgs(parser);
+    var deprecatedArgs = getDeprecatedArgs(parser, args);
     if (_.size(deprecatedArgs)) {
       logger.warn("Deprecated server args: " + JSON.stringify(deprecatedArgs));
     }


### PR DESCRIPTION
I just realized that the deprecation warnings would _always_ be displayed, even if you didn't use the argument. :-1: Check both the presence of the arg, and its deprecation status.
