### PR TITLE
Fix test for iOS 6 findByUiAutomation

### DIFF
--- a/test/functional/ios/uicatalog-61/find-element-specs.js
+++ b/test/functional/ios/uicatalog-61/find-element-specs.js
@@ -297,7 +297,7 @@ describe('uicatalog - find element @skip-ios7', function () {
     });
     it('should process UIAutomation queries if user leaves out the first period', function (done) {
       driver
-        .elements(byUIA, 'elements()').then(filterDisplayed)
+        .elements(byUIA, '$.mainWindow().elements()').then(filterDisplayed)
           .should.eventually.have.length(2)
         .nodeify(done);
     });


### PR DESCRIPTION
Use the same UIAutomation query as the iOS [7.x tests](https://github.com/appium/appium/blob/master/test/functional/ios/uicatalog/find-by-ui-automation-specs.js#L39).
