### PR TITLE
Figure out location of adb earlier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ build/
 lib/devices/ios/uiauto/lib/status.js
 lib/devices/ios/uiauto/appium/xpath.js
 *DerivedData
+__pycache__

--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -322,7 +322,6 @@ androidCommon.prepareDevice = function (onReady) {
   logger.debug("Preparing device for session");
   async.series([
     function (cb) { this.checkAppPresent(cb); }.bind(this),
-    function (cb) { this.adb.checkAdbPresent(cb); }.bind(this),
     function (cb) { this.prepareEmulator(cb); }.bind(this),
     function (cb) { this.prepareActiveDevice(cb); }.bind(this),
     function (cb) { this.adb.waitForDevice(cb); }.bind(this),
@@ -1058,8 +1057,10 @@ androidCommon.initJavaVersion = function (cb) {
 androidCommon.initAdb = function (cb) {
   if (this.adb === null) {
     this.adb = new ADB(this.args);
+    this.adb.checkAdbPresent(cb);
+  } else {
+    return cb();
   }
-  return cb();
 };
 
 module.exports = androidCommon;


### PR DESCRIPTION
If `adb` is present but not in the `PATH` (as is the case for Android on Sauce Labs), in some cases (particularly if not auto-launching the app) `adb` will be called before the correct path has been figured out.

Error from [this test](https://saucelabs.com/tests/1806008e3fbe4b7c9d7664cb07e532ae):

``` shell
242015-01-13 20:43:37:542 - info: [debug] Getting device API level
252015-01-13 20:43:37:544 - info: [debug] executing cmd: adb shell "getprop ro.build.version.sdk"
262015-01-13 20:43:37:549 - warn: killed=false, code=127, signal=null
272015-01-13 20:43:37:550 - info: [debug] Responding to client with error: {"status":1,"value":{"message":"Unable to launch the app: Error: Command failed: /bin/sh: 1: adb: not found\n"},"sessionId":"7a31d7e2-9911-4ff4-99c2-33544f01bb58"}
282015-01-13 20:43:37:551 - info: <-- POST /wd/hub/session/7a31d7e2-9911-4ff4-99c2-33544f01bb58/appium/device/start_activity 500 14.111 ms - 163 29
```

So move the initialization to earlier.
