### PR TITLE
[1.3.x] Move builtin Safari app to a new name containing SDK version

### DIFF
--- a/lib/devices/ios/simulator.js
+++ b/lib/devices/ios/simulator.js
@@ -137,7 +137,7 @@ Simulator.prototype.getAppDirs = function (appFile, appBundleId) {
 };
 
 Simulator.prototype.getSafari7Dirs = function () {
-  return this.getApp7Dirs(["MobileSafari.app", "Appium-MobileSafari.app"]);
+  return this.getApp7Dirs(["MobileSafari.app", "Appium-MobileSafari-" + this.platformVer + ".app"]);
 };
 
 Simulator.prototype.getApp7Dirs = function (appFiles) {
@@ -345,7 +345,7 @@ Simulator.prototype.getBuiltInApp = function (appName, cb) {
 
 Simulator.prototype.prepareBuiltInApp = function (appName, tmpDir, cb) {
   logger.debug("Looking for built in app " + appName);
-  var newAppDir = path.resolve(tmpDir, 'Appium-' + appName + '.app');
+  var newAppDir = path.resolve(tmpDir, 'Appium-' + appName + '-' + this.platformVer + '.app');
   var checkApp = function (s, appPath, cb) {
     if (!s.isDirectory()) {
       cb(new Error("App package was not a directory"), appPath);


### PR DESCRIPTION
This is needed because we need an ability to launch 7.0 and 7.1 on the same machine. There could be situations when `MobileSafari.app` from 7.0 was left in the temp directory and we are launching 7.1.
