### PR TITLE
Add default packages to uiautomator id search

### DIFF
--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -99,9 +99,9 @@ Android.prototype.start = function (cb, onDie) {
   async.series([
     this.initJavaVersion.bind(this),
     this.initAdb.bind(this),
+    this.packageAndLaunchActivityFromManifest.bind(this),
     this.initUiautomator.bind(this),
     this.prepareDevice.bind(this),
-    this.packageAndLaunchActivityFromManifest.bind(this),
     this.checkApiLevel.bind(this),
     this.pushStrings.bind(this),
     this.processFromManifest.bind(this),

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
@@ -2,6 +2,7 @@ package io.appium.android.bootstrap;
 
 import com.android.uiautomator.testrunner.UiAutomatorTestCase;
 import io.appium.android.bootstrap.exceptions.SocketServerException;
+import io.appium.android.bootstrap.handler.Find;
 
 /**
  * The Bootstrap class runs the socket server.
@@ -10,6 +11,8 @@ import io.appium.android.bootstrap.exceptions.SocketServerException;
 public class Bootstrap extends UiAutomatorTestCase {
 
   public void testRunServer() {
+    Find.params = getParams();
+
     SocketServer server;
     try {
       server = new SocketServer(4724);

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -2,6 +2,7 @@ package io.appium.android.bootstrap.handler;
 
 import com.android.uiautomator.core.UiObjectNotFoundException;
 import com.android.uiautomator.core.UiSelector;
+import android.os.Bundle;
 import static io.appium.android.bootstrap.utils.API.API_18;
 import io.appium.android.bootstrap.AndroidCommand;
 import io.appium.android.bootstrap.AndroidCommandResult;
@@ -42,6 +43,7 @@ public class Find extends CommandHandler {
   // These variables are expected to persist across executions.
   AndroidElementsHash  elements          = AndroidElementsHash.getInstance();
   static JSONObject    apkStrings        = null;
+  public static Bundle params            = null;
   UiAutomatorParser    uiAutomatorParser = new UiAutomatorParser();
   /**
    * java_package : type / name
@@ -271,13 +273,36 @@ public class Find extends CommandHandler {
         // 3. strings.xml id
         //
         // If text is a resource id then only use the resource id selector.
-        if (API_18 && resourceIdRegex.matcher(text).matches()) {
-          sel = sel.resourceId(text);
-          if (!many) {
-            sel = sel.instance(0);
+        if (API_18) {
+          if (resourceIdRegex.matcher(text).matches()) {
+            sel = sel.resourceId(text);
+            if (!many) {
+              sel = sel.instance(0);
+            }
+            selectors.add(sel);
+            break;
+          } else {
+            // not a fully qualified resource id
+            // transform "textToBeChanged" into:
+            // com.example.android.testing.espresso.BasicSample:id/textToBeChanged
+            // android:id/textToBeChanged
+            // either it's prefixed with the app package or the android system page.
+            String pkg = (String) params.get("pkg");
+
+            if (pkg != null) {
+              sel = sel.resourceId(pkg + ":id/" + text);
+              if (!many) {
+                sel = sel.instance(0);
+              }
+              selectors.add(sel);
+            }
+
+            sel = sel.resourceId("android:id/" + text);
+            if (!many) {
+              sel = sel.instance(0);
+            }
+            selectors.add(sel);
           }
-          selectors.add(sel);
-          break;
         }
 
         // must create a new selector or the selector from

--- a/lib/devices/android/uiautomator.js
+++ b/lib/devices/android/uiautomator.js
@@ -20,6 +20,7 @@ var UiAutomator = function (adb, opts) {
   this.webSocket = opts.webSocket;
   this.systemPort = opts.systemPort;
   this.resendLastCommand = function () {};
+  this.appPackage = opts.appPackage;
 };
 
 UiAutomator.prototype.start = function (readyCb) {
@@ -28,7 +29,7 @@ UiAutomator.prototype.start = function (readyCb) {
     if (err) return readyCb(err);
     logger.debug("Running bootstrap");
     var args = ["shell", "uiautomator", "runtest", "AppiumBootstrap.jar", "-c",
-        "io.appium.android.bootstrap.Bootstrap"];
+        "io.appium.android.bootstrap.Bootstrap", "-e", "pkg", this.appPackage];
 
     this.alreadyExited = false;
     this.onSocketReady = readyCb;

--- a/test/functional/android/apidemos/find/basics-specs.js
+++ b/test/functional/android/apidemos/find/basics-specs.js
@@ -101,4 +101,23 @@ describe("apidemo - find - basics", function () {
       })
       .nodeify(done);
   });
+  it('should find a single element by resource-id with implicit package', function (done) {
+    driver
+      .elementById(singleResourceId).should.eventually.exist
+      .nodeify(done);
+  });
+  it('should find multiple elements by resource-id with implicit package', function (done) {
+    driver
+      .elementsById('text1')
+        .should.eventually.have.length.at.least(10)
+      .nodeify(done);
+  });
+  it('should find multiple elements by resource-id  with implicit package even when theres just one', function (done) {
+    driver
+      .elementsById(singleResourceId)
+      .then(function (els) {
+        els.length.should.equal(1);
+      })
+      .nodeify(done);
+  });
 });


### PR DESCRIPTION
Given an element with resource id: com.example.android.testing.espresso.BasicSample:id/textToBeChanged

Now we can find this element using only id('textToBeChanged')
In addition to checking the default package name, the android package is also searched:

android:id/textToBeChanged

Fix #4416 

I'm working on DroidDriver and the need to fully qualify the ids was getting annoying.
