### PR TITLE
Workaround for issue where UiAUtomator fails to find visible elements. Fixes #4200

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Source.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Source.java
@@ -1,5 +1,6 @@
 package io.appium.android.bootstrap.handler;
 
+import com.android.uiautomator.common.ReflectionUtils;
 import io.appium.android.bootstrap.AndroidCommand;
 import io.appium.android.bootstrap.AndroidCommandResult;
 import io.appium.android.bootstrap.CommandHandler;
@@ -21,6 +22,7 @@ import java.io.StringWriter;
 public class Source extends CommandHandler {
   @Override
   public AndroidCommandResult execute(AndroidCommand command) throws JSONException {
+    ReflectionUtils.clearAccessibilityCache();
 
     Document doc = (Document) XMLHierarchy.getFormattedXMLDoc();
 


### PR DESCRIPTION
Some control updates fail to trigger AccessibilityEvents, resulting in stale AccessibilityNodeInfo instances. In these cases, UIAutomator will fail to locate visible elements. As a work-around, this change force clears the AccessibilityInteractionClient's cache and instigates another search. This technique also makes some Appium's searches conclude more quickly since it obviates the need for polling.  Since there is a general benefit, I do not believe users should have to opt-in.
