### PR TITLE
Fix for sendkeys with Selendroid in CHROMIUM context

### DIFF
--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -539,7 +539,7 @@ Selendroid.prototype.setValue = function (elementId, value, cb) {
     }
   }
   var reqUrl = this.proxyHost + ':' + this.proxyPort +
-      '/wd/hub/session/' + this.selendroidSessionId +
+      '/wd/hub/session/' + this.proxySessionId +
       '/element/' + elementId + '/value';
   doRequest(reqUrl, 'POST', { value: [value] }, null, function (err) {
     if (err) return cb(err);


### PR DESCRIPTION
Now when in CHROMIUM context 'sendkeys' ('value') request is sent with the Selendroid sessionId.
