### PR TITLE
allow tmp dir customization via env variable

### DIFF
--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -31,7 +31,10 @@ Device.prototype.configure = function (args, caps) {
     this.setArgFromCap(cap, cap);
   }.bind(this));
   if (this.args.tmpDir === null) {
-    this.args.tmpDir = helpers.isWindows() ? "C:\\Windows\\Temp" : "/tmp";
+    // use a custom tmp dir to avoid loosing data and app
+    // when computer is restarted
+    this.args.tmpDir = process.env.APPIUM_TMP_DIR ||
+      (helpers.isWindows() ? "C:\\Windows\\Temp" : "/tmp");
   }
   if (this.args.traceDir === null) {
     this.args.traceDir = path.resolve(this.args.tmpDir , 'appium-instruments');


### PR DESCRIPTION
This is the old story of Appium moving an app to the tmp dir and then crashing. The tmpdir is cleaned or pc restarted and we loose the app.

Loosing builtin apps can be prevented by configuring APPIUM_TMP_DIR in shell startup script.

@jlipps is it ok? ping @Jonahss.
