### PR TITLE
Add waitForAppScript to ios caps handler

### DIFF
--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -88,6 +88,7 @@ var iosCaps = [
 , 'showIOSLog'
 , 'loggingPrefs'
 , 'sendKeyStrategy'
+, 'waitForAppScript'
 ];
 
 var Capabilities = function (capabilities) {


### PR DESCRIPTION
waitForAppScript logic was added in #4191, but the caps handler doesn't
know about it, so it never gets executed. Analogous to #4249 for
sendKeyStrategy cap.
