### PR TITLE
Fix EPERM error in Windows when using a remote apk already signed

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -15,6 +15,7 @@ exports.downloadFile = function (fileUrl, suffix, cb) {
   // We will be downloading the files to a directory, so make sure it's there
   // This step is not required if you have manually created the directory
   tempdir.open({prefix: 'appium-app', suffix: suffix}, function (err, info) {
+    fs.close(info.fd);
     var file = fs.createWriteStream(info.path);
     request(fileUrl).pipe(file).on('close', function () {
       logger.debug(fileUrl + ' downloaded to ' + info.path);


### PR DESCRIPTION
If a remote signed apk is tested on Windows, Appium returns the following error "error: Failed to start an Appium session, err was: Error: EPERM, rename 'C:\Users\username\AppData\Local\Temp\appium114921-10216-1lljdnj.tmp'"

When Appium downloads the remote apk, the file descriptor, opened by tmpdir, is never closed.
If the apk is already signed for debug, Appium executes the zipalign and tries to overwrite the temporal apk.
In Windows, this overwriting is forbidden and generates the EPERM error.

Solution: close the file descriptor returned by tmpdir
