### PR TITLE
Fix handling of metacharacters in unicode mode

### DIFF
--- a/test/functional/common/android-keyboard-base.js
+++ b/test/functional/common/android-keyboard-base.js
@@ -171,5 +171,17 @@ module.exports = function () {
       var testText = 'тестирование';
       runTextEditTest(testText, done);
     });
+
+    describe('pressing device key with unicode keyboard', function () {
+      it('should be able to send combination keyevents', function (done) {
+        driver
+          .waitForElementByClassName('android.widget.EditText')
+            .clear()
+          .pressDeviceKey(29, 193)
+          .elementByClassName('android.widget.EditText')
+            .text().should.become('A')
+          .nodeify(done);
+      });
+    });
   });
 };


### PR DESCRIPTION
Metastates were being mishandled by the unicode keyboard. Fixes #3631.
