### PR TITLE
Fix issue 4532: Check if plist file exists before parsing

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1243,6 +1243,10 @@ IOS.prototype.parseLocalizableStrings = function (/* language, stringFile, cb */
   if (!fs.existsSync(strings)) {
     strings = path.resolve(this.args.app, this.args.localizableStringsDir, stringFile);
   }
+  if (!fs.existsSync(strings)) {
+     logger.warn("Plist file does not exist at " + strings);
+     return cb();
+  }
 
   parsePlistFile(strings, function (err, obj) {
     if (err) {


### PR DESCRIPTION
Original issue: appium crash while parsing SafariLauncher's not existing plist file
