### PR TITLE
Handle iOS 8.2 remote debugger

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1545,7 +1545,7 @@ IOS.prototype.navToLatestAvailableWebview = function (cb) {
 };
 
 IOS.prototype.navToViewThroughFavorites = function (cb) {
-  logger.debug("We're on iOS7 simulator: clicking apple button to get into " +
+  logger.debug("We're on iOS7+ simulator: clicking apple button to get into " +
               "a webview");
   var oldImpWait = this.implicitWaitMs;
   this.implicitWaitMs = 7000; // wait 7s for apple button to exist
@@ -1559,7 +1559,7 @@ IOS.prototype.navToViewThroughFavorites = function (cb) {
     }
     this.nativeTap(res.value.ELEMENT, function (err, res) {
       if (err || res.status !== status.codes.Success.code) {
-        var msg = "Could click button to get into webview. " +
+        var msg = "Could not click button to get into webview. " +
                   "Proceeding on the assumption we have a working one.";
         logger.error(msg);
       }

--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -127,33 +127,43 @@ RemoteDebugger.prototype.selectApp = function (appIdKey, cb, tries) {
   try { assert.ok(this.connId); } catch (err) { return cb(err); }
   this.appIdKey = appIdKey;
   var connectToApp = messages.connectToApp(this.connId, this.appIdKey);
-  this.logger.debug("Selecting app " + this.appIdKey);
+  this.logger.debug("Selecting app " + this.appIdKey + " (try #" + tries + ")");
   var responded = false;
 
   var onConnect = function (appIdKey, pageDict) {
     // appIdKey comes in but we trust that it's the same here, otherwise
     // we'll stall out and not call cb
+
+    // in iOS 8.2 the connect logic happens, but with an empty dictionary
+    // which leads to the remote debugger getting disconnected, and into a loop
+    if (_.isEmpty(pageDict)) {
+      var msg = "Empty page dictionary received. Trying again.";
+      return onRequiresRetry(this.appIdKey, msg);
+    }
     if (responded) return;
     responded = true;
     cb(this.pageArrayFromDict(pageDict));
     this.specialCbs['_rpc_forwardGetListing:'] = this.onPageChange.bind(this);
   }.bind(this);
 
-  var onConnectToBadApp = function (correctAppIdKey) {
+  var onRequiresRetry = function (correctAppIdKey, msg) {
     if (responded) return;
     responded = true;
     if (tries < 4) {
-      this.logger.info("We were notified we connected to possibly the wrong " +
-                       "app. Using the id key suggested and trying again");
+      if (!msg) {
+        msg = "We were notified we connected to possibly the wrong " +
+              "app. Using the id key suggested and trying again";
+      }
+      this.logger.info(msg);
       this.selectApp(correctAppIdKey, cb, tries + 1);
     } else {
-      var msg = "Could not connect to a valid app after " + tries + " tries.";
+      msg = "Could not connect to a valid app after " + tries + " tries.";
       this.logger.error(msg);
       cb(new Error(msg));
     }
   }.bind(this);
 
-  this.send(connectToApp, onConnect, onConnectToBadApp);
+  this.send(connectToApp, onConnect, onRequiresRetry);
 };
 
 RemoteDebugger.prototype.pageArrayFromDict = function (pageDict) {


### PR DESCRIPTION
In the last two beta releases of iOS 8.2 the remote debugger returns a valid app connection but no content. The context code would then disconnect the remote debugger, there being no windows, and the whole thing would cycle like that until it timed out. So check for that condition, and retry.
