### PR TITLE
Move autoAcceptAlerts to bootstrap env

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -355,7 +355,8 @@ IOS.prototype.makeInstruments = function (cb) {
   prepareBootstrap({
     sock: this.sock,
     interKeyDelay: this.args.interKeyDelay,
-    justLoopInfinitely: this.shouldIgnoreInstrumentsExit()
+    justLoopInfinitely: this.shouldIgnoreInstrumentsExit(),
+    autoAcceptAlerts: !(!this.args.autoAcceptAlerts || this.args.autoAcceptAlerts === 'false')
   }).then(
     function (bootstrapPath) {
       var instruments = new Instruments({
@@ -431,13 +432,11 @@ IOS.prototype.setInitialOrientation = function (cb) {
 
 IOS.prototype.configureBootstrap = function (cb) {
   logger.debug("Setting bootstrap config keys/values");
-  var autoAcceptAlerts = !(!this.args.autoAcceptAlerts || this.args.autoAcceptAlerts === 'false');
   var isVerbose = logger.transports.console.level === 'debug';
   var cmd = '';
   cmd += 'target = $.target();\n';
   cmd += 'au = $;\n';
   cmd += '$.isVerbose = ' + isVerbose + ';\n';
-  cmd += 'autoAcceptAlerts = ' + autoAcceptAlerts + ';\n';
   // Not using uiauto grace period because of bug.
   // cmd += '$.target().setTimeout(1);\n';
   this.proxy(cmd, cb);


### PR DESCRIPTION
Rather than send `autoAcceptAlerts` as a configuration parameter, move it to a little earlier in the dynamic bootstrap code, so that it can catch as many early alerts (e.g., the elusive location alert) as possible. appium-uiauto code already in place.
