### PR TITLE
Allow to get contexts even if platformVersion is not set through arguments

### DIFF
--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -24,7 +24,7 @@ iOSHybrid.closeAlertBeforeTest = function (cb) {
 
 iOSHybrid.getDebuggerAppKey = function (appDict, bundleId) {
   var appKey = null;
-  if (parseFloat(this.args.platformVersion) >= 8) {
+  if (this.getNumericVersion() >= 8) {
     _.each(appDict, function (data, key) {
       if (data.bundleId === bundleId) {
         appKey = key;

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -220,7 +220,7 @@ IOS.prototype.preCleanup = function (cb) {
 };
 
 IOS.prototype.getNumericVersion = function () {
-  return parseFloat(this.args.platformVersion);
+  return parseFloat(this.args.platformVersion || this.iOSSDKVersion);
 };
 
 IOS.prototype.start = function (cb, onDie) {


### PR DESCRIPTION
I haven't run any appium test, only appium ruby ones. But the fix is pretty straightforward, it seems all should be fine.
