### PR TITLE
How about having the app client code and the test code at the same place?

### DIFF
--- a/test/functional/titanium-alloy/code-injector.js
+++ b/test/functional/titanium-alloy/code-injector.js
@@ -1,0 +1,141 @@
+"use strict";
+
+var env = require("../../helpers/env"),
+    express = require('express'),
+    http = require('http'),
+    bodyParser = require('body-parser'),
+    Q = require('q'),
+    request = Q.denodeify(require('request'));
+
+function CodeInjector(opts) {
+  this.port = opts.port;
+  this.opts = opts || {};
+  this.code = null;
+}
+
+CodeInjector.prototype.start = function () {
+  this.app = express();
+  this.app.use( bodyParser.json() );
+
+  this.app.post('/code', function (req, res) {
+    // caching code and returning 200
+    this.code = req.body.code;
+    console.log('code injector is saving code.  code -->', this.code);
+    res.send(200);
+  }.bind(this));
+
+  this.app.get('/code', function (req, res) {
+    // retrieving the code and removing it from cache
+    var code = this.code;
+    if (!this.opts.noDelete) this.code = null;
+    console.log('code injector is sending code. code -->', code);
+    res.json({ code: code });
+  }.bind(this));
+
+  this.server = http.createServer(this.app);
+  console.log('code injector listening on', this.port);
+  var listen = Q.nbind(this.server.listen, this.server);
+  return listen(this.port);
+};
+
+CodeInjector.prototype.stop = function () {
+  console.log('stoping code injector');
+  var close = Q.nbind(this.server.close, this.server);
+  return close();
+};
+
+CodeInjector.prototype.postCode = function (code) {
+  code = '' + code;
+  return request({
+    uri: 'http://localhost:' + this.port + '/code',
+    json: {
+      code: code
+    },
+    method: 'POST'
+  }).spread(function (res) {
+    if (res.statusCode !== 200) throw new Error('code POST failed, statusCode -->', res.statusCode, ' .');
+  });
+};
+
+CodeInjector.prototype.injectCode =  function (driver, code) {
+  return this.postCode(code).then(function () {
+    if (env.IOS) {
+      return driver
+        .waitForElementByAccessibilityId('welcome_start')
+          .click()
+        .waitForElementByAccessibilityId('test_close');
+    } else if (env.ANDROID) {
+      return driver
+        .elementByAndroidUIAutomator( 'new UiSelector().descriptionContains("welcome_start")')
+          .click()
+        .waitForElementByAndroidUIAutomator('new UiSelector().descriptionContains("test_close")');
+    } else throw new Error('Unknown env.');
+  }.bind(this));
+};
+
+CodeInjector.prototype.clearCode = function (driver) {
+  if (env.IOS) {
+    return driver
+      .waitForElementById('test_close')
+        .click()
+      .waitForElementById('welcome_start');
+ } else if (env.ANDROID) {
+     return driver
+      .waitForElementByAndroidUIAutomator('new UiSelector().descriptionContains("test_close")')
+        .click()
+      .waitForElementByAndroidUIAutomator('new UiSelector().descriptionContains("welcome_start")');
+  } else throw new Error('Unknown env.');
+};
+
+module.exports = CodeInjector;
+
+// Some code to test the server
+// TODO: write a real test
+function test() {
+  var codeServer = new CodeInjector({port: 8085});
+  codeServer
+    .start()
+    .then(function () {
+      return codeServer.postCode('console.log("Hey I am running some real code here!")');
+    }).then(function () {
+      return request({
+        uri: 'http://localhost:' + codeServer.port + '/code',
+        method: 'GET'
+      });
+    }).spread(function (res) {
+      if (res.statusCode !== 200) throw new Error('code GET failed, statusCode --> ' + res.statusCode + '.');
+      var code = (typeof res.body === 'string' ? JSON.parse(res.body) : res.body).code;
+      // jshint evil: true
+      eval(code);
+    }).then(function () { return codeServer.stop(); })
+    .done();
+}
+if (false) test();
+
+// while doing dev
+// TODO: remove
+function dev() {
+  var clientCode = function (testView) {
+    /* global Ti  */
+    console.log('Hey I am running some real code here!');
+    var label = Ti.UI.createLabel({
+      color:'purple',
+      text: 'Wow I was generated dynamically!',
+      accessibilityLabel: 'dynamicLabel',
+      accessibilityValue: 'Wow I was generated dynamically!',
+      textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
+      top: '40%',
+      width: 'auto',
+      height: 'auto'
+    });
+    testView.add(label);
+  };
+  var codeServer = new CodeInjector({port: 8085, noDelete: true, oneCode: true});
+  codeServer
+    .start()
+    .then(function () {
+      return codeServer.postCode(clientCode);
+    })
+    .done();
+}
+if (false) dev();

--- a/test/functional/titanium-alloy/poc-specs.js
+++ b/test/functional/titanium-alloy/poc-specs.js
@@ -1,0 +1,66 @@
+// Run with:
+// DEVICE=ios81 mocha test/functional/titanium-alloy/poc-specs.js
+// DEVICE=android mocha test/functional/titanium-alloy/poc-specs.js
+
+"use strict";
+
+var env = require('../../helpers/env'),
+    setup = require('./setup-base');
+
+describe('titanium-alloy - poc', function () {
+
+  var driver, codeInjector;
+  setup(this).spread(function (_driver, _codeInjector) {
+    driver = _driver;
+    codeInjector = _codeInjector;
+  });
+
+  describe('Checking the value of a static field', function () {
+    // inject client code
+    before(function () {
+      return codeInjector.injectCode(driver, function (testView) {
+        /* global Ti  */
+        console.log('Hey I am running some real code here!');
+        var label = Ti.UI.createLabel({
+          color:'purple',
+          text: 'Wow I was generated dynamically!',
+          accessibilityLabel: 'dynamicLabel',
+          accessibilityValue: 'Wow I was generated dynamically!',
+          textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
+          top: '40%',
+          width: 'auto',
+          height: 'auto'
+        });
+        testView.add(label);
+      });
+    });
+    // run test
+    if (env.IOS) {
+      it.only('should-work', function () {
+        return driver
+          .waitForElementById('dynamicLabel')
+            .should.eventually.exist
+          .source().print()
+          .waitForElementById('dynamicLabel').getValue()
+            .should.become('Wow I was generated dynamically!');
+      });
+    } else if (env.ANDROID) {
+      it.only('should-work', function () {
+        return driver
+          .waitForElementByAndroidUIAutomator(
+            'new UiSelector().descriptionContains("dynamicLabel")')
+            .should.eventually.exist
+          .source().print()
+          .waitForElementByAndroidUIAutomator(
+              'new UiSelector().descriptionContains("dynamicLabel")').text()
+            .should.become('Wow I was generated dynamically!');
+      });
+    }
+    // cleanup
+    after(function () {
+      return codeInjector.clearCode(driver);
+    });
+  });
+
+});
+

--- a/test/functional/titanium-alloy/setup-base.js
+++ b/test/functional/titanium-alloy/setup-base.js
@@ -1,0 +1,61 @@
+"use strict";
+var env = require('../../helpers/env')
+  , initSession = require('../../helpers/session').initSession
+  , getTitle = require('../../helpers/title').getTitle
+  , wd = require('wd')
+  , chai = require('chai')
+  , chaiAsPromised = require('chai-as-promised')
+  , CodeInjector = require('./code-injector')
+  , Q = require('q');
+
+chai.use(chaiAsPromised);
+chai.should();
+chaiAsPromised.transferPromiseness = wd.transferPromiseness;
+require("colors");
+
+module.exports = function (context) {
+  var deferred = Q.defer();
+  context.timeout(env.MOCHA_INIT_TIMEOUT);
+
+
+  var desired;
+
+  if (env.IOS) {
+    desired = {
+      app: process.env.APPIUM_LOCAL_IOS_DYNAMIC_APP ||
+        'https://github.com/sebv/DynamicApp/raw/master/assets/ios/simulator/DynamicApp.app.zip'
+    };
+  } else if (env.ANDROID) {
+    desired = {
+      app: process.env.APPIUM_LOCAL_ANDROID_DYNAMIC_APP ||
+        'https://github.com/sebv/DynamicApp/raw/master/assets/android/DynamicApp.apk'
+    };
+  }
+  var session = initSession(desired, {});
+  var allPassed = true;
+  var codeInjector = new CodeInjector({port: 8085});
+
+  session.promisedBrowser.then(function (driver) {
+    deferred.resolve([driver, codeInjector]);
+  });
+
+  before(function () {
+    return codeInjector.start();
+  });
+
+  before(function () {
+    return session.setUp(getTitle(context));
+  });
+
+  after(function () { return session.tearDown(allPassed); });
+
+  after(function () {
+    return codeInjector.stop();
+  });
+
+  afterEach(function () {
+    allPassed = allPassed && this.currentTest.state === 'passed';
+  });
+  return deferred.promise;
+};
+


### PR DESCRIPTION
DO NOT MERGE!

So we have app [here](https://github.com/sebv/DynamicApp) which is able to download code on demand and run it. The app is a Titanium Alloy app so it is written in Javascript and can be deployed on Android, iOS.

Because it's all JS, we can write the client code in the mocha `before` and clean it in `after`, and create the native UI element we need for the following test.

I got it working in iOS, to try run this:

```
DEVICE=ios81 mocha test/functional/titanium-alloy/poc-specs.js
DEVICE=android mocha test/functional/titanium-alloy/poc-specs.js
```

This could potentially replace 90% of our tests, preventing us having to fiddle with multiple test application. 

Also the test suite would run faster, since the app itself does nothing, this is easily recyclable for the next test.
