### PR TITLE
Ensure an already-running AVD's language/locale settings are correct

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -354,28 +354,40 @@ androidCommon.prepareEmulator = function (cb) {
           err.message.indexOf('No emulators') === -1) return cb(err);
       if (runningAVD !== null) {
         logger.debug("Did not launch AVD because it was already running.");
-        return cb();
+        return this.ensureDeviceLocale(cb);
       }
       this.adb.launchAVD(this.args.avd, this.args.avdArgs, this.args.language, this.args.locale,
         this.args.avdLaunchTimeout, this.args.avdReadyTimeout, cb);
     }.bind(this));
-  } else if (typeof this.args.language === "string" || typeof this.args.locale === "string") {
-    var adbCmd = "";
-    if (this.args.language && typeof this.args.language === "string") {
-      logger.debug("Setting Android Device Language to " + this.args.language);
-      adbCmd += "setprop persist.sys.language " + this.args.language.toLowerCase() + ";";
-    }
-    if (this.args.locale && typeof this.args.locale === "string") {
-      logger.debug("Setting Android Device Country to " + this.args.locale);
-      adbCmd += "setprop persist.sys.country " + this.args.locale.toUpperCase() + ";";
-    }
-    this.adb.shell(adbCmd, function (err) {
-      if (err) return cb(err);
-      this.adb.reboot(cb);
-    }.bind(this));
   } else {
-    cb();
+    this.ensureDeviceLocale(cb);
   }
+};
+
+androidCommon.ensureDeviceLocale = function (cb) {
+  var haveLanguage = this.args.language && typeof this.args.language === "string";
+  var haveCountry = this.args.locale && typeof this.args.locale === "string";
+  if (!haveLanguage && !haveCountry) return cb();
+  this.getDeviceLanguage(function (err, language) {
+    if (err) return cb(err);
+    this.getDeviceCountry(function (err, country) {
+      if (err) return cb(err);
+      var adbCmd = "";
+      if (haveLanguage && this.args.language !== language) {
+        logger.debug("Setting Android Device Language to " + this.args.language);
+        adbCmd += "setprop persist.sys.language " + this.args.language.toLowerCase() + ";";
+      }
+      if (haveCountry && this.args.locale !== country) {
+        logger.debug("Setting Android Device Country to " + this.args.locale);
+        adbCmd += "setprop persist.sys.country " + this.args.locale.toUpperCase() + ";";
+      }
+      if (adbCmd === "") return cb();
+      this.adb.shell(adbCmd, function (err) {
+        if (err) return cb(err);
+        this.adb.reboot(cb);
+      }.bind(this));
+    }.bind(this));
+  }.bind(this));
 };
 
 androidCommon.prepareActiveDevice = function (cb) {
@@ -753,16 +765,24 @@ androidCommon.getCurrentActivity = function (cb) {
   });
 };
 
-androidCommon.getDeviceLanguage = function (cb) {
-  this.adb.shell("getprop persist.sys.language", function (err, stdout) {
+androidCommon.getDeviceProperty = function (property, cb) {
+  this.adb.shell("getprop " + property, function (err, stdout) {
     if (err) {
-      logger.error("Error getting device language: " + err);
+      logger.error("Error getting device property " + property + ": " + err);
       cb(err, null);
     } else {
-      logger.debug("Current device language: " + stdout.trim());
+      logger.debug("Current device " + property + ": " + stdout.trim());
       cb(null, stdout.trim());
     }
   }.bind(this));
+};
+
+androidCommon.getDeviceLanguage = function (cb) {
+  this.getDeviceProperty("persist.sys.language", cb);
+};
+
+androidCommon.getDeviceCountry = function (cb) {
+  this.getDeviceProperty("persist.sys.country", cb);
 };
 
 androidCommon.extractLocalizedStrings = function (language, outputPath, cb) {


### PR DESCRIPTION
Currently, when requesting that Appium launch an AVD with a specified language and/or locale  (desired capabilities: 'avd' plus one or more of 'language', 'locale'), if the AVD is already running then the language/locale settings are ignored.

This patch refactors the logic that applies the language/locale settings such that the settings are applied in all cases. Further, it only applies the settings if they are non-null AND they differ from the device's current settings (thus potentially eliminating some pointless reboots).

Full disclosure: I do not have prior Node or JavaScript experience. This patch works for me and passes the existing unit tests, but should probably be checked thoroughly.
