### PR TITLE
Fix arguments to iOS parseLocalizableStrings

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -28,7 +28,8 @@ var path = require('path')
   , prepareBootstrap = require('./uiauto').prepareBootstrap
   , CommandProxy = require('./uiauto').CommandProxy
   , UnknownError = errors.UnknownError
-  , binaryPlist = true;
+  , binaryPlist = true
+  , Args = require("vargs").Constructor;
 
 // XML Plist library helper
 var parseXmlPlistFile = function (plistFilename, cb) {
@@ -1216,38 +1217,40 @@ IOS.prototype.prelaunchSimulator = function (cb) {
   }.bind(this));
 };
 
-IOS.prototype.parseLocalizableStrings = function (language, stringFile, cb) {
+IOS.prototype.parseLocalizableStrings = function (/* language, stringFile, cb */) {
+  var args = new Args(arguments);
+  var cb = args.callback;
   if (this.args.app === null) {
     logger.debug("Localizable.strings is not currently supported when using real devices.");
-    cb();
-  } else {
-    var strings = null;
-    language = language || this.args.language;
-    stringFile = stringFile || "Localizable.strings";
-    if (language) {
-      strings = path.resolve(this.args.app, language + ".lproj", stringFile);
-    }
-    if (!fs.existsSync(strings)) {
-      if (language) {
-        logger.debug("No strings file '" + stringFile + "' for language '" + language + "', getting default strings");
-      }
-      strings = path.resolve(this.args.app, stringFile);
-    }
-    if (!fs.existsSync(strings)) {
-      strings = path.resolve(this.args.app, this.args.localizableStringsDir, stringFile);
-    }
-
-    parsePlistFile(strings, function (err, obj) {
-      if (err) {
-        logger.warn("Could not parse app " + stringFile +" assuming it " +
-        "doesn't exist");
-      } else {
-        logger.debug("Parsed app " + stringFile);
-        this.localizableStrings = obj;
-      }
-      cb();
-    }.bind(this));
+    return cb();
   }
+  var language = args.all[0] || this.args.language
+    , stringFile = args.all[1] || "Localizable.strings"
+    , strings = null;
+
+  if (language) {
+    strings = path.resolve(this.args.app, language + ".lproj", stringFile);
+  }
+  if (!fs.existsSync(strings)) {
+    if (language) {
+      logger.debug("No strings file '" + stringFile + "' for language '" + language + "', getting default strings");
+    }
+    strings = path.resolve(this.args.app, stringFile);
+  }
+  if (!fs.existsSync(strings)) {
+    strings = path.resolve(this.args.app, this.args.localizableStringsDir, stringFile);
+  }
+
+  parsePlistFile(strings, function (err, obj) {
+    if (err) {
+      logger.warn("Could not parse app " + stringFile +" assuming it " +
+                  "doesn't exist");
+    } else {
+      logger.debug("Parsed app " + stringFile);
+      this.localizableStrings = obj;
+    }
+    cb();
+  }.bind(this));
 };
 
 

--- a/test/unit/ios-device-specs.js
+++ b/test/unit/ios-device-specs.js
@@ -6,7 +6,10 @@
 var path = require('path')
   , _ = require('underscore')
   , IOS = require('../../lib/devices/ios/ios.js')
-  , expect = require('chai').expect;
+  , chai = require('chai')
+  , expect = chai.expect;
+
+chai.should();
 
 describe('IOS', function () {
   var device;


### PR DESCRIPTION
We call `ios.parseLocalizableStrings` in different ways. Handle arguments so that it actually works.

Fixes #4201.
