### PR TITLE
ios touch move fix

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -2212,7 +2212,7 @@ iOSController.parseTouch = function (gestures, cb) {
         // iOS expects absolute coordinates, so we need to save these as offsets
         // and then translate when everything is done
         tapPoint = {
-          offset: true,
+          offset: false,
           x: (gesture.options.x || 0),
           y: (gesture.options.y || 0)
         };


### PR DESCRIPTION
DO NOT MERGE YET!

see https://github.com/appium/appium/issues/3021

The aim is to make stuff `touch.moveTo(null, x, y)` use an absolute position. This is what is happening on Android (see [here](https://github.com/appium/appium/blob/master/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchEvent.java#L77)). 

I don't think the behavior was properly specified in the specs, but @Jonahss javadoc [here](http://appium.github.io/java-client/io/appium/java_client/TouchAction.html#moveTo%28org.openqa.selenium.WebElement,%20int,%20int%29) mention `absolute position`. (not only for  moveTo, but also for press)

@imurchie @jlipps you think it is correct behavior/ correct fix? 

Do we need to restrict to specific actions? 
