### PR TITLE
Use last coordinates for touch release

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -913,6 +913,21 @@ androidController.performTouch = function (gestures, cb) {
     // the `longPress` and `tap` methods release on their own
     gestures.pop();
   }
+
+  if (actions[actions.length - 1] === 'release') {
+    // without coordinates, `release` uses the center of the screen, which,
+    // generally speaking, is not what we want
+    // therefore: loop backwards and use the last command with an element and/or
+    // offset coordinates
+    for (var i = actions.length - 2; i >= 0; i--) {
+      var opts = gestures[i].options || {};
+      if (opts.element || (opts.x && opts.y)) {
+        gestures[gestures.length - 1].options = _.clone(opts);
+        break;
+      }
+    }
+  }
+
   var cycleThroughGestures = function (err, res) {
     if (err) return cb(err);
 


### PR DESCRIPTION
When a `release` action is sent to the Android bootstrap, there is no element or coordinates, so the system uses the center of the screen. To get around this, use the last known coordinates (or a `move` or `press`, say) for the `release`.

Should fix #3726.
