### PR TITLE
Fixed release bug when released element is not valid, promise poc

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -14,7 +14,8 @@ var errors = require('../../server/errors.js')
   , path = require('path')
   , AdmZip = require("adm-zip")
   , helpers = require('../../helpers.js')
-  , Args = require("vargs").Constructor;
+  , Args = require("vargs").Constructor
+  , Q = require('q');
 
 var androidController = {};
 
@@ -871,11 +872,11 @@ androidController.doTouchAction = function (action, opts, cb) {
 
 // drag is *not* press-move-release, so we need to translate
 // drag works fine for scroll, as well
-var doTouchDrag = function (gestures, cb) {
+var _doTouchDrag = function (gestures, cb) {
   var longPress = gestures[0];
   var elementId = longPress.options.element;
   this.getLocation(elementId, function (err, res) {
-    if (err) return cb(err);
+  if (err) return cb(err);
 
     var startX = res.value.x;
     var startY = res.value.y;
@@ -904,42 +905,101 @@ var doTouchDrag = function (gestures, cb) {
 };
 
 androidController.performTouch = function (gestures, cb) {
-  // some things are special
+  // promisifying methods
+  var doTouchAction = Q.nbind(this.doTouchAction, this);
+  var doTouchDrag = Q.nbind(_doTouchDrag, this);
+  var getLocation = Q.nbind(this.getLocation, this);
+  var getSize = Q.nbind(this.getSize, this);
+
   var actions = _.pluck(gestures, "action");
+  var promise;
+
+  // some things are special
   if (actions[0] === 'longPress' && actions[1] === 'moveTo' && actions[2] === 'release') {
-    return doTouchDrag.apply(this, [gestures, cb]);
-  } else if ((actions[actions.length - 2] === 'tap' ||
-    actions[actions.length - 2] === 'longPress') && actions[actions.length - 1] === 'release') {
-    // the `longPress` and `tap` methods release on their own
-    gestures.pop();
-  }
+    promise = doTouchDrag(gestures);
+  } else {
+    promise = Q.fcall(function () {
+      // initialization
 
-  if (actions[actions.length - 1] === 'release') {
-    // without coordinates, `release` uses the center of the screen, which,
-    // generally speaking, is not what we want
-    // therefore: loop backwards and use the last command with an element and/or
-    // offset coordinates
-    for (var i = actions.length - 2; i >= 0; i--) {
-      var opts = gestures[i].options || {};
-      if (opts.element || (opts.x && opts.y)) {
-        gestures[gestures.length - 1].options = _.clone(opts);
-        break;
+      // the `longPress` and `tap` methods release on their own
+      if ((actions[actions.length - 2] === 'tap' ||
+        actions[actions.length - 2] === 'longPress') && actions[actions.length - 1] === 'release') {
+        gestures.pop();
+        actions.pop();
       }
-    }
+
+      // fixing release action
+      if (actions[actions.length - 1] === 'release') {
+        var release = gestures[actions.length - 1];
+
+        // nothing to do if release options are already set
+        if (release.options.element || (release.options.x && release.options.y)) return;
+
+        // without coordinates, `release` uses the center of the screen, which,
+        // generally speaking, is not what we want
+        // therefore: loop backwards and use the last command with an element and/or
+        // offset coordinates
+        var ref = _(gestures).chain().initial().filter(function (gesture) {
+          var opts = gesture.options;
+          return opts.element || (opts.x && opts.y);
+        }).last().value();
+        if (ref) {
+          var opts = ref.options || {};
+          if (opts.element) {
+            // we retrieve the element location, might be useful in
+            // case the element becomes invalid
+            return Q.all([
+              getLocation(opts.element),
+              getSize(opts.element)
+            ]).then(function (res) {
+              var loc = res[0].value, size = res[1].value;
+              release.options = {
+                element: opts.element,
+                x: loc.x + size.width / 2,
+                y: loc.y + size.height / 2
+              };
+            });
+          }
+          if (opts.x && opts.y) release.options = _.pick(opts, 'x', 'y');
+        }
+      }
+
+    }.bind(this)).then(
+      // execute actions recursively
+
+      function cycleThroughGestures() {
+        var gesture = gestures.shift();
+        if (typeof gesture === "undefined") return { value: true, status: 0 };
+        return doTouchAction(gesture.action, gesture.options || {}) // execute action
+          .then(function (res) {
+            // sometime the element is not available when releasing, retry without it
+            if (res && res.status === 7 &&
+               gesture.action === 'release' && gesture.options.element) {
+               delete gesture.options.element;
+               logger.debug('retrying release without element opts:', gestures.options, '.');
+               return doTouchAction(gesture.action, gesture.options || {});
+            }
+
+            // otherwise continue normally
+            return res;
+
+          }).then(function (res) { // check result
+            if (res.status !== 0) {
+              var err = new Error();
+              err.res = res;
+              throw err;
+            }
+          }).then(cycleThroughGestures);
+      }
+    );
   }
 
-  var cycleThroughGestures = function (err, res) {
-    if (err) return cb(err);
-
-    var gesture = gestures.shift();
-    if (typeof gesture === "undefined") return cb(null, res);
-
-    var action = gesture.action;
-    var options = gesture.options || {};
-
-    this.doTouchAction(action, options, cycleThroughGestures);
-  }.bind(this);
-  cycleThroughGestures();
+  promise.then(function (res) { return res;}).catch(function (err) {
+    // centralized error handling
+    if (err.res) return err.res;
+    logger.error(err, err.stack);
+    throw err;
+  }).nodeify(cb); // convert back to node style callback
 };
 
 androidController.parseTouch = function (gestures, cb) {


### PR DESCRIPTION
 Note: This contains new code pattern proposal for this project, this is aimed at extensive discussion.

Following discussion on slack this week I felt people would benefits from a 'promise in action' example. At the same time when fixing this bug I had to introduce extra level of callbacks in an already complicated code, so I felt compelled to use promises. I've refrained from using complicated promise patterns so should be easy to follow.

Since the discussion is probably gonna go this way, if we decide to move to generator later, it is a good intermediary step, all you have to do is make replace the fcall/then by yield call, and catch by regular try/catch. 

If we choose not to use promise, I'll convert it to Async.js so no worry.

This also contains:
- Bugfix for https://github.com/appium/appium/issues/3855. Now when we default an element in release, we also compute the current element position. In the case the release fails with status 7, we strip the el argument from the release gesture and try again.

pinging @jlipps, @0x1mason , @Jonahss , @imurchie , @bootstraponline feel free to invite more.
