### PR TITLE
Ensure a string is returned from iOS getText

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -875,7 +875,11 @@ iOSController.getText = function (elementId, cb) {
     }.bind(this));
   } else {
     var command = ["au.getElement('", elementId, "').text()"].join('');
-    this.proxy(command, cb);
+    this.proxy(command, function (err, res) {
+      // in some cases instruments returns in integer. we only want a string
+      res.value = res.value ? res.value.toString() : '';
+      cb(err, res);
+    });
   }
 };
 


### PR DESCRIPTION
In some cases the return value from instruments is not a string. So make sure it is. Fixes #4098
