### PR TITLE
Add slight delay to keyboard tests

### DIFF
--- a/test/functional/common/android-keyboard-base.js
+++ b/test/functional/common/android-keyboard-base.js
@@ -29,6 +29,7 @@ module.exports = function () {
         }
       })
       .then(function () { return el.sendKeys(testText); })
+      .sleep(100)
       .then(function () { return el.text().should.become(testText); })
       .nodeify(done);
   };


### PR DESCRIPTION
Selendroid tests were sometimes failing because `sendKeys` returned too fast, and the last couple of characters were not being typed before the `text` call happened.
