### PR TITLE
Make sure we skip UICatalog tests in iOS 6

### DIFF
--- a/test/functional/ios/uicatalog/stability-specs.js
+++ b/test/functional/ios/uicatalog/stability-specs.js
@@ -3,7 +3,7 @@
 var setup = require("../../common/setup-base")
   , desired = require("./desired");
 
-describe("uicatalog - stability @skip-ci", function () {
+describe("uicatalog - stability @skip-ci @skip-ios6", function () {
 
   var runs = 20;
 

--- a/test/functional/ios/uicatalog/touch-specs.js
+++ b/test/functional/ios/uicatalog/touch-specs.js
@@ -5,7 +5,7 @@ var setup = require("../../common/setup-base")
   , wd = require("wd")
   , TouchAction = wd.TouchAction;
 
-describe('uicatalog - touch', function () {
+describe('uicatalog - touch @skip-ios6', function () {
   var driver;
   setup(this, desired).then(function (d) { driver = d; });
 


### PR DESCRIPTION
Two UICatalog tests were not being skipped for iOS 6.
