### PR TITLE
add userAgent reporting

### DIFF
--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -149,6 +149,8 @@ exports.createSession = function (req, res) {
     req.body = JSON.parse(req.body);
   }
 
+  logger.info('Client User-Agent string:', req.headers['user-agent']);
+
   var next = function (reqHost, sessionId) {
     safely(req, function () {
       res.set('Location', "http://" + reqHost + "/wd/hub/session/" + sessionId);


### PR DESCRIPTION
@bootstraponline and I went ahead and added the mvp of client reporting: adding info to the useragent on JSONWP requests.

just `author/libraryName/version`

Now appium reports the useragent string on session requests, so we can better debug from user-supplied logs.

see:
https://github.com/admc/wd/pull/342
 appium/ruby_lib@af6d44c
