### PR TITLE
Fix getting sim dirs

### DIFF
--- a/lib/devices/ios/simulator.js
+++ b/lib/devices/ios/simulator.js
@@ -78,7 +78,7 @@ Simulator.prototype.getDirs = function () {
     }
     return [];
   } else {
-    var sdk = this.sdkVer.toString();
+    var sdk = this.platformVer.toString();
     base = this.getRootDir();
     var list = [];
     try {

--- a/test/functional/ios/testapp/localization/calendar-format-specs.js
+++ b/test/functional/ios/testapp/localization/calendar-format-specs.js
@@ -7,7 +7,7 @@ var env = require('../../../../helpers/env'),
     rimraf = require('rimraf'),
     path = require('path');
 
-describe('localization - calendarFormat @skip-ios8 @skip-ios6', function () {
+describe('localization - calendarFormat @skip-ios8', function () {
   this.timeout(env.MOCHA_INIT_TIMEOUT);
 
   after(function () {

--- a/test/functional/ios/testapp/localization/locale-specs.js
+++ b/test/functional/ios/testapp/localization/locale-specs.js
@@ -7,7 +7,7 @@ var env = require('../../../../helpers/env'),
     rimraf = require('rimraf'),
     path = require('path');
 
-describe('localization - locale @skip-ios6', function () {
+describe('localization - locale', function () {
   this.timeout(env.MOCHA_INIT_TIMEOUT);
 
   after(function () {

--- a/test/functional/ios/testapp/location-specs.js
+++ b/test/functional/ios/testapp/location-specs.js
@@ -38,7 +38,7 @@ describe('testapp - location - 1 @skip-ci', function () {
 });
 
 // TODO: location tests are not working well on sauce
-describe('testapp - location - 2 @skip-ios6 @skip-ci', function () {
+describe('testapp - location - 2 @skip-ci', function () {
   var driver;
   var newDesired = _.clone(desired);
   _.extend(newDesired, {
@@ -57,7 +57,7 @@ describe('testapp - location - 2 @skip-ios6 @skip-ci', function () {
 });
 
 // TODO: location tests are not working well on sauce
-describe('testapp - location - 3  @skip-ci', function () {
+describe('testapp - location - 3 @skip-ci', function () {
   var newDesired = _.clone(desired);
   _.extend(newDesired, {
     locationServicesAuthorized: true
@@ -75,7 +75,7 @@ describe('testapp - location - 3  @skip-ci', function () {
 });
 
 // TODO: location tests are not working well on sauce
-describe('testapp - location - 4  @skip-ci @skip-ios6', function () {
+describe('testapp - location - 4 @skip-ci', function () {
   var driver;
   var newDesired = _.clone(desired);
   _.extend(newDesired, {
@@ -93,7 +93,7 @@ describe('testapp - location - 4  @skip-ci @skip-ios6', function () {
   });
 });
 
-describe('testapp - location - 5  @skip-ci @skip-ios6', function () {
+describe('testapp - location - 5 @skip-ci', function () {
   var driver;
   var newDesired = _.clone(desired);
   _.extend(newDesired, {


### PR DESCRIPTION
Rather than using the SDK version to find the correct directory for the simulator files, use the platform version. Otherwise when using a version of Xcode with multiple simulator versions will fail in certain situations.

E.g., with Xcode `5.1.1`, which has an SDK version of `7.1`, if you install, and request, a `6.1` simulator, Appium would try to use `/Users/isaac/Library/Application Support/iPhone Simulator/7.1` as the root for the simulator, rather than `/Users/isaac/Library/Application Support/iPhone Simulator/6.1`.

Fixes #4137.
