### PR TITLE
fixed app path for real devices

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -354,7 +354,8 @@ IOS.prototype.makeInstruments = function (cb) {
   }).then(
     function (bootstrapPath) {
       var instruments = new Instruments({
-        app: this.args.app || this.args.bundleId
+        // on real devices bundleId is always used
+        app: (!this.args.udid ? this.args.app : null) || this.args.bundleId
       , udid: this.args.udid
       , processArguments: this.args.processArguments
       , ignoreStartupExit: this.shouldIgnoreInstrumentsExit()


### PR DESCRIPTION
Real devices must use bundle id to start apps, they don't know about local apps or ipa paths.
