### PR TITLE
Don't kill the iOS simulator when running on device.

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1302,6 +1302,9 @@ IOS.prototype.cleanupSimState = function (cb) {
 };
 
 IOS.prototype.runSimReset = function (cb) {
+  if (this.args.udid !== null) {
+    return cb();
+  }
   if (this.args.reset || this.args.fullReset) {
     logger.debug("Running ios sim reset flow");
     // The simulator process must be ended before we delete applications.


### PR DESCRIPTION
Current behavior makes it impossible to work on something in the simulator while running tests on device.
