### PR TITLE
Allow location services in zip file

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -198,8 +198,9 @@ IOS.prototype.configureApp = function (cb) {
     }
     cb();
   } else if (this.args.bundleId &&
-             this.appIsPackageOrBundle(this.args.bundleId)) {
-    // we have a bundle ID
+             this.appIsPackageOrBundle(this.args.bundleId) &&
+             (app === "" || this.appIsPackageOrBundle(app))) {
+    // we have a bundle ID, but no app, or app is also a bundle
     logger.debug("App is an iOS bundle, will attempt to run as pre-existing");
     cb();
   } else {

--- a/test/functional/ios/testapp/location-specs.js
+++ b/test/functional/ios/testapp/location-specs.js
@@ -92,3 +92,23 @@ describe('testapp - location - 4  @skip-ci', function () {
       .nodeify(done);
   });
 });
+
+describe('testapp - location - 5  @skip-ci', function () {
+  var driver;
+  var newDesired = _.clone(desired);
+  _.extend(newDesired, {
+    locationServicesAuthorized: true,
+    bundleId: 'io.appium.TestApp',
+    app: 'assets/TestApp7.1.app.zip'
+  });
+
+  setup(this, newDesired, {'no-reset': true}).then(function (d) { driver = d; });
+
+  it('should be able to be turned on when using a zip/ipa file', function (done) {
+    driver
+      .elementByName('locationStatus').getValue().then(function (checked) {
+        checked.should.equal(1);
+      })
+      .nodeify(done);
+  });
+});


### PR DESCRIPTION
Give the possibility of specifying a `bundleId` and an `app`, so that you can turn on location services but still process a zip or ipa file. I've run all our tests, and the added condition does not seem to cause any problems. Resolves #3769.
