### PR TITLE
Fix for Chromedriver not connecting to adb running on non-default port. Take 2

### DIFF
--- a/lib/devices/android/chromedriver.js
+++ b/lib/devices/android/chromedriver.js
@@ -10,7 +10,8 @@ var proxyTo = require('../common.js').proxyTo
   , isWindows = require('../../helpers.js').isWindows()
   , isLinux = require('../../helpers.js').isLinux()
   , path = require('path')
-  , fs = require('fs');
+  , fs = require('fs')
+  , ADB = require('./adb.js');
 
 var Chromedriver = function (args, onDie) {
   this.proxyHost = '127.0.0.1';
@@ -23,6 +24,7 @@ var Chromedriver = function (args, onDie) {
   this.exitCb = null;
   this.shuttingDown = false;
   this.executable = args.executable;
+  this.adb = new ADB(args);
 };
 
 Chromedriver.prototype.initChromedriverPath = function (cb) {
@@ -93,7 +95,7 @@ Chromedriver.prototype.start = function (cb) {
   this.onChromedriverStart = cb;
   logger.debug("Spawning chromedriver with: " + this.chromedriver);
   var alreadyReturned = false;
-  var args = ["--url-base=wd/hub", "--port=" + this.proxyPort];
+  var args = ["--url-base=wd/hub", "--port=" + this.proxyPort, "--adb-port=" + ADB.getAdbServerPort()];
   this.proc = spawn(this.chromedriver, args);
   this.proc.stdout.setEncoding('utf8');
   this.proc.stderr.setEncoding('utf8');


### PR DESCRIPTION
Fixes #3717 
Depends on appium/appium-adb#47 being merged in.
