### PR TITLE
iOS: Fix for a bug when driver.get() never returns for page with alert.

### DIFF
--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -363,27 +363,37 @@ RemoteDebugger.prototype.navToUrl = function (url, cb) {
 
 RemoteDebugger.prototype.pageLoad = function () {
   clearTimeout(this.loadingTimeout);
+  clearTimeout(this.pageReadyTimeout);
+
   var cbs = this.pageLoadedCbs
     , waitMs = 60000
     , intMs = 500
     , start = Date.now();
   this.logger.debug("Page loaded, verifying whether ready through readyState");
+
+  var callOnloadCbs = function() {
+    this.logger.debug("Page is ready, calling onload cbs");
+    this.pageLoadedCbs = [];
+    this.pageLoading = false;
+    _.each(cbs, function (cb) {
+      cb();
+    });
+  }.bind(this);
+
   var verify = function () {
     this.checkPageIsReady(function (err, isReady) {
       if (isReady || (start + waitMs) < Date.now()) {
-        this.logger.debug("Page is ready, calling onload cbs");
-        this.pageLoadedCbs = [];
-        this.pageLoading = false;
-        _.each(cbs, function (cb) {
-          cb();
-        });
+        clearTimeout(this.pageReadyTimeout);
+        callOnloadCbs();
       } else {
         this.logger.debug("Page was not ready, retrying");
         this.loadingTimeout = setTimeout(verify, intMs);
       }
     }.bind(this));
   }.bind(this);
+
   this.loadingTimeout = setTimeout(verify, intMs);
+  this.pageReadyTimeout = setTimeout(callOnloadCbs, waitMs);
 };
 
 RemoteDebugger.prototype.startTimeline = function (fn, cb) {
@@ -609,7 +619,7 @@ RemoteDebugger.prototype.receive = function (data) {
     try {
       msgLength = bufferpack.unpack('L', prefix)[0];
     } catch (e) {
-      this.logger.error("Butter could not unpack");
+      this.logger.error("Buffer could not unpack");
       return this.logger.debug(e);
     }
 


### PR DESCRIPTION
Running:

``` python
driver.switch_to.context("WEBVIEW")
driver.get("http://twitch.tv")
alert = driver.switch_to.alert()
alert.dismiss()
```

Appium gets stuck after `driver.get` forever (or until it hits the command timeout and the session is closed).
The website in the test, _twitch.tv_, opens up an alert while we are checking for readyState and it blocks the javascript thread it seems. As a result the call to `checkPageIsReady` never returns while the alert is present.
Regardless, the `pageLoad` function is not supposed to take more than `waitMs` and this is what my fix tries to achieve by adding a new timeout. 
