### PR TITLE
Isaac ios delete

### DIFF
--- a/test/functional/ios/testapp/accents-specs.js
+++ b/test/functional/ios/testapp/accents-specs.js
@@ -22,10 +22,10 @@ describe('testapp - accented characters', function () {
     driver
       .elementsByClassName('UIATextField').at(1)
         .clear()
-        .sendKeys("abc")
-        .sendKeys('\uE003\uE003\uE003')
+        .sendKeys("abcd")
+        .sendKeys('\uE003\uE003')
         .text()
-        .should.become("")
+        .should.become("ab")
       .nodeify(done);
   });
 });


### PR DESCRIPTION
The current test for sending delete keys to Appium is not able to distinguish _clearing_ from _deleting_. So rather than deleting all the text, just delete half.
