### PR TITLE
Add sendKeyStrategy to cap handler

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -78,6 +78,6 @@
 |`processArguments`| Arguments to pass to the AUT using instruments|e.g., `-myflag`|
 |`interKeyDelay`| The delay, in ms, between keystrokes sent to an element when typing.|e.g., `100`|
 |`showIOSLog`| Whether to show any logs captured from a device in the appium logs. Default `false`|`true` or `false`|
-|`sendKeyStrategy`| strategy to use to type test into a test field. Simulator default: `oneByOne`. Real device default: 'grouped' |`oneByOne`, `grouped` or setValue|
+|`sendKeyStrategy`| strategy to use to type test into a test field. Simulator default: `oneByOne`. Real device default: `grouped` |`oneByOne`, `grouped` or `setValue`|
 |`screenshotWaitTimeout`| Max timeout in sec to wait for a screenshot to be generated. default: 10 |e.g., `5`|
-|`waitForAppScript`| The ios automation script used to determined if the app has been launched, by default the system wait for the page source not to be empty. The result must be a boolean |e.g. `true;`, `target.elements().length > 0;`, '$.delay(5000); true;` |
+|`waitForAppScript`| The ios automation script used to determined if the app has been launched, by default the system wait for the page source not to be empty. The result must be a boolean |e.g. `true;`, `target.elements().length > 0;`, `$.delay(5000); true;` |

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -86,6 +86,7 @@ var iosCaps = [
 , 'interKeyDelay'
 , 'showIOSLog'
 , 'loggingPrefs'
+, 'sendKeyStrategy'
 ];
 
 var Capabilities = function (capabilities) {


### PR DESCRIPTION
The `sendKeyStrategy` was added but not to the capabilities handler, so we'd always get the debug line

``` shell
info: [debug] The following desired capabilities were provided, but not recognized by appium. They will be passed on to any other services running on this server. : sendKeyStrategy
```
