### PR TITLE
Add support for getting the resourceId attribute of an element

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
@@ -9,17 +9,17 @@ import java.util.Hashtable;
 
 /**
  * This handler is used to get an attribute of an element.
- * 
+ *
  */
 public class GetAttribute extends CommandHandler {
 
   /*
    * @param command The {@link AndroidCommand} used for this handler.
-   * 
+   *
    * @return {@link AndroidCommandResult}
-   * 
+   *
    * @throws JSONException
-   * 
+   *
    * @see io.appium.android.bootstrap.CommandHandler#execute(io.appium.android.
    * bootstrap.AndroidCommand)
    */
@@ -34,7 +34,7 @@ public class GetAttribute extends CommandHandler {
         final AndroidElement el = command.getElement();
         final String attr = params.get("attribute").toString();
         if (attr.equals("name") || attr.equals("text")
-            || attr.equals("className")) {
+            || attr.equals("className") || attr.equals("resourceId")) {
           return getSuccessResult(el.getStringAttribute(attr));
         } else {
           return getSuccessResult(String.valueOf(el.getBoolAttribute(attr)));

--- a/test/functional/android/apidemos/attributes-specs.js
+++ b/test/functional/android/apidemos/attributes-specs.js
@@ -8,6 +8,12 @@ describe("apidemos - attributes", function () {
   var driver;
   setup(this, desired).then(function (d) { driver = d; });
 
+  it('should be able to find resourceId attribute', function (done) {
+    driver
+      .elementByName('Animation').getAttribute('resourceId')
+        .should.become("android:id/text1")
+      .nodeify(done);
+  });
   it('should be able to find text attribute', function (done) {
     driver
       .elementByName('Animation').getAttribute('text')


### PR DESCRIPTION
It makes a lot of sense in our tests to get access to the resource id of an element. This pull requests add support for getting it through the getAtrribute api.
