### PR TITLE
Fix #3383: Added ability to launch ios app via bundleId

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -61,7 +61,8 @@
 |Capability|Description|Values|
 |----|-----------|-------|
 |`calendarFormat`| (Sim-only) Calendar format to set for the iOS Simulator|e.g. `gregorian`|
-|`bundleId`| Bundle ID of the app under test. Useful for starting an app on a real device or for using other caps which require the bundle ID during test startup|e.g. `io.appium.TestApp`|
+|`bundleId`| Bundle ID of the app under test. Useful for starting an app on a real device or for using other caps which require the bundle ID during test startup. To run a test on a real device using the bundle ID, you may omit the 'app' capability, but you must provide 'udid'.|e.g. `io.appium.TestApp`|
+|`udid`| Unique device identifier of the connected physical device|e.g. `1ae203187fc012g`|
 |`launchTimeout`| Amount of time in ms to wait for instruments before assuming it hung and failing the session|e.g. `20000`|
 |`locationServicesEnabled`| (Sim-only) Force location services to be either on or off. Default is to keep current sim setting.|`true` or `false`|
 |`locationServicesAuthorized`| (Sim-only) Set location services to be authorized or not authorized for app via plist, so that location services alert doesn't pop up. Default is to keep current sim setting. Note that if you use this setting you MUST also use the `bundleId` capability to send in your app's bundle ID.|`true` or `false`|

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -136,14 +136,16 @@ IOS.prototype.configure = function (args, caps, cb) {
     return cb(new Error(msg));
   }
 
-  if (this.args.app) {
-    return this.configureApp(cb);
+  if (!this.args.app &&
+      !(this.args.udid && this.args.bundleId)) {
+    msg = "Please provide the 'app' capability or start appium with the --app argument. Alternatively, you " +
+          "may provide the 'bundleId' and 'udid' capabilities for an app under test on a real device.";
+    logger.error(msg);
+
+    return cb(new Error(msg));
   }
 
-
-  msg = "No app set; either start appium with --app or use 'app' cap";
-  logger.error(msg);
-  cb(new Error(msg));
+  return this.configureApp(cb);
 };
 
 IOS.prototype.setIOSArgs = function () {
@@ -172,14 +174,19 @@ IOS.prototype.configureApp = function (cb) {
     }
     _cb(err);
   }.bind(this);
+
   var app = this.appString();
-  if (app.toLowerCase() === "settings") {
+
+  // if the app name is a bundleId assign it to the bundleId property
+  if (!this.args.bundleId && this.appIsPackageOrBundle(app)) {
+    this.args.bundleId = app;
+  }
+
+  if (app !== "" && app.toLowerCase() === "settings") {
     this.configurePreferences(cb);
-  } else if (this.appIsPackageOrBundle(app)) {
+  } else if (this.args.bundleId && this.appIsPackageOrBundle(this.args.bundleId)) {
     // we have a bundle ID
     logger.debug("App is an iOS bundle, will attempt to run as pre-existing");
-    this.args.bundleId = app;
-    this.args.app = null;
     cb();
   } else {
     Device.prototype.configureApp.call(this, cb);
@@ -382,6 +389,7 @@ IOS.prototype.onInstrumentsLaunch = function (cb) {
 
 IOS.prototype.setBundleId = function (cb) {
   if (this.args.bundleId) {
+    // We already have a bundle Id
     cb();
   } else {
     this.proxy('au.bundleId()', function (err, bId) {
@@ -783,7 +791,7 @@ IOS.prototype.detectUdid = function (cb) {
 
 IOS.prototype.setBundleIdFromApp = function (cb) {
   // This method will try to extract the bundleId from the app
-  if (this.args.app === null) {
+  if (this.args.bundleId) {
     // We aleady have a bundle Id
     cb();
   } else {

--- a/test/unit/ios-device-specs.js
+++ b/test/unit/ios-device-specs.js
@@ -3,11 +3,10 @@
 // http://visionmedia.github.com/mocha/
 "use strict";
 
-require('chai');
-
 var path = require('path')
   , _ = require('underscore')
-  , IOS = require('../../lib/devices/ios/ios.js');
+  , IOS = require('../../lib/devices/ios/ios.js')
+  , expect = require('chai').expect;
 
 describe('IOS', function () {
   var device;
@@ -59,6 +58,33 @@ describe('IOS', function () {
     it('should return a dictionary', function (done) {
       device.parseLocalizableStrings(function () {
         device.localizableStrings.should.eql({ 'main.button.computeSum' : 'Compute Sum' });
+        done();
+      });
+    });
+  });
+
+  describe('io#configure', function () {
+    var getCaps = function () {
+      return {platformName: 'iOS', platformVersion: '7.1',
+              deviceName: 'iPhone Simulator', bundleId: 'com.test.foo',
+              udid: '132412341234'};
+    };
+
+    it('should work with just a bundleId', function (done) {
+      var iosDevice = new IOS();
+      iosDevice.configure(getCaps(), {}, function (err) {
+        expect(err).to.be.undefined;
+        done();
+      });
+    });
+
+    it('should work with app field as bundleId', function (done) {
+      var iosDevice = new IOS();
+      var caps = getCaps();
+      caps.app = caps.bundleId;
+      caps.bundleId = undefined;
+      iosDevice.configure(caps, {}, function (err) {
+        expect(err).to.be.undefined;
         done();
       });
     });


### PR DESCRIPTION
This change is designed to enable running tests on a real ios device without setting the 'app' capability. I have provided unit tests, however I have not tested it on a real device.  I would feel much better if someone can do so before we merge.
