### PR TITLE
Added server flag '--suppress-adb-kill-server' to the available arguments

### DIFF
--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -82,3 +82,4 @@ All flags are optional, but some are required in conjunction with certain others
 |`--intent-category`|android.intent.category.LAUNCHER|(Android-only) Intent category which will be used to start activity|`--intent-category android.intent.category.APP_CONTACTS`|
 |`--intent-flags`|0x10200000|(Android-only) Flags that will be used to start activity|`--intent-flags 0x10200000`|
 |`--intent-args`|null|(Android-only) Additional intent arguments that will be used to start activity|`--intent-args 0x10200000`|
+|`--suppress-adb-kill-server`|false|(Android-only) If set, prevents Appium from killing the adb server instance||

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -622,6 +622,14 @@ var args = [
   , action: 'storeTrue'
   , required: false
   , help: "Add exaggerated spacing in logs to help with visual inspection"
+  }],
+
+  [['--suppress-adb-kill-server'], {
+    dest: 'suppressAdbKillServer'
+  , defaultValue: false
+  , required: false
+  , help: "(Android-only) If set, prevents Appium from killing the adb server instance"
+  , nargs: 0
   }]
 ];
 


### PR DESCRIPTION
This flag will prevent Appium from killing the adb server. Useful when devices are connected to adb over the network by IP address rather than usb. See comment in commit for details on the use-case for this flag.
