### PR TITLE
[1.2.x] Move builtin Safari app to a new name containing SDK version

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -149,7 +149,7 @@ exports.unzipApp = function (zipPath, appExt, cb) {
 
 exports.checkBuiltInApp = function (appName, version, tmpDir, cb) {
   logger.debug("Looking for built in app " + appName);
-  var newAppDir = path.resolve(tmpDir, 'Appium-' + appName + '.app');
+  var newAppDir = path.resolve(tmpDir, 'Appium-' + appName + '-' + version + '.app');
   var checkApp = function (s, appPath, cb) {
     if (!s.isDirectory()) {
       cb(new Error("App package was not a directory"), appPath);


### PR DESCRIPTION
This is needed because we need an ability to launch 7.0 and 7.1 on the same machine. There could be situations when `MobileSafari.app` from 7.0 was left in the temp directory and we are launching 7.1.
