### PR TITLE
Fix for issue 4177 - SendKeys on Android hinted TextViews switches the focus and influences neighbour controls

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Clear.java
@@ -170,9 +170,7 @@ public class Clear extends CommandHandler {
       Logger.debug("Could not check for hint text: " + e.getMessage());
       return false;
     }
-    sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_BUTTON_THUMBR, 0);
-    sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_DEL, 0);
-    sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_BUTTON_THUMBL, 0);
+    
     sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_DEL, 0);
     sendKey.invoke(utils.getController(), KeyEvent.KEYCODE_FORWARD_DEL, 0);
     return currText.equals(el.getText());


### PR DESCRIPTION
The fix implementation would not sent KeyEvent.KEYCODE_BUTTON_THUMBR and KeyEvent.KEYCODE_BUTTON_THUMBL keys to the text view thus preventing from switching the focus to the next/previous controls
