### PR TITLE
Handle hint text when setting text in Android

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
@@ -46,7 +46,10 @@ public class SetText extends CommandHandler {
         String currText = el.getText();
         new Clear().execute(command);
         if (!el.getText().isEmpty()) {
-          Logger.debug("clearText not successful, continuing with setText anyway");
+          // clear could have failed, or we could have a hint in the field
+          // we'll assume it is the latter
+          Logger.debug("Text not cleared. Assuming remainder is hint text.");
+          currText = "";
         }
         if (!replace) {
           text = currText + text;


### PR DESCRIPTION
Fix issue where hint text is prepended to text being set in an EditText field. Also clean up `Clear` logic. 

`Clear` will still fail when there is hint text, since even after doing everything to clear the text, the `getText` method gets the hint text. There is, therefore, no way to distinguish a failure to clear, and the presence of the hint text. It's unfortunate that there is no way to get the underlying `EditText` object from the `UIObject`.
