### PR TITLE
Reset Push Notification privacy setting

### DIFF
--- a/lib/devices/ios/simulator.js
+++ b/lib/devices/ios/simulator.js
@@ -291,6 +291,7 @@ Simulator.prototype.cleanSim = function (keepKeychains) {
   var toDeletes = [
     'Library/TCC',
     'Library/Caches/locationd',
+    'Library/BackBoard/applicationState.plist',
     'Media'
   ];
   if (!keepKeychains) {


### PR DESCRIPTION
When performing a clean of the simulator, the push notification privacy setting is now reset as well

https://github.com/appium/appium/issues/3755
