### PR TITLE
Fixed touch-specs failure and added detection of negative percentage offsets (fix #3992)

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/PositionHelper.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/PositionHelper.java
@@ -23,7 +23,7 @@ public abstract class PositionHelper {
     
     if (pointCoord == 0) {
       translatedCoord = length * 0.5;
-    } else if (pointCoord > 0 && pointCoord < 1) {
+    } else if (Math.abs(pointCoord) > 0 && Math.abs(pointCoord) < 1) {
       translatedCoord = length * pointCoord;
     } else {
       translatedCoord = pointCoord;

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -507,10 +507,10 @@ exports.mobileSwipe = function (gestures, req, res) {
           if (er) {
             respondError(req, res, er);
           } else {
-            var offsetX = (endX < 1 && endX > 0) ?
+            var offsetX = (Math.abs(endX) < 1 && Math.abs(endX) > 0) ?
                       sizeResult.value.width * endX :
                       endX;
-            var offsetY = (endY < 1 && endY > 0) ?
+            var offsetY = (Math.abs(endY) < 1 && Math.abs(endY) > 0) ?
                       sizeResult.value.height * endY :
                       endY;
 

--- a/test/functional/ios/testapp/touch-specs.js
+++ b/test/functional/ios/testapp/touch-specs.js
@@ -170,7 +170,7 @@ describe('testapp - swipe actions', function () {
       driver
         // test: press {element, x, y}, moveTo {destEl, x, y}
         .performTouchAction((new TouchAction())
-          .press({el: slider, x: 0, y: 0.5}).wait({ms: 500}).moveTo({el: destEl, x: -90, y: 0.5}).release())
+          .press({el: slider, x: 0, y: 0.5}).wait({ms: 500}).moveTo({el: destEl, x: -120, y: 0.5}).release())
         .then(getSliderValue)
         .then(testSliderValueNear50)
         .nodeify(done);


### PR DESCRIPTION
Fixes #3992.

Unrelated change: Adds support for negative percentage offsets for the dest element, which is already supported in the bootstrap code.
