### PR TITLE
Add to unicode docs

### DIFF
--- a/docs/en/writing-running-appium/unicode.md
+++ b/docs/en/writing-running-appium/unicode.md
@@ -1,28 +1,87 @@
 ## Multi-lingual Support
 
+One problem with dealing with non-Latin characters programmatically is that, for characters
+with accents, there can be multiple ways of encoding the form. So, for the letter
+`é`, there are two encodings: a single combining character `é` (Unicode's
+`LATIN SMALL LETTER E WITH ACUTE`), and the combination of the letter `e` followed
+by the accent, `́` (`COMBINING ACUTE ACCENT`). In order to deal with this, there
+is `normalization`, an operation that makes ["equivalent strings have a unique
+binary representation"](http://www.unicode.org/reports/tr15/).
+
+Luckily, normalizing ASCII text (i.e., text that doesn't need to be normalized)
+does not cause any changes, and performing
+the operation multiple times does not have an effect. Thus a normalization
+function can be called on text without risking adverse effects.
+
+```javascript
+// javascript
+var unorm = require('unorm');
+
+'some ASCII text' === unorm.nfd('some ASCII text');
+unorm.nfd('Adélaïde Hervé') === unorm.nfd(unorm.nfd('Adélaïde Hervé'));
+```
+
+So, when dealing with unicode text within a test, you need to normalize, preferably
+on both the text expected and that received from Appium. There are a number of
+ways to do the normalization, so be sure to perform the same operation on both
+strings!
+
+```javascript
+// javascript
+var unorm = require('unorm');
+driver
+  .elementByAccessibilityId('find')
+    .text()
+    .then(function (txt) {
+      unorm.nfd(txt).should.be(unorm.nfd("é Œ ù ḍ"));
+    });
+```
+
+One tell-tale sign that the problem is with the encoding of the unicode text is
+an assertion that fails but reports what look to be the same string:
+
+```shell
+AssertionError: expected 'François Gérard' to deeply equal 'François Gérard'
+      + expected - actual
+
+      +"François Gérard"
+      -"François Gérard"
+```
+
+Since the error is just encoding, the output _looks_ the same. Normalized, these
+should equal programmatically as well as visually.
+
+
+### Finders
+
+Finding by text can also require normalization. For instance, if you have a button
+in an iOS app with the name `Найти` you may need to normalize the text within the
+find command.
+
+```javascript
+// javascript
+var unorm = require('unorm');
+driver
+  .findElementByXPath(unorm.nfd("//UIAButton[@name='Найти']"))
+    .should.eventually.exist;
+```
+
+Otherwise the elements may not be found.
+
+
+### Text Fields
+
 By default the automation tools for both iOS and Android do not support non-ASCII
 characters sent to editable fields through the keyboard.
 
-### iOS
+#### iOS
 
 Appium sends non-ASCII characters to iOS editable fields directly, bypassing the
 keyboard altogether. While this allows the text to be inputted in tests, it should
 be kept in mind that any business logic triggered by keyboard input will therefore
 not be tested.
 
-One main caveat to this behavior is the encoding of the strings sent and received.
-Unicode also has the concept of “combining characters”, which are diacritical
-modifications of other characters. Rather than a single character representing
-what is seen, two (or more, in the case of heavily accented characters) separate
-characters are sometimes used to represent one, with the system overlaying them.
-
-Thus, while in Unicode the letter `é` (Unicode's "LATIN SMALL LETTER E WITH ACUTE")
-can be encoded as a single letter, the iOS simulator will return the equally
-valid representation of the letter `e` followed by the accent, `́` ("COMBINING
-ACUTE ACCENT"). When this occurs a test may be reported but the expected
-and actual results will look exactly the same. The solution to this is to
-[normalize](http://www.unicode.org/faq/normalization.html) the text before asserting
-on it.
+As above, the text received may need to be normalized before asserting on it.
 
 ```javascript
 // javascript
@@ -36,7 +95,7 @@ driver
   .nodeify(done);
 ```
 
-### Android
+#### Android
 
 Android tests allow for Unicode input by installing and using a [specialized
 keyboard](https://github.com/appium/io.appium.android.ime) that allows the text


### PR DESCRIPTION
Add text about normalizing non-latin strings in a variety of contexts. Related to #2495.
