### PR TITLE
Fix pull file for iOS

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -507,13 +507,24 @@ iOSController._getFullPath = function (remotePath, cb) {
     }
   }
 
-  if (remotePath.indexOf(appName) === 1) {
+  // de-absolutize the path
+  if (helpers.isWindows()) {
+    if (remotePath.indexof("://") === 1) {
+      remotePath = remotePath.slice(4);
+    }
+  } else {
+    if (remotePath.indexOf("/") === 0) {
+      remotePath = remotePath.slice(1);
+    }
+  }
+
+  if (remotePath.indexOf(appName) === 0) {
     logger.debug("We want an app-relative file");
 
     var findPath = basePath;
     if (this.iOSSDKVersion >= 8) {
-      // the .app file appears in /Containers/Data and /Containers/Bundle both. We only want /Data
-      findPath = path.resolve(basePath, "Containers", "Data");
+      // the .app file appears in /Containers/Data and /Containers/Bundle both. We only want /Bundle
+      findPath = path.resolve(basePath, "Containers", "Bundle");
     }
     findPath =  findPath.replace(/\s/g, '\\ ');
 
@@ -521,7 +532,7 @@ iOSController._getFullPath = function (remotePath, cb) {
     exec(findCmd, function (err, stdout) {
       if (err) return cb(err);
       var appRoot = stdout.replace(/\n$/, '');
-      var subPath = remotePath.substring(appName.length + 2);
+      var subPath = remotePath.substring(appName.length + 1);
       fullPath = path.resolve(appRoot, subPath);
       cb(null, fullPath);
     }.bind(this));


### PR DESCRIPTION
Fixes #3844

Also deals with an issue in which any file could be retrieved from the file system simply by requesting to pull an absolute path (since Node's [path.resolve](http://nodejs.org/docs/latest/api/path.html#path_path_resolve_from_to) only tries to make a full path if it doesn't already have one). The fix handles pulling and pushing of both files and folders.
