### PR TITLE
Properly bracket unicode encoding

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -155,11 +155,27 @@ androidController.setValueImmediate = function (elementId, value, cb) {
 };
 
 androidController.setValue = function (elementId, value, cb) {
-  this.proxy(["element:setText", {elementId: elementId, text: value, replace: false}], cb);
+  var params = {
+    elementId: elementId,
+    text: value,
+    replace: false
+  };
+  if (this.args.unicodeKeyboard) {
+    params.unicodeKeyboard = true;
+  }
+  this.proxy(["element:setText", params], cb);
 };
 
 androidController.replaceValue = function (elementId, value, cb) {
-  this.proxy(["element:setText", {elementId: elementId, text: value, replace: true}], cb);
+  var params = {
+    elementId: elementId,
+    text: value,
+    replace: true
+  };
+  if (this.args.unicodeKeyboard) {
+    params.unicodeKeyboard = true;
+  }
+  this.proxy(["element:setText", params], cb);
 };
 
 androidController.click = function (elementId, cb) {
@@ -254,7 +270,14 @@ androidController.getPageIndex = function (elementId, cb) {
 };
 
 androidController.keys = function (elementId, keys, cb) {
-  this.proxy(["element:setText", {elementId: elementId, text: keys}], cb);
+  var params = {
+    elementId: elementId,
+    text: keys
+  };
+  if (this.args.unicodeKeyboard) {
+    params.unicodeKeyboard = true;
+  }
+  this.proxy(["element:setText", params], cb);
 };
 
 androidController.frame = function (frame, cb) {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
@@ -232,7 +232,12 @@ public class AndroidElement {
   }
 
   public boolean setText(final String text) throws UiObjectNotFoundException {
-    if (UnicodeEncoder.needsEncoding(text)) {
+    return setText(text, false);
+  }
+
+  public boolean setText(final String text, boolean unicodeKeyboard)
+      throws UiObjectNotFoundException {
+    if (unicodeKeyboard && UnicodeEncoder.needsEncoding(text)) {
       Logger.debug("Sending Unicode text to element: " + text);
       String encodedText = UnicodeEncoder.encode(text);
       Logger.debug("Encoded text: " + encodedText);

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
@@ -9,17 +9,17 @@ import java.util.Hashtable;
 
 /**
  * This handler is used to set text in elements that support it.
- * 
+ *
  */
 public class SetText extends CommandHandler {
 
   /*
    * @param command The {@link AndroidCommand} used for this handler.
-   * 
+   *
    * @return {@link AndroidCommandResult}
-   * 
+   *
    * @throws JSONException
-   * 
+   *
    * @see io.appium.android.bootstrap.CommandHandler#execute(io.appium.android.
    * bootstrap.AndroidCommand)
    */
@@ -39,6 +39,10 @@ public class SetText extends CommandHandler {
           text = text.replace("\\n", "");
           Logger.debug("Will press enter after setting text");
         }
+        boolean unicodeKeyboard = false;
+        if (params.get("unicodeKeyboard") != null) {
+          unicodeKeyboard = Boolean.parseBoolean(params.get("unicodeKeyboard").toString());
+        }
         String currText = el.getText();
         new Clear().execute(command);
         if (!el.getText().isEmpty()) {
@@ -47,7 +51,7 @@ public class SetText extends CommandHandler {
         if (!replace) {
           text = currText + text;
         }
-        final boolean result = el.setText(text);
+        final boolean result = el.setText(text, unicodeKeyboard);
         if (pressEnter) {
           final UiDevice d = UiDevice.getInstance();
           d.pressEnter();

--- a/test/functional/android/apidemos/keyboard-specs.js
+++ b/test/functional/android/apidemos/keyboard-specs.js
@@ -20,33 +20,74 @@ describe("apidemo - keyboard @skip-ci", function () {
       .nodeify(done);
   };
 
-  setup(this,  _.defaults({
-    appActivity: ".view.Controls1",
-    unicodeKeyboard: true,
-    resetKeyboard: true
-  }, desired)).then(function (d) { driver = d; });
+  describe('editing ascii text field', function () {
+    setup(this,  _.defaults({
+      appActivity: ".view.Controls1"
+    }, desired)).then(function (d) { driver = d; });
 
-  it('should be able to edit a text field', function (done) {
-    var testText = "Life, the Universe and Everything.";
-    runTextEditTest(testText, done);
-  });
+    it('should be able to edit a text field', function (done) {
+      var testText = "Life, the Universe and Everything.";
+      runTextEditTest(testText, done);
+    });
 
-  // TODO: clear is not reliable
-  it('should be able to edit and clear a text field', function (done) {
-    var testText = "The answer is 42.", el;
-    driver
-      .waitForElementByClassName('android.widget.EditText')
-      .then(function (_el) { el = _el; })
-      .then(function () { return safeClear(el); })
-      .then(function () { return el.sendKeys(testText).text().should.become(testText); })
-      .then(function () { return safeClear(el); })
-      // TODO: there is a bug here we should not need safeClear
-      // workaround for now.
-      .then(function () { return el.text().should.become(""); })
-      .nodeify(done);
+    // TODO: clear is not reliable
+    it('should be able to edit and clear a text field', function (done) {
+      var testText = "The answer is 42.", el;
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .then(function (_el) { el = _el; })
+        .then(function () { return safeClear(el); })
+        .then(function () { return el.sendKeys(testText).text().should.become(testText); })
+        .then(function () { return safeClear(el); })
+        // TODO: there is a bug here we should not need safeClear
+        // workaround for now.
+        .then(function () { return el.text().should.become(""); })
+        .nodeify(done);
+    });
+
+    it('should be able to send &-', function (done) {
+      var testText = '&-';
+      runTextEditTest(testText, done);
+    });
+
+    it('should be able to send & and - in other text', function (done) {
+      var testText = 'In the mid-1990s he ate fish & chips as mayor-elect.';
+      runTextEditTest(testText, done);
+    });
+
+    it('should be able to send - in text', function (done) {
+      var testText = 'Super-test.';
+      runTextEditTest(testText, done);
+    });
   });
 
   describe('editing unicode text field', function () {
+    setup(this,  _.defaults({
+      appActivity: ".view.Controls1",
+      unicodeKeyboard: true,
+      resetKeyboard: true
+    }, desired)).then(function (d) { driver = d; });
+
+    it('should be able to edit a text field', function (done) {
+      var testText = "Life, the Universe and Everything.";
+      runTextEditTest(testText, done);
+    });
+
+    // TODO: clear is not reliable
+    it('should be able to edit and clear a text field', function (done) {
+      var testText = "The answer is 42.", el;
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .then(function (_el) { el = _el; })
+        .then(function () { return safeClear(el); })
+        .then(function () { return el.sendKeys(testText).text().should.become(testText); })
+        .then(function () { return safeClear(el); })
+        // TODO: there is a bug here we should not need safeClear
+        // workaround for now.
+        .then(function () { return el.text().should.become(""); })
+        .nodeify(done);
+    });
+
     it('should be able to send &-', function (done) {
       var testText = '&-';
       runTextEditTest(testText, done);


### PR DESCRIPTION
The unicode encoding functionality uses `&` as a delimiter, so text with `&` in would get encoded, and come out as `&-`, unless using the unicode keyboard, which properly decoded it back to its original form. (For error, see #3435).

The solution is to pass in the flag for using the unicode encoding, if the cap is set, and only encode if it is on.
