### PR TITLE
Use plist.parse instead of plist.parseFileSync

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -31,9 +31,10 @@ var path = require('path')
   , binaryPlist = true;
 
 // XML Plist library helper
-var parseXmlPlistFile = function (plist, cb) {
+var parseXmlPlistFile = function (plistFilename, cb) {
   try {
-    var result = xmlplist.parse(plist);
+    var xmlContent = fs.readFileSync(plistFilename, 'utf8');
+    var result = xmlplist.parse(xmlContent);
     return cb(null, result);
   } catch (ex) {
     return cb(ex);

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -33,7 +33,7 @@ var path = require('path')
 // XML Plist library helper
 var parseXmlPlistFile = function (plist, cb) {
   try {
-    var result = xmlplist.parseFileSync(plist);
+    var result = xmlplist.parse(plist);
     return cb(null, result);
   } catch (ex) {
     return cb(ex);


### PR DESCRIPTION
When running Appium, I got a warning / error stating that:

```
`parseFileSync()` is deprecated. Use `parseStringSync()` instead.
```

and my task was halted.

Appium uses `"plist": "~1.0.0"` in `package.json`.

`plist` v1.0.0 and up says that `parseFileSync()` is deprecated, and
that it should be replaced with `parseStringSync()`.  However,
`parseStringSync()` is _also_ deprecated, to be replaced with `parse()`.
This all is based on:
- https://github.com/TooTallNate/plist.js/blob/v1.0.0/lib/node.js#L15
- https://github.com/TooTallNate/plist.js/blob/v1.0.0/lib/parse.js#L16

So I changed the related line in the iOS configuration file to point to
the new method `parse()`. This appears to resolve this error and allows
me to continue.
