### PR TITLE
Replace hardcoded selendroid version to variable

### DIFF
--- a/reset.sh
+++ b/reset.sh
@@ -390,7 +390,7 @@ reset_selendroid_quick() {
     echo "* Selendroid version is ${selendroid_version}"
     echo "* Downloading selendroid server"
     run_cmd wget https://github.com/selendroid/selendroid/releases/download/${selendroid_version}/selendroid-standalone-${selendroid_version}-with-dependencies.jar
-    ANDROID_MANIFEST=$(jar tf selendroid-standalone-0.12.0-with-dependencies.jar| grep AndroidManifest | grep -v class)
+    ANDROID_MANIFEST=$(jar tf selendroid-standalone-${selendroid_version}-with-dependencies.jar| grep AndroidManifest | grep -v class)
     run_cmd jar xf selendroid-standalone-${selendroid_version}-with-dependencies.jar $ANDROID_MANIFEST prebuild/selendroid-server-${selendroid_version}.apk
     mv $ANDROID_MANIFEST AndroidManifest.xml
     run_cmd cp /tmp/appium/selendroid/prebuild/selendroid-server-${selendroid_version}.apk "${appium_home}/build/selendroid/selendroid.apk"


### PR DESCRIPTION
Fix this issue:

```
$ ./reset.sh --selendroid-quick
---- Resetting / Initializing Appium ----
RESETTING NPM
* Installing new or updated NPM modules (including devDeps)
RESETTING GENERAL
* Setting git revision data
RESETTING SELENDROID (QUICK)
* Downloading metatata
* Selendroid version is 0.14.0
* Downloading selendroid server
java.io.FileNotFoundException: selendroid-standalone-0.12.0-with-dependencies.jar (No such file or directory)
    at java.util.zip.ZipFile.open(Native Method)
    at java.util.zip.ZipFile.<init>(ZipFile.java:220)
    at java.util.zip.ZipFile.<init>(ZipFile.java:150)
    at java.util.zip.ZipFile.<init>(ZipFile.java:121)
    at sun.tools.jar.Main.list(Main.java:1060)
    at sun.tools.jar.Main.run(Main.java:291)
    at sun.tools.jar.Main.main(Main.java:1233)
---- FAILURE: reset.sh exited with status 1 ----
---- Retry with --verbose to see errors ----
```
