### PR TITLE
Don't try to call 'kill' on null procs.

### DIFF
--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -97,7 +97,9 @@ IosLog.prototype.finishStartingLogCapture = function (cb) {
 
 IosLog.prototype.stopCapture = function () {
   logger.debug("Stopping iOS log capture");
-  this.proc.kill();
+  if (this.proc) {
+    this.proc.kill();
+  }
   this.proc = null;
 };
 


### PR DESCRIPTION
When iOS log capture has been unsuccessful, attempting to kill the proc
doing the capture crashes Appium.

This isn't nice.
