### PR TITLE
Make hideKeyboard do nothing when keyboard is present but not closable

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -709,10 +709,17 @@ androidController.hideKeyboard = function () {
   // parameters only used for iOS. Please ignore them for android.
   var args = new(Args)(arguments);
   var cb = args.callback;
-  this.adb.isSoftKeyboardPresent(function (err, isKeyboardPresent) {
+  this.adb.isSoftKeyboardPresent(function (err, isKeyboardPresent, canCloseKeyboard) {
     if (err) return cb(err);
     if (isKeyboardPresent) {
-      this.back(cb);
+      if (canCloseKeyboard) {
+        this.back(cb);
+      } else {
+        cb(null, {
+          status: status.codes.Success.code
+        , value: "Keyboard has no UI; no closing necessary"
+        });
+      }
     } else {
       return cb(new Error("Soft keyboard not present, cannot hide keyboard"));
     }


### PR DESCRIPTION
`hideKeyboard` performs a back-button press to hide the keyboard UI, but it will do so even when the keyboard has no UI to back out of (hardware keyboard, Appium UnicodeIME). This pull request relies on appium/appium-adb#59 to provide additional information about whether or not the current keyboard has a closeable UI. If there is no UI to close, `hideKeyboard` simply returns successfully.
