### PR TITLE
Fixed incorrect arguments in lock-specs.js that were causing tests to fail

### DIFF
--- a/test/functional/android/apidemos/lock-specs.js
+++ b/test/functional/android/apidemos/lock-specs.js
@@ -9,25 +9,25 @@ describe("apidemos - lock", function () {
 
   it('should lock the screen', function (done) {
     driver
-        .lockDevice({seconds: 3})
+        .lockDevice(3)
         .nodeify(done);
   });
   it('should know it\'s locked', function (done) {
     driver
-        .lockDevice({seconds: 3})
+        .lockDevice(3)
         .isLocked()
         .should.eventually.equal(true)
         .nodeify(done);
   });
   it('should unlock the screen', function (done) {
     driver
-        .lockDevice({seconds: 3})
+        .lockDevice(3)
         .unlockDevice()
         .nodeify(done);
   });
   it('should know it\'s unlocked', function (done) {
     driver
-        .lockDevice({seconds: 3})
+        .lockDevice(3)
         .unlockDevice()
         .isLocked()
         .should.eventually.equal(false)


### PR DESCRIPTION
Was passing the wrong parameter type.
