### PR TITLE
allow native safari automation on real devices >= 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "appium-adb": "~1.3.15",
     "appium-atoms": "~0.0.5",
     "appium-instruments": "~1.4.2",
-    "appium-uiauto": "~1.7.2",
+    "appium-uiauto": "~1.7.4",
     "argparse": "~0.1.15",
     "async": "~0.9.0",
     "binary-cookies": "~0.1.1",


### PR DESCRIPTION
turns out maybe it was only 6.x that didn't allow us to do this - fix #3331

also, create a mode where if we expect instruments to exit, we don't try to
connect the bootstrap to the command proxy, avoiding error crashes
- fix #3539, fix #3397 

this depends on https://github.com/appium/appium-uiauto/pull/49
