### PR TITLE
URGENT QFE: Fix for app breaking regression in android.js

### DIFF
--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -123,7 +123,7 @@ Android.prototype.start = function (cb, onDie) {
     this.unlockScreen.bind(this),
     this.getDataDir.bind(this),
     this.setupCompressedLayoutHierarchy.bind(this),
-    this.startApp.bind(this),
+    this.startAppUnderTest.bind(this),
     this.initAutoWebview.bind(this)
   ], function (err) {
     if (err) {


### PR DESCRIPTION
Not sure how this happened, but the latest code breaks all Android device tests.  Here's the fix.
