### PR TITLE
fixed chromedriver support for Chromium/ChromeShell

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -233,7 +233,7 @@ Appium.prototype.getDeviceTypeFromPackage = function (pkg) {
   var chromePkgs = [
     "com.android.chrome"
   , "com.chrome.beta"
-  , "org.chromium.chrome.testshell"
+  , "org.chromium.chrome.shell"
   , "com.android.browser"
   ];
   if (_.contains(chromePkgs, pkg)) {

--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -53,8 +53,8 @@ ChromeAndroid.prototype.configure = function (args, caps, cb) {
   var app = this.appString().toLowerCase() ||
             bName.toString().toLowerCase();
   if (app === "chromium") {
-    this.args.androidPackage = "org.chromium.chrome.testshell";
-    this.args.androidActivity = "org.chromium.chrome.testshell.Main";
+    this.args.androidPackage = "org.chromium.chrome.shell";
+    this.args.androidActivity = ".ChromeShellActivity";
   } else if (app === "chromebeta") {
     this.args.androidPackage = "com.chrome.beta";
     this.args.androidActivity = "com.google.android.apps.chrome.Main";
@@ -122,15 +122,18 @@ ChromeAndroid.prototype.pushAndUnlock = function (cb) {
 ChromeAndroid.prototype.createSession = function (cb) {
   var caps = {
     chromeOptions: {
-      androidPackage: this.args.appPackage,
-      androidActivity: this.args.appActivity
+      androidPackage: this.args.appPackage
     }
   };
-  var knownPackages = ["org.chromium.chrome.testshell", "com.android.chrome",
+
+  var knownPackages = ["org.chromium.chrome.shell",
+                       "com.android.chrome",
                        "com.chrome.beta"];
-  if (_.contains(knownPackages, this.args.appPackage)) {
-    delete caps.chromeOptions.androidActivity;
+
+  if (!_.contains(knownPackages, this.args.appPackage)) {
+    caps.chromeOptions.androidActivity = this.args.appActivity;
   }
+
   this.chromedriver.createSession(caps, cb);
 };
 


### PR DESCRIPTION
Looks like Chromium classes changed names at some point.  Updated to allow so that Appium will work with newer versions of Chromium/ChromeShell.
