### PR TITLE
fix appFile to array on getAppDirs in lib/devices/ios/simulator.js

### DIFF
--- a/lib/devices/ios/simulator.js
+++ b/lib/devices/ios/simulator.js
@@ -146,7 +146,7 @@ Simulator.prototype.getAppDirs = function (appFile, appBundleId) {
     var bundleDirs = wrapInArray(this.getApp8Dir(appBundleId, "Bundle"));
     return dataDirs.concat(bundleDirs);
   } else {
-    return this.getApp7Dirs(appFile);
+    return this.getApp7Dirs([appFile]);
   }
 };
 


### PR DESCRIPTION
In ios8 branch, I found a bug that sometimes customApp directory, exist under ~/Library/Developer/CoreSimulator/Devices/xxxx/data/Applications/, remaining even cleanCustomApp called with ios7 caps.

In this pull request fix it.

After adopting this pull request, customApp directory in ~/Library/Developer/CoreSimulator/Devices/xxxx/data/Applications/ removed every cleanCustomApp called.
