### PR TITLE
Fix for installing IPA packages on iOS devices.

### DIFF
--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -83,6 +83,9 @@ Device.prototype.configureLocalApp = function (cb) {
     logger.debug("Using local " + ext + " from " + origin + ": " + appPath);
     this.unzipLocalApp(appPath, function (zipErr, newAppPath) {
       if (zipErr) return cb(zipErr);
+      if (ext === ".ipa") {
+        this.args.ipa = this.args.app;
+      }
       this.args.app = newAppPath;
       logger.debug("Using locally extracted app: " + this.args.app);
       cb();


### PR DESCRIPTION
If this.args.app is an IPA, this.args.ipa should get the same value,
so that installIpa() is called from installToRealDevice().
