### PR TITLE
do not use Configurator during class initialization

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
@@ -23,8 +23,6 @@ import static io.appium.android.bootstrap.utils.API.API_18;
  */
 public class AndroidElement {
 
-  private final Configurator mConfig = Configurator.getInstance();
-
   private final UiObject el;
   private String         id;
 
@@ -146,7 +144,7 @@ public class AndroidElement {
       ReflectionUtils utils = new ReflectionUtils();
       Method method = utils.getMethod(el.getClass(), "findAccessibilityNodeInfo", long.class);
 
-      AccessibilityNodeInfo node = (AccessibilityNodeInfo)method.invoke(el, mConfig.getWaitForSelectorTimeout());
+      AccessibilityNodeInfo node = (AccessibilityNodeInfo)method.invoke(el, Configurator.getInstance().getWaitForSelectorTimeout());
 
       if (node == null) {
         throw new UiObjectNotFoundException(el.getSelector().toString());


### PR DESCRIPTION
UIAutomator currently crashes on devices with API Level < 18 when initializing an AndroidElement (so basically always)

checkout https://discuss.appium.io/t/appium-1-3-4-1-did-not-work-for-me-with-android-os-4-2-2-device/1895/2
