### PR TITLE
safari realdevice fix

### DIFF
--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -40,7 +40,7 @@ Safari.prototype.configure = function (args, caps, cb) {
 };
 
 Safari.prototype.moveBuiltInApp = function (cb) {
-  if (this.args.app !== null) {
+  if (!this.args.udid && this.args.app !== null) {
     logger.debug("Trying to use mobile safari, version " +
                  this.args.platformVersion);
     this.sim.prepareSafari(this.args.tmpDir, function (err, attemptedApp, origApp) {


### PR DESCRIPTION
Fixes this: https://github.com/appium/appium/issues/2778, pretty straightforward.
Tested on yosemite.
