### PR TITLE
v1.3.5 branch

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,8 @@ CHANGES IN VERSION 1.3.5
 #### iOS
 - fix for a bug when driver.get() never returns for page with alert.
 - iOS 8.2 support.
+- fixed safari startup crashes.
+- ensure Appium drops into the right continuation cb when selecting hybrid contexts.
 
 #### Android
 - now finds the location of adb earlier.
@@ -25,8 +27,6 @@ CHANGES IN VERSION 1.3.4
 - functional test fixes.
 
 #### iOS
-- fixed safari startup crashes
-- ensure Appium drops into the right continuation cb when selecting hybrid contexts
 - allow location services in zip file.
 - ensure a string is returned from iOS getText.
 - simpler device type detection logic.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,20 @@
+CHANGES IN VERSION 1.3.5
+======================================
+
+#### iOS
+- fix for a bug when driver.get() never returns for page with alert.
+- iOS 8.2 support.
+
+#### Android
+- now finds the location of adb earlier.
+- ensure encoding closes correcting in Bootstrap.jar.
+- add workaround for issue where UiAUtomator fails to find visible elements.
+- fixed undefined member error for the release object.
+- add a delete key test.
+
+#### Selendroid
+- upgrade to Selendroid 0.13.0.
+
 CHANGES IN VERSION 1.3.4
 ======================================
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -25,6 +25,8 @@ CHANGES IN VERSION 1.3.4
 - functional test fixes.
 
 #### iOS
+- fixed safari startup crashes
+- ensure Appium drops into the right continuation cb when selecting hybrid contexts
 - allow location services in zip file.
 - ensure a string is returned from iOS getText.
 - simpler device type detection logic.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,7 @@ CHANGES IN VERSION 1.3.5
 
 #### Android
 - now finds the location of adb earlier.
-- ensure encoding closes correcting in Bootstrap.jar.
+- ensure encoding stream in Bootstrap.jar closes correctly.
 - add workaround for issue where UiAUtomator fails to find visible elements.
 - fixed undefined member error for the release object.
 - add a delete key test.
@@ -42,7 +42,7 @@ CHANGES IN VERSION 1.3.4
 - exec refactoring.
 - uses for latest apktool (2.0.0-RC2) when Java 7 is detected.
 - ADB.jars refactored into instance property.
-- smart keyboard  closing fix.
+- smart keyboard closing fix.
 - added support for getting the resourceId attribute of an element.
 - clear text fix for large centered edit fields.
 - better handling of errors in clear text.

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/Find.java
@@ -147,17 +147,17 @@ public class Find extends CommandHandler {
             final List<AndroidElement> elementsFromSelector = fetchElements(
                 sel, contextId);
             foundElements.addAll(elementsFromSelector);
-            found |= foundElements.size() > 0;
           } catch (final UiObjectNotFoundException ignored) {
           }
         }
         if (strategy == Strategy.ANDROID_UIAUTOMATOR) {
           foundElements = ElementHelpers.dedupe(foundElements);
         }
+        found = foundElements.size() > 0;
         result = elementsToJSONArray(foundElements);
       }
 
-      if (found) {
+      if (!found) {
         if (!isRetry) {
           Logger
               .debug("Failed to locate element. Clearing Accessibility cache and retrying.");

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/ReflectionUtils.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/utils/ReflectionUtils.java
@@ -19,7 +19,6 @@ public class ReflectionUtils {
     boolean success = false;
 
     try {
-      final ReflectionUtils utils = new ReflectionUtils();
       final Class c = Class
           .forName("android.view.accessibility.AccessibilityInteractionClient");
       final Method getInstance = ReflectionUtils.method(c, "getInstance");

--- a/lib/devices/android/bootstrap/src/io/appium/uiautomator/core/InteractionController.java
+++ b/lib/devices/android/bootstrap/src/io/appium/uiautomator/core/InteractionController.java
@@ -14,7 +14,7 @@ public class InteractionController {
   private static final String METHOD_INJECT_EVENT_SYNC = "injectEventSync";
   private static final String METHOD_TOUCH_DOWN = "touchDown";
   private static final String METHOD_TOUCH_UP = "touchUp";
-  private static final String METHOD_TOUCH_MOVE = "touchDown";
+  private static final String METHOD_TOUCH_MOVE = "touchMove";
   public static final String METHOD_PERFORM_MULTI_POINTER_GESTURE = "performMultiPointerGesture";
 
   private final Object interactionController;

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "firefoxos",
     "testing"
   ],
-  "version": "1.3.5-beta",
+  "version": "1.3.5",
   "author": "https://github.com/appium",
   "licenses": [
     {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "firefoxos",
     "testing"
   ],
-  "version": "1.3.4",
+  "version": "1.3.5-beta",
   "author": "https://github.com/appium",
   "licenses": [
     {


### PR DESCRIPTION
Includes cache clearing fix for the findElements case and cherry-picked paymand's `Fix for a typo that broke 'touchMove' gesture.` fix.
