### PR TITLE
Fix sending of delete keys

### DIFF
--- a/bin/ios-webkit-debug-proxy-launcher.js
+++ b/bin/ios-webkit-debug-proxy-launcher.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/*
+ * Small tool, launching and monitoring ios-web-kit-proxy, and relauching
+ * on predefined errors.
+ *
+ * Usage:
+ *  ./bin/ios-webkit-debug-proxy-launcher.js [args]
+ *  args: ios-webkit-debug-proxy args (they will be passed over)
+ *
+ * Example:
+ *  ./bin/ios-webkit-debug-proxy-launcher.js -c <UDID>:27753 -d
+ *
+ *  Note:
+ *   For iOS8.1 try this first:
+ *     brew install --HEAD ideviceinstaller
+ */
+
+"use strict";
+
+var spawn = require('child_process').spawn,
+    _ = require('underscore');
+
+var args = process.argv.slice(2);
+
+var RESTART_ON_MESSAGES = [
+  'Invalid message _rpc_applicationUpdated'];
+var PROXY_CMD = 'ios_webkit_debug_proxy';
+
+function startProxy() {
+  console.log('RUNNING:', PROXY_CMD, args.join(' '));
+
+  var proxy = spawn(PROXY_CMD, args);
+
+  proxy.stdout.on('data', function (data) {
+    console.log('stdout: ' + data);
+  });
+
+  proxy.stderr.on('data', function (data) {
+    console.log('stderr: ' + data);
+    var restartMessage = _(RESTART_ON_MESSAGES).find(function (message) {
+       return ('' + data).indexOf(message) >= 0;
+    });
+    if (restartMessage) {
+      console.log('Detected error message:', restartMessage);
+      console.log('Killing proxy!');
+      proxy.kill('SIGTERM');
+      process.nextTick(startProxy);
+    }
+  });
+
+  proxy.on('close', function (code) {
+    console.log('child process exited with code ' + code);
+  });
+}
+
+startProxy();
+

--- a/docs/en/advanced-concepts/hybrid.md
+++ b/docs/en/advanced-concepts/hybrid.md
@@ -185,12 +185,28 @@ it yourself:
 > sudo make install
 ```
 
+If you use a recent device, you may need to install the latest
+ideviceinstaller, this is optional:
+
+```
+brew install --HEAD ideviceinstaller
+```
+
 Once installed you can start the proxy with the following command:
 
 ``` center
 # Change the udid to be the udid of the attached device and make sure to set the port to 27753
 # as that is the port the remote-debugger uses.
 > ios_webkit_debug_proxy -c 0e4b2f612b65e98c1d07d22ee08678130d345429:27753 -d
+```
+
+You may also use the ios-webkit-debug-proxy-launcher to launch the
+proxy. It monitors the proxy log for errors, and relaunch the proxy
+where needed. This is also optional and may help with recent devices
+
+``` center
+# change the udid
+> ./bin/ios-webkit-debug-proxy-launcher.js -c 0e4b2f612b65e98c1d07d22ee08678130d345429:27753 -d
 ```
 
 **NOTE:** the proxy requires the **"web inspector"** to be turned on to

--- a/docs/en/advanced-concepts/hybrid.md
+++ b/docs/en/advanced-concepts/hybrid.md
@@ -202,7 +202,7 @@ Once installed you can start the proxy with the following command:
 
 You may also use the ios-webkit-debug-proxy-launcher to launch the
 proxy. It monitors the proxy log for errors, and relaunch the proxy
-where needed. This is also optional and may help with recent devices
+where needed. This is also optional and may help with recent devices:
 
 ``` center
 # change the udid

--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -79,3 +79,4 @@
 |`interKeyDelay`| The delay, in ms, between keystrokes sent to an element when typing.|e.g., `100`|
 |`showIOSLog`| Whether to show any logs captured from a device in the appium logs. Default `false`|`true` or `false`|
 |`sendKeyStrategy`| strategy to use to type test into a test field. Simulator default: `oneByOne`. Real device default: 'grouped' |`oneByOne`, `grouped` or setValue|
+|`screenshotWaitTimeout`| Max timeout in sec to wait for a screenshot to be generated. default: 10 |e.g., `5`|

--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -76,7 +76,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--keep-keychains`|false|(iOS) Whether to keep keychains (Library/Keychains) when reset app between sessions||
 |`--strict-caps`|false|Cause sessions to fail if desired caps are sent in that Appium does not recognize as valid for the selected device||
 |`--isolate-sim-device`|false|Xcode 6 has a bug on some platforms where a certain simulator can only be launched without error if all other simulator devices are first deleted. This option causes Appium to delete all devices other than the one being used by Appium. Note that this is a permanent deletion, and you are responsible for using simctl or xcode to manage the categories of devices used with Appium.||
-|`--tmp`|null|Absolute path to directory Appium can use to manage temporary files, like built-in iOS apps it needs to move around. Defaults to the APPIUM_TMP_DIR variable and then to /tmp on *nix/Mac defaults and to the TEMP variable on windows||
+|`--tmp`|null|Absolute path to directory Appium can use to manage temporary files, like built-in iOS apps it needs to move around. Defaults to the `APPIUM_TMP_DIR` variable and then to `/tmp` on *nix/Mac and to the `TEMP` variable on windows.||
 |`--trace-dir`|null|Absolute path to directory Appium use to save ios instruments traces, defaults to <tmp dir>/appium-instruments||
 |`--intent-action`|android.intent.action.MAIN|(Android-only) Intent action which will be used to start activity|`--intent-action android.intent.action.MAIN`|
 |`--intent-category`|android.intent.category.LAUNCHER|(Android-only) Intent category which will be used to start activity|`--intent-category android.intent.category.APP_CONTACTS`|

--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -76,7 +76,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--keep-keychains`|false|(iOS) Whether to keep keychains (Library/Keychains) when reset app between sessions||
 |`--strict-caps`|false|Cause sessions to fail if desired caps are sent in that Appium does not recognize as valid for the selected device||
 |`--isolate-sim-device`|false|Xcode 6 has a bug on some platforms where a certain simulator can only be launched without error if all other simulator devices are first deleted. This option causes Appium to delete all devices other than the one being used by Appium. Note that this is a permanent deletion, and you are responsible for using simctl or xcode to manage the categories of devices used with Appium.||
-|`--tmp`|null|Absolute path to directory Appium can use to manage temporary files, like built-in iOS apps it needs to move around. On *nix/Mac defaults to /tmp, on Windows defaults to C:\Windows\Temp||
+|`--tmp`|null|Absolute path to directory Appium can use to manage temporary files, like built-in iOS apps it needs to move around. Defaults to the APPIUM_TMP_DIR variable and then to /tmp on *nix/Mac defaults and to the TEMP variable on windows||
 |`--trace-dir`|null|Absolute path to directory Appium use to save ios instruments traces, defaults to <tmp dir>/appium-instruments||
 |`--intent-action`|android.intent.action.MAIN|(Android-only) Intent action which will be used to start activity|`--intent-action android.intent.action.MAIN`|
 |`--intent-category`|android.intent.category.LAUNCHER|(Android-only) Intent category which will be used to start activity|`--intent-category android.intent.category.APP_CONTACTS`|

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -150,7 +150,17 @@ Appium.prototype.getDeviceType = function (args, caps) {
 
   // TODO: Set DT_SELENDROID type based on platformVersion
   var type = this.getDeviceTypeFromPlatform(platform);
-  if (type === DT_ANDROID) {
+
+  if (type === DT_IOS) {
+     // Detect Safari browser from browserName, app and args
+    if (
+        args.safari ||
+        this.isSafariBrowser(browser) ||
+        this.isSafariBrowser(app)
+      ) {
+      type = DT_SAFARI;
+    }
+  } else if (type === DT_ANDROID) {
     // Detect Chrome browser from browserName, app and pkg
     if (
         this.isChromeBrowser(browser) ||
@@ -160,15 +170,6 @@ Appium.prototype.getDeviceType = function (args, caps) {
       type = DT_CHROME;
     } else if (this.isSelendroidAutomation(automation)) {
       type = DT_SELENDROID;
-    }
-  } else if (type === DT_IOS) {
-    // Detect Safari browser from browserName, app and args
-    if (
-        args.safari ||
-        this.isSafariBrowser(browser) ||
-        this.isSafariBrowser(app)
-      ) {
-      type = DT_SAFARI;
     }
   }
 
@@ -220,7 +221,6 @@ Appium.prototype.getDeviceTypeFromPlatform = function (caps) {
 
 Appium.prototype.configure = function (args, desiredCaps, cb) {
   var deviceType;
-
   try {
     deviceType = this.getDeviceType(args, desiredCaps);
     if (!args.launch) desiredCaps.checkValidity(deviceType, args.enforceStrictCaps);

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -129,25 +129,16 @@ Appium.prototype.start = function (desiredCaps, cb) {
 };
 
 Appium.prototype.getDeviceType = function (args, caps) {
-  // TODO: 'deviceName' and 'platformName' caps are now required, so the majority of this code could be removed
-  var type =  this.getDeviceFromMJSONWP(args, caps) ||
-              this.getDeviceTypeFromArgsOrNamedApp(args, caps) ||
-              this.getDeviceTypeFromAppOrPackage(args, caps);
-  if (type) {
-    return type;
-  }
-  throw new Error("Could not determine your device from Appium arguments " +
-                "or desired capabilities. Please make sure to specify the " +
-                "'deviceName' and 'platformName' capabilities");
-};
-
-Appium.prototype.getDeviceFromMJSONWP = function (args, caps) {
   var platform = caps.platformName || args.platformName;
   platform = platform ? platform.toString().toLowerCase() : '';
   var browser = caps.browserName || args.browserName;
   browser = browser ? browser.toString().toLowerCase() : '';
   var automation = caps.automationName || args.automationName;
   automation = automation ? automation.toString().toLowerCase() : '';
+  var app = args.app || caps.app;
+  app = app ? app.toString().toLowerCase() : '';
+  var pkg = args.androidPackage || caps.appPackage;
+  pkg = pkg ? pkg.toString().toLowerCase() : '';
 
   var validPlatforms = ['ios', 'android', 'firefoxos'];
   if (platform && !_.contains(validPlatforms, platform)) {
@@ -156,43 +147,62 @@ Appium.prototype.getDeviceFromMJSONWP = function (args, caps) {
                     "is not a supported platform. Supported platforms are: " +
                     "iOS, Android and FirefoxOS");
   }
-  var type =  this.getDeviceTypeFromAutomationName(automation) ||
-              this.getDeviceTypeFromBrowserName(browser) ||
-              this.getDeviceTypeFromPlatformCap(platform);
-  if (type) return type;
-};
 
-Appium.prototype.getDeviceTypeFromArgsOrNamedApp = function (args, caps) {
-  var app = args.app || caps.app;
-  app = app ? app.toString().toLowerCase() : '';
-  var type = this.getDeviceTypeFromNamedApp(app) ||
-             this.getDeviceTypeFromArgs(args);
-  if (type) return type;
-};
-
-Appium.prototype.getDeviceTypeFromAppOrPackage = function (args, caps) {
-  var app = args.app || caps.app;
-  app = app ? app.toString().toLowerCase() : '';
-  var pkg = args.androidPackage || caps.appPackage;
-  pkg = pkg ? pkg.toString().toLowerCase() : '';
-  var type =  this.getDeviceTypeFromApp(app) ||
-              this.getDeviceTypeFromPackage(pkg);
-  if (type) return type;
-};
-
-Appium.prototype.getDeviceTypeFromAutomationName = function (automation) {
-  if (automation.indexOf('selendroid') !== -1) return DT_SELENDROID;
-};
-
-Appium.prototype.getDeviceTypeFromBrowserName = function (browser) {
-  if (browser === "safari") {
-    return DT_SAFARI;
-  } else if (_.contains(["chrome", "chromium", "chromebeta", "browser"], browser)) {
-    return DT_CHROME;
+  // TODO: Set DT_SELENDROID type based on platformVersion
+  var type = this.getDeviceTypeFromPlatform(platform);
+  if (type === DT_ANDROID) {
+    // Detect Chrome browser from browserName, app and pkg
+    if (
+        this.isChromeBrowser(browser) ||
+        this.isChromeBrowser(app) ||
+        this.isChromePackage(pkg)
+      ) {
+      type = DT_CHROME;
+    } else if (this.isSelendroidAutomation(automation)) {
+      type = DT_SELENDROID;
+    }
+  } else if (type === DT_IOS) {
+    // Detect Safari browser from browserName, app and args
+    if (
+        args.safari ||
+        this.isSafariBrowser(browser) ||
+        this.isSafariBrowser(app)
+      ) {
+      type = DT_SAFARI;
+    }
   }
+
+  if (!type) {
+    throw new Error("Could not determine your device from Appium arguments " +
+                  "or desired capabilities. Please make sure to specify the " +
+                  "'deviceName' and 'platformName' capabilities");
+  }
+  return type;
 };
 
-Appium.prototype.getDeviceTypeFromPlatformCap = function (caps) {
+Appium.prototype.isSelendroidAutomation = function (automation) {
+  return automation.indexOf('selendroid') !== -1;
+};
+
+Appium.prototype.isChromeBrowser = function (browser) {
+  return _.contains(["chrome", "chromium", "chromebeta", "browser"], browser);
+};
+
+Appium.prototype.isChromePackage = function (pkg) {
+  var chromePkgs = [
+    "com.android.chrome"
+  , "com.chrome.beta"
+  , "org.chromium.chrome.shell"
+  , "com.android.browser"
+  ];
+  return _.contains(chromePkgs, pkg);
+};
+
+Appium.prototype.isSafariBrowser = function (browser) {
+  return browser === "safari";
+};
+
+Appium.prototype.getDeviceTypeFromPlatform = function (caps) {
   var device = null;
   switch (caps) {
   case 'ios':
@@ -206,63 +216,6 @@ Appium.prototype.getDeviceTypeFromPlatformCap = function (caps) {
     break;
   }
   return device;
-};
-
-Appium.prototype.getDeviceTypeFromDeviceCap = function (device) {
-
-  if (device.indexOf('iphone') !== -1) {
-    return DT_IOS;
-  } else if (device.indexOf('ipad') !== -1) {
-    return DT_IOS;
-  } else if (device.indexOf('selendroid') !== -1) {
-    return DT_SELENDROID;
-  } else if (device.indexOf('firefox') !== -1) {
-    return DT_FIREFOX_OS;
-  } else if (device.indexOf('android') !== -1) {
-    return DT_ANDROID;
-  }
-};
-
-Appium.prototype.getDeviceTypeFromNamedApp = function (app) {
-  if (app  === "safari") {
-    return DT_SAFARI;
-  } else if (app === "settings") {
-    return DT_IOS;
-  } else if (_.contains(["chrome", "chromium", "chromebeta", "browser"], app)) {
-    return DT_CHROME;
-  }
-};
-
-Appium.prototype.getDeviceTypeFromApp = function (app) {
-  if (/\.app$/.test(app) || /\.app\.zip$/.test(app)) {
-    return DT_IOS;
-  } else if (/\.apk$/.test(app) || /\.apk\.zip$/.test(app)) {
-    return DT_ANDROID;
-  }
-};
-
-Appium.prototype.getDeviceTypeFromPackage = function (pkg) {
-  var chromePkgs = [
-    "com.android.chrome"
-  , "com.chrome.beta"
-  , "org.chromium.chrome.shell"
-  , "com.android.browser"
-  ];
-  if (_.contains(chromePkgs, pkg)) {
-    return DT_CHROME;
-  } else if (pkg) {
-    return DT_ANDROID;
-  }
-};
-
-Appium.prototype.getDeviceTypeFromArgs = function (args) {
-  if (args.ipa && /\.ipa$/.test(args.ipa.toString().toLowerCase())) {
-    return DT_IOS;
-  } else if (args.safari) {
-    return DT_SAFARI;
-  } else if (args.forceIphone || args.forceIpad) {
-    return DT_IOS;
-  }
 };
 
 Appium.prototype.configure = function (args, desiredCaps, cb) {

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -11,7 +11,8 @@ var logger = require('../../server/logger.js').get('appium')
   , errors = require('../../server/errors.js')
   , Device = require('../device.js')
   , ADB = require('appium-adb')
-  , NotYetImplementedError = errors.NotYetImplementedError;
+  , NotYetImplementedError = errors.NotYetImplementedError
+  , Args = require("vargs").Constructor;
 
 var logTypesSupported = {
   'logcat' : 'Logs for Android applications on real device and emulators ' +
@@ -980,6 +981,20 @@ androidCommon.deactivateIMEEngine = function (cb) {
         value: null
       });
     });
+  }.bind(this));
+};
+
+androidCommon.hideKeyboard = function () {
+  // parameters only used for iOS. Please ignore them for android.
+  var args = new Args(arguments);
+  var cb = args.callback;
+  this.adb.isSoftKeyboardPresent(function (err, isKeyboardPresent) {
+    if (err) return cb(err);
+    if (isKeyboardPresent) {
+      this.back(cb);
+    } else {
+      return cb(new Error("Soft keyboard not present, cannot hide keyboard"));
+    }
   }.bind(this));
 };
 

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -712,10 +712,17 @@ androidController.hideKeyboard = function () {
   // parameters only used for iOS. Please ignore them for android.
   var args = new(Args)(arguments);
   var cb = args.callback;
-  this.adb.isSoftKeyboardPresent(function (err, isKeyboardPresent) {
+  this.adb.isSoftKeyboardPresent(function (err, isKeyboardPresent, canCloseKeyboard) {
     if (err) return cb(err);
     if (isKeyboardPresent) {
-      this.back(cb);
+      if (canCloseKeyboard) {
+        this.back(cb);
+      } else {
+        cb(null, {
+          status: status.codes.Success.code
+        , value: "Keyboard has no UI; no closing necessary"
+        });
+      }
     } else {
       return cb(new Error("Soft keyboard not present, cannot hide keyboard"));
     }

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -710,7 +710,7 @@ androidController.setLocation = function (latitude, longitude, altitude, horizon
 
 androidController.hideKeyboard = function () {
   // parameters only used for iOS. Please ignore them for android.
-  var args = new(Args)(arguments);
+  var args = new (Args)(arguments);
   var cb = args.callback;
   this.adb.isSoftKeyboardPresent(function (err, isKeyboardPresent, canCloseKeyboard) {
     if (err) return cb(err);

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -13,8 +13,7 @@ var errors = require('../../server/errors.js')
   , mkdirp = require('mkdirp')
   , path = require('path')
   , AdmZip = require("adm-zip")
-  , helpers = require('../../helpers.js')
-  , Args = require("vargs").Constructor;
+  , helpers = require('../../helpers.js');
 
 var androidController = {};
 
@@ -706,27 +705,6 @@ androidController.setLocation = function (latitude, longitude, altitude, horizon
     , value: res
     });
   });
-};
-
-androidController.hideKeyboard = function () {
-  // parameters only used for iOS. Please ignore them for android.
-  var args = new (Args)(arguments);
-  var cb = args.callback;
-  this.adb.isSoftKeyboardPresent(function (err, isKeyboardPresent, canCloseKeyboard) {
-    if (err) return cb(err);
-    if (isKeyboardPresent) {
-      if (canCloseKeyboard) {
-        this.back(cb);
-      } else {
-        cb(null, {
-          status: status.codes.Success.code
-        , value: "Keyboard has no UI; no closing necessary"
-        });
-      }
-    } else {
-      return cb(new Error("Soft keyboard not present, cannot hide keyboard"));
-    }
-  }.bind(this));
 };
 
 androidController.url = function (url, cb) {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
@@ -155,9 +155,18 @@ public class Clear extends CommandHandler {
     String currText = el.getText();
 
     final Method sendKey = utils.getControllerMethod("sendKey", int.class, int.class);
-    sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_DPAD_RIGHT, 0);
+    try {
+      if (!el.getBoolAttribute("focused")) {
+        Logger.debug("Could not check for hint text because the element is not focused!");
+        return false;
+      }
+    } catch(final Exception e) {
+      Logger.debug("Could not check for hint text: " + e.getMessage());
+      return false;
+    }
+    sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_BUTTON_THUMBR, 0);
     sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_DEL, 0);
-    sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_DPAD_LEFT, 0);
+    sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_BUTTON_THUMBL, 0);
     sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_DEL, 0);
 
     return currText.equals(el.getText());

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
@@ -53,7 +53,7 @@ public class Clear extends CommandHandler {
 
         final ReflectionUtils utils = new ReflectionUtils();
 
-	// see if there is hint text
+        // see if there is hint text
         if (hasHintText(el, utils)) {
           Logger.debug("Text remains after clearing, "
               + "but it appears to be hint text.");
@@ -67,7 +67,7 @@ public class Clear extends CommandHandler {
           return getSuccessResult(true);
         }
 
-	// see if there is hint text
+        // see if there is hint text
         if (hasHintText(el, utils)) {
           Logger.debug("Text remains after clearing, "
               + "but it appears to be hint text.");
@@ -87,7 +87,9 @@ public class Clear extends CommandHandler {
             Logger.debug("Text remains after clearing, " +
                          "but it appears to be hint text.");
             return getSuccessResult(true);
-          } else {
+          } else if (!el.getText().isEmpty()) {
+            Logger.debug("Exhausted all means to clear text but '" +
+                         el.getText() + "' remains.");
             return getErrorResult("Clear text not successful.");
           }
         }
@@ -127,17 +129,19 @@ public class Clear extends CommandHandler {
     String tempTextHolder = "";
     final Object bridgeObject = utils.getBridge();
     final Method injectInputEvent = utils.getMethodInjectInputEvent();
+
     // Preventing infinite while loop.
     while (!el.getText().isEmpty() && !tempTextHolder.equalsIgnoreCase(el.getText())) {
       tempTextHolder = el.getText();
       // Trying send delete keys after clicking in text box.
       el.click();
-      // Sending 25 delete keys asynchronously
+      // Sending correct delete keys asynchronously
+      final int length = tempTextHolder.length();
       final long eventTime = SystemClock.uptimeMillis();
       KeyEvent deleteEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN,
               KeyEvent.KEYCODE_DEL, 0, 0, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0,
               InputDevice.SOURCE_KEYBOARD);
-      for (int count = 0; count < 25; count++) {
+      for (int count = 0; count < length; count++) {
           injectInputEvent.invoke(bridgeObject, deleteEvent, false);
       }
     }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
@@ -132,17 +132,19 @@ public class Clear extends CommandHandler {
 
     // Preventing infinite while loop.
     while (!el.getText().isEmpty() && !tempTextHolder.equalsIgnoreCase(el.getText())) {
-      tempTextHolder = el.getText();
       // Trying send delete keys after clicking in text box.
       el.click();
-      // Sending correct delete keys asynchronously
-      final int length = tempTextHolder.length();
-      final long eventTime = SystemClock.uptimeMillis();
-      KeyEvent deleteEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN,
-              KeyEvent.KEYCODE_DEL, 0, 0, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0,
-              InputDevice.SOURCE_KEYBOARD);
-      for (int count = 0; count < length; count++) {
-          injectInputEvent.invoke(bridgeObject, deleteEvent, false);
+      // Sending delete keys asynchronously, both forward and backward
+      for (int key : new int[]{ KeyEvent.KEYCODE_DEL, KeyEvent.KEYCODE_FORWARD_DEL }) {
+        tempTextHolder = el.getText();
+        final int length = tempTextHolder.length();
+        final long eventTime = SystemClock.uptimeMillis();
+        KeyEvent deleteEvent = new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN,
+                key, 0, 0, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0,
+                InputDevice.SOURCE_KEYBOARD);
+        for (int count = 0; count < length; count++) {
+            injectInputEvent.invoke(bridgeObject, deleteEvent, false);
+        }
       }
     }
 
@@ -172,6 +174,7 @@ public class Clear extends CommandHandler {
     sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_DEL, 0);
     sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_BUTTON_THUMBL, 0);
     sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_DEL, 0);
+    sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_FORWARD_DEL, 0);
 
     return currText.equals(el.getText());
   }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
@@ -55,6 +55,9 @@ public class SetText extends CommandHandler {
           text = currText + text;
         }
         final boolean result = el.setText(text, unicodeKeyboard);
+        if (!result) {
+          return getErrorResult("el.setText() failed!");
+        }
         if (pressEnter) {
           final UiDevice d = UiDevice.getInstance();
           d.pressEnter();

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -550,4 +550,8 @@ Selendroid.prototype.setValue = function (elementId, value, cb) {
   });
 };
 
+Selendroid.prototype.back = function (cb) {
+  this.keyevent(4, null, cb);
+};
+
 module.exports = Selendroid;

--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -31,7 +31,10 @@ Device.prototype.configure = function (args, caps) {
     this.setArgFromCap(cap, cap);
   }.bind(this));
   if (this.args.tmpDir === null) {
-    this.args.tmpDir = helpers.isWindows() ? "C:\\Windows\\Temp" : "/tmp";
+    // use a custom tmp dir to avoid loosing data and app
+    // when computer is restarted
+    this.args.tmpDir = process.env.APPIUM_TMP_DIR ||
+      (helpers.isWindows() ? process.env.TEMP : "/tmp");
   }
   if (this.args.traceDir === null) {
     this.args.traceDir = path.resolve(this.args.tmpDir , 'appium-instruments');

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1232,24 +1232,26 @@ iOSController.getScreenshot = function (cb) {
         function (cb) { this.getOrientation(function () { cb(); }); }.bind(this),
         function (cb) { this.proxy(command, cb); }.bind(this),
         function (response, cb) {
-          var data = null;
-          var count = 0;
+          var data;
+          var screenshotWaitTimeout = (this.args.screenshotWaitTimeout || 10) * 1000;
+          logger.debug('Waiting ' + screenshotWaitTimeout + ' ms for screenshot to ge generated.');
+          var startMs = Date.now();
+          var lastErr;
           async.until(
-            function () { return data; },
+            function () { return data || Date.now() - startMs > screenshotWaitTimeout; },
             function (cb) {
               setTimeout(function () {
                 fs.readFile(shotPath, function (err, _data) {
-                  if (err && ++count > 20) {
-                    return cb(new Error("Timed out waiting for screenshot file. " + err.toString()));
-                  }
-                  if (!err) {
-                    data = _data;
-                  }
+                  lastErr = err;
+                  if (!err) { data = _data; }
                   cb();
                 });
               }, 300);
             },
             function (err) {
+              if (!data) {
+                return cb(new Error("Timed out waiting for screenshot file. " + (lastErr || '').toString()));
+              }
               cb(err, response, data);
             }
           );

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -158,7 +158,6 @@ IOS.prototype.configure = function (args, caps, cb) {
 IOS.prototype.setIOSArgs = function () {
   this.args.withoutDelay = !this.args.nativeInstrumentsLib;
   this.args.reset = !this.args.noReset;
-  this.args.deviceName = this.args.deviceName || this.args.platformName;
   this.args.initialOrientation = this.capabilities.deviceOrientation ||
                                  this.args.orientation ||
                                  "PORTRAIT";

--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -299,7 +299,7 @@ function getRequestContext(req) {
 // Mainly used to wrap http response methods, or for cases where errors
 // perdure the domain
 var safely = function () {
-  var args = new(Args)(arguments);
+  var args = new (Args)(arguments);
   var req = args.all[0];
   var fn = args.callback;
   try {

--- a/test/functional/android/apidemos/clear-specs.js
+++ b/test/functional/android/apidemos/clear-specs.js
@@ -17,88 +17,118 @@ describe("apidemos - clear", function () {
   }, desired);
   setup(this, _desired).then(function (d) { driver = d; });
 
-  it('should hide the keyboard using the default strategy', function (done) {
-    driver
-      .waitForElementByClassName('android.widget.EditText')
-      .click()
-      .sleep(1000)
-      .hideKeyboard()
-      .sleep(1000)
-      .elementByClassName('android.widget.EditText')
-      .should.eventually.exist
-      .nodeify(done);
+  describe('clear', function () {
+    it('should clear an empty field with hint', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .clear()
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .text().should.become('hint text')
+        .nodeify(done);
+    });
+
+    it('should clear a field with hint', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sendKeys('Are you looking at me!')
+        .sleep(1000)
+        .clear()
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .text().should.become('hint text')
+        .nodeify(done);
+    });
+
   });
 
-  it('should hide the keyboard using the "Done" key', function (done) {
-    driver
-      .waitForElementByClassName('android.widget.EditText')
-      .click()
-      .sleep(1000)
-      .hideKeyboard('Done')
-      .sleep(1000)
-      .elementByClassName('android.widget.EditText')
-      .should.eventually.exist
-      .nodeify(done);
-  });
+  describe('hideKeyboard', function () {
 
-  it('should hide the keyboard using the "press" strategy and "Done" key', function (done) {
-    driver
-      .waitForElementByClassName('android.widget.EditText')
-      .click()
-      .sleep(1000)
-      .hideKeyboard({strategy:'press', key: 'Done'})
-      .sleep(1000)
-      .elementByClassName('android.widget.EditText')
-      .should.eventually.exist
-      .nodeify(done);
-  });
+    it('should hide the keyboard using the default strategy', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard()
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
 
-  it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
-    driver
-      .waitForElementByClassName('android.widget.EditText')
-      .click()
-      .sleep(1000)
-      .hideKeyboard({strategy:'pressKey', key: 'Done'})
-      .sleep(1000)
-      .elementByClassName('android.widget.EditText')
-      .should.eventually.exist
-      .nodeify(done);
-  });
+    it('should hide the keyboard using the "Done" key', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard('Done')
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
 
-  it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
-    driver
-      .waitForElementByClassName('android.widget.EditText')
-      .click()
-      .sleep(1000)
-      .hideKeyboard({strategy:'swipeDown'})
-      .sleep(1000)
-      .elementByClassName('android.widget.EditText')
-      .should.eventually.exist
-      .nodeify(done);
-  });
+    it('should hide the keyboard using the "press" strategy and "Done" key', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'press', key: 'Done'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
 
-  it('should hide the keyboard using the "tapOutside" strategy', function (done) {
-    driver
-      .waitForElementByClassName('android.widget.EditText')
-      .click()
-      .sleep(1000)
-      .hideKeyboard({strategy:'tapOutside'})
-      .sleep(1000)
-      .elementByClassName('android.widget.EditText')
-      .should.eventually.exist
-      .nodeify(done);
-  });
+    it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'pressKey', key: 'Done'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
 
-  it('should hide the keyboard using the "tapOut" strategy', function (done) {
-    driver
-      .waitForElementByClassName('android.widget.EditText')
-      .click()
-      .sleep(1000)
-      .hideKeyboard({strategy:'tapOut'})
-      .sleep(1000)
-      .elementByClassName('android.widget.EditText')
-      .should.eventually.exist
-      .nodeify(done);
-  });
+    it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'swipeDown'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
 
+    it('should hide the keyboard using the "tapOutside" strategy', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'tapOutside'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
+
+    it('should hide the keyboard using the "tapOut" strategy', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'tapOut'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
+  });
 });

--- a/test/functional/android/apidemos/clear-specs.js
+++ b/test/functional/android/apidemos/clear-specs.js
@@ -1,0 +1,104 @@
+"use strict";
+
+var setup = require("../../common/setup-base")
+    , desired = require("./desired")
+    , _ = require('underscore')
+    , getAppPath = require('../../../helpers/app').getAppPath;
+
+
+describe("apidemos - clear", function () {
+  var driver;
+  var _desired = _.defaults({
+    app: getAppPath('ApiDemos'),
+    appActivity: '.view.Controls1',
+    newCommandTimeout: 90,
+    language: 'en',
+    locale: 'en_US'
+  }, desired);
+  setup(this, _desired).then(function (d) { driver = d; });
+
+  it('should hide the keyboard using the default strategy', function (done) {
+    driver
+      .waitForElementByClassName('android.widget.EditText')
+      .click()
+      .sleep(1000)
+      .hideKeyboard()
+      .sleep(1000)
+      .elementByClassName('android.widget.EditText')
+      .should.eventually.exist
+      .nodeify(done);
+  });
+
+  it('should hide the keyboard using the "Done" key', function (done) {
+    driver
+      .waitForElementByClassName('android.widget.EditText')
+      .click()
+      .sleep(1000)
+      .hideKeyboard('Done')
+      .sleep(1000)
+      .elementByClassName('android.widget.EditText')
+      .should.eventually.exist
+      .nodeify(done);
+  });
+
+  it('should hide the keyboard using the "press" strategy and "Done" key', function (done) {
+    driver
+      .waitForElementByClassName('android.widget.EditText')
+      .click()
+      .sleep(1000)
+      .hideKeyboard({strategy:'press', key: 'Done'})
+      .sleep(1000)
+      .elementByClassName('android.widget.EditText')
+      .should.eventually.exist
+      .nodeify(done);
+  });
+
+  it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
+    driver
+      .waitForElementByClassName('android.widget.EditText')
+      .click()
+      .sleep(1000)
+      .hideKeyboard({strategy:'pressKey', key: 'Done'})
+      .sleep(1000)
+      .elementByClassName('android.widget.EditText')
+      .should.eventually.exist
+      .nodeify(done);
+  });
+
+  it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
+    driver
+      .waitForElementByClassName('android.widget.EditText')
+      .click()
+      .sleep(1000)
+      .hideKeyboard({strategy:'swipeDown'})
+      .sleep(1000)
+      .elementByClassName('android.widget.EditText')
+      .should.eventually.exist
+      .nodeify(done);
+  });
+
+  it('should hide the keyboard using the "tapOutside" strategy', function (done) {
+    driver
+      .waitForElementByClassName('android.widget.EditText')
+      .click()
+      .sleep(1000)
+      .hideKeyboard({strategy:'tapOutside'})
+      .sleep(1000)
+      .elementByClassName('android.widget.EditText')
+      .should.eventually.exist
+      .nodeify(done);
+  });
+
+  it('should hide the keyboard using the "tapOut" strategy', function (done) {
+    driver
+      .waitForElementByClassName('android.widget.EditText')
+      .click()
+      .sleep(1000)
+      .hideKeyboard({strategy:'tapOut'})
+      .sleep(1000)
+      .elementByClassName('android.widget.EditText')
+      .should.eventually.exist
+      .nodeify(done);
+  });
+
+});

--- a/test/functional/common/prelaunch-specs.js
+++ b/test/functional/common/prelaunch-specs.js
@@ -8,7 +8,10 @@ var env = require('../../helpers/env')
       "apps", "ApiDemos", "bin", "ApiDemos-debug.apk")
   , spawn = require('child_process').spawn
   , crazyPort = 4799
-  , _ = require('underscore');
+  , _ = require('underscore')
+  , chai = require('chai');
+
+chai.should();
 
 function log(data) {
   data = (data || "").replace(/(\r)?\n$/, '');
@@ -70,33 +73,44 @@ describe("common - prelaunch @skip-ci @skip-ios6", function () {
       }, 3000);
     });
 
+    it('should fail with a nice error message', function (done) {
+      console.log('Expecting Appium to crash.');
+      var data;
+      proc = waitForLaunch(iosApp, [], function () {
+        data.should.include('platformName');
+        done();
+      });
+      proc.stderr.on('data', function (_data) {
+        data += _data;
+      });
+    });
+
     it('should work for ios', function (done) {
-      proc = waitForLaunch(iosApp, [], done);
+      proc = waitForLaunch(iosApp, ['--platform-name', 'iOS'], done);
     });
 
     it('should work with force ipad', function (done) {
-      proc = waitForLaunch(iosApp, ['--force-ipad'], done);
+      proc = waitForLaunch(iosApp, ['--force-ipad', '--platform-name', 'iOS'], done);
     });
 
     it('should work with force iphone', function (done) {
-      proc = waitForLaunch(iosApp, ['--force-iphone'], done);
+      proc = waitForLaunch(iosApp, ['--force-iphone', '--platform-name', 'iOS'], done);
     });
 
     it('should work for safari via --safari', function (done) {
-      proc = waitForLaunch(null, ['--safari'], done);
+      proc = waitForLaunch(null, ['--safari', '--platform-name', 'iOS'], done);
     });
 
     it('should work for safari', function (done) {
-      proc  = waitForLaunch('safari', [], done);
+      proc  = waitForLaunch('safari', ['--platform-name', 'iOS'], done);
     });
 
   });
 
-  // TODO
-  describe('android @skip-ios-all @skip-android-all', function () {
+  describe('android @skip-ios-all', function () {
     it('should work for android', function (done) {
       var args = ["--app-pkg", "io.appium.android.apis", "--app-activity",
-        ".ApiDemos"];
+        ".ApiDemos", '--platform-name', 'Android'];
       waitForLaunch(androidApp, args, done);
     });
   });

--- a/test/functional/dynamic-app/code-injector.js
+++ b/test/functional/dynamic-app/code-injector.js
@@ -1,0 +1,141 @@
+"use strict";
+
+var env = require("../../helpers/env"),
+    express = require('express'),
+    http = require('http'),
+    bodyParser = require('body-parser'),
+    Q = require('q'),
+    request = Q.denodeify(require('request'));
+
+function CodeInjector(opts) {
+  this.port = opts.port;
+  this.opts = opts || {};
+  this.code = null;
+}
+
+CodeInjector.prototype.start = function () {
+  this.app = express();
+  this.app.use( bodyParser.json() );
+
+  this.app.post('/code', function (req, res) {
+    // caching code and returning 200
+    this.code = req.body.code;
+    console.log('code injector is saving code.  code -->', this.code);
+    res.send(200);
+  }.bind(this));
+
+  this.app.get('/code', function (req, res) {
+    // retrieving the code and removing it from cache
+    var code = this.code;
+    if (!this.opts.noDelete) this.code = null;
+    console.log('code injector is sending code. code -->', code);
+    res.json({ code: code });
+  }.bind(this));
+
+  this.server = http.createServer(this.app);
+  console.log('code injector listening on', this.port);
+  var listen = Q.nbind(this.server.listen, this.server);
+  return listen(this.port);
+};
+
+CodeInjector.prototype.stop = function () {
+  console.log('stoping code injector');
+  var close = Q.nbind(this.server.close, this.server);
+  return close();
+};
+
+CodeInjector.prototype.postCode = function (code) {
+  code = '' + code;
+  return request({
+    uri: 'http://localhost:' + this.port + '/code',
+    json: {
+      code: code
+    },
+    method: 'POST'
+  }).spread(function (res) {
+    if (res.statusCode !== 200) throw new Error('code POST failed, statusCode -->', res.statusCode, ' .');
+  });
+};
+
+CodeInjector.prototype.injectCode =  function (driver, code) {
+  return this.postCode(code).then(function () {
+    if (env.IOS) {
+      return driver
+        .waitForElementByAccessibilityId('welcome_start')
+          .click()
+        .waitForElementByAccessibilityId('test_close');
+    } else if (env.ANDROID) {
+      return driver
+        .elementByAndroidUIAutomator( 'new UiSelector().descriptionContains("welcome_start")')
+          .click()
+        .waitForElementByAndroidUIAutomator('new UiSelector().descriptionContains("test_close")');
+    } else throw new Error('Unknown env.');
+  }.bind(this));
+};
+
+CodeInjector.prototype.clearCode = function (driver) {
+  if (env.IOS) {
+    return driver
+      .waitForElementById('test_close')
+        .click()
+      .waitForElementById('welcome_start');
+ } else if (env.ANDROID) {
+     return driver
+      .waitForElementByAndroidUIAutomator('new UiSelector().descriptionContains("test_close")')
+        .click()
+      .waitForElementByAndroidUIAutomator('new UiSelector().descriptionContains("welcome_start")');
+  } else throw new Error('Unknown env.');
+};
+
+module.exports = CodeInjector;
+
+// Some code to test the server
+// TODO: write a real test
+function test() {
+  var codeServer = new CodeInjector({port: 8085});
+  codeServer
+    .start()
+    .then(function () {
+      return codeServer.postCode('console.log("Hey I am running some real code here!")');
+    }).then(function () {
+      return request({
+        uri: 'http://localhost:' + codeServer.port + '/code',
+        method: 'GET'
+      });
+    }).spread(function (res) {
+      if (res.statusCode !== 200) throw new Error('code GET failed, statusCode --> ' + res.statusCode + '.');
+      var code = (typeof res.body === 'string' ? JSON.parse(res.body) : res.body).code;
+      // jshint evil: true
+      eval(code);
+    }).then(function () { return codeServer.stop(); })
+    .done();
+}
+if (false) test();
+
+// while doing dev
+// TODO: remove
+function dev() {
+  var clientCode = function (testView) {
+    /* global Ti  */
+    console.log('Hey I am running some real code here!');
+    var label = Ti.UI.createLabel({
+      color:'purple',
+      text: 'Wow I was generated dynamically!',
+      accessibilityLabel: 'dynamicLabel',
+      accessibilityValue: 'Wow I was generated dynamically!',
+      textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
+      top: (20 + Math.floor(Math.random()*40)) + '%',
+      width: 'auto',
+      height: 'auto'
+    });
+    testView.add(label);
+  };
+  var codeServer = new CodeInjector({port: 8085, noDelete: true, oneCode: true});
+  codeServer
+    .start()
+    .then(function () {
+      return codeServer.postCode(clientCode);
+    })
+    .done();
+}
+if (false) dev();

--- a/test/functional/dynamic-app/poc-specs.js
+++ b/test/functional/dynamic-app/poc-specs.js
@@ -1,0 +1,110 @@
+// Run with:
+// DEVICE=ios81 mocha test/functional/dynamic-app/poc-specs.js
+// DEVICE=android mocha test/functional/dynamic-app/poc-specs.js
+
+"use strict";
+
+var env = require('../../helpers/env'),
+    setup = require('./setup-base');
+
+describe('titanium-alloy - poc', function () {
+
+  var driver, codeInjector;
+  setup(this).spread(function (_driver, _codeInjector) {
+    driver = _driver;
+    codeInjector = _codeInjector;
+  });
+
+  describe('Checking the value of a static field', function () {
+    // inject client code
+    before(function () {
+      return codeInjector.injectCode(driver, function (testView) {
+        /* global Ti  */
+        console.log('Hey I am running some real code here!');
+        var label = Ti.UI.createLabel({
+          color:'purple',
+          text: 'Wow I was generated dynamically!',
+          accessibilityLabel: 'dynamicLabel',
+          accessibilityValue: 'Wow I was generated dynamically!',
+          textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
+          top: (20 + Math.floor(Math.random()*40)) + '%',
+          width: 'auto',
+          height: 'auto'
+        });
+        testView.add(label);
+      });
+    });
+    // run test
+    if (env.IOS) {
+      it('should-work', function () {
+        return driver
+          .waitForElementById('dynamicLabel')
+            .should.eventually.exist
+          .source().print()
+          .waitForElementById('dynamicLabel').getValue()
+            .should.become('Wow I was generated dynamically!');
+      });
+    } else if (env.ANDROID) {
+      it('should-work', function () {
+        return driver
+          .waitForElementByAndroidUIAutomator(
+            'new UiSelector().descriptionContains("dynamicLabel")')
+            .should.eventually.exist
+          .source().print()
+          .waitForElementByAndroidUIAutomator(
+              'new UiSelector().descriptionContains("dynamicLabel")').text()
+            .should.become('Wow I was generated dynamically!');
+      });
+    }
+    // cleanup
+    after(function () {
+      return codeInjector.clearCode(driver);
+    });
+  });
+
+  describe('Clearing center aligned field', function () {
+    // inject client code
+    before(function () {
+      return codeInjector.injectCode(driver, function (testView) {
+        /* global Ti  */
+        var textField = Ti.UI.createTextField({
+          accessibilityLabel: 'theTextField',
+          borderStyle: Ti.UI.INPUT_BORDERSTYLE_ROUNDED,
+          borderColor: 'black',
+          textAlign: Ti.UI.TEXT_ALIGNMENT_CENTER,
+          top: '40%',
+          width: '300',
+          height: 'auto',
+          color: 'black',
+          value: 'Some random text.',
+        });
+        testView.add(textField);
+      });
+    });
+
+    if (env.ANDROID) {
+      // bug repro, need fixing
+      it.skip('should-work', function () {
+        var el;
+        return driver
+          .sleep(2000)
+          .waitForElementByAndroidUIAutomator(
+            'new UiSelector().descriptionContains("theTextField")')
+          .then(function (_el) {
+            el = _el;
+            return el.text()
+              .should.become('Some random text.');
+          }).then(function () { return el.clear(); })
+          .sleep(2000)
+          .then(function () { return el.text().should.become(''); })
+          .sleep(2000);
+      });
+    }
+    // cleanup
+    after(function () {
+      return codeInjector.clearCode(driver);
+    });
+  });
+
+});
+

--- a/test/functional/dynamic-app/setup-base.js
+++ b/test/functional/dynamic-app/setup-base.js
@@ -1,0 +1,61 @@
+"use strict";
+var env = require('../../helpers/env')
+  , initSession = require('../../helpers/session').initSession
+  , getTitle = require('../../helpers/title').getTitle
+  , wd = require('wd')
+  , chai = require('chai')
+  , chaiAsPromised = require('chai-as-promised')
+  , CodeInjector = require('./code-injector')
+  , Q = require('q');
+
+chai.use(chaiAsPromised);
+chai.should();
+chaiAsPromised.transferPromiseness = wd.transferPromiseness;
+require("colors");
+
+module.exports = function (context) {
+  var deferred = Q.defer();
+  context.timeout(env.MOCHA_INIT_TIMEOUT);
+
+
+  var desired;
+
+  if (env.IOS) {
+    desired = {
+      app: process.env.APPIUM_LOCAL_IOS_DYNAMIC_APP ||
+        'https://github.com/sebv/DynamicApp/raw/master/assets/ios/simulator/DynamicApp.app.zip'
+    };
+  } else if (env.ANDROID) {
+    desired = {
+      app: process.env.APPIUM_LOCAL_ANDROID_DYNAMIC_APP ||
+        'https://github.com/sebv/DynamicApp/raw/master/assets/android/DynamicApp.apk'
+    };
+  }
+  var session = initSession(desired, {});
+  var allPassed = true;
+  var codeInjector = new CodeInjector({port: 8085});
+
+  session.promisedBrowser.then(function (driver) {
+    deferred.resolve([driver, codeInjector]);
+  });
+
+  before(function () {
+    return codeInjector.start();
+  });
+
+  before(function () {
+    return session.setUp(getTitle(context));
+  });
+
+  after(function () { return session.tearDown(allPassed); });
+
+  after(function () {
+    return codeInjector.stop();
+  });
+
+  afterEach(function () {
+    allPassed = allPassed && this.currentTest.state === 'passed';
+  });
+  return deferred.promise;
+};
+

--- a/test/functional/ios/safari/screenshot-specs.js
+++ b/test/functional/ios/safari/screenshot-specs.js
@@ -3,27 +3,43 @@
 var setup = require("../../common/setup-base");
 
 describe('safari - screenshots @skip-ios6', function () {
-  var driver;
-  setup(this, {browserName: 'safari'}).then(function (d) { driver = d; });
+  describe('default' ,function () {
+    var driver;
+    setup(this, {browserName: 'safari'}).then(function (d) { driver = d; });
 
-  it('should get an app screenshot', function (done) {
-    driver
-      .takeScreenshot()
-        .should.eventually.exist
+    it('should get an app screenshot', function (done) {
+      driver
+        .takeScreenshot()
+          .should.eventually.exist
+        .nodeify(done);
+    });
+    it('should get an app screenshot in landscape mode', function (done) {
+      driver.takeScreenshot().then(function (screenshot1) {
+        screenshot1.should.exist;
+        return driver
+          .setOrientation("LANDSCAPE")
+          // A useless error does often exist here, let's ignore it
+          .catch(function () {})
+          .takeScreenshot().then(function (screenshot2) {
+            screenshot2.should.exist;
+            screenshot2.should.not.eql(screenshot1);
+          });
+      }).sleep(3000) // cooldown
       .nodeify(done);
+    });
   });
-  it('should get an app screenshot in landscape mode', function (done) {
-    driver.takeScreenshot().then(function (screenshot1) {
-      screenshot1.should.exist;
-      return driver
-        .setOrientation("LANDSCAPE")
-        // A useless error does often exist here, let's ignore it
-        .catch(function () {})
-        .takeScreenshot().then(function (screenshot2) {
-          screenshot2.should.exist;
-          screenshot2.should.not.eql(screenshot1);
-        });
-    }).sleep(3000) // cooldown
-    .nodeify(done);
+
+  describe('setting screenshotWaitTimeout' ,function () {
+    var driver;
+    setup(this, {browserName: 'safari', screenshotWaitTimeout: 5})
+      .then(function (d) { driver = d; });
+
+    it('should get an app screenshot', function (done) {
+      driver
+        .takeScreenshot()
+          .should.eventually.exist
+        .nodeify(done);
+    });
   });
+
 });

--- a/test/functional/selendroid/clear-specs.js
+++ b/test/functional/selendroid/clear-specs.js
@@ -1,0 +1,134 @@
+"use strict";
+
+var setup = require("../common/setup-base")
+    , desired = require("./desired")
+    , _ = require('underscore')
+    , getAppPath = require('../../helpers/app').getAppPath;
+
+
+describe("apidemos - clear", function () {
+  var driver;
+  var _desired = _.defaults({
+    app: getAppPath('ApiDemos'),
+    appActivity: '.view.Controls1',
+    newCommandTimeout: 90,
+    language: 'en',
+    locale: 'en_US'
+  }, desired);
+  setup(this, _desired).then(function (d) { driver = d; });
+
+  describe('clear', function () {
+    it('should clear an empty field with hint', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .clear()
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .text().should.become('')
+        .nodeify(done);
+    });
+
+    it('should clear a field with hint', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sendKeys('Are you looking at me!')
+        .sleep(1000)
+        .clear()
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .text().should.become('')
+        .nodeify(done);
+    });
+
+  });
+
+  describe('hideKeyboard', function () {
+
+    it('should hide the keyboard using the default strategy', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard()
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
+
+    it('should hide the keyboard using the "Done" key', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard('Done')
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
+
+    it('should hide the keyboard using the "press" strategy and "Done" key', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'press', key: 'Done'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
+
+    it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'pressKey', key: 'Done'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
+
+    it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'swipeDown'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
+
+    it('should hide the keyboard using the "tapOutside" strategy', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'tapOutside'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
+
+    it('should hide the keyboard using the "tapOut" strategy', function (done) {
+      driver
+        .waitForElementByClassName('android.widget.EditText')
+        .click()
+        .sleep(1000)
+        .hideKeyboard({strategy:'tapOut'})
+        .sleep(1000)
+        .elementByClassName('android.widget.EditText')
+        .should.eventually.exist
+        .nodeify(done);
+    });
+  });
+});

--- a/test/unit/configuration-specs.js
+++ b/test/unit/configuration-specs.js
@@ -16,10 +16,10 @@ describe('Appium', function () {
     // test is [args, caps, device]
     var appium = getAppium({});
     describe('mjsonwp spec capabilities', function () {
-      describe('deviceName', function () {
+      describe('platformName', function () {
 
         var deviceCapabilities = [
-            [{}, {platformName: 'iOS'}, 'ios'],
+            [{}, {platformName: 'iOS'}, 'ios']
           , [{}, {platformName: 'Android'}, 'android']
           , [{}, {platformName: 'FirefoxOS'}, 'firefoxos']
           , [{platformName: 'Android'}, {}, 'android']
@@ -41,6 +41,8 @@ describe('Appium', function () {
           , [{}, {platformName: 'Android', browserName: 'browser'}, 'chrome']
           , [{browserName: 'browser'}, {platformName: 'Android'}, 'chrome']
           , [{browserName: 'Safari'}, {platformName: 'ios'}, 'safari']
+          , [{browserName: 'browser'}, {platformName: 'ios'}, 'ios']
+          , [{browserName: 'Safari'}, {platformName: 'android'}, 'android']
           ];
         _.each(browserCapabilities, function (test) {
           assertCapsGiveCorrectDevices(appium, test);
@@ -64,57 +66,46 @@ describe('Appium', function () {
     describe('non compliant capabilitites using', function () {
       describe('argument cases', function () {
         var argsCases  = [
-          [{ipa: '/path/to/my.ipa'}, {}, 'ios']
-        , [{ipa: '/path/to/MY.IPA'}, {}, 'ios']
-        , [{forceIphone: true}, {}, 'ios']
-        , [{forceIpad: true}, {}, 'ios']
-        , [{ipa: '/path/to/my.ipa', safari: true}, {}, 'ios']
-        , [{safari: true}, {}, 'safari']
-        , [{safari: true}, {app: '/path/to/my.apk'}, 'safari']
-        , [{safari: false}, {app: 'safari'}, 'safari']
-        , [{forceIpad: true}, {app: 'safari'}, 'safari']
+          [{platformName: 'ios', safari: true}, {}, 'safari']
+        , [{platformName: 'ios', safari: true}, {app: 'chrome'}, 'safari']
+        , [{platformName: 'ios', safari: false}, {app: 'safari'}, 'safari']
         ];
         _.each(argsCases, function (test) {
           assertCapsGiveCorrectDevices(appium, test);
         });
       });
 
-      describe('app capabilities', function () {
+      describe('app arguments and capabilities', function () {
         var appCases = [
-          [{}, {app: 'Safari'}, 'safari']
-        , [{}, {app: 'settings'}, 'ios']
-        , [{}, {app: 'Settings'}, 'ios']
-        , [{}, {app: 'chrome'}, 'chrome']
-        , [{}, {app: 'chromium'}, 'chrome']
-        , [{}, {app: 'chromebeta'}, 'chrome']
-        , [{}, {app: 'browser'}, 'chrome']
-        , [{}, {app: 'http://www.site.com/my.app.zip'}, 'ios']
-        , [{}, {app: 'http://www.site.com/MY.APP.ZIp'}, 'ios']
-        , [{}, {app: 'http://www.site.com/my.apk.zip'}, 'android']
-        , [{}, {app: 'http://www.site.com/my.apk'}, 'android']
-        , [{}, {app: 'HTTP://WWW.Site.COM/MY.APk'}, 'android']
-        , [{}, {app: '/path/to/my.app'}, 'ios']
-        , [{}, {app: '/path/to/my.apk'}, 'android']
-        , [{}, {app: '/path/to/my.apk'}, 'android']
-        , [{}, {app: '/path/to/my.apk.app'}, 'ios']
-        , [{}, {app: '/path/to/my.app.apk'}, 'android']
+          [{}, {platformName: 'ios', app: 'safari'}, 'safari']
+        , [{platformName: 'ios', app: 'Safari'}, {}, 'safari']
+        , [{}, {platformName: 'ios', app: 'settings'}, 'ios']
+        , [{}, {platformName: 'ios', app: 'lol'}, 'ios']
+        , [{}, {platformName: 'android', app: 'chrome'}, 'chrome']
+        , [{}, {platformName: 'android', app: 'chromium'}, 'chrome']
+        , [{}, {platformName: 'android', app: 'chromebeta'}, 'chrome']
+        , [{}, {platformName: 'android', app: 'browser'}, 'chrome']
+        , [{platformName: 'android', app: 'Chrome'}, {}, 'chrome']
+        , [{}, {platformName: 'android', app: 'lol'}, 'android']
+        , [{platformName: 'ios', app: 'chrome'}, {}, 'ios']
         ];
         _.each(appCases, function (test) {
           assertCapsGiveCorrectDevices(appium, test);
         });
       });
-    });
 
-    describe('package arguments and capabilities', function () {
-      var packageCases = [
-        [{}, {appPackage: 'com.android.chrome'}, 'chrome']
-      , [{}, {appPackage: 'Com.Android.Chrome'}, 'chrome']
-      , [{}, {appPackage: 'lol'}, 'android']
-      , [{androidPackage: 'com.foo'}, {}, 'android']
-      , [{androidPackage: 'com.android.browser'}, {}, 'chrome']
-      ];
-      _.each(packageCases, function (test) {
-        assertCapsGiveCorrectDevices(appium, test);
+      describe('package arguments and capabilities', function () {
+        var packageCases = [
+          [{}, {platformName: 'android', appPackage: 'com.android.chrome'}, 'chrome']
+        , [{}, {platformName: 'android', appPackage: 'Com.Android.Chrome'}, 'chrome']
+        , [{}, {platformName: 'android', appPackage: 'lol'}, 'android']
+        , [{platformName: 'android', androidPackage: 'com.foo'}, {}, 'android']
+        , [{platformName: 'android', androidPackage: 'com.android.browser'}, {}, 'chrome']
+        , [{platformName: 'ios', androidPackage: 'com.android.browser'}, {}, 'ios']
+        ];
+        _.each(packageCases, function (test) {
+          assertCapsGiveCorrectDevices(appium, test);
+        });
       });
     });
   });


### PR DESCRIPTION
Sometimes the `click` event leaves the cursor in the middle of the textfield (for instance, when the textfield is center-aligned (see #3803)). In that case sending delete keys doesn't work fully. So send `KeyEvent.KEYCODE_FORWARD_DEL` events in addition to `KeyEvent.KEYCODE_DEL` events.

@sebv 
