### PR TITLE
Use correct port for getting window_handles on Selendroid.

### DIFF
--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -503,7 +503,7 @@ Selendroid.prototype.getContexts = function (cb) {
     }
 
     var selendroidViews = [];
-    var reqUrl = this.proxyHost + ':' + this.proxyPort + '/wd/hub/session/' + this.selendroidSessionId;
+    var reqUrl = this.proxyHost + ':' + this.selendroidPort + '/wd/hub/session/' + this.selendroidSessionId;
     doRequest(reqUrl + '/window_handles', 'GET', {}, null, function (err, res) {
       if (err) return cb(err);
       selendroidViews = JSON.parse(res.body).value;


### PR DESCRIPTION
Fix for a bug on Selendroid backend  where `driver.contexts` fails
after switching to `CHROMIUM` context.

Here's what this bug is about:

``` python
In [1]: opera.driver.contexts
Out[1]: [u'NATIVE_APP', u'CHROMIUM']

In [2]: opera.switch_to_webview()

In [3]: opera.driver.contexts
Out[3]: 
[{u'message': u'no such session\n  (Driver info: OperaDriver=0.1.289193,platform=Linux 3.13.0-33-generic x86_64)'},
 u'CHROMIUM']
```
