### PR TITLE
Fix Android location test

### DIFF
--- a/test/functional/android/apidemos/location-specs.js
+++ b/test/functional/android/apidemos/location-specs.js
@@ -13,7 +13,13 @@ describe("apidemo - location @skip-real-device", function () {
   setup(this, desired).then(function (d) { driver = d; });
 
   it('should set geo location', function (done) {
-    var getText = function () { return driver.elementByXPath("//android.widget.TextView[2]").text(); };
+    var getText = function () {
+      return driver
+        .elementsByClassName("android.widget.TextView")
+        .then(function (els) {
+          return els[1].text();
+        });
+    };
     var newLat = "27.17";
     var newLong = "78.04";
     driver


### PR DESCRIPTION
This test consistently fails, but it is because of the xpath to get the element.
