### PR TITLE
Update ios-controller to execute a 'click' JS atom when a click event is sent

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -367,7 +367,7 @@ iOSController.useAtomsElement = deviceCommon.useAtomsElement;
 iOSController.click = function (elementId, cb) {
   if (this.isWebContext()) {
     this.useAtomsElement(elementId, cb, function (atomsElement) {
-      this.executeAtom('tap', [atomsElement], cb);
+      this.executeAtom('click', [atomsElement], cb);
     }.bind(this));
   } else {
     if (this.useRobot) {


### PR DESCRIPTION
Appium is executing a 'tap' event on iOS devices when sending a 'click' event. 'Tap' event fires off two click events on mobile safari. 
