### PR TITLE
iOS flick: Support for element flick in the webview

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -755,9 +755,8 @@ iOSController.clickCoords = function (coords, cb) {
   }
 };
 
-iOSController.clickWebCoords = function (cb) {
-  var coords = this.curWebCoords
-    , wvCmd = "au.getElementsByType('webview')"
+iOSController.translateWebCoords = function (coords, cb) {
+  var wvCmd = "au.getElementsByType('webview')"
     , webviewIndex = this.webContextIndex();
 
   // add static offset for safari in landscape mode
@@ -807,17 +806,23 @@ iOSController.clickWebCoords = function (cb) {
           // ios8 includes the service bar height in the app
           serviceBarHeight = 0;
         }
-        coords = {
-          x: wvPos.x + (xRatio * coords.x)
-        , y: wvPos.y + yOffset + (yRatio * coords.y) - serviceBarHeight
+        var newCoords = {
+          x: wvPos.x + Math.round(xRatio * coords.x)
+        , y: wvPos.y + yOffset + Math.round(yRatio * coords.y) - serviceBarHeight
         };
-        logger.debug("Converted web coords " + JSON.stringify(this.curWebCoords) +
-                    "into real coords " + JSON.stringify(coords));
-        this.clickCoords(coords, cb);
+        logger.debug("Converted web coords " + JSON.stringify(coords) +
+                    "into real coords " + JSON.stringify(newCoords));
+        cb(newCoords);
       }
     }.bind(this);
     step1();
     step2();
+  }.bind(this));
+};
+
+iOSController.clickWebCoords = function (cb) {
+  this.translateWebCoords(this.curWebCoords, function (coords) {
+    this.clickCoords(coords, cb);
   }.bind(this));
 };
 
@@ -1300,12 +1305,33 @@ iOSController.fakeFlick = function (xSpeed, ySpeed, swipe, cb) {
 };
 
 iOSController.fakeFlickElement = function (elementId, xoffset, yoffset, speed, cb) {
+  var command = "";
   if (this.isWebContext()) {
-    return cb(new NotYetImplementedError(), null);
-  }
-  var command = ["au.getElement('", elementId, "').touchFlick(", xoffset, ",",
+    this.useAtomsElement(elementId, cb, function (atomsElement) {
+      this.executeAtom('get_top_left_coordinates', [atomsElement], function (err, res) {
+        if (err || res.status !== 0) return cb(err, res);
+        var x = res.value.x, y = res.value.y;
+        this.executeAtom('get_size', [atomsElement], function (err, res) {
+          if (err || res.status !== 0) return cb(err, res);
+          var w = res.value.width, h = res.value.height;
+          var clickX = x + (w / 2);
+          var clickY = y + (h / 2);
+
+          this.translateWebCoords({x: clickX, y: clickY}, function (from) {
+            this.translateWebCoords({x: clickX + xoffset, y: clickY + yoffset}, function (to) {
+              // speed is not used because underlying UIATarget.flickFromTo doesn't support it
+              command = ["au.flick(", JSON.stringify({from: from, to: to}), ")"].join('');
+              this.proxy(command, cb);
+            }.bind(this));
+          }.bind(this));
+        }.bind(this));
+      }.bind(this));
+    }.bind(this));
+  } else {
+    command = ["au.getElement('", elementId, "').touchFlick(", xoffset, ",",
       yoffset, ",", speed, ")"].join('');
-  this.proxyWithMinTime(command, FLICK_MS, cb);
+    this.proxyWithMinTime(command, FLICK_MS, cb);
+  }
 };
 
 iOSController.drag = function (startX, startY, endX, endY, duration, touchCount, elId, destElId, cb) {

--- a/lib/server/static/test/touch.html
+++ b/lib/server/static/test/touch.html
@@ -1,0 +1,56 @@
+
+<!DOCTYPE html>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+<html>
+<head>
+  <title>I am a page title</title>
+  <script type="text/javascript" src="/js/jquery.min.js"></script>
+  <style>
+    .flickElem {
+      position: relative;
+      width: 10px;
+      height: 10px;
+      left: 40px;
+      background-color: #ff0000;
+    }
+  </style>
+</head>
+<body style1="border: solid 1px red; margin: 0; padding: 0">
+
+<h1>This page is a Selenium sandbox</h1>
+
+<div id="flickElem" class="flickElem">&nbsp;</div><br/><span></span>
+
+<script type="text/javascript">
+  $(document).ready(function(){
+    var flickElem = $("#flickElem");
+
+    flickElem.bind("touchstart", function(event) {
+      var x = event.originalEvent.touches[0].pageX,
+          y = event.originalEvent.touches[0].pageY,
+          offset = flickElem.offset(),
+          dx = x - offset.left,
+          dy = y - offset.top;
+
+      flickElem.bind("touchmove", function(event) {
+        flickElem.offset({
+          left: event.originalEvent.touches[0].pageX - dx,
+          top: event.originalEvent.touches[0].pageY - dy
+        });
+      });
+
+      flickElem.bind("touchend", function(event) {
+        flickElem.offset({
+          left: event.originalEvent.changedTouches[0].pageX - dx,
+          top: event.originalEvent.changedTouches[0].pageY - dy
+        });
+
+        flickElem.unbind("touchmove");
+      });
+    });
+  });
+
+</script>
+
+</body>
+</html>

--- a/test/functional/ios/safari/touch-specs.js
+++ b/test/functional/ios/safari/touch-specs.js
@@ -1,0 +1,39 @@
+"use strict";
+
+var setup = require("../../common/setup-base"),
+    webviewHelper = require("../../../helpers/webview"),
+    testEndpoint = webviewHelper.testEndpoint;
+
+describe('touch', function () {
+  var driver,
+      desired = {
+        "browserName": "safari"
+      };
+
+  setup(this, desired, {'no-reset': true}).then(function (d) { driver = d; });
+
+  it('should flick element', function (done) {
+    driver
+      .get(testEndpoint(desired) + 'touch.html')
+      .elementById('flickElem')
+      .getLocation()
+      .then(function (l1) {
+        var dx = 30,
+            dy = 30;
+        return driver
+          .elementById('flickElem')
+          .flick(dx, dy, 0)
+          .sleep(1000)
+          .getLocation()
+          .then(function (l2) {
+            // UI Atomation's flickFromTo() seems to be not prices enough.
+            // And in most cases safari receives the last touchmove event
+            // with the coordinates which are by one pixel less than desired
+            // destination. Hence allow some deviation here.
+            l2.x.should.be.within(l1.x + dx - 2, l1.x + dx + 2);
+            l2.y.should.be.within(l1.y + dy - 2, l1.y + dy + 2);
+          });
+       })
+       .nodeify(done);
+  });
+});


### PR DESCRIPTION
This PR implements flick functionality in the webview when element is specified. Flick starts from the center of the element and finishes at the point calculated using specified offsets. Under the hood the flick() method  is used from the uiauto/mechanic patch.
