### PR TITLE
Fix swipe action with target element: #3647

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -597,7 +597,10 @@ androidController.swipe = function (startX, startY, endX, endY, duration, touchC
   , endY: endY
   , steps: Math.round(duration * this.swipeStepsPerSec)
   };
-  if (elId !== null) {
+
+  // going the long way and checking for undefined and null since
+  // we can't be assured `elId` is a string and not an int
+  if (typeof elId !== "undefined" && elId !== null) {
     swipeOpts.elementId = elId;
     this.proxy(["element:swipe", swipeOpts], cb);
   } else {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
@@ -63,63 +63,14 @@ public class AndroidElement {
       return false;
     }
   }
-
-  public Point getAbsolutePosition(final Double X, final Double Y)
-      throws UiObjectNotFoundException, InvalidCoordinatesException {
-    final Point point = new Point(X, Y);
-    return getAbsolutePosition(point, false);
-  }
-
-  public Point getAbsolutePosition(final Double X, final Double Y,
-      final boolean boundsChecking) throws UiObjectNotFoundException,
-      InvalidCoordinatesException {
-    final Point point = new Point(X, Y);
-    return getAbsolutePosition(point, boundsChecking);
-  }
-
+  
   public Point getAbsolutePosition(final Point point)
       throws UiObjectNotFoundException, InvalidCoordinatesException {
-    return getAbsolutePosition(point, false);
-  }
-
-  public Point getAbsolutePosition(final Point point,
-      final boolean boundsChecking) throws UiObjectNotFoundException,
-      InvalidCoordinatesException {
-    final Rect rect = el.getBounds();
-    final Point pos = new Point();
+    final Rect rect = this.getBounds();
+    
     Logger.debug("Element bounds: " + rect.toShortString());
-
-    if (point.x == 0) {
-      pos.x = rect.width() * 0.5 + rect.left;
-    } else if (point.x <= 1) {
-      pos.x = rect.width() * point.x + rect.left;
-    } else {
-      pos.x = rect.left + point.x;
-    }
-    if (boundsChecking) {
-      if (pos.x > rect.right || pos.x < rect.left) {
-        throw new InvalidCoordinatesException("X coordinate ("
-            + pos.x.toString() + " is outside of element rect: "
-            + rect.toShortString());
-      }
-    }
-
-    if (point.y == 0) {
-      pos.y = rect.height() * 0.5 + rect.top;
-    } else if (point.y <= 1) {
-      pos.y = rect.height() * point.y + rect.top;
-    } else {
-      pos.y = rect.left + point.y;
-    }
-    if (boundsChecking) {
-      if (pos.y > rect.bottom || pos.y < rect.top) {
-        throw new InvalidCoordinatesException("Y coordinate ("
-            + pos.y.toString() + " is outside of element rect: "
-            + rect.toShortString());
-      }
-    }
-
-    return pos;
+    
+    return PositionHelper.getAbsolutePosition(point, rect, new Point(rect.left, rect.top), false);
   }
 
   public boolean getBoolAttribute(final String attr)

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/CommandHandler.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/CommandHandler.java
@@ -1,6 +1,8 @@
 package io.appium.android.bootstrap;
 
+import android.graphics.Rect;
 import com.android.uiautomator.core.UiDevice;
+import com.android.uiautomator.core.UiObjectNotFoundException;
 import io.appium.android.bootstrap.exceptions.InvalidCoordinatesException;
 import io.appium.android.bootstrap.utils.Point;
 import org.json.JSONException;
@@ -9,71 +11,14 @@ import java.util.ArrayList;
 
 /**
  * Base class for all handlers.
- * 
+ *
  */
 public abstract class CommandHandler {
 
   /**
-   * Given a position, it will return either the position based on percentage
-   * (by passing in a double between 0 and 1) or absolute position based on the
-   * coordinates entered.
-   * 
-   * @param coordVals
-   * @return ArrayList<Integer>
-   */
-  protected static ArrayList<Integer> absPosFromCoords(final Double[] coordVals) {
-    final ArrayList<Integer> retPos = new ArrayList<Integer>();
-    final UiDevice d = UiDevice.getInstance();
-
-    final Double screenX = (double) d.getDisplayWidth();
-    final Double screenY = (double) d.getDisplayHeight();
-
-    if (coordVals[0] < 1 && coordVals[1] < 1) {
-      retPos.add((int) (screenX * coordVals[0]));
-      retPos.add((int) (screenY * coordVals[1]));
-    } else {
-      retPos.add(coordVals[0].intValue());
-      retPos.add(coordVals[1].intValue());
-    }
-
-    return retPos;
-  }
-
-  protected static Point getDeviceAbsPos(final Point point)
-      throws InvalidCoordinatesException {
-    final UiDevice d = UiDevice.getInstance();
-    final Point retPos = new Point(point); // copy inputed point
-
-    final Double width = (double) d.getDisplayWidth();
-    if (point.x < 1) {
-      retPos.x = width * point.x;
-    }
-
-    if (retPos.x > width || retPos.x < 0) {
-      throw new InvalidCoordinatesException("X coordinate ("
-          + retPos.x.toString() + " is outside of screen width: "
-          + width.toString());
-    }
-
-    final Double height = (double) d.getDisplayHeight();
-    if (point.y < 1) {
-      retPos.y = height * point.y;
-    }
-
-    if (retPos.y > height || retPos.y < 0) {
-      throw new InvalidCoordinatesException("Y coordinate ("
-          + retPos.y.toString() + " is outside of screen height: "
-          + height.toString());
-    }
-
-    return retPos;
-  }
-
-  /**
    * Abstract method that handlers must implement.
-   * 
-   * @param command
-   *          A {@link AndroidCommand}
+   *
+   * @param command A {@link AndroidCommand}
    * @return {@link AndroidCommandResult}
    * @throws JSONException
    */
@@ -82,7 +27,7 @@ public abstract class CommandHandler {
 
   /**
    * Returns a generic unknown error message along with your own message.
-   * 
+   *
    * @param msg
    * @return {@link AndroidCommandResult}
    */
@@ -92,11 +37,12 @@ public abstract class CommandHandler {
 
   /**
    * Returns success along with the payload.
-   * 
+   *
    * @param value
    * @return {@link AndroidCommandResult}
    */
   protected AndroidCommandResult getSuccessResult(final Object value) {
     return new AndroidCommandResult(WDStatus.SUCCESS, value);
   }
+
 }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/PositionHelper.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/PositionHelper.java
@@ -1,0 +1,74 @@
+package io.appium.android.bootstrap;
+
+import android.graphics.Rect;
+import com.android.uiautomator.core.UiDevice;
+import com.android.uiautomator.core.UiObjectNotFoundException;
+import io.appium.android.bootstrap.exceptions.InvalidCoordinatesException;
+import io.appium.android.bootstrap.utils.Point;
+
+public abstract class PositionHelper {
+  
+  /**
+   * Given a position, it will return either the position based on percentage
+   * (by passing in a double between 0 and 1) or absolute position based on the
+   * coordinates entered.
+   *
+   * @param pointCoord The position to translate.
+   * @param length Length of side to use for percentage positions.
+   * @param offset Position offset.
+   * @return
+   */
+  private static double translateCoordinate(double pointCoord, double length, double offset) {
+    double translatedCoord = 0;
+    
+    if (pointCoord == 0) {
+      translatedCoord = length * 0.5;
+    } else if (pointCoord > 0 && pointCoord < 1) {
+      translatedCoord = length * pointCoord;
+    } else {
+      translatedCoord = pointCoord;
+    }
+    
+    return translatedCoord + offset;
+  }
+  
+  /**
+   * Translates coordinates relative to an element rectangle into absolute coordinates.
+   *
+   * @param point A point in relative coordinates.
+   * @param displayRect The display rectangle to which the point is relative.
+   * @param offsets X and Y values by which to offset the point. These are typically
+   * the absolute coordinates of the display rectangle.
+   * @param shouldCheckBounds Throw if the translated point is outside displayRect?
+   * @return
+   * @throws UiObjectNotFoundException
+   * @throws InvalidCoordinatesException
+   */
+  public static Point getAbsolutePosition(final Point point, final Rect displayRect, 
+                                          final Point offsets, final boolean shouldCheckBounds)
+      throws UiObjectNotFoundException, InvalidCoordinatesException {
+    final Point absolutePosition = new Point();
+    
+    absolutePosition.x = translateCoordinate(point.x, displayRect.width(), offsets.x);
+    absolutePosition.y = translateCoordinate(point.y, displayRect.height(), offsets.y);
+    
+    if (shouldCheckBounds &&
+        !displayRect.contains(absolutePosition.x.intValue(), absolutePosition.y.intValue())) {
+      throw new InvalidCoordinatesException("Coordinate " + absolutePosition.toString() +
+          " is outside of element rect: " + displayRect.toShortString());
+    }
+      
+    return absolutePosition;
+  }
+
+  public static Point getDeviceAbsPos(final Point point)
+      throws UiObjectNotFoundException, InvalidCoordinatesException {
+    final UiDevice d = UiDevice.getInstance();
+    final Rect displayRect = new Rect(0, 0, d.getDisplayWidth(), d.getDisplayHeight());
+    
+    Logger.debug("Display bounds: " + displayRect.toShortString());
+    
+    return getAbsolutePosition(point, displayRect, new Point(), true);
+  }
+  
+}

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Click.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Click.java
@@ -3,6 +3,8 @@ package io.appium.android.bootstrap.handler;
 import com.android.uiautomator.core.UiDevice;
 import com.android.uiautomator.core.UiObjectNotFoundException;
 import io.appium.android.bootstrap.*;
+import io.appium.android.bootstrap.exceptions.InvalidCoordinatesException;
+import io.appium.android.bootstrap.utils.Point;
 import org.json.JSONException;
 
 import java.util.ArrayList;
@@ -42,11 +44,20 @@ public class Click extends CommandHandler {
       }
     } else {
       final Hashtable<String, Object> params = command.params();
-      final Double[] coords = { Double.parseDouble(params.get("x").toString()),
-          Double.parseDouble(params.get("y").toString()) };
-      final ArrayList<Integer> posVals = absPosFromCoords(coords);
-      final boolean res = UiDevice.getInstance().click(posVals.get(0),
-          posVals.get(1));
+      Point coords = new Point(Double.parseDouble(params.get("x").toString()),
+          Double.parseDouble(params.get("y").toString()) );
+      
+      try {
+        coords = PositionHelper.getDeviceAbsPos(coords);
+      } catch (final UiObjectNotFoundException e) {
+        return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
+            e.getMessage());
+      } catch (final InvalidCoordinatesException e) {
+        return new AndroidCommandResult(WDStatus.INVALID_ELEMENT_COORDINATES,
+            e.getMessage());
+      }
+      
+      final boolean res = UiDevice.getInstance().click(coords.x.intValue(), coords.y.intValue());
       return getSuccessResult(res);
     }
   }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Drag.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Drag.java
@@ -66,11 +66,13 @@ public class Drag extends CommandHandler {
     final UiDevice device = UiDevice.getInstance();
 
     try {
-      absStartPos = getDeviceAbsPos(dragArgs.start);
-      absEndPos = getDeviceAbsPos(dragArgs.end);
+      absStartPos = PositionHelper.getDeviceAbsPos(dragArgs.start);
+      absEndPos = PositionHelper.getDeviceAbsPos(dragArgs.end);
     } catch (final InvalidCoordinatesException e) {
       return getErrorResult(e.getMessage());
-    }
+    } catch (final UiObjectNotFoundException e) {
+        return getErrorResult(e.getMessage());
+      } 
 
     Logger.debug("Dragging from " + absStartPos.toString() + " to "
         + absEndPos.toString() + " with steps: " + dragArgs.steps.toString());
@@ -88,10 +90,12 @@ public class Drag extends CommandHandler {
 
     if (dragArgs.destEl == null) {
       try {
-        absEndPos = getDeviceAbsPos(dragArgs.end);
+        absEndPos = PositionHelper.getDeviceAbsPos(dragArgs.end);
       } catch (final InvalidCoordinatesException e) {
         return getErrorResult(e.getMessage());
-      }
+      } catch (final UiObjectNotFoundException e) {
+        return getErrorResult(e.getMessage());
+      } 
 
       Logger.debug("Dragging the element with id " + dragArgs.el.getId()
           + " to " + absEndPos.toString() + " with steps: "

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Flick.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Flick.java
@@ -1,6 +1,7 @@
 package io.appium.android.bootstrap.handler;
 
 import com.android.uiautomator.core.UiDevice;
+import com.android.uiautomator.core.UiObjectNotFoundException;
 import io.appium.android.bootstrap.*;
 import io.appium.android.bootstrap.exceptions.InvalidCoordinatesException;
 import io.appium.android.bootstrap.utils.Point;
@@ -87,11 +88,13 @@ public class Flick extends CommandHandler {
             Math.sqrt(xSpeed * xSpeed + ySpeed * ySpeed));
         steps = 1250.0 / speed + 1;
 
-        start = getDeviceAbsPos(start);
+        start = PositionHelper.getDeviceAbsPos(start);
         end = calculateEndPoint(start, xSpeed, ySpeed);
       } catch (final InvalidCoordinatesException e) {
         return getErrorResult(e.getMessage());
-      }
+      } catch (final UiObjectNotFoundException e) {
+        return getErrorResult(e.getMessage());
+      } 
     }
 
     steps = Math.abs(steps);

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Swipe.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Swipe.java
@@ -37,25 +37,21 @@ public class Swipe extends CommandHandler {
     Point absStartPos = new Point();
     Point absEndPos = new Point();
 
-    if (command.isElementCommand()) {
-      try {
+    try {
+      if (command.isElementCommand()) {
         final AndroidElement el = command.getElement();
         absStartPos = el.getAbsolutePosition(start);
-        absEndPos = el.getAbsolutePosition(end, false);
-      } catch (final UiObjectNotFoundException e) {
-        return getErrorResult(e.getMessage());
-      } catch (final InvalidCoordinatesException e) {
-        return getErrorResult(e.getMessage());
-      } catch (final Exception e) { // handle NullPointerException
-        return getErrorResult("Unknown error");
+        absEndPos = el.getAbsolutePosition(end);
+      } else {
+        absStartPos = PositionHelper.getDeviceAbsPos(start);
+        absEndPos = PositionHelper.getDeviceAbsPos(end);
       }
-    } else {
-      try {
-        absStartPos = getDeviceAbsPos(start);
-        absEndPos = getDeviceAbsPos(end);
-      } catch (final InvalidCoordinatesException e) {
-        return getErrorResult(e.getMessage());
-      }
+    } catch (final UiObjectNotFoundException e) {
+      return getErrorResult(e.getMessage());
+    } catch (final InvalidCoordinatesException e) {
+      return getErrorResult(e.getMessage());
+    } catch (final Exception e) { // handle NullPointerException
+      return getErrorResult("Unknown error");
     }
 
     Logger.debug("Swiping from " + absStartPos.toString() + " to "

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchEvent.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/TouchEvent.java
@@ -3,6 +3,8 @@ package io.appium.android.bootstrap.handler;
 import android.graphics.Rect;
 import com.android.uiautomator.core.UiObjectNotFoundException;
 import io.appium.android.bootstrap.*;
+import io.appium.android.bootstrap.exceptions.InvalidCoordinatesException;
+import io.appium.android.bootstrap.utils.Point;
 import org.json.JSONException;
 
 import java.util.ArrayList;
@@ -64,8 +66,11 @@ public abstract class TouchEvent extends CommandHandler {
       } else { // no element so extract x and y from params
         final Object paramX = params.get("x");
         final Object paramY = params.get("y");
-        double targetX = 0.5;
-        double targetY = 0.5;
+        
+        // these will be defaulted to 0.5 when passed to getDeviceAbsPos
+        double targetX = 0;
+        double targetY = 0;
+        
         if (paramX != null) {
           targetX = Double.parseDouble(paramX.toString());
         }
@@ -73,11 +78,12 @@ public abstract class TouchEvent extends CommandHandler {
         if (paramY != null) {
           targetY = Double.parseDouble(paramY.toString());
         }
-
-        final ArrayList<Integer> posVals = absPosFromCoords(new Double[] {
-            targetX, targetY });
-        clickX = posVals.get(0);
-        clickY = posVals.get(1);
+        
+        Point coords = new Point(targetX, targetY);
+        coords = PositionHelper.getDeviceAbsPos(coords);
+       
+        clickX = coords.x.intValue();
+        clickY = coords.y.intValue();
       }
 
       if (executeTouchEvent()) {
@@ -86,6 +92,9 @@ public abstract class TouchEvent extends CommandHandler {
 
     } catch (final UiObjectNotFoundException e) {
       return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT, e.getMessage());
+    } catch (final InvalidCoordinatesException e) {
+      return new AndroidCommandResult(WDStatus.INVALID_ELEMENT_COORDINATES, 
+          e.getMessage());
     } catch (final Exception e) {
       return getErrorResult(e.getMessage());
     }

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -452,7 +452,7 @@ iOSController.pushFile = function (base64Data, remotePath, cb) {
         } catch (e) {
           cb(e);
         }
-      }.bind(this),
+      }.bind(this)
     ], function (err) {
       logger.debug("Returning response");
       if (err) return cb(err);
@@ -2150,8 +2150,12 @@ iOSController.parseTouch = function (gestures, cb) {
         state.touch[0].x += prevPos.x;
         state.touch[0].y += prevPos.y;
       }
-      delete state.touch[0].offset;
-      prevPos = state.touch[0];
+      // prevent wait => press => moveto crash
+      if (state.touch[0]) {
+        delete state.touch[0].offset;
+        prevPos = state.touch[0];
+      }
+
 
       var timeOffset = state.timeOffset;
       time += timeOffset;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -347,3 +347,17 @@ exports.truncateDecimals = function (number, digits) {
 
   return truncatedNum / multiplier;
 };
+
+// return true if the the value is not undefined, null, or NaN.
+exports.notNullOrUndefined = function (val) {
+  var isDefined = false;
+
+  // avoid incorrectly evaluating `0` as false
+  if (_.isNumber(val)) {
+    isDefined = !_.isNaN(val);
+  } else {
+    isDefined = !_.isUndefined(val) && !_.isNull(val);
+  }
+
+  return isDefined;
+};

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -15,6 +15,7 @@ var status = require('./status.js')
   , checkMissingParams = responses.checkMissingParams
   , notYetImplemented = responses.notYetImplemented
   , helpers = require('../helpers.js')
+  , notNullOrUndefined = helpers.notNullOrUndefined
   , logCustomDeprecationWarning = helpers.logCustomDeprecationWarning
   , _ = require('underscore')
   , safely = require('./helpers').safely
@@ -319,29 +320,12 @@ exports.performTouch = function (req, res) {
   }
 
   // press-wait-moveTo-release is `swipe`, so use native method
-  if (gestures.length === 4) {
-    if ((gestures[0].action === 'press') && (gestures[1].action === 'wait') && (gestures[2].action === 'moveTo') && (gestures[3].action === 'release')) {
-      // the touch action api uses ms, we want seconds
-      // 0.8 is the default time for the operation
-      var duration = 0.8;
-      if (typeof gestures[1].options.ms !== 'undefined' && gestures[1].options.ms) {
-        duration = gestures[1].options.ms / 1000;
-        if (duration === 0) {
-          // set to a very low number, since they wanted it fast
-          // but below 0.1 becomes 0 steps, which causes errors
-          duration = 0.1;
-        }
-      }
-      var body = {
-        startX: gestures[0].options.x,
-        startY: gestures[0].options.y,
-        endX: gestures[2].options.x,
-        endY: gestures[2].options.y,
-        duration: duration
-      };
-      req.body = body;
-      return exports.mobileSwipe(req, res);
-    }
+  if (gestures.length === 4 &&
+      gestures[0].action === 'press' &&
+      gestures[1].action === 'wait' &&
+      gestures[2].action === 'moveTo' &&
+      gestures[3].action === 'release') {
+      return exports.mobileSwipe(gestures, req, res);
   }
 
   req.device.performTouch(gestures, getResponseHandler(req, res));
@@ -479,25 +463,82 @@ exports.mobileDrag = function (req, res) {
   req.device.drag(startX, startY, endX, endY, duration, touchCount, element, destEl, getResponseHandler(req, res));
 };
 
-exports.mobileSwipe = function (req, res) {
-  req.body = _.defaults(req.body, {
-    touchCount: 1
-  , startX: 0.5
-  , startY: 0.5
-  , endX: 0.5
-  , endY: 0.5
-  , duration: 0.8
-  , element: null
-  });
-  var touchCount = req.body.touchCount
-    , element = req.body.element
-    , duration = req.body.duration
-    , startX = req.body.startX
-    , startY = req.body.startY
-    , endX = req.body.endX
-    , endY = req.body.endY;
+var _getSwipeTouchDuration = function (waitGesture) {
+  // the touch action api uses ms, we want seconds
+  // 0.8 is the default time for the operation
+  var duration = 0.8;
 
-  req.device.swipe(startX, startY, endX, endY, duration, touchCount, element, getResponseHandler(req, res));
+  if (typeof waitGesture.options.ms !== 'undefined' && waitGesture.options.ms) {
+    duration = waitGesture.options.ms / 1000;
+    if (duration === 0) {
+      // set to a very low number, since they wanted it fast
+      // but below 0.1 becomes 0 steps, which causes errors
+      duration = 0.1;
+    }
+  }
+  return duration;
+};
+
+exports.mobileSwipe = function (gestures, req, res) {
+
+  var getCoordDefault = function (val) {
+    // going the long way and checking for undefined and null since
+    // we can't be assured `elId` is a string and not an int. Same
+    // thing with destElement below.
+    return notNullOrUndefined(val) ? val : 0.5;
+  };
+
+  var touchCount = req.body.touchCount || 1
+  , startX =  getCoordDefault(gestures[0].options.x)
+  , startY = getCoordDefault(gestures[0].options.y)
+  , endX = getCoordDefault(gestures[2].options.x)
+  , endY = getCoordDefault(gestures[2].options.y)
+  , duration = _getSwipeTouchDuration(gestures[1])
+  , element = gestures[0].options.element
+  , destElement = gestures[2].options.element || gestures[0].options.element;
+
+  // there's no destination element handling in bootstrap and since it applies to all platforms, we handle it here
+  if (notNullOrUndefined(destElement)) {
+    req.device.getLocation(destElement, function (err, locResult) {
+      if (err) {
+        respondError(req, res, err);
+      } else {
+        req.device.getSize(destElement, function (er, sizeResult) {
+          if (er) {
+            respondError(req, res, er);
+          } else {
+            var offsetX = (endX < 1 && endX > 0) ?
+                      sizeResult.value.width * endX :
+                      endX;
+            var offsetY = (endY < 1 && endY > 0) ?
+                      sizeResult.value.height * endY :
+                      endY;
+
+            var destX = locResult.value.x + offsetX;
+            var destY = locResult.value.y + offsetY;
+
+            // if the target element was provided, the coordinates for the destination need to be relative to it.
+            if (notNullOrUndefined(element)) {
+              req.device.getLocation(element, function (e, firstElLocation) {
+                if (e) {
+                  respondError(req, res, e);
+                } else {
+                  destX -= firstElLocation.value.x;
+                  destY -= firstElLocation.value.y;
+
+                  req.device.swipe(startX, startY, destX, destY, duration, touchCount, element, getResponseHandler(req, res));
+                }
+              });
+            } else {
+              req.device.swipe(startX, startY, destX, destY, duration, touchCount, element, getResponseHandler(req, res));
+            }
+          }
+        });
+      }
+    });
+  } else {
+    req.device.swipe(startX, startY, endX, endY, duration, touchCount, element, getResponseHandler(req, res));
+  }
 };
 
 exports.mobileRotation = function (req, res) {

--- a/test/functional/android/apidemos/touch/swipe-specs.js
+++ b/test/functional/android/apidemos/touch/swipe-specs.js
@@ -12,38 +12,117 @@ describe("apidemo - touch - swipe", function () {
   var driver;
   setup(this, desired).then(function (d) { driver = d; });
 
+  var contentEl, animationEl, viewsEl;
+
   if (env.FAST_TESTS) {
     beforeEach(function () {
       return reset(driver);
     });
   }
 
-  describe('swipe', function () {
-    it('should be possible with press/moveTo/release', function (done) {
-      driver.elementByName("Content")
+  var _assertResultAndReset = function () {
+    if (!viewsEl) {
+      return driver.elementByName("Views")
         .then(function (el) {
-          var action = new TouchAction(driver);
-          action.press({el: el});
-          driver
-            .elementByName("Animation")
-            .then(function (el2) {
-              return action.moveTo({el: el2}).release().perform();
-            });
-        })
-        .sleep(500)
-        .elementByName("Views").should.eventually.exist
-        .nodeify(done);
-    });
+          viewsEl = el;
+          return _assertResultAndReset();
+        });
+    } else {
+      return viewsEl.isDisplayed().should.become(true)
+        .then(function () {
+          return new TouchAction(driver)
+            .press({el: contentEl}).wait({ms: 500}).moveTo({el: viewsEl}).release().perform()
+            .elementByName("Accessibility").isDisplayed().should.become(true);
+        });
+    }
+  };
 
-    it('should be possible with press/moveTo/release and pixel offset', function (done) {
-      driver.elementByName("Content")
-        .then(function (el) {
-          var action = new TouchAction(driver);
-          action.press({el: el}).moveTo({x: 0, y: -400 }).release().perform();
-        })
-        .sleep(3000)
-        .elementByName("Views").should.eventually.exist
-        .nodeify(done);
-    });
+  var x = 0, y = 0, hOffset;
+  var contentElPos = { x: 0, y: 0 }
+    , animationElPos = { x: 0, y: 0 }
+    , delta = { x: 0, y: 0 };
+
+  it('should properly initialize the test', function (done) {
+    driver
+      .elementByName("Content")
+      .then(function (el) { contentEl = el; return contentEl; })
+      .getLocation()
+      .then(function (loc) {x = loc.x; y = loc.y; return contentEl;})
+      .getSize()
+      .then(function (re) {
+        hOffset = re.height * 0.5;
+        contentElPos.x = x + (re.width * 0.5);
+        contentElPos.y = y + hOffset;
+      })
+      .elementByName("Animation")
+      .then(function (el) {
+        animationEl = el;
+        return animationEl;
+      })
+      .getLocation()
+      .then(function (loc) {
+        animationElPos.x = contentElPos.x;
+        animationElPos.y = loc.y + hOffset;
+        delta.x = 0;
+        delta.y = animationElPos.y - contentElPos.y;
+        return contentEl;
+      })
+      .nodeify(done);
   });
+
+  it('should work with: press {element}, moveTo {destEl}', function (done) {
+    driver.chain()
+      // test: press {element}, moveTo {element}
+      .then(function () {
+        return new TouchAction(driver)
+          .press({el: contentEl}).wait({ms: 500}).moveTo({el: animationEl}).release().perform();
+      })
+      .then(_assertResultAndReset)
+      .nodeify(done);
+  });
+
+  it('should work with: press {element, x, y}, moveTo {element, x, y}', function (done) {
+    driver.chain()
+      // test: press {element, x, y}, moveTo {element, x, y}
+      .then(function () {
+        return new TouchAction(driver)
+          .press({el: contentEl, x: 20, y: 0.4}).wait({ms: 500}).moveTo({el: contentEl, x: delta.x, y: delta.y }).release().perform();
+      })
+      .then(_assertResultAndReset)
+      .nodeify(done);
+  });
+
+  it('should work with: press {x, y}, moveTo {x, y}', function (done) {
+    driver.chain()
+      // test: press {x, y}, moveTo {x, y}
+      .then(function () {
+        return new TouchAction(driver)
+          .press(contentElPos).wait({ms: 500}).moveTo(animationElPos).release().perform();
+      })
+      .then(_assertResultAndReset)
+      .nodeify(done);
+  });
+
+  it('should work with: {element, x, y}, moveTo {destEl, x, y}', function (done) {
+    driver.chain()
+      // test: press {element, x, y}, moveTo {destEl, x, y}
+      .then(function () {
+        return new TouchAction(driver)
+          .press({el: contentEl, x: 0.6, y: 35}).wait({ms: 500}).moveTo({el: animationEl, x: 25, y: 25 }).release().perform();
+      })
+      .then(_assertResultAndReset)
+      .nodeify(done);
+  });
+
+  it("should work with press {x, y}, moveTo {destEl}", function (done) {
+    driver.chain()
+    // test: press {x, y}, moveTo {destEl}
+    .then(function () {
+      return new TouchAction(driver)
+        .press(contentElPos).wait({ms: 500}).moveTo({el: animationEl}).release().perform();
+    })
+      .then(_assertResultAndReset)
+      .nodeify(done);
+  });
+
 });

--- a/test/functional/ios/testapp/touch-specs.js
+++ b/test/functional/ios/testapp/touch-specs.js
@@ -25,6 +25,7 @@ describe('testapp - touch actions', function () {
         }
       });
   }
+
   describe('tap', function () {
     it('should tap on a specified element', function (done) {
       driver
@@ -42,19 +43,6 @@ describe('testapp - touch actions', function () {
     });
   });
 
-  describe('swipe', function () {
-    it('should move the page', function (done) {
-      driver
-        .resolve(goToMap())
-        .elementByXPath('//UIAMapView')
-        .then(function (el) {
-          return driver.performTouchAction((new TouchAction())
-            .press({el: el}).moveTo({el: el, x: 0, y: 100 }).release());
-        }).sleep(5000)
-        .nodeify(done);
-    });
-  });
-
   describe('wait', function () {
     it('should move the page and wait a bit', function (done) {
       driver
@@ -64,7 +52,7 @@ describe('testapp - touch actions', function () {
           return driver.performTouchAction(
             new TouchAction().press({el: el}).moveTo({el: el, x: 0, y: 100 })
               .wait({ ms: 5000 }).moveTo({el: el, x: 0, y: 0 }).release());
-        }).sleep(5000)
+        })
         .nodeify(done);
     });
   });
@@ -82,7 +70,6 @@ describe('testapp - touch actions', function () {
           return driver
             .performMultiAction(multiAction);
         })
-        .sleep(5000)
         .nodeify(done);
     });
 
@@ -99,7 +86,102 @@ describe('testapp - touch actions', function () {
           );
           return driver.performMultiAction(multiAction);
         })
-        .sleep(5000)
+        .nodeify(done);
+    });
+  });
+});
+
+describe('testapp - swipe actions', function () {
+  var driver;
+  setup(this, desired).then(function (d) { driver = d; });
+
+  describe('swipe', function () {
+    var getNumericValue = function (pctVal) {
+      pctVal = pctVal.replace("%", "");
+      pctVal = parseInt(pctVal, 10);
+      return pctVal;
+    };
+
+    var testSliderValueNear50 = function (value) {
+      value = getNumericValue(value);
+      // should be ~50
+      value.should.be.above(45);
+      value.should.be.below(55);
+    };
+
+    var getSliderValue = function () {
+      return slider.getAttribute("value");
+    };
+
+    var slider, destEl, x = 0, y = 0;
+    var leftPos = { x: 0, y: 0 },
+      rightPos = { x: 0, y: 0 },
+      centerPos = { x: 0, y: 0 };
+
+    before(function (done) {
+      driver
+        .elementByClassName("UIASlider")
+        .then(function (el) { slider = el; return slider; })
+        .getLocation()
+        .then(function (loc) {x = loc.x; y = loc.y; return slider;})
+        .getSize()
+        .then(function (re) {
+          leftPos.x = x - 5;
+          centerPos.x = x + (re.width * 0.5);
+          rightPos.x = x + re.width + 5;
+          leftPos.y = rightPos.y = centerPos.y = y + (re.height * 0.5);
+        })
+        .elementByAccessibilityId("Access'ibility")
+        .then(function (el) { destEl = el;})
+        .then(getSliderValue)
+        .then(testSliderValueNear50)
+        .nodeify(done);
+    });
+
+    it('should work with: press {element}, moveTo {destEl}', function (done) {
+      driver
+        // test: press {element}, moveTo {destEl}
+        .performTouchAction((new TouchAction())
+          .press({el: slider}).wait({ms: 500}).moveTo({el: destEl}).release())
+        .then(getSliderValue).should.become("100%")
+        .nodeify(done);
+    });
+
+    it('should work with: press {element, x, y}, moveTo {element, x, y}', function (done) {
+      driver
+        // test: press {element, x, y}, moveTo {element, x, y}
+        .performTouchAction((new TouchAction())
+          .press({el: slider, x: 0.8665, y: 0.5}).wait({ms: 500}).moveTo({el: slider, x: 0.5, y: 0.5}).release())
+        .then(getSliderValue)
+        .then(testSliderValueNear50)
+        .nodeify(done);
+    });
+
+    it('should work with: press {x, y}, moveTo {x, y}', function (done) {
+      driver
+        // test: press {x, y}, moveTo {x, y}
+        .performTouchAction((new TouchAction())
+          .press({x: centerPos.x, y: centerPos.y}).wait({ms: 500}).moveTo({x: leftPos.x, y: leftPos.y}).release())
+        .then(getSliderValue).should.become("0%")
+        .nodeify(done);
+    });
+
+    it('should work with: {element, x, y}, moveTo {destEl, x, y}', function (done) {
+      driver
+        // test: press {element, x, y}, moveTo {destEl, x, y}
+        .performTouchAction((new TouchAction())
+          .press({el: slider, x: 0, y: 0.5}).wait({ms: 500}).moveTo({el: destEl, x: -90, y: 0.5}).release())
+        .then(getSliderValue)
+        .then(testSliderValueNear50)
+        .nodeify(done);
+    });
+
+    it("should work with press {x, y}, moveTo {destEl}", function (done) {
+      driver
+        // test: press {x, y}, moveTo {destEl}
+        .performTouchAction((new TouchAction())
+          .press({x: centerPos.x, y: centerPos.y}).wait({ms: 500}).moveTo({el: destEl}).release())
+        .then(getSliderValue).should.become("100%")
         .nodeify(done);
     });
   });

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -23,16 +23,38 @@ describe("Helpers", function () {
       });
     });
 
+    describe("notNullOrUndefined ", function () {
+      it("should work as expected", function () {
+        var undef
+          , nan = NaN
+          , none = null
+          , f = function () {}
+          , o = {}
+          , n = 0
+          , s = "string"
+          , b = false;
+
+        helpers.notNullOrUndefined(undef).should.be.false;
+        helpers.notNullOrUndefined(nan).should.be.false;
+        helpers.notNullOrUndefined(none).should.be.false;
+        helpers.notNullOrUndefined(f).should.be.true;
+        helpers.notNullOrUndefined(o).should.be.true;
+        helpers.notNullOrUndefined(n).should.be.true;
+        helpers.notNullOrUndefined(s).should.be.true;
+        helpers.notNullOrUndefined(b).should.be.true;
+      });
+    });
+
     describe("with a desired capability", function () {
       it("emits the capability message", function () {
         var deprecated = "oldCap";
         var replacement = "newCap";
         var expected = "[DEPRECATED] The " + deprecated + " capability has " +
-                       "been deprecated and will be removed.  Please use " +
-                       "the " + replacement + " capability instead.";
+          "been deprecated and will be removed.  Please use " +
+          "the " + replacement + " capability instead.";
         var warning = helpers.formatDeprecationWarning('capability',
-                                                        deprecated,
-                                                        replacement);
+          deprecated,
+          replacement);
         warning.should.equal(expected);
       });
     });


### PR DESCRIPTION
@Jonahss @imurchie (this reviewers of the first merge request that I closed because the new changes are a lot different) 
-  The original scope of this change was adding the ability to specify a destination element when doing a swipe.  Those are the changes you'll see in the server JS.
-  I added a bunch of tests.
-  When I started expanding the test suite for Android, I uncovered some nasty bugs w relative coordinates.  At least one was caused by copy/pasting.  I then discovered similar code (not nec buggy, but using the same patterns) in multiple places in the project.  I consolidated the logic to decrease the likelihood of bugs and ensure that absolute coordinates were all derived in the same way.
-  There's a bunch of spaghetti code.  If you have any suggestions on how I can get rid of it, lmk.
-  There's a change to the sample code that goes along with this.
-  I ran all the Android `touch` tests and they passed, with the exception of 'should work like `longPress` when released after a pause', which also failed for me before the refactoring
