### PR TITLE
Fixed location pref tests for iOS7 iOS8

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -705,9 +705,10 @@ IOS.prototype.setLocServicesPrefs = function () {
     locServ = locServ ? 1 : 0;
     logger.debug("Setting location services to " + locServ);
     settings.updateSettings(this.sim, 'locationServices', {
-        LocationServicesEnabled: locServ,
-        'LocationServicesEnabledIn7.0': locServ
-      }
+         LocationServicesEnabled: locServ,
+        'LocationServicesEnabledIn7.0': locServ,
+        'LocationServicesEnabledIn8.0': locServ
+       }
     );
   }
   if (typeof this.capabilities.locationServicesAuthorized !== "undefined") {

--- a/lib/devices/ios/settings.js
+++ b/lib/devices/ios/settings.js
@@ -47,6 +47,7 @@ var prefs = {
   locationServices: {
     LocationServicesEnabled: [0, 1],
     'LocationServicesEnabledIn7.0': [0, 1],
+    'LocationServicesEnabledIn8.0': [0, 1],
     ObsoleteDataDeleted: [true, false]
   },
   preferences: {

--- a/lib/devices/ios/simctl.js
+++ b/lib/devices/ios/simctl.js
@@ -36,20 +36,22 @@ Simctl.delete = function (udid, cb) {
 };
 
 Simctl.erase = function (udid, cb) {
+  // wait at least 2s for simctl to do its thing
+  var cmdTimeout = 2000, cmdRetry = 5;
 
   var erase = function (callback) {
-    Simctl.exec("erase", 500, [udid], function (err, stdout, stderr) {
+    var ms = Date.now();
+    Simctl.exec("erase", cmdTimeout, [udid], function (err, stdout, stderr) {
       if (err) {
         err.message += " // stderr: " + stderr;
-        callback(err);
+        setTimeout(callback.bind(null, err), Math.max(cmdTimeout - (Date.now() - ms), 1));
       } else {
         callback();
       }
     });
   };
 
-
-  async.retry(5, erase, cb);
+  async.retry(cmdRetry, erase, cb);
 };
 
 Simctl.getDevices = function (forSdk, cb) {

--- a/test/functional/ios/prefs/location-settings-specs.js
+++ b/test/functional/ios/prefs/location-settings-specs.js
@@ -10,8 +10,7 @@ var desired = {
   app: 'settings'
 };
 
-describe("prefs @skip-ios6 @skip-ios7 @skip-ios8", function () {
-  // on ios8 sim it crashes when tapping on "location services"
+describe("prefs @skip-ios6", function () {
   // TODO: cannot install settings app on ios6
 
   var checkLocServ = function (driver, expected, cb) {
@@ -19,10 +18,10 @@ describe("prefs @skip-ios6 @skip-ios7 @skip-ios8", function () {
       .elementsByClassName('UIATableCell').at(1).click()
       .sleep(1000)
       .elementByClassName('UIATableCell').click()
+      .sleep(1000)
       .elementByClassName('UIASwitch')
-      .getValue().then(function (checked) {
-        checked.should.eql(expected);
-      }).nodeify(cb);
+      .getValue().should.become(expected)
+      .nodeify(cb);
   };
 
   describe('settings app with location services', function () {


### PR DESCRIPTION
@jlipps can you check if this fixes the test for you. There was instability cause by failed xcrun erase leaving the Simulator folder in a bad state. 

@Jonahss could you check the xcrun erase part, 500ms was not enough.
