### PR TITLE
Simplify calculation of device type

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -129,25 +129,16 @@ Appium.prototype.start = function (desiredCaps, cb) {
 };
 
 Appium.prototype.getDeviceType = function (args, caps) {
-  // TODO: 'deviceName' and 'platformName' caps are now required, so the majority of this code could be removed
-  var type =  this.getDeviceFromMJSONWP(args, caps) ||
-              this.getDeviceTypeFromArgsOrNamedApp(args, caps) ||
-              this.getDeviceTypeFromAppOrPackage(args, caps);
-  if (type) {
-    return type;
-  }
-  throw new Error("Could not determine your device from Appium arguments " +
-                "or desired capabilities. Please make sure to specify the " +
-                "'deviceName' and 'platformName' capabilities");
-};
-
-Appium.prototype.getDeviceFromMJSONWP = function (args, caps) {
   var platform = caps.platformName || args.platformName;
   platform = platform ? platform.toString().toLowerCase() : '';
   var browser = caps.browserName || args.browserName;
   browser = browser ? browser.toString().toLowerCase() : '';
   var automation = caps.automationName || args.automationName;
   automation = automation ? automation.toString().toLowerCase() : '';
+  var app = args.app || caps.app;
+  app = app ? app.toString().toLowerCase() : '';
+  var pkg = args.androidPackage || caps.appPackage;
+  pkg = pkg ? pkg.toString().toLowerCase() : '';
 
   var validPlatforms = ['ios', 'android', 'firefoxos'];
   if (platform && !_.contains(validPlatforms, platform)) {
@@ -156,43 +147,62 @@ Appium.prototype.getDeviceFromMJSONWP = function (args, caps) {
                     "is not a supported platform. Supported platforms are: " +
                     "iOS, Android and FirefoxOS");
   }
-  var type =  this.getDeviceTypeFromAutomationName(automation) ||
-              this.getDeviceTypeFromBrowserName(browser) ||
-              this.getDeviceTypeFromPlatformCap(platform);
-  if (type) return type;
-};
 
-Appium.prototype.getDeviceTypeFromArgsOrNamedApp = function (args, caps) {
-  var app = args.app || caps.app;
-  app = app ? app.toString().toLowerCase() : '';
-  var type = this.getDeviceTypeFromNamedApp(app) ||
-             this.getDeviceTypeFromArgs(args);
-  if (type) return type;
-};
-
-Appium.prototype.getDeviceTypeFromAppOrPackage = function (args, caps) {
-  var app = args.app || caps.app;
-  app = app ? app.toString().toLowerCase() : '';
-  var pkg = args.androidPackage || caps.appPackage;
-  pkg = pkg ? pkg.toString().toLowerCase() : '';
-  var type =  this.getDeviceTypeFromApp(app) ||
-              this.getDeviceTypeFromPackage(pkg);
-  if (type) return type;
-};
-
-Appium.prototype.getDeviceTypeFromAutomationName = function (automation) {
-  if (automation.indexOf('selendroid') !== -1) return DT_SELENDROID;
-};
-
-Appium.prototype.getDeviceTypeFromBrowserName = function (browser) {
-  if (browser === "safari") {
-    return DT_SAFARI;
-  } else if (_.contains(["chrome", "chromium", "chromebeta", "browser"], browser)) {
-    return DT_CHROME;
+  // TODO: Set DT_SELENDROID type based on platformVersion
+  var type = this.getDeviceTypeFromPlatform(platform);
+  if (type === DT_ANDROID) {
+    // Detect Chrome browser from browserName, app and pkg
+    if (
+        this.isChromeBrowser(browser) ||
+        this.isChromeBrowser(app) ||
+        this.isChromePackage(pkg)
+      ) {
+      type = DT_CHROME;
+    } else if (this.isSelendroidAutomation(automation)) {
+      type = DT_SELENDROID;
+    }
+  } else if (type === DT_IOS) {
+    // Detect Safari browser from browserName, app and args
+    if (
+        args.safari ||
+        this.isSafariBrowser(browser) ||
+        this.isSafariBrowser(app)
+      ) {
+      type = DT_SAFARI;
+    }
   }
+
+  if (!type) {
+    throw new Error("Could not determine your device from Appium arguments " +
+                  "or desired capabilities. Please make sure to specify the " +
+                  "'deviceName' and 'platformName' capabilities");
+  }
+  return type;
 };
 
-Appium.prototype.getDeviceTypeFromPlatformCap = function (caps) {
+Appium.prototype.isSelendroidAutomation = function (automation) {
+  return automation.indexOf('selendroid') !== -1;
+};
+
+Appium.prototype.isChromeBrowser = function (browser) {
+  return _.contains(["chrome", "chromium", "chromebeta", "browser"], browser);
+};
+
+Appium.prototype.isChromePackage = function (pkg) {
+  var chromePkgs = [
+    "com.android.chrome"
+  , "com.chrome.beta"
+  , "org.chromium.chrome.shell"
+  , "com.android.browser"
+  ];
+  return _.contains(chromePkgs, pkg);
+};
+
+Appium.prototype.isSafariBrowser = function (browser) {
+  return browser === "safari";
+};
+
+Appium.prototype.getDeviceTypeFromPlatform = function (caps) {
   var device = null;
   switch (caps) {
   case 'ios':
@@ -206,63 +216,6 @@ Appium.prototype.getDeviceTypeFromPlatformCap = function (caps) {
     break;
   }
   return device;
-};
-
-Appium.prototype.getDeviceTypeFromDeviceCap = function (device) {
-
-  if (device.indexOf('iphone') !== -1) {
-    return DT_IOS;
-  } else if (device.indexOf('ipad') !== -1) {
-    return DT_IOS;
-  } else if (device.indexOf('selendroid') !== -1) {
-    return DT_SELENDROID;
-  } else if (device.indexOf('firefox') !== -1) {
-    return DT_FIREFOX_OS;
-  } else if (device.indexOf('android') !== -1) {
-    return DT_ANDROID;
-  }
-};
-
-Appium.prototype.getDeviceTypeFromNamedApp = function (app) {
-  if (app  === "safari") {
-    return DT_SAFARI;
-  } else if (app === "settings") {
-    return DT_IOS;
-  } else if (_.contains(["chrome", "chromium", "chromebeta", "browser"], app)) {
-    return DT_CHROME;
-  }
-};
-
-Appium.prototype.getDeviceTypeFromApp = function (app) {
-  if (/\.app$/.test(app) || /\.app\.zip$/.test(app)) {
-    return DT_IOS;
-  } else if (/\.apk$/.test(app) || /\.apk\.zip$/.test(app)) {
-    return DT_ANDROID;
-  }
-};
-
-Appium.prototype.getDeviceTypeFromPackage = function (pkg) {
-  var chromePkgs = [
-    "com.android.chrome"
-  , "com.chrome.beta"
-  , "org.chromium.chrome.shell"
-  , "com.android.browser"
-  ];
-  if (_.contains(chromePkgs, pkg)) {
-    return DT_CHROME;
-  } else if (pkg) {
-    return DT_ANDROID;
-  }
-};
-
-Appium.prototype.getDeviceTypeFromArgs = function (args) {
-  if (args.ipa && /\.ipa$/.test(args.ipa.toString().toLowerCase())) {
-    return DT_IOS;
-  } else if (args.safari) {
-    return DT_SAFARI;
-  } else if (args.forceIphone || args.forceIpad) {
-    return DT_IOS;
-  }
 };
 
 Appium.prototype.configure = function (args, desiredCaps, cb) {

--- a/test/unit/configuration-specs.js
+++ b/test/unit/configuration-specs.js
@@ -16,10 +16,10 @@ describe('Appium', function () {
     // test is [args, caps, device]
     var appium = getAppium({});
     describe('mjsonwp spec capabilities', function () {
-      describe('deviceName', function () {
+      describe('platformName', function () {
 
         var deviceCapabilities = [
-            [{}, {platformName: 'iOS'}, 'ios'],
+            [{}, {platformName: 'iOS'}, 'ios']
           , [{}, {platformName: 'Android'}, 'android']
           , [{}, {platformName: 'FirefoxOS'}, 'firefoxos']
           , [{platformName: 'Android'}, {}, 'android']
@@ -41,6 +41,8 @@ describe('Appium', function () {
           , [{}, {platformName: 'Android', browserName: 'browser'}, 'chrome']
           , [{browserName: 'browser'}, {platformName: 'Android'}, 'chrome']
           , [{browserName: 'Safari'}, {platformName: 'ios'}, 'safari']
+          , [{browserName: 'browser'}, {platformName: 'ios'}, 'ios']
+          , [{browserName: 'Safari'}, {platformName: 'android'}, 'android']
           ];
         _.each(browserCapabilities, function (test) {
           assertCapsGiveCorrectDevices(appium, test);
@@ -64,57 +66,46 @@ describe('Appium', function () {
     describe('non compliant capabilitites using', function () {
       describe('argument cases', function () {
         var argsCases  = [
-          [{ipa: '/path/to/my.ipa'}, {}, 'ios']
-        , [{ipa: '/path/to/MY.IPA'}, {}, 'ios']
-        , [{forceIphone: true}, {}, 'ios']
-        , [{forceIpad: true}, {}, 'ios']
-        , [{ipa: '/path/to/my.ipa', safari: true}, {}, 'ios']
-        , [{safari: true}, {}, 'safari']
-        , [{safari: true}, {app: '/path/to/my.apk'}, 'safari']
-        , [{safari: false}, {app: 'safari'}, 'safari']
-        , [{forceIpad: true}, {app: 'safari'}, 'safari']
+          [{platformName: 'ios', safari: true}, {}, 'safari']
+        , [{platformName: 'ios', safari: true}, {app: 'chrome'}, 'safari']
+        , [{platformName: 'ios', safari: false}, {app: 'safari'}, 'safari']
         ];
         _.each(argsCases, function (test) {
           assertCapsGiveCorrectDevices(appium, test);
         });
       });
 
-      describe('app capabilities', function () {
+      describe('app arguments and capabilities', function () {
         var appCases = [
-          [{}, {app: 'Safari'}, 'safari']
-        , [{}, {app: 'settings'}, 'ios']
-        , [{}, {app: 'Settings'}, 'ios']
-        , [{}, {app: 'chrome'}, 'chrome']
-        , [{}, {app: 'chromium'}, 'chrome']
-        , [{}, {app: 'chromebeta'}, 'chrome']
-        , [{}, {app: 'browser'}, 'chrome']
-        , [{}, {app: 'http://www.site.com/my.app.zip'}, 'ios']
-        , [{}, {app: 'http://www.site.com/MY.APP.ZIp'}, 'ios']
-        , [{}, {app: 'http://www.site.com/my.apk.zip'}, 'android']
-        , [{}, {app: 'http://www.site.com/my.apk'}, 'android']
-        , [{}, {app: 'HTTP://WWW.Site.COM/MY.APk'}, 'android']
-        , [{}, {app: '/path/to/my.app'}, 'ios']
-        , [{}, {app: '/path/to/my.apk'}, 'android']
-        , [{}, {app: '/path/to/my.apk'}, 'android']
-        , [{}, {app: '/path/to/my.apk.app'}, 'ios']
-        , [{}, {app: '/path/to/my.app.apk'}, 'android']
+          [{}, {platformName: 'ios', app: 'safari'}, 'safari']
+        , [{platformName: 'ios', app: 'Safari'}, {}, 'safari']
+        , [{}, {platformName: 'ios', app: 'settings'}, 'ios']
+        , [{}, {platformName: 'ios', app: 'lol'}, 'ios']
+        , [{}, {platformName: 'android', app: 'chrome'}, 'chrome']
+        , [{}, {platformName: 'android', app: 'chromium'}, 'chrome']
+        , [{}, {platformName: 'android', app: 'chromebeta'}, 'chrome']
+        , [{}, {platformName: 'android', app: 'browser'}, 'chrome']
+        , [{platformName: 'android', app: 'Chrome'}, {}, 'chrome']
+        , [{}, {platformName: 'android', app: 'lol'}, 'android']
+        , [{platformName: 'ios', app: 'chrome'}, {}, 'ios']
         ];
         _.each(appCases, function (test) {
           assertCapsGiveCorrectDevices(appium, test);
         });
       });
-    });
 
-    describe('package arguments and capabilities', function () {
-      var packageCases = [
-        [{}, {appPackage: 'com.android.chrome'}, 'chrome']
-      , [{}, {appPackage: 'Com.Android.Chrome'}, 'chrome']
-      , [{}, {appPackage: 'lol'}, 'android']
-      , [{androidPackage: 'com.foo'}, {}, 'android']
-      , [{androidPackage: 'com.android.browser'}, {}, 'chrome']
-      ];
-      _.each(packageCases, function (test) {
-        assertCapsGiveCorrectDevices(appium, test);
+      describe('package arguments and capabilities', function () {
+        var packageCases = [
+          [{}, {platformName: 'android', appPackage: 'com.android.chrome'}, 'chrome']
+        , [{}, {platformName: 'android', appPackage: 'Com.Android.Chrome'}, 'chrome']
+        , [{}, {platformName: 'android', appPackage: 'lol'}, 'android']
+        , [{platformName: 'android', androidPackage: 'com.foo'}, {}, 'android']
+        , [{platformName: 'android', androidPackage: 'com.android.browser'}, {}, 'chrome']
+        , [{platformName: 'ios', androidPackage: 'com.android.browser'}, {}, 'ios']
+        ];
+        _.each(packageCases, function (test) {
+          assertCapsGiveCorrectDevices(appium, test);
+        });
       });
     });
   });


### PR DESCRIPTION
The problem is that using current code it is not possible to configure Appium as a Selenium node using this configuration:

``` js
{
  "capabilities":
      [
        {
          "browserName": "iOS",
          "version":"7.0",
          "maxInstances": 1,
          "platform":"MAC"
        }
      ],
  "configuration": {}
}
```

And then launch Safari browser using this capabilities (and there is no another way to do it either).

``` js
{
  browserName: 'iOS',
  version: '7.1',
  platform: 'MAC',
  platformName: 'iOS',
  platformVersion: '7.1',
  deviceName: 'iPhone Simulator',
  app: 'Safari'
}
```
