### PR TITLE
Make sure release has options in Android touch

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -896,6 +896,8 @@ androidController.performTouch = function (gestures, cb) {
   var fixRelease = function (cb) {
     if (actions[actions.length - 1] === 'release') {
       var release = gestures[actions.length - 1];
+      // sometimes there are no options
+      release.options = release.options || {};
 
       // nothing to do if release options are already set
       if (release.options.element || (release.options.x && release.options.y)) return;


### PR DESCRIPTION
In case the client does not send the options for the release action (as in #4310).
