### PR TITLE
Added waitForAppScript cap

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -80,3 +80,4 @@
 |`showIOSLog`| Whether to show any logs captured from a device in the appium logs. Default `false`|`true` or `false`|
 |`sendKeyStrategy`| strategy to use to type test into a test field. Simulator default: `oneByOne`. Real device default: 'grouped' |`oneByOne`, `grouped` or setValue|
 |`screenshotWaitTimeout`| Max timeout in sec to wait for a screenshot to be generated. default: 10 |e.g., `5`|
+|`waitForAppScript`| The ios automation script used to determined if the app has been launched, by default the system wait for the page source not to be empty. The result must be a boolean |e.g. `true;`, `target.elements().length > 0;`, '$.delay(5000); true;` |

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -430,27 +430,41 @@ IOS.prototype.waitForAppLaunched = function (cb) {
   // on iOS8 in particular, we can get a working session before the app
   // is ready to respond to commands; in that case the source will be empty
   // so we just spin until it's not
-  logger.debug("Waiting for app source to contain elements");
-  var condFn = function (cb) {
-    this.getSourceForElementForXML(null, function (err, res) {
-      if (err || !res || res.status !== status.codes.Success.code) {
-        return cb(false, err);
-      }
-      var sourceObj, appEls;
-      try {
-        sourceObj = JSON.parse(res.value);
-        appEls = sourceObj.UIAApplication['>'];
-        if (appEls.length > 0) {
-          return cb(true);
-        } else {
-          return cb(false, new Error("App did not have elements"));
+  var condFn;
+  if (this.args.waitForAppScript) {
+    // the default getSourceForElementForXML does not fit some use case, so making this customizable.
+    // TODO: collect script from customer and propose several options, please comment in issue #4190.
+    logger.debug("Using custom script to wait for app start:" + this.args.waitForAppScript);
+    condFn = function (cb) {
+      this.proxy('try{\n' + this.args.waitForAppScript +
+                 '\n} catch(err) { $.log("waitForAppScript err: " + error); false; };',
+        function (err, res) {
+          cb(!!res.value, err);
+        });
+    }.bind(this);
+  } else {
+    logger.debug("Waiting for app source to contain elements");
+    condFn = function (cb) {
+      this.getSourceForElementForXML(null, function (err, res) {
+        if (err || !res || res.status !== status.codes.Success.code) {
+          return cb(false, err);
         }
-      } catch (e) {
-        return cb(false, new Error("Couldn't parse JSON source"));
-      }
-      return cb(true, err);
-    });
-  }.bind(this);
+        var sourceObj, appEls;
+        try {
+          sourceObj = JSON.parse(res.value);
+          appEls = sourceObj.UIAApplication['>'];
+          if (appEls.length > 0) {
+            return cb(true);
+          } else {
+            return cb(false, new Error("App did not have elements"));
+          }
+        } catch (e) {
+          return cb(false, new Error("Couldn't parse JSON source"));
+        }
+        return cb(true, err);
+      });
+    }.bind(this);
+  }
   this.waitForCondition(10000, condFn, cb, 500);
 };
 

--- a/test/functional/ios/testapp/wait-for-app-specs.js
+++ b/test/functional/ios/testapp/wait-for-app-specs.js
@@ -1,0 +1,38 @@
+// This is basically a port of webdriver-test.py
+// https://github.com/hugs/appium/blob/master/sample-code/webdriver-test.py
+"use strict";
+
+var setup = require("../../common/setup-base")
+  , desired = require('./desired')
+  , _ = require('underscore');
+
+describe('testapp - wait-for-apps', function () {
+
+  var test = function (desc, script, checkAfter) {
+    script = 'env.currentTest = "' + desc + '"; ' + script;
+    describe(desc, function () {
+      var driver;
+      setup(this, _.defaults({waitForAppScript: script}, desired))
+        .then(function (d) { driver = d; });
+
+      it('should work', function (done) {
+        driver
+          .waitForElementByClassName('UIAButton')
+            .should.eventually.exist
+          .then(function () {
+            if (checkAfter) {
+              return driver
+                .execute('env.currentTest')
+                .should.become(desc);
+            }
+          })
+         .nodeify(done);
+      });
+    });
+  };
+
+  test('just waiting', '$.delay(5000); true;', true);
+  test('waiting for one element', 'target.elements().length > 0;', true);
+  test('bad script', 'blagimarg!!;', false);
+});
+


### PR DESCRIPTION
This is a workaround for #4032. Script samples will be collected in #4190.

@jlipps will merge now it and put in a 1.3.4-beta2 release, but can you check. 
