### PR TITLE
Fix for #3885: Strip colors from the log when requested.

### DIFF
--- a/lib/server/logger.js
+++ b/lib/server/logger.js
@@ -21,6 +21,8 @@ var colors = {
 
 var logger = null;
 var timeZone = null;
+var consoleLogLevel = null;
+var fileLogLevel = null;
 
 var timestamp = function () {
   var date = new Date();
@@ -40,20 +42,6 @@ var _createConsoleTransport = function (args, logLvl) {
     , json: false
     , level: logLvl
   });
-};
-
-var _createFileTransport = function (args, logLvl) {
-  return new (winston.transports.File)({
-      name: "file"
-      , timestamp: timestamp
-      , filename: args.log
-      , maxFiles: 1
-      , handleExceptions: true
-      , exitOnError: false
-      , json: false
-      , level: logLvl
-    }
-  );
 };
 
 var _createWebhookTransport = function (args, logLvl) {
@@ -80,35 +68,7 @@ var _createWebhookTransport = function (args, logLvl) {
 
 var _createTransports = function (args) {
   var transports = [];
-  var consoleLogLevel = null,
-      fileLogLevel = null;
-
-  if (args.loglevel && args.loglevel.match(":")) {
-    // --log-level arg can optionally provide diff logging levels for console and file  separated by a colon
-    var lvlPair = args.loglevel.split(':');
-    consoleLogLevel =  lvlPair[0] || consoleLogLevel;
-    fileLogLevel = lvlPair[1] || fileLogLevel;
-  } else {
-    consoleLogLevel = fileLogLevel = args.loglevel;
-  }
-
   transports.push(_createConsoleTransport(args, consoleLogLevel));
-
-  if (args.log) {
-    try {
-      // if we don't delete the log file, winston will always append and it will grow infinitely large;
-      // winston allows for limiting log file size, but as of 9.2.14 there's a serious bug when using
-      // maxFiles and maxSize together. https://github.com/flatiron/winston/issues/397
-      if (fs.existsSync(args.log)) {
-        fs.unlinkSync(args.log);
-      }
-
-      transports.push(_createFileTransport(args, fileLogLevel));
-    } catch (e) {
-      console.log("Tried to attach logging to file " + args.log +
-                  " but an error occurred: " + e.msg);
-    }
-  }
 
   if (args.webhook) {
     try {
@@ -122,6 +82,38 @@ var _createTransports = function (args) {
   return transports;
 };
 
+var _createFileTransport = function (args) {
+  var transports = [];
+  var fileLogLevel = null;
+
+  try {
+    // if we don't delete the log file, winston will always append and it will grow infinitely large;
+    // winston allows for limiting log file size, but as of 9.2.14 there's a serious bug when using
+    // maxFiles and maxSize together. https://github.com/flatiron/winston/issues/397
+    if (fs.existsSync(args.log)) {
+      fs.unlinkSync(args.log);
+    }
+
+    var fileTransport = new (winston.transports.File)({
+      name: "file"
+      , timestamp: timestamp
+      , filename: args.log
+      , maxFiles: 1
+      , handleExceptions: true
+      , exitOnError: false
+      , json: false
+      , level: fileLogLevel
+    });
+    transports.push(fileTransport);
+  } catch (e) {
+    console.log("Tried to attach logging to file " + args.log +
+                " but an error occurred: " + e.msg);
+  }
+
+  return transports;
+};
+
+
 module.exports.init = function (args) {
   // set de facto param passed to timestamp function
   timeZone = args.localTimezone;
@@ -132,16 +124,47 @@ module.exports.init = function (args) {
     winston.addColors(colors);
   }
 
+  if (args.loglevel && args.loglevel.match(":")) {
+    // --log-level arg can optionally provide diff logging levels for console and file separated by a colon
+    var lvlPair = args.loglevel.split(':');
+    consoleLogLevel =  lvlPair[0] || consoleLogLevel;
+    fileLogLevel = lvlPair[1] || fileLogLevel;
+  } else {
+    consoleLogLevel = fileLogLevel = args.loglevel;
+  }
+
   logger = new (winston.Logger)({
     transports: _createTransports(args)
   });
 
   logger.setLevels(levels);
+  logger.stripColors = args.logNoColors;
 
   // 8/19/14 this is a hack to force Winston to print debug messages to stdout rather than stderr.
   // TODO: remove this if winston provides an API for directing streams.
   if (levels[logger.transports.console.level] === levels.debug) {
     logger.debug = function (msg) { logger.info('[debug] ' + msg); };
+  }
+
+  if (args.log) {
+    var fileLogger = new (winston.Logger)({
+      transports: _createFileTransport(args)
+    });
+    fileLogger.setLevels(levels);
+    fileLogger.stripColors = true;
+
+    var decorateWithCallback = function (func, callback) {
+      return function () {
+        var args = Array.prototype.slice.call(arguments);
+        func.apply(this, args);
+        callback.apply(this, args);
+      };
+    };
+
+    logger.info = decorateWithCallback(logger.info, fileLogger.info);
+    logger.debug = decorateWithCallback(logger.debug, fileLogger.debug);
+    logger.warn = decorateWithCallback(logger.warn, fileLogger.warn);
+    logger.error = decorateWithCallback(logger.error, fileLogger.error);
   }
 };
 


### PR DESCRIPTION
We will use two loggers: one for files with stripColors=true and
one for everything else with stripColors=args.logNoColors.
