### PR TITLE
Add test for clearing password

### DIFF
--- a/test/functional/android/apidemos/clear-specs.js
+++ b/test/functional/android/apidemos/clear-specs.js
@@ -10,125 +10,117 @@ describe("apidemos - clear", function () {
   var driver;
   var _desired = _.defaults({
     app: getAppPath('ApiDemos'),
-    appActivity: '.view.Controls1',
+    appActivity: '.view.TableLayout10',
     newCommandTimeout: 90,
     language: 'en',
     locale: 'en_US'
   }, desired);
   setup(this, _desired).then(function (d) { driver = d; });
 
-  describe('clear', function () {
+  describe('clear textfield', function () {
     it('should clear an empty field with hint', function (done) {
+      var el;
       driver
         .waitForElementByClassName('android.widget.EditText')
-        .click()
-        .sleep(1000)
+        .then(function (_el) {
+          el = _el;
+          return el;
+        })
         .clear()
-        .sleep(1000)
-        .elementByClassName('android.widget.EditText')
-        .text().should.become('hint text')
+        .sleep(100)
+        .then(function () {
+          return el;
+        })
+        .text().should.become('enter username')
         .nodeify(done);
     });
 
     it('should clear a field with hint', function (done) {
+      var el;
       driver
         .waitForElementByClassName('android.widget.EditText')
-        .click()
+        .then(function (_el) {
+          el = _el;
+          return el;
+        })
         .sendKeys('Are you looking at me!')
-        .sleep(1000)
+        .sleep(100)
         .clear()
-        .sleep(1000)
-        .elementByClassName('android.widget.EditText')
-        .text().should.become('hint text')
+        .sleep(100)
+        .then(function () {
+          return el;
+        })
+        .text().should.become('enter username')
+        .nodeify(done);
+    });
+
+  });
+
+  describe('clear password textfield', function () {
+    it('should clear', function (done) {
+      var el;
+      driver
+        .waitForElementsByClassName('android.widget.EditText')
+        .then(function (els) {
+          el = els[1];
+          return el;
+        })
+        .sendKeys('super secure password')
+        .sleep(100)
+        .then(function () {
+          el.text().should.become('super secure password');
+          return el;
+        })
+        .clear()
+        .sleep(100)
+        .then(function () {
+          return el;
+        })
+        .text().should.become('')
         .nodeify(done);
     });
 
   });
 
   describe('hideKeyboard', function () {
-
-    it('should hide the keyboard using the default strategy', function (done) {
+    var testHideKeyboard = function (args, done) {
       driver
         .waitForElementByClassName('android.widget.EditText')
         .click()
-        .sleep(1000)
-        .hideKeyboard()
-        .sleep(1000)
+        .sleep(500)
+        .hideKeyboard(args)
+        .sleep(500)
         .elementByClassName('android.widget.EditText')
-        .should.eventually.exist
+          .should.eventually.exist
         .nodeify(done);
+    };
+
+    it('should hide the keyboard using the default strategy', function (done) {
+      testHideKeyboard(null, done);
     });
 
     it('should hide the keyboard using the "Done" key', function (done) {
-      driver
-        .waitForElementByClassName('android.widget.EditText')
-        .click()
-        .sleep(1000)
-        .hideKeyboard('Done')
-        .sleep(1000)
-        .elementByClassName('android.widget.EditText')
-        .should.eventually.exist
-        .nodeify(done);
+      testHideKeyboard('Done', done);
     });
 
     it('should hide the keyboard using the "press" strategy and "Done" key', function (done) {
-      driver
-        .waitForElementByClassName('android.widget.EditText')
-        .click()
-        .sleep(1000)
-        .hideKeyboard({strategy:'press', key: 'Done'})
-        .sleep(1000)
-        .elementByClassName('android.widget.EditText')
-        .should.eventually.exist
-        .nodeify(done);
+      testHideKeyboard({strategy:'press', key: 'Done'}, done);
     });
 
     it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
-      driver
-        .waitForElementByClassName('android.widget.EditText')
-        .click()
-        .sleep(1000)
-        .hideKeyboard({strategy:'pressKey', key: 'Done'})
-        .sleep(1000)
-        .elementByClassName('android.widget.EditText')
-        .should.eventually.exist
-        .nodeify(done);
+      testHideKeyboard({strategy:'pressKey', key: 'Done'}, done);
     });
 
     it('should hide the keyboard using the "pressKey" strategy and "Done" key', function (done) {
-      driver
-        .waitForElementByClassName('android.widget.EditText')
-        .click()
-        .sleep(1000)
-        .hideKeyboard({strategy:'swipeDown'})
-        .sleep(1000)
-        .elementByClassName('android.widget.EditText')
-        .should.eventually.exist
-        .nodeify(done);
+      testHideKeyboard({strategy:'swipeDown'}, done);
     });
 
     it('should hide the keyboard using the "tapOutside" strategy', function (done) {
-      driver
-        .waitForElementByClassName('android.widget.EditText')
-        .click()
-        .sleep(1000)
-        .hideKeyboard({strategy:'tapOutside'})
-        .sleep(1000)
-        .elementByClassName('android.widget.EditText')
-        .should.eventually.exist
-        .nodeify(done);
+      testHideKeyboard({strategy:'tapOutside'}, done);
     });
 
     it('should hide the keyboard using the "tapOut" strategy', function (done) {
-      driver
-        .waitForElementByClassName('android.widget.EditText')
-        .click()
-        .sleep(1000)
-        .hideKeyboard({strategy:'tapOut'})
-        .sleep(1000)
-        .elementByClassName('android.widget.EditText')
-        .should.eventually.exist
-        .nodeify(done);
+      testHideKeyboard({strategy:'tapOut'}, done);
     });
   });
 });


### PR DESCRIPTION
Switch clear element tests to use `TableLayout10`, so that we can also test against a password field (see #3610). Also clean up some redundancy in testing hide keyboard.
