### PR TITLE
#3957 added string file parameter to getStrings request for iOS.

### DIFF
--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -326,7 +326,7 @@ Android.prototype.pushStrings = function (cb, language) {
   }.bind(this), language);
 };
 
-Android.prototype.getStrings = function (language, cb) {
+Android.prototype.getStrings = function (language, stringFile, cb) {
   if (this.language && this.language === language) {
     // Return last strings
     return cb(null, {

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -468,7 +468,7 @@ Selendroid.prototype.extractStringsSelendroid = function (cb) {
   });
 };
 
-Selendroid.prototype.getStrings = function (language, cb) {
+Selendroid.prototype.getStrings = function (language, stringFile, cb) {
   if (this.language && this.language === language) {
     // Return last strings
     return cb(null, {

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -623,7 +623,7 @@ iOSController.toggleLocationServices = function (cb) {
   cb(new NotYetImplementedError(), null);
 };
 
-iOSController.getStrings = function (language, cb, stringFile) {
+iOSController.getStrings = function (language, stringFile, cb) {
   this.parseLocalizableStrings(function () {
     var strings = this.localizableStrings;
     if (strings && strings.length >= 1) strings = strings[0];

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -624,7 +624,7 @@ iOSController.toggleLocationServices = function (cb) {
 };
 
 iOSController.getStrings = function (language, stringFile, cb) {
-  this.parseLocalizableStrings(function () {
+  this.parseLocalizableStrings(language, stringFile, function () {
     var strings = this.localizableStrings;
     if (strings && strings.length >= 1) strings = strings[0];
 
@@ -632,7 +632,7 @@ iOSController.getStrings = function (language, stringFile, cb) {
       status: status.codes.Success.code
     , value: strings
     });
-  }.bind(this), language, stringFile);
+  }.bind(this));
 };
 
 iOSController.executeAtom = function (atom, args, cb, alwaysDefaultFrame) {

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -623,7 +623,7 @@ iOSController.toggleLocationServices = function (cb) {
   cb(new NotYetImplementedError(), null);
 };
 
-iOSController.getStrings = function (language, cb) {
+iOSController.getStrings = function (language, cb, stringFile) {
   this.parseLocalizableStrings(function () {
     var strings = this.localizableStrings;
     if (strings && strings.length >= 1) strings = strings[0];
@@ -632,7 +632,7 @@ iOSController.getStrings = function (language, cb) {
       status: status.codes.Success.code
     , value: strings
     });
-  }.bind(this), language);
+  }.bind(this), language, stringFile);
 };
 
 iOSController.executeAtom = function (atom, args, cb, alwaysDefaultFrame) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1201,32 +1201,33 @@ IOS.prototype.prelaunchSimulator = function (cb) {
   }.bind(this));
 };
 
-IOS.prototype.parseLocalizableStrings = function (cb, language) {
+IOS.prototype.parseLocalizableStrings = function (cb, language, stringFile) {
   if (this.args.app === null) {
     logger.debug("Localizable.strings is not currently supported when using real devices.");
     cb();
   } else {
     var strings = null;
     language = language || this.args.language;
+    stringFile = stringFile || "Localizable.strings";
     if (language) {
-      strings = path.resolve(this.args.app, language + ".lproj", "Localizable.strings");
+      strings = path.resolve(this.args.app, language + ".lproj", stringFile);
     }
     if (!fs.existsSync(strings)) {
       if (language) {
-        logger.debug("No Localizable.strings for language '" + language + "', getting default strings");
+        logger.debug("No strings file '" + stringFile + "' for language '" + language + "', getting default strings");
       }
-      strings = path.resolve(this.args.app, "Localizable.strings");
+      strings = path.resolve(this.args.app, stringFile);
     }
     if (!fs.existsSync(strings)) {
-      strings = path.resolve(this.args.app, this.args.localizableStringsDir, "Localizable.strings");
+      strings = path.resolve(this.args.app, this.args.localizableStringsDir, stringFile);
     }
 
     parsePlistFile(strings, function (err, obj) {
       if (err) {
-        logger.warn("Could not parse app Localizable.strings; assuming it " +
-                    "doesn't exist");
+        logger.warn("Could not parse app " + stringFile +" assuming it " +
+        "doesn't exist");
       } else {
-        logger.debug("Parsed app Localizable.strings");
+        logger.debug("Parsed app " + stringFile);
         this.localizableStrings = obj;
       }
       cb();

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1201,7 +1201,7 @@ IOS.prototype.prelaunchSimulator = function (cb) {
   }.bind(this));
 };
 
-IOS.prototype.parseLocalizableStrings = function (cb, language, stringFile) {
+IOS.prototype.parseLocalizableStrings = function (language, stringFile, cb) {
   if (this.args.app === null) {
     logger.debug("Localizable.strings is not currently supported when using real devices.");
     cb();

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -1101,10 +1101,12 @@ exports.getLogTypes = function (req, res) {
 
 exports.getStrings = function (req, res) {
   req.body = _.defaults(req.body, {
-    language: null
+    language: null,
+    stringFile: null
   });
-  var language = req.body.language;
-  req.device.getStrings(language, getResponseHandler(req, res));
+  var language = req.body.language,
+      stringFile = req.body.stringFile;
+  req.device.getStrings(language, getResponseHandler(req, res), stringFile);
 };
 
 exports.unknownCommand = function (req, res) {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -1106,7 +1106,7 @@ exports.getStrings = function (req, res) {
   });
   var language = req.body.language,
       stringFile = req.body.stringFile;
-  req.device.getStrings(language, getResponseHandler(req, res), stringFile);
+  req.device.getStrings(language, stringFile, getResponseHandler(req, res));
 };
 
 exports.unknownCommand = function (req, res) {

--- a/test/fixtures/localization_tests/StubApp.app/en.lproj/custom.strings
+++ b/test/fixtures/localization_tests/StubApp.app/en.lproj/custom.strings
@@ -1,0 +1,10 @@
+<!--?xml version="1.0" encoding="UTF-8"?-->
+
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>key</key>
+    <string>custom file</string>
+</dict>
+</plist>

--- a/test/unit/ios-device-specs.js
+++ b/test/unit/ios-device-specs.js
@@ -56,7 +56,7 @@ describe('IOS', function () {
     });
 
     it('should return a dictionary with data from Localizable.strings file', function (done) {
-      device.parseLocalizableStrings(device.args.language, undefined, function () {
+      device.parseLocalizableStrings(device.args.language, null, function () {
         device.localizableStrings.should.eql({ 'main.button.computeSum' : 'Compute Sum' });
         done();
       });

--- a/test/unit/ios-device-specs.js
+++ b/test/unit/ios-device-specs.js
@@ -55,9 +55,26 @@ describe('IOS', function () {
       });
     });
 
-    it('should return a dictionary', function (done) {
-      device.parseLocalizableStrings(function () {
+    it('should return a dictionary with data from Localizable.strings file', function (done) {
+      device.parseLocalizableStrings(device.args.language, undefined, function () {
         device.localizableStrings.should.eql({ 'main.button.computeSum' : 'Compute Sum' });
+        done();
+      });
+    });
+
+    it('should return a dictionary for custom.strings file', function (done) {
+      device.parseLocalizableStrings(device.args.language, 'custom.strings', function () {
+        device.localizableStrings.should.eql({'key' : 'custom file'});
+        done();
+      });
+    });
+
+    it('should return an empty object for unknown file', function (done) {
+      _.extend(device.args,{
+        localizableStringsDir: stubApp + "/en.lporj"
+      });
+      device.parseLocalizableStrings(device.args.language, 'unknown_file', function () {
+        expect(device.localizableStrings).to.be.empty;
         done();
       });
     });


### PR DESCRIPTION
Pull request for Issue #3957. 
I added a parameter stringFile to the getAppStrings request for iOS. Tested it with my app and its working.

One strange behavior occurs when passing a file name that does not exists I get the content of the Localizable.strings. Shouldn't be the response value empty? Here the log output.

info: --> POST /wd/hub/session/eb260020-f235-400d-95f6-bcef06e92c4a/appium/app/strings {"language":"en","stringFile":"xxx"}
info: [debug] No strings file 'xxx' for language 'en', getting default strings
info: [debug] Could not parse plist file (as binary) at /Users/me/Library/Developer/Xcode/DerivedData/MyApp-dspsyeiacfmescfzmsleijgpgcwk/Build/Products/Debug-iphonesimulator/Idealo.app/en.lproj/xxx
info: Will try to parse the plist file as XML
`parseFileSync()` is deprecated. Use `parseStringSync()` instead.
info: [debug] Could not parse plist file (as XML) at /Users/me/Library/Developer/Xcode/DerivedData/MyApp-dspsyeiacfmescfzmsleijgpgcwk/Build/Products/Debug-iphonesimulator/Idealo.app/en.lproj/xxx
warn: Could not parse app xxx assuming it doesn't exist
info: [debug] Responding to client with success: {"status":0,"value":{"PUSH_ALERT":"Congratulations! Your product has reached its target price."},"sessionId":"eb260020-f235-400d-95f6-bcef06e92c4a"}
info: <-- POST /wd/hub/session/eb260020-f235-400d-95f6-bcef06e92c4a/appium/app/strings 200 4.955 ms - 155 {"status":0,"value":{"PUSH_ALERT":"Congratulations! Your product has reached its target price."},"sessionId":"eb260020-f235-400d-95f6-bcef06e92c4a"}
info: --> DELETE /wd/hub/session/eb260020-f235-400d-95f6-bcef06e92c4a {}
