### PR TITLE
Show output if error on parsing Xcode version

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -514,7 +514,7 @@ exports.getXcodeVersion = function (cb) {
           var versionPattern = /\d\.\d\.*\d*/;
           var match = versionPattern.exec(stdout);
           if (match === null) {
-            cb(new Error("Could not parse Xcode version"), null);
+            cb(new Error("Could not parse Xcode version (xcodebuild output was: " + stdout + ")"), null);
           } else {
             var versionNumber = match[0];
             cb(null, versionNumber);


### PR DESCRIPTION
This just prints stdout and might be useful in debugging. The problem I was seeing was that the output was empty because on that  particular run/machine xcodebuild was being very slow to answer. Not sure what the best approach is to fix that though - bigger timeout? Retry if stdout is empty string?
