### PR TITLE
Hidding session immediatly after stop is called,

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -34,6 +34,7 @@ var Appium = function (args) {
   this.deviceType = null;
   this.device = null;
   this.sessionId = null;
+  this.dyingSessionId = null;
   this.desiredCapabilities = {};
   this.oldDesiredCapabilities = {};
   this.session = null;
@@ -359,8 +360,6 @@ Appium.prototype.cleanupSession = function (err, cb) {
     this.commandTimeout = null;
   }
   this.commandTimeoutMs = this.defCommandTimeoutMs;
-  var dyingSession = this.sessionId;
-  this.sessionId = null;
   this.device = null;
   this.args = _.clone(this.serverArgs);
   this.oldDesiredCapabilities = _.clone(this.desiredCapabilities.desired);
@@ -368,7 +367,7 @@ Appium.prototype.cleanupSession = function (err, cb) {
   if (cb) {
     if (err) return cb(err);
     cb(null, {status: status.codes.Success.code, value: null,
-      sessionId: dyingSession});
+      sessionId: this.dyingSessionId});
   }
 };
 
@@ -401,8 +400,9 @@ Appium.prototype.stop = function (cb) {
     logger.debug("Trying to stop appium but there's no session, doing nothing");
     return cb();
   }
-
   logger.info('Shutting down appium session');
+  this.dyingSessionId = this.sessionId;
+  this.sessionId = null;
   this.device.stop(function (err) {
     this.cleanupSession(err, cb);
   }.bind(this));
@@ -429,6 +429,7 @@ Appium.prototype.reset = function (cb) {
         this.resetting = false;
         this.device.implicitWaitMs = oldImpWait;
         this.sessionId = oldId;
+        this.dyingSessionId = null;
         this.setCommandTimeout(oldCommandTimeoutMs / 1000, cb);
       }.bind(this));
     }.bind(this));


### PR DESCRIPTION
This should make appium more stable, The closing process takes time, and commands were not prevented from coming in. Now they will be blocked by [sessionBeforeFilter](https://github.com/appium/appium/blob/master/lib/server/controller.js#L51).

@jlipps can you check. @0x1mason that fixes the timeout issue.

Also noticed that sessionBeforeFilter returns 404 which I think is inaccurate, but will open another issue for that, should be part of a minor release.
