### PR TITLE
Create Opera device which sets Opera specific capabilities

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -10,6 +10,7 @@ var loggerjs = require('./server/logger.js')
   , Android = require('./devices/android/android.js')
   , Selendroid = require('./devices/android/selendroid.js')
   , Chrome = require('./devices/android/chrome.js')
+  , Opera = require('./devices/android/opera.js')
   , FirefoxOs = require('./devices/firefoxos/firefoxos.js')
   , jwpResponse = require('./devices/common.js').jwpResponse
   , status = require("./server/status.js");
@@ -18,6 +19,7 @@ var DT_IOS = "ios"
   , DT_SAFARI = "safari"
   , DT_ANDROID = "android"
   , DT_CHROME = "chrome"
+  , DT_OPERA = "opera"
   , DT_SELENDROID = "selendroid"
   , DT_FIREFOX_OS = "firefoxos";
 
@@ -61,6 +63,7 @@ Appium.prototype.registerConfig = function (configObj) {
 Appium.prototype.deviceIsRegistered = function (deviceType) {
   if (deviceType === DT_SAFARI) deviceType = DT_IOS;
   if (deviceType === DT_CHROME) deviceType = DT_ANDROID;
+  if (deviceType === DT_OPERA) deviceType = DT_ANDROID;
   return _.has(this.serverConfig, deviceType);
 };
 
@@ -168,6 +171,8 @@ Appium.prototype.getDeviceType = function (args, caps) {
         this.isChromePackage(pkg)
       ) {
       type = DT_CHROME;
+    } else if (this.isOperaBrowser(browser)) {
+      type = DT_OPERA;
     } else if (this.isSelendroidAutomation(automation)) {
       type = DT_SELENDROID;
     }
@@ -203,6 +208,10 @@ Appium.prototype.isSafariBrowser = function (browser) {
   return browser === "safari";
 };
 
+Appium.prototype.isOperaBrowser = function (browser) {
+  return browser === "opera";
+};
+
 Appium.prototype.getDeviceTypeFromPlatform = function (caps) {
   var device = null;
   switch (caps) {
@@ -234,7 +243,7 @@ Appium.prototype.configure = function (args, desiredCaps, cb) {
                  "but that device hasn't been configured. Run config");
     return cb(new Error("Device " + deviceType + " not configured yet"));
   }
-  this.device = this.getNewDevice(deviceType);
+  this.device = this.getNewDevice(deviceType, desiredCaps);
   this.device.configure(args, desiredCaps, cb);
   // TODO: better collaboration between the Appium and Device objects
   this.device.onResetTimeout = function () { this.resetTimeout(); }.bind(this);
@@ -274,7 +283,7 @@ Appium.prototype.invoke = function (cb) {
   }
 };
 
-Appium.prototype.getNewDevice = function (deviceType) {
+Appium.prototype.getNewDevice = function (deviceType, desiredCaps) {
   var DeviceClass = (function () {
     switch (deviceType) {
       case DT_IOS:
@@ -285,6 +294,8 @@ Appium.prototype.getNewDevice = function (deviceType) {
         return Android;
       case DT_CHROME:
         return Chrome;
+      case DT_OPERA:
+        return Opera;
       case DT_SELENDROID:
         return Selendroid;
       case DT_FIREFOX_OS:
@@ -294,7 +305,7 @@ Appium.prototype.getNewDevice = function (deviceType) {
                         deviceType);
     }
   })();
-  return new DeviceClass();
+  return new DeviceClass(desiredCaps);
 };
 
 Appium.prototype.timeoutWaitingForCommand = function () {

--- a/lib/devices/android/opera.js
+++ b/lib/devices/android/opera.js
@@ -1,0 +1,84 @@
+"use strict";
+
+var Android = require('./android.js')
+  , Selendroid = require('./selendroid.js')
+  , _ = require('underscore')
+  , androidCommon = require('./android-common.js')
+  ;
+
+var Opera = function (desiredCaps) {
+
+  if (desiredCaps.automationName && desiredCaps.automationName.indexOf('selendroid') !== -1) {
+	_.extend(Opera.prototype, Selendroid.prototype);
+    Opera.prototype._installAppForTest = Selendroid.prototype.installAppForTest;
+  }
+  else {
+	_.extend(Opera.prototype, Android.prototype);
+    Opera.prototype._installAppForTest = androidCommon.installAppForTest;
+  }
+
+  Opera.prototype.installAppForTest = function (cb) {
+    this._installAppForTest(function (err) {
+      if (this.args.autoLaunch === false) {
+        cb(err);
+      }
+      else {
+        if (err) return cb(err);
+        var deducedCapabilities = getDeducedCapabilities(this.args.appPackage);
+        if (!deducedCapabilities) return cb(new Error("Couldn't deduce Opera capabilities for package " + this.args.appPackage));
+        this.args.androidDeviceSocket = deducedCapabilities.socket;
+        this.adb.shell("echo 'opera --disable-fre --enable-remote-debugging --metrics-recording-only' > /data/local/tmp/" + deducedCapabilities.commandLineFile, cb);
+      }
+    }.bind(this));
+  };
+};
+
+operaBase.installAppForTest = function (cb) {
+	this
+	._installAppForTest(function(err) {
+		if (this.args.autoLaunch === false) {
+			cb(err);
+		} else {
+			if (err)
+				return cb(err);
+			var deducedCapabilities = getDeducedCapabilities(this.args.appPackage);
+			if (!deducedCapabilities)
+				return cb(new Error(
+						"Couldn't deduce Opera capabilities for package " +
+						this.args.appPackage));
+			this.args.androidDeviceSocket = deducedCapabilities.socket;
+			this.adb
+			.shell(
+					"echo 'opera --disable-fre --enable-remote-debugging --metrics-recording-only' > /data/local/tmp/" +
+					deducedCapabilities.commandLineFile,
+					cb);
+		}
+	}.bind(this));
+};
+
+function getDeducedCapabilities(packageName) {
+  var productName = "", betaPart = "";
+  var packageParts = packageName.split(".");
+  for (var i = 0; i < packageParts.length; i++) {
+    var part = packageParts[i];
+    if (part === "opera" || part === "mini") {
+      productName = part;
+    }
+    else if (part === "beta") {
+      betaPart = "_beta";
+    }
+    else if (part !== "com" && part !== "browser" && part !== "android") {
+      return; //ERROR
+    }
+  }
+  if (productName) {
+    var socket = productName + betaPart + "_devtools_remote";
+    var commandLineFile = productName === "mini" ? "opera-mini-command-line" : "opera-browser-command-line";
+    return {'socket' : socket, 'commandLineFile' : commandLineFile };
+  }
+  else {
+    return; //ERROR
+  }
+}
+
+module.exports = Opera;

--- a/lib/devices/android/opera.js
+++ b/lib/devices/android/opera.js
@@ -6,36 +6,46 @@ var Android = require('./android.js')
   , androidCommon = require('./android-common.js')
   ;
 
-var Opera = function (desiredCaps) {
+var defaultOperaDesiredCapabilities = {
+  appPackage : 'com.opera.browser',
+  appActivity : 'com.opera.Opera',
+  androidDeviceSocket : 'opera_devtools_remote',
+  intentAction : 'com.opera.android.action.PROTECTED_INTENT',
+  optionalIntentArguments : ' -e cmd DISMISS_INTRO -d data:, ',
+  autoWebviewTimeout : 4000,
+  autoWebview : true,
+};
 
+var Opera = function (desiredCaps) {
+  this.init(desiredCaps);
+};
+
+Opera.prototype.init = function (desiredCaps) {
   if (desiredCaps.automationName && desiredCaps.automationName.indexOf('selendroid') !== -1) {
-	_.extend(Opera.prototype, Selendroid.prototype);
+    _.defaults(Opera.prototype, Selendroid.prototype);
     Opera.prototype._installAppForTest = Selendroid.prototype.installAppForTest;
+    Opera.prototype._init = Selendroid.prototype.init;
   }
   else {
-	_.extend(Opera.prototype, Android.prototype);
+    _.defaults(Opera.prototype, Android.prototype);
     Opera.prototype._installAppForTest = androidCommon.installAppForTest;
+    Opera.prototype._init = Android.prototype.init;
   }
+  _.extend(Opera.prototype, operaBase);
 
-  Opera.prototype.installAppForTest = function (cb) {
-    this._installAppForTest(function (err) {
-      if (this.args.autoLaunch === false) {
-        cb(err);
-      }
-      else {
-        if (err) return cb(err);
-        var deducedCapabilities = getDeducedCapabilities(this.args.appPackage);
-        if (!deducedCapabilities) return cb(new Error("Couldn't deduce Opera capabilities for package " + this.args.appPackage));
-        this.args.androidDeviceSocket = deducedCapabilities.socket;
-        this.adb.shell("echo 'opera --disable-fre --enable-remote-debugging --metrics-recording-only' > /data/local/tmp/" + deducedCapabilities.commandLineFile, cb);
-      }
-    }.bind(this));
-  };
+  this._init();
+  _.defaults(desiredCaps, defaultOperaDesiredCapabilities);
+  this.avoidProxy = _.union(this.avoidProxy, [
+                     ['POST', new RegExp('^/wd/hub/session/[^/]+/touch/perform')],
+                     ['POST', new RegExp('^/wd/hub/session/[^/]+/touch/multi/perform')]
+                   ]);
 };
+
+var operaBase = {};
 
 operaBase.installAppForTest = function (cb) {
 	this
-	._installAppForTest(function(err) {
+	._installAppForTest(function (err) {
 		if (this.args.autoLaunch === false) {
 			cb(err);
 		} else {
@@ -54,6 +64,10 @@ operaBase.installAppForTest = function (cb) {
 					cb);
 		}
 	}.bind(this));
+};
+
+operaBase.defaultWebviewName = function () {
+	return "CHROMIUM";
 };
 
 function getDeducedCapabilities(packageName) {

--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -26,7 +26,7 @@ Device.prototype.init = function () {
 
 Device.prototype.configure = function (args, caps) {
   _.extend(this.args, args);
-  _.extend(this.capabilities, caps);
+  this.capabilities = _.extend(this.capabilities, caps);
   _.each(caps, function (val, cap) {
     this.setArgFromCap(cap, cap);
   }.bind(this));

--- a/test/functional/android/chrome/chrome-specs.js
+++ b/test/functional/android/chrome/chrome-specs.js
@@ -5,7 +5,7 @@ var desired = require('./desired')
   , loadWebView = webviewHelper.loadWebView
   , setup = require("../../common/setup-base");
 
-describe("chrome @android-arm-only", function () {
+describe(desired.browserName + " @android-arm-only", function () {
   var tests = ['alerts', 'basics', 'cookies', 'execute-async', 'execute',
                'frames', 'iframes', 'implicit-wait', 'touch', 'window-title'];
   _.each(tests, function (test) {
@@ -27,7 +27,7 @@ describe("chrome @android-arm-only", function () {
           ctxs.should.contain("NATIVE_APP");
           return driver.context("NATIVE_APP");
         })
-        .source().should.eventually.include("android.widget.Button")
+        .source().should.eventually.include("android.widget.FrameLayout")
         .nodeify(done);
     });
   });

--- a/test/helpers/webview.js
+++ b/test/helpers/webview.js
@@ -23,7 +23,7 @@ var loadWebView = function (desired, browser, urlToLoad, titleToSpin) {
 
   var uuid = uuidGenerator.v1();
   if (typeof urlToLoad === "undefined") {
-    if (app === "chrome" || app === "chromium" || app === "chromebeta") {
+    if (app === "chrome" || app === "chromium" || app === "chromebeta" || app === "opera") {
       urlToLoad = env.CHROME_GUINEA_TEST_END_POINT + '?' + uuid;
     } else {
       urlToLoad = env.GUINEA_TEST_END_POINT + '?' + uuid;
@@ -32,7 +32,7 @@ var loadWebView = function (desired, browser, urlToLoad, titleToSpin) {
   if (typeof titleToSpin === "undefined") {
     titleToSpin = uuid;
   }
-  if (_.contains(["safari", "chrome", "chromium", "chromebeta"], app)) {
+  if (_.contains(["safari", "chrome", "chromium", "chromebeta", "opera"], app)) {
     return browser
       .get(urlToLoad)
       .sleep(3000)


### PR DESCRIPTION
The purpose of these changes is to make it as easy as possible to setup typical tests using Opera browser.
Also they let the user to use opera analogously to other browsers supported by Appium.
