### PR TITLE
cleanSafari fix

### DIFF
--- a/lib/devices/ios/simulator.js
+++ b/lib/devices/ios/simulator.js
@@ -35,7 +35,7 @@ var wrapInArray = function (res) {
 };
 
 var rmrf = function (delPath, cb) {
-  exec("rm -rf " + delPath, function (err) {
+  exec("rm -rf '" + delPath + "'", function (err) {
     cb(err);
   });
 };
@@ -225,7 +225,7 @@ Simulator.prototype.cleanSafari = function (keepPrefs, cb) {
     'Caches/Snapshots/com.apple.mobilesafari'
     , 'Caches/com.apple.mobilesafari/Cache.db*'
     , 'Caches/com.apple.WebAppCache/*.db'
-    , 'Safari/*.plist'
+    , 'Safari'
     , 'WebKit/LocalStorage/*.*'
     , 'WebKit/GeolocationSites.plist'
     , 'Cookies/*.binarycookies'


### PR DESCRIPTION
@jlipps found badass bug in cleanSafari, the 'rm -rf' wasn't working for paths containing spaces like 'Application Support'.
Is it ok to delete the whole Safari? If I don't it doesn't start the next time.
