### PR TITLE
Don't crash when touch actions sent to webviews

### DIFF
--- a/lib/devices/android/android-context-controller.js
+++ b/lib/devices/android/android-context-controller.js
@@ -81,6 +81,10 @@ androidContextController.setContext = function (name, cb) {
   }.bind(this));
 };
 
+androidContextController.isWebContext = function () {
+  return this.curContext !== null && this.curContext !== 'NATIVE_APP';
+};
+
 androidContextController.getWindowHandle = function (cb) {
   cb(new NotYetImplementedError(), null);
 };

--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -35,7 +35,9 @@ ChromeAndroid.prototype.setChromedriverMode = function () {
   // are trapped by appium for its own purposes
   this.avoidProxy = [
     ['POST', new RegExp('^/wd/hub/session/[^/]+/context')],
-    ['GET', new RegExp('^/wd/hub/session/[^/]+/context')]
+    ['GET', new RegExp('^/wd/hub/session/[^/]+/context')],
+    ['POST', new RegExp('^/wd/hub/session/[^/]+/touch/perform')],
+    ['POST', new RegExp('^/wd/hub/session/[^/]+/touch/multi/perform')]
   ];
 };
 

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -293,6 +293,11 @@ exports.replaceValue = function (req, res) {
 };
 
 exports.performTouch = function (req, res) {
+  // touch actions do not work in webview
+  if (req.device.isWebContext()) {
+    return notYetImplemented(req, res);
+  }
+
   // first, assume that we are getting and array of gestures
   var gestures = req.body;
 
@@ -333,6 +338,11 @@ exports.performTouch = function (req, res) {
 };
 
 exports.performMultiAction = function (req, res) {
+  // touch actions do not work in webview
+  if (req.device.isWebContext()) {
+    return notYetImplemented(req, res);
+  }
+
   var elementId = req.body.elementId;
   var actions = req.body.actions;
 

--- a/test/functional/android/chrome/touch-specs.js
+++ b/test/functional/android/chrome/touch-specs.js
@@ -1,0 +1,6 @@
+"use strict";
+var desired = require('./desired');
+
+describe("chrome", function () {
+  require('../../common/webview/touch-base')(desired);
+});

--- a/test/functional/common/webview/touch-base.js
+++ b/test/functional/common/webview/touch-base.js
@@ -1,0 +1,56 @@
+"use strict";
+
+
+var setup = require("../setup-base"),
+    webviewHelper = require("../../../helpers/webview"),
+    loadWebView = webviewHelper.loadWebView,
+    wd = require("wd"),
+    TouchAction = wd.TouchAction,
+    MultiAction = wd.MultiAction,
+    _ = require("underscore");
+
+module.exports = function (desired) {
+
+  describe('touch actions', function () {
+    var driver;
+    setup(this, _.defaults({
+      'noReset': true
+    }, desired)).then(function (d) { driver = d; });
+
+    beforeEach(function (done) {
+      loadWebView(desired, driver).nodeify(done);
+    });
+
+    it('should not be able to do native touch actions', function (done) {
+      driver
+        .elementById('comments')
+          .then(function (el) {
+            var action = new TouchAction(driver);
+            action.tap({
+              el: el,
+              count: 10
+            });
+            return action.perform();
+          })
+        .should.be.rejectedWith("status: 13")
+        .nodeify(done);
+    });
+
+    it('should not be able to do native multi touch actions', function (done) {
+      driver
+        .elementById('comments')
+          .then(function (el) {
+            var action = new TouchAction(driver);
+            action.tap({
+              el: el,
+              count: 10
+            });
+            var ma = new MultiAction(driver);
+            ma.add(action, action);
+            return ma.perform();
+          })
+        .should.be.rejectedWith("status: 13")
+        .nodeify(done);
+    });
+  });
+};

--- a/test/functional/ios/safari/webview/touch-specs.js
+++ b/test/functional/ios/safari/webview/touch-specs.js
@@ -1,0 +1,6 @@
+"use strict";
+var desired = require('./desired');
+
+describe("safari - webview @skip-ios6", function () {
+  require('../../../common/webview/touch-base')(desired);
+});


### PR DESCRIPTION
When the touch actions or multi touch actions are called outside of a native context, return `not yet implemented` error. Resolves #3518.
