### PR TITLE
Refactor Settings update

### DIFF
--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -72,14 +72,14 @@ Android.prototype.init = function () {
   , ['GET', new RegExp('^/wd/hub/session/[^/]+/appium')]
   ];
 
-  // listen for changes to ignoreUnimportantViews
-  this.settings.on("update", function (update) {
-    if (update.key === "ignoreUnimportantViews") {
-      this.setCompressedLayoutHierarchy(update.value, update.callback);
+  // listen for changes to the settings object
+  this.settings.onPropertyChanged = function (propName, value, cb) {
+    if (propName === "ignoreUnimportantViews") {
+      this.setCompressedLayoutHierarchy(value, cb);
     } else {
-      update.callback();
+      cb();
     }
-  }.bind(this));
+  }.bind(this);
 };
 
 Android.prototype._deviceConfigure = Device.prototype.configure;
@@ -413,8 +413,6 @@ Android.prototype.stop = function (cb) {
   } else {
     completeShutdown(cb);
   }
-
-
 };
 
 Android.prototype.cleanup = function () {
@@ -519,17 +517,15 @@ Android.prototype.getDataDir = function (cb) {
 
 // Set CompressedLayoutHierarchy on the device based on current settings object
 Android.prototype.setupCompressedLayoutHierarchy = function (cb) {
-
-  // setup using cap
+  // setup using cap if present, else use default value
   if (_.has(this.args, 'ignoreUnimportantViews')) {
-    // set the setting directly on the internal _settings object, this way we don't trigger an update event
-    this.settings._settings.ignoreUnimportantViews = this.args.ignoreUnimportantViews;
+    // setCompressedLayoutHierarchy will be fired by the this.settings.onPropertyChanged
+    // delegate if the new ignoreUnimportantViews value differs from the default
+    this.settings.update({'ignoreUnimportantViews': this.args.ignoreUnimportantViews}, cb);
+  } else {
+    // nothing to do, will use default settings
+    cb();
   }
-
-  if (_.isUndefined(this.getSetting("ignoreUnimportantViews"))) {
-    return cb();
-  }
-  this.setCompressedLayoutHierarchy(this.getSetting("ignoreUnimportantViews"), cb);
 };
 
 // Set CompressedLayoutHierarchy on the device
@@ -541,12 +537,9 @@ Android.prototype.waitForActivityToStop = function (cb) {
   this.adb.waitForNotActivity(this.args.appWaitPackage, this.args.appWaitActivity, cb);
 };
 
-
 Android.prototype.resetTimeout = deviceCommon.resetTimeout;
 Android.prototype.waitForCondition = deviceCommon.waitForCondition;
 Android.prototype.implicitWaitForCondition = deviceCommon.implicitWaitForCondition;
-Android.prototype.getSettings = deviceCommon.getSettings;
-Android.prototype.updateSettings = deviceCommon.updateSettings;
 
 _.extend(Android.prototype, androidController);
 _.extend(Android.prototype, androidContextController);

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -74,9 +74,6 @@ Selendroid.prototype.init = function () {
   this.curContext = this.defaultContext();
 };
 
-Selendroid.prototype.getSettings = deviceCommon.getSettings;
-Selendroid.prototype.updateSettings = deviceCommon.updateSettings;
-
 _.extend(Selendroid.prototype, androidCommon);
 Selendroid.prototype._deviceConfigure = Device.prototype.configure;
 Selendroid.prototype._setAndroidArgs = androidCommon.setAndroidArgs;

--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -347,32 +347,3 @@ exports.jwpResponse = function (err, val, cb) {
   }
   return exports.jwpSuccess(val, cb);
 };
-
-// methods for appium session Settings
-// These should really be on a Session object instead of the Device, but Sessions don't exist yet
-exports.getSettings = function (cb) {
-  if (!this.settings) {
-    return cb(new UnknownError('No settings object for session'));
-  }
-
-  return cb(null, {
-    status: status.codes.Success.code
-  , value: this.settings._settings
-  });
-};
-
-// settings passed in update matching keys in existing settings object, create if not present.
-exports.updateSettings = function (newSettings, cb) {
-  if (!this.settings) {
-    return cb(new UnknownError('No settings object for session'));
-  }
-  this.settings.update(newSettings, function (err) {
-    if (err) {
-      return cb(new UnknownError('err updating setting: ' + err));
-    }
-    return cb(null, {
-      status: status.codes.Success.code
-    , value: null
-    });
-  });
-};

--- a/lib/devices/device-settings.js
+++ b/lib/devices/device-settings.js
@@ -1,64 +1,73 @@
 "use strict";
 
-var EventEmitter = require('events').EventEmitter
-  , CamelBackPromise = require('camel-back-promise') // The straw that breaks the camels back. Instantiate by passing in a deferred promise and a number n. After the CamelBackPromise is called n times, the deferred promise is resolved.
-  , _ = require('underscore')
-  , Q = require('q')
-  ;
+var SUCCESS_CODE = require('../server/status.js').codes.Success.code;
 
-// EventEmitter which emits an 'update' event every time a setting is changed. One call to "updateSettings" could trigger multiple update events.
-// The value of the event is a tuple: {key, value, oldValue, callback}.
-// Any listeners *MUST* call the function stored in 'callback' to tell the appium server that it it can continue to take commands. This is to prevent race conditions between enabling a setting and calling the next command.
-// `callback` is a node-style callback, so passing an argument will cause the updateSettings command to throw an error. Note that the setting still gets changed, even if the subscriber doesn't affect the change. It's up to the client to resolve this case.
-var DeviceSettings = function () {
-  this.init();
-};
+// private container that encapsulates settings; declare default values here
+var _settings = {'ignoreUnimportantViews': false};
 
-_.extend(DeviceSettings.prototype, EventEmitter.prototype);
+// Ctor
+var DeviceSettings = function () { };
 
-DeviceSettings.prototype.init = function () {
+// Setting this delegate allows a listener to hook property changes.
+// Delegate signature: func (propName, value, cb) { ... }
+DeviceSettings.prototype.onPropertyChanged = null;
 
-  this._settings = {};
-
-  // this is where default settings can be declared
-  this._settings.ignoreUnimportantViews = false;
-};
-
-DeviceSettings.prototype.update = function (newSettings, cb) {
-  // if this code looks familiar, it's because it's modified from the underscore.js implementation of `extend`
-  if (!_.isObject(newSettings)) {
-    cb();
+// Sets error, 'value', and 'status' data and returns it via client callback
+var _doCallback = function (val, err, cb) {
+  // assert(cb);
+  if (err) {
+    return cb(err);
   }
-  var numListeners = this.listeners("update").length;
 
-  var prop;
-  var pendingUpdates = [];
+  return cb(null, {
+    status: SUCCESS_CODE
+    , value: val
+  });
+};
 
-  for (prop in newSettings) {
-    if (hasOwnProperty.call(newSettings, prop)) {
-      var deferred = Q.defer();
-      pendingUpdates.push(deferred.promise);
+// Set the settings collection asynchronously and invoke the cb when all operations complete
+DeviceSettings.prototype.set = function (newSettings, cb) {
 
-      var updatePayload = {
-        key: prop,
-        value: newSettings[prop],
-        oldValue: this._settings[prop],
-        callback: new CamelBackPromise(deferred, numListeners)
-      };
+  // remaining async operations to complete
+  var remainingOperations = 0;
+  // the first error encountered; could handle multiple error msgs if needed
+  var delegateErr = null;
 
-      this._settings[prop] = newSettings[prop];
-      this.emit("update", updatePayload);
+  var onComplete = function (err) {
+    if (err && !delegateErr) {
+      delegateErr = err;
+    }
+
+    if (--remainingOperations === 0) {
+      _doCallback(null, delegateErr, cb);
+    }
+  };
+
+  for (var propName in newSettings) {
+    var propertyChanged = _settings[propName] !== newSettings[propName];
+    _settings[propName] = newSettings[propName];
+
+    // if a property has changed and there is a listener, notify the listener
+    if (propertyChanged && this.onPropertyChanged) {
+      ++remainingOperations;
+      this.onPropertyChanged(propName, _settings[propName], onComplete);
     }
   }
 
-  Q.all(pendingUpdates).then(
-    function () {
-      return cb();
-    },
-    function (err) {
-      return cb(err);
-    }
-  );
+  if (remainingOperations === 0) {
+    // no changes were required
+    _doCallback(null, null, cb);
+  }
+};
+
+// Get the setting collection via callback
+DeviceSettings.prototype.get = function (cb) {
+  _doCallback(_settings, null, cb);
+};
+
+// Get a single setting
+DeviceSettings.prototype.getSetting = function (settingName) {
+  return _settings[settingName];
 };
 
 module.exports = DeviceSettings;

--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -172,9 +172,4 @@ Device.prototype.downloadAndUnzipApp = function (appUrl, cb) {
   }.bind(this));
 };
 
-// get a specific setting
-Device.prototype.getSetting = function (str) {
-  return this.settings._settings[str];
-};
-
 module.exports = Device;

--- a/lib/devices/firefoxos/firefoxos.js
+++ b/lib/devices/firefoxos/firefoxos.js
@@ -163,14 +163,11 @@ Firefox.prototype.receive = function (data) {
 };
 
 Firefox.prototype.proxy = deviceCommon.proxy;
-Firefox.prototype.getSettings = deviceCommon.getSettings;
-Firefox.prototype.updateSettings = deviceCommon.updateSettings;
 
 Firefox.prototype.push = function (elem) {
   this.queue.push(elem);
   this.executeNextCommand();
 };
-
 
 Firefox.prototype.respond = function (data, cb) {
   if (typeof data.error !== "undefined") {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1346,8 +1346,6 @@ IOS.prototype.implicitWaitForCondition = deviceCommon.implicitWaitForCondition;
 IOS.prototype.proxy = deviceCommon.proxy;
 IOS.prototype.proxyWithMinTime = deviceCommon.proxyWithMinTime;
 IOS.prototype.respond = deviceCommon.respond;
-IOS.prototype.getSettings = deviceCommon.getSettings;
-IOS.prototype.updateSettings = deviceCommon.updateSettings;
 
 IOS.prototype.initQueue = function () {
 

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -1188,12 +1188,12 @@ exports.setNetworkConnection = function (req, res) {
 };
 
 exports.getSettings = function (req, res) {
-  req.device.getSettings(getResponseHandler(req, res));
+  req.device.settings.get(getResponseHandler(req, res));
 };
 
 exports.updateSettings = function (req, res) {
   var settings = req.body.settings || req.body.parameters.settings;
   if (checkMissingParams(req, res, {settings: settings})) {
-    req.device.updateSettings(settings, getResponseHandler(req, res));
+    req.device.settings.set(settings, getResponseHandler(req, res));
   }
 };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "bplist-parser": "~0.0.5",
     "bufferpack": "0.0.6",
     "bytes": "~1.0.0",
-    "camel-back-promise": "^1.0.0",
     "colors": "~0.6.2",
     "date-utils": "~1.2.15",
     "difflib": "~0.2.4",


### PR DESCRIPTION
@Jonahss settings changes touched off a 31 message exchange of chunky emails between Jonathan and me.  He helped me better understand Jonah's changes within the context of Node.  There were two major results from that discussion:
1. I see now that Jonah did all the right things; and,
2. I believe that my concerns can be resolved by refining Jonah's approach rather than supplanting it.

As I worked through the code with jlipp's help, the refactoring I did looked more and more like Jonah's solution.  However, I've been able to simplify things in several ways:
1. I encapsulated all the settings-related logic in the DeviceSettings object. This allowed me to remove the repetitive references to "get/updateSettings" from the various devices.
2. Encapsulation also helped me make updating settings more straightforward.  There's no need to worry about when to use `settings.update` vs `settings._settings`. There's only `settings.set` (well, there is a non-obvious way using `get`, but I won't get into that). 
3. In roughly the same amount of code that Jonah had written for DeviceSettings, I was able to provide the same functionality without using the EventEmitting class or Q or any other library.  The code I have works very similarly to EventEmitter, but it's less abstract, provides the functionality we need and nothing more, and requires a lot less code in aggregate.

Take a gander and let me know.  I'm hoping it's an "everybody is happy" solution. 
