### PR TITLE
Made ios hideKeyboard function more robust; Fix for #2930

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -3,7 +3,6 @@ var uuid = require('uuid-js')
   , path = require('path')
   , fs = require('fs')
   , async = require('async')
-  , path = require('path')
   , _ = require('underscore')
   , exec = require('child_process').exec
   , status = require("../../server/status.js")
@@ -1422,11 +1421,21 @@ iOSController.setLocation = function (latitude, longitude, altitude, horizontalA
 };
 
 iOSController.hideKeyboard = function (strategy, key, cb) {
-  this.proxy("au.hideKeyboard(" +
-    "'" + strategy + "'" +
-    (key ? ",'" + key + "'" : "") +
-    ")",
-  cb);
+  /*jshint multistr: true */
+  var proxyScript = " \
+    if (!au.mainApp().keyboard().isNil()) { \
+      au.hideKeyboard('@@strategy@@', '@@keyname@@'); \
+      var interval = 50, t = 0; \
+      while(t < 3000 && !au.mainApp().keyboard().isNil()) { \
+        t += interval; \
+        au.delay(interval); \
+      } \
+      if (!au.mainApp().keyboard().isNil()) { \
+        throw new Error('Failed to hide keyboard.'); \
+      } \
+    };".replace(/@@strategy@@/g, strategy).replace(/@@keyname@@/g, key || '');
+
+  this.proxy(proxyScript, cb);
 };
 
 iOSController.url = function (url, cb) {

--- a/test/functional/ios/testapp/clear-specs.js
+++ b/test/functional/ios/testapp/clear-specs.js
@@ -49,5 +49,4 @@ describe('testapp - clear', function () {
 
       .nodeify(done);
   });
-
 });


### PR DESCRIPTION
I wasn't able to get all of @bootstraponline's suggestions implemented, namely this little bit:

```
 var key = au.mainApp().keyboard().buttons()['<somekeyname>']
if (key.isNil()) {
var startY = au.mainApp().keyboard().rect().origin.y - 10;
var endY = au.mainWindow().rect().size.height - 10;
au.flickApp(0, startY, 0, endY);
} else {
key.tap();
}
```

Whenever I provided a bogus button name, I'd get a 'selenium failed to find the element' error.  I spent some time debugging it, but after talking to @jlipps, we decided to stop for now with the work I confirmed was passing tests.  We can create a ticket to get this final piece working if we need to.
