### PR TITLE
fix async bug in ios crash waterfall

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -76,3 +76,4 @@
 |`localizableStringsDir`| Where to look for localizable strings. Default `en.lproj`|`en.lproj`|
 |`processArguments`| Arguments to pass to the AUT using instruments|e.g., `-myflag`|
 |`interKeyDelay`| The delay, in ms, between keystrokes sent to an element when typing.|e.g., `100`|
+|`showIOSLog`| Whether to show any logs captured from a device in the appium logs. Default `false`|`true` or `false`|

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -37,6 +37,12 @@ var logTypesSupported = {
   'crashlog': 'Crash logs for iOS applications on real devices and simulators'
 };
 
+iOSController.getStatusExtensions = function () {
+  var ext = {};
+  ext.isShuttingDown = this.isShuttingDown; // this is for testing purposes
+  return ext;
+};
+
 iOSController.createGetElementCommand = function (strategy, selector, ctx,
     many) {
   var ext = many ? 's' : '';

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -122,6 +122,7 @@ IOS.prototype.init = function () {
   this.landscapeWebCoordsOffset = 0;
   this.localizableStrings = {};
   this.keepAppToRetainPrefs = false;
+  this.isShuttingDown = false;
 };
 
 IOS.prototype._deviceConfigure = Device.prototype.configure;
@@ -440,22 +441,24 @@ IOS.prototype.configureBootstrap = function (cb) {
 
 IOS.prototype.onUnexpectedInstrumentsExit = function (code) {
   logger.debug("Instruments exited unexpectedly");
-  if (typeof this.cbForCurrentCmd === "function") {
-    // we were in the middle of waiting for a command when it died
-    // so let's actually respond with something
-    var error = new UnknownError("Instruments died while responding to " +
-                                 "command, please check appium logs");
-    this.cbForCurrentCmd(error, null);
-    if (!code) {
-      code = 1; // this counts as an error even if instruments doesn't think so
+  this.isShuttingDown = true;
+  var postShutdown = function () {
+    if (typeof this.cbForCurrentCmd === "function") {
+      logger.debug("We were in the middle of processing a command when " +
+                   "instruments died; responding with a generic error");
+      var error = new UnknownError("Instruments died while responding to " +
+                                   "command, please check appium logs");
+      this.onInstrumentsDie(error, this.cbForCurrentCmd);
+    } else {
+      this.onInstrumentsDie();
     }
-  }
+  }.bind(this);
   if (this.commandProxy) {
     this.commandProxy.safeShutdown(function () {
-      this.shutdown(code, this.onInstrumentsDie);
+      this.shutdown(code, postShutdown);
     }.bind(this));
   } else {
-    this.shutdown(code, this.onInstrumentsDie);
+    this.shutdown(code, postShutdown);
   }
 };
 
@@ -1251,6 +1254,11 @@ IOS.prototype.postCleanup = function (cb) {
     this.stopRemote();
   }
 
+  var final = function () {
+    this.isShuttingDown = false;
+    cb();
+  }.bind(this);
+
   if (this.args.reset || this.args.fullReset) {
     // The simulator process must be ended before we delete applications.
     async.series([
@@ -1269,10 +1277,10 @@ IOS.prototype.postCleanup = function (cb) {
           cb();
         }
       }.bind(this),
-    ], cb);
+    ], final);
   } else {
     logger.debug("Reset set to false, not ending sim or cleaning up app state");
-    cb();
+    final();
   }
 
 };

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -82,6 +82,7 @@ var iosCaps = [
 , 'keepKeyChains'
 , 'localizableStringsDir'
 , 'interKeyDelay'
+, 'showIOSLog'
 ];
 
 var Capabilities = function (capabilities) {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -62,6 +62,9 @@ exports.getStatus = function (req, res) {
   if (typeof gitSha !== "undefined") {
     data.build.revision = gitSha;
   }
+  if (req.device && typeof req.device.getStatusExtensions === "function") {
+    data = _.extend(data, req.device.getStatusExtensions());
+  }
   respondSuccess(req, res, data);
 };
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "adm-zip": "~0.4.4",
     "appium-adb": "~1.3.13",
     "appium-atoms": "~0.0.5",
-    "appium-instruments": "~1.4.1",
+    "appium-instruments": "~1.4.2",
     "appium-uiauto": "~1.7.1",
     "argparse": "~0.1.15",
     "async": "~0.9.0",

--- a/test/functional/ios/crash-specs.js
+++ b/test/functional/ios/crash-specs.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var setup = require("../common/setup-base")
+  , _ = require("underscore")
   , getAppPath = require('../../helpers/app').getAppPath;
 
 describe('crash recovery', function () {
@@ -32,6 +33,30 @@ describe('crash recovery', function () {
       })
       .source() // will 404 because the session is gone
         .should.eventually.be.rejectedWith('6')
+    .nodeify(done);
+  });
+});
+
+describe('crash commands', function () {
+
+  var driver;
+  var desired = {
+    app: getAppPath('TestApp')
+  };
+
+  setup(this, desired, {}, {FAST_TESTS: false}).then(function (d) { driver = d; });
+
+  it('should not process new commands until after crash shutdown', function (done) {
+    driver
+      .execute("$.crash()") // this causes instruments to shutdown during
+                            // this command
+        .should.eventually.be.rejectedWith('13')
+      .status()
+      .then(function (s) {
+        if (_.has(s, 'isShuttingDown')) {
+          s.isShuttingDown.should.eql(false);
+        }
+      })
     .nodeify(done);
   });
 });

--- a/test/functional/ios/uicatalog/controls-specs.js
+++ b/test/functional/ios/uicatalog/controls-specs.js
@@ -17,7 +17,7 @@ describe('uicatalog - controls @skip-ios6', function () {
     });
   }
 
-  it('should be able to get and set a picker value', function (done) {
+  it('should be able to get and set a picker value(s)', function (done) {
     driver
       .elementByXPath("//UIAStaticText[contains(@label,'Picker View')]").click()
       .elementByXPath("//UIAPickerWheel[@name = 'Red color component value']")
@@ -45,6 +45,9 @@ describe('uicatalog - controls @skip-ios6', function () {
             .getAttribute("value")
               .should.become("70. 15 of 52");
       })
+      .elementByClassName("UIAPickerWheel")
+        .getAttribute("values")
+          .should.eventually.have.length(52)
       .nodeify(done);
   });
 

--- a/test/functional/ios/uicatalog/reset-specs.js
+++ b/test/functional/ios/uicatalog/reset-specs.js
@@ -19,5 +19,16 @@ describe('uicatalog - reset @skip-ios6', function () {
           .should.eventually.have.length(1)
         .nodeify(done);
     });
+
+    it('should successfully close an app', function (done) {
+      driver
+        .closeApp()
+        .elementsByClassName('UIATableView')
+          .should.eventually.be.rejectedWith('7')
+        .launchApp()
+        .elementsByClassName('UIATableView')
+          .should.eventually.have.length(1)
+        .nodeify(done);
+    });
   });
 });


### PR DESCRIPTION
previously, we'd respond to the client's current callback and then start
the shutdown sequence. this opened up a situation where the client could
then call another command (say driver.quit) during shutdown, enabling
the possibility of two simultaneous shutdown flows causing undefined
behavior. this fix makes sure we don't respond to the client for a
command that caused a crash until we're done shutting down.
