### PR TITLE
Activate docker based infrastructure on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: objective-c
 xcode_sdk: 7.1
+sudo: false
 notifications:
   email: true
   slack:


### PR DESCRIPTION
Don't merge. I'm testing to see if the [docker based Travis](https://github.com/Microsoft/TypeScript/pull/1085) works for appium/appium.
