### PR TITLE
Restart chromedriver when webview closes

### DIFF
--- a/lib/devices/android/android-hybrid.js
+++ b/lib/devices/android/android-hybrid.js
@@ -123,25 +123,14 @@ androidHybrid.startChromedriverProxy = function (context, cb) {
     return cb(new Error("We already have a chromedriver instance running"));
   }
 
-  if (this.sessionChromedrivers[context]) {
-    logger.debug("Found existing Chromedriver for context '" + context + "'." +
-                 " Using it.");
-    this.rememberProxyState();
-    this.chromedriver = this.sessionChromedrivers[context];
-    this.proxyHost = this.chromedriver.proxyHost;
-    this.proxyPort = this.chromedriver.proxyPort;
-    this.proxySessionId = this.chromedriver.chromeSessionId;
-    this.isProxy = true;
-    cb();
-  } else {
+  var setupNewChromeDriver = function (ocb) {
     var chromeArgs = {
       port: this.args.chromeDriverPort
     , executable: this.args.chromedriverExecutable
     , deviceId: this.adb.curDeviceId
     , enablePerformanceLogging: this.args.enablePerformanceLogging
     };
-    this.chromedriver = new Chromedriver(chromeArgs,
-        this.onChromedriverExit.bind(this));
+    this.chromedriver = new Chromedriver(chromeArgs, this.onChromedriverExit.bind(this));
     this.rememberProxyState();
     this.proxyHost = this.chromedriver.proxyHost;
     this.proxyPort = this.chromedriver.proxyPort;
@@ -177,8 +166,38 @@ androidHybrid.startChromedriverProxy = function (context, cb) {
       logger.debug("Setting proxy session id to " + sessId);
       this.proxySessionId = sessId;
       this.sessionChromedrivers[context] = this.chromedriver;
-      cb();
+      ocb();
     }.bind(this));
+  }.bind(this);
+
+  if (this.sessionChromedrivers[context]) {
+    logger.debug("Found existing Chromedriver for context '" + context + "'." +
+                 " Using it.");
+    this.rememberProxyState();
+    this.chromedriver = this.sessionChromedrivers[context];
+    this.proxyHost = this.chromedriver.proxyHost;
+    this.proxyPort = this.chromedriver.proxyPort;
+    this.proxySessionId = this.chromedriver.chromeSessionId;
+    this.isProxy = true;
+
+    // check the status by sending a simple window-based command to ChromeDriver
+    // if there is an error, we want to recreate the ChromeDriver session
+    var url = '/wd/hub/session/' + this.proxySessionId + '/url';
+    this.chromedriver.proxyTo(url, 'GET', {}, function (err, res, body) {
+      body = JSON.parse(body);
+      if ((body.status === status.codes.NoSuchWindow.code && body.value.message.indexOf('no such window: window was already closed') !== -1) ||
+          (body.status === 100 && body.value.message.indexOf('chrome not reachable') !== -1)) {
+        // the window is closed and we need to reinitialize
+        logger.debug("ChromeDriver is not associated with a window. Re-initializing the session.");
+        this.cleanupChromedriver(this.chromedriver, function () {
+          setupNewChromeDriver(cb);
+        });
+      } else {
+        cb();
+      }
+    }.bind(this));
+  } else {
+    setupNewChromeDriver(cb);
   }
 };
 

--- a/test/functional/common/android-webview-base.js
+++ b/test/functional/common/android-webview-base.js
@@ -20,9 +20,10 @@ module.exports = function () {
 
   before(function (done) {
     driver
-      .sleep(1000)
+      .waitForElementByClassName('android.webkit.WebView')
       .contexts()
       .then(function (ctxs) {
+        ctxs.should.have.length(2);
         return driver.context(ctxs[ctxs.length - 1]);
       })
       .nodeify(done);
@@ -100,6 +101,27 @@ module.exports = function () {
         return driver.context(ctxs[ctxs.length - 1]);
       })
       // should find the element in the web context
+      .elementById('i_am_a_textbox')
+        .should.not.be.rejected
+      .nodeify(done);
+  });
+
+  it('should be able to get into a webview even after the webview ChromeDriver has is closed', function (done) {
+    driver
+      .context('WEBVIEW')
+      .elementById('i_am_a_textbox')
+        .should.not.be.rejected
+      .context('NATIVE_APP')
+
+      // restart activity anew, so old webview is gone
+      .startActivity({
+        appPackage: 'io.appium.android.apis',
+        appActivity: '.view.WebView1'
+      })
+      .waitForElementByClassName('android.webkit.WebView')
+      .contexts()
+        .should.eventually.have.length(2)
+      .context('WEBVIEW')
       .elementById('i_am_a_textbox')
         .should.not.be.rejected
       .nodeify(done);


### PR DESCRIPTION
When the window ChromeDriver has a reference to is lost, subsequent commands will fail. So test that it is there (by sending the simplest non-destructive command possible, `/url`) and, if not, reinitialize the session.

Fixes #3775.
