### PR TITLE
Updating clients.plist file for 8.1 format

### DIFF
--- a/lib/devices/ios/settings.js
+++ b/lib/devices/ios/settings.js
@@ -182,25 +182,45 @@ settings.updateLocationSettings = function (sim, bundleId, authorized) {
   });
   var curSettings = settings.getSettings(sim, 'locationClients');
   _.each(curSettings, function (settingSet, file) {
-    // add this random data to the clients.plist since it always seems to be there
-    if (!_.has(settingSet, weirdLocKey)) {
-      settingSet[weirdLocKey] = {
-        BundlePath: "/System/Library/PrivateFrameworks/AOSNotification.framework",
-        Whitelisted: false,
-        Executable: "",
-        Registered: ""
-      };
-    }
-    // now add our app's data
-    if (!_.has(settingSet, bundleId)) {
-      settingSet[bundleId] = {};
-    }
-    _.extend(settingSet[bundleId], newPrefs);
-    if (!_.has(settingSet, 'Executable')) {
-      settingSet.Executable = "";
-    }
-    if (!_.has(settingSet, 'Registered')) {
-      settingSet.Registered = "";
+    // 8.1 changed the format a bit.
+    if (sim.sdkVer === "8.1") {
+      logger.debug("Using 8.1 format locationd plist format.");
+      _.extend(newPrefs,  {
+        Authorization: 2,
+        SupportedAuthorizationMask: 3,
+      });
+      // now add our app's data
+      if (!_.has(settingSet, bundleId)) {
+        settingSet[bundleId] = {};
+      }
+      _.extend(settingSet[bundleId], newPrefs);
+      if (!_.has(settingSet[bundleId], 'Executable')) {
+        settingSet[bundleId].Executable = "";
+      }
+      if (!_.has(settingSet[bundleId], 'Registered')) {
+        settingSet[bundleId].Registered = "";
+      }
+    }  else {
+      // add this random data to the clients.plist since it always seems to be there
+      if (!_.has(settingSet, weirdLocKey)) {
+        settingSet[weirdLocKey] = {
+          BundlePath: "/System/Library/PrivateFrameworks/AOSNotification.framework",
+          Whitelisted: false,
+          Executable: "",
+          Registered: ""
+        };
+      }
+      // now add our app's data
+      if (!_.has(settingSet, bundleId)) {
+        settingSet[bundleId] = {};
+      }
+      _.extend(settingSet[bundleId], newPrefs);
+      if (!_.has(settingSet, 'Executable')) {
+        settingSet.Executable = "";
+      }
+      if (!_.has(settingSet, 'Registered')) {
+        settingSet.Registered = "";
+      }
     }
     prefSetPerFile[file] = settingSet;
   });


### PR DESCRIPTION
This is a rough cut at what I think is needed. This makes location work
in the simulator on 8.1 (before it was crashing and respawning every 3
seconds endlessly). Fixes #4552. Works for me on 8.1 with Xcode 
Version 6.1.1 (6A2008a)
