### PR TITLE
Delete appBundleId.plist for iOS8

### DIFF
--- a/lib/devices/ios/simulator.js
+++ b/lib/devices/ios/simulator.js
@@ -279,6 +279,19 @@ Simulator.prototype.cleanCustomApp = function (appFile, appBundleId) {
     logger.debug("Deleting " + appDir);
     safeRimRafSync(appDir);
   });
+
+  if (parseFloat(this.platformVer) >= 8) {
+    var toDeletes = [
+        'Library/Preferences/' + appBundleId + '.plist'
+    ];
+    _.each(this.getDirs(), function (simDir) {
+      _.each(toDeletes, function (relRmPath) {
+        var rmPath = path.resolve(simDir, relRmPath);
+        logger.debug("Deleting " + rmPath);
+        safeRimRafSync(rmPath);
+      });
+    });
+  }
 };
 
 Simulator.prototype.cleanSim = function (keepKeychains) {


### PR DESCRIPTION
Under iOS7 Simulator, they stored appBundleId.plist in "Data/Application/xxxxxxxxxx/Library/Preferences/appBundleId.plist".
But iOS8 Simulator stored appBundleId.plist in "Library/Preferences/appBundleId.plist" directory.

So, I add deleting plist for parseFloat(this.platformVer) >= 8.

The following log is an example when I add this PR.

```
info: [debug] Cleaning sim preferences
info: [debug] Cleaning app data files
info: [debug] Deleting /Users/myname/Library/Developer/CoreSimulator/Devices/EEC7B8C2-AAAC-4456-A7D4-9CF679C94EB0/data/Containers/Data/Application/9583BD90-872C-44C0-A6E6-8CA3878F89DC
info: [debug] Deleting /Users/myname/Library/Developer/CoreSimulator/Devices/EEC7B8C2-AAAC-4456-A7D4-9CF679C94EB0/data/Library/Preferences/appBundleId.plist
info: [debug] Setting locale information
info: [debug] New language: ja
```

I add in cleanCustomApp because I referred PR https://github.com/appium/appium/pull/3756 .
