### PR TITLE
Fix UiSelector instance in find_elements

### DIFF
--- a/test/functional/android/apidemos/find/by-xpath-specs.js
+++ b/test/functional/android/apidemos/find/by-xpath-specs.js
@@ -31,6 +31,16 @@ describe("apidemo - find - by xpath", function () {
         .should.become("Accessibility")
       .nodeify(done);
   });
+  // This test verifies a specific XPath issue has been resolved.
+  // https://github.com/appium/appium/pull/3730
+  it('should find exactly one element via elementsByXPath', function (done) {
+    driver
+      .elementsByXPath("//" + t + "[@text='Accessibility']").then(function (els) {
+        els.length.should.equal(1);
+        els[0].text().should.become("Accessibility");
+      })
+      .nodeify(done);
+  });
   it('should find element by partial text', function (done) {
     driver
       .elementByXPath("//" + t + "[contains(@text, 'Accessibility')]").text()


### PR DESCRIPTION
If a UiSelector already uses instance, then invoking instance again
will replace the original instance number. The UiSelector will then
point to a completely different element.

To fix this problem, these selectors ending with instance are detected
via a regex and the extra .instance call is avoided.

Fix https://github.com/appium/java-client/issues/100
Fix #3729

---

I verified this solves the issue. I haven't done additional testing. It probably makes sense to add a unit test for this so find_elements doesn't regress in the future. If the feedback on this change is positive then I'll write a test before it's merged.
