### PR TITLE
New MobileSafari logic bypassing Apple page

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -72,6 +72,7 @@
 |`autoDismissAlerts`| Dismiss iOS privacy access permission alerts (e.g., location, contacts, photos) automatically if they pop up. Default is false.|`true` or `false`|
 |`nativeInstrumentsLib`| Use native intruments lib (ie disable instruments-without-delay).|`true` or `false`|
 |`nativeWebTap`| (Sim-only) Enable "real", non-javascript-based web taps in Safari. Default: `false`. Warning: depending on viewport size/ratio this might not accurately tap an element|`true` or `false`|
+|`safariInitialUrl`| (Sim-only) (>= 8.1) Initial safari url, default is a local welcome page | e.g. `https://www.github.com` |
 |`safariAllowPopups`| (Sim-only) Allow javascript to open new windows in Safari. Default keeps current sim setting|`true` or `false`|
 |`safariIgnoreFraudWarning`| (Sim-only) Prevent Safari from showing a fraudulent website warning. Default keeps current sim setting.|`true` or `false`|
 |`safariOpenLinksInBackground`| (Sim-only) Whether Safari should allow links to open in new windows. Default keeps current sim setting.|`true` or `false`|

--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -230,6 +230,10 @@ androidController.asyncScriptTimeout = function (ms, cb) {
   cb(new NotYetImplementedError(), null);
 };
 
+androidController.pageLoadTimeout = function (ms, cb) {
+  cb(new NotYetImplementedError(), null);
+};
+
 androidController.executeAsync = function (script, args, responseUrl, cb) {
   cb(new NotYetImplementedError(), null);
 };

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1098,6 +1098,17 @@ iOSController.asyncScriptTimeout = function (ms, cb) {
   });
 };
 
+iOSController.pageLoadTimeout = function (ms, cb) {
+  this.pageLoadMs = parseInt(ms, 10);
+  if (this.remote) this.remote.pageLoadMs = this.pageLoadMs;
+  logger.debug("Set iOS page load timeout to " + ms + "ms");
+  cb(null, {
+    status: status.codes.Success.code
+  , value: null
+  });
+};
+
+
 iOSController.elementDisplayed = function (elementId, cb) {
   if (this.isWebContext()) {
     this.useAtomsElement(elementId, cb, function (atomsElement) {

--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -87,6 +87,10 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
       this.remote.pageArrayFromJson(onDone);
     } else {
       this.remote = rd.init(exitCb);
+      this.remote.configureExtraOpts({
+        useNewSafari: this.useNewSafari(),
+        pageLoadMs: this.pageLoadMs
+      });
       this.remote.connect(function (appDict) {
         var appKey;
         try {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -111,6 +111,7 @@ IOS.prototype.init = function () {
   this.webElementIds = [];
   this.implicitWaitMs = 0;
   this.asyncWaitMs = 0;
+  this.pageLoadMs = 60000;
   this.asyncResponseCb = null;
   this.returnedFromExecuteAtom = {};
   this.executedAtomsCounter = 0;
@@ -1543,7 +1544,7 @@ IOS.prototype.getLatestWebviewContextForTitle = function (titleRegex, cb) {
     if (err) return cb(err);
     var matchingCtx;
     _(contexts).each(function (ctx) {
-      if (ctx.view && (ctx.view.title || "").match(titleRegex)) {
+      if (ctx.view && ctx.view.url !== "about:blank" && (ctx.view.title || "").match(titleRegex)) {
         matchingCtx = ctx;
       }
     });
@@ -1551,17 +1552,55 @@ IOS.prototype.getLatestWebviewContextForTitle = function (titleRegex, cb) {
   });
 };
 
+// Right now we don't necessarily wait for webview
+// and frame to load, which leads to race conditions and flakiness
+// , let see if we can transition to something better
+IOS.prototype.useNewSafari = function () {
+  return this.iOSSDKVersion === '8.1' && this.args.platformVersion === '8.1' && !this.args.udid && this.capabilities.safari;
+};
+
 IOS.prototype.navToInitialWebview = function (cb) {
   var timeout = 0;
   if (this.args.udid) timeout = parseInt(this.iOSSDKVersion, 10) >= 8 ? 4000 : 6000;
   if (timeout > 0) logger.debug('Waiting for ' + timeout + ' ms before navigating to view.');
   setTimeout(function () {
-    if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.args.udid && this.capabilities.safari) {
+    if (this.useNewSafari()) {
+      return this.typeAndNavToUrl(cb);
+    } else if (parseInt(this.iOSSDKVersion, 10) >= 7 && !this.args.udid && this.capabilities.safari) {
       this.navToViewThroughFavorites(cb);
     } else {
       this.navToViewWithTitle(/.*/, cb);
     }
   }.bind(this), timeout);
+};
+
+IOS.prototype.typeAndNavToUrl = function (cb) {
+  var initialUrl = this.args.safariInitialUrl || 'http://127.0.0.1:' + this.args.port + '/welcome';
+  var oldImpWait = this.implicitWaitMs;
+  this.implicitWaitMs = 7000;
+  function noArgsCb(cb) { return function (err) { cb(err); }; }
+  async.waterfall([
+    this.findElement.bind(this, 'name', 'URL'),
+    function (res, cb) {
+      this.implicitWaitMs = oldImpWait;
+      this.nativeTap(res.value.ELEMENT, noArgsCb(cb));
+    }.bind(this),
+    this.findElements.bind(this, 'name', 'Address'),
+    function (res, cb) {
+      var addressEl = res.value[res.value.length -1].ELEMENT;
+      this.setValueImmediate(addressEl, initialUrl, noArgsCb(cb));
+    }.bind(this),
+    this.findElement.bind(this, 'name', 'go'),
+    function (res, cb) {
+      this.nativeTap(res.value.ELEMENT, noArgsCb(cb));
+    }.bind(this)
+  ], function () {
+    this.navToViewWithTitle(/.*/i, function (err) {
+      if (err) return cb(err);
+      // Waits for page to finish loading.
+      this.remote.pageUnload(cb);
+    }.bind(this));
+  }.bind(this));
 };
 
 IOS.prototype.navToViewThroughFavorites = function (cb) {

--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -12,8 +12,8 @@ var net = require('net')
   , bufferpack = require('bufferpack')
   , uuid = require('node-uuid')
   , noop = function () {}
-  , assert = require('assert');
-
+  , assert = require('assert')
+  , Args = require("vargs").Constructor;
 // ====================================
 // CONFIG
 // ====================================
@@ -65,6 +65,15 @@ RemoteDebugger.prototype.init = function (debuggerType, onDisconnect) {
     }
   };
 
+};
+
+// temporarily using separate method to avoid conflict with webkit remote
+// debugger
+RemoteDebugger.prototype.configureExtraOpts = function (opts) {
+  opts = opts || {};
+  this.useNewSafari = opts.useNewSafari || false;
+  this.pageLoadMs = opts.pageLoadMs;
+  this.logger.debug('useNewSafari --> ' + this.useNewSafari);
 };
 
 // ====================================
@@ -364,23 +373,23 @@ RemoteDebugger.prototype.navToUrl = function (url, cb) {
   var navToUrl = messages.setUrl(url, this.appIdKey, this.connId,
       this.senderId, this.pageIdKey, this.debuggerType);
   this.send(navToUrl, noop);
+  var pageLoadStartMs = Date.now();
   setTimeout(function () {
     this.waitForFrameNavigated(function () {
-      this.waitForDom(cb);
+      this.waitForDom(pageLoadStartMs, cb);
     }.bind(this));
-  }.bind(this), 1000);
+  }.bind(this), this.useNewSafari ? 0 : 1000);
 };
 
-RemoteDebugger.prototype.pageLoad = function () {
+RemoteDebugger.prototype.pageLoad = function (startPageLoadMs) {
   clearTimeout(this.loadingTimeout);
   var cbs = this.pageLoadedCbs
-    , waitMs = 60000
     , intMs = 500
-    , start = Date.now();
+    , start = startPageLoadMs || Date.now();
   this.logger.debug("Page loaded, verifying whether ready through readyState");
   var verify = function () {
     this.checkPageIsReady(function (err, isReady) {
-      if (isReady || (start + waitMs) < Date.now()) {
+      if (isReady || (this.pageLoadMs > 0 && (start + this.pageLoadMs) < Date.now())) {
         this.logger.debug("Page is ready, calling onload cbs");
         this.pageLoadedCbs = [];
         this.pageLoading = false;
@@ -439,18 +448,36 @@ RemoteDebugger.prototype.pageUnload = function (cb) {
   this.waitForDom(cb);
 };
 
-RemoteDebugger.prototype.waitForDom = function (cb) {
+RemoteDebugger.prototype.waitForDom = function () {
+  var args = new Args(arguments);
+  var startPageLoadMs = args.all[0];
+  var cb = args.callback;
   this.logger.debug("Waiting for dom...");
   if (typeof cb === "function") {
     this.pageLoadedCbs.push(_.once(cb));
   }
-  this.pageLoad();
+  this.pageLoad(startPageLoadMs);
 };
 
 RemoteDebugger.prototype.waitForFrameNavigated = function (cb) {
   this.logger.debug("Waiting for frame navigated...");
+  var startMs = Date.now();
+
+  // wrapping cb to be able to log some data
+  var _cb = cb;
+  cb = function () {
+    this.logger.debug('frame navigated in ' + ((Date.now() - startMs)/1000) + ' sec.' );
+    var args = [].slice.call(arguments);
+    _cb.apply(null, args);
+  }.bind(this);
+
   this.frameNavigatedCbs.push(cb);
-  this.navigatingTimeout = setTimeout(this.frameNavigated.bind(this), 500);
+  if (!this.useNewSafari || this.pageLoadMs >= 0) {
+    this.navigatingTimeout = setTimeout(function () {
+       this.logger.debug('frame navigated timeout triggered');
+       this.frameNavigated();
+    }.bind(this), this.useNewSafari ? this.pageLoadMs : 500);
+  }
 };
 
 // ====================================

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -81,6 +81,7 @@ var iosCaps = [
 , 'nativeInstrumentsLib'
 , 'nativeWebTap'
 , 'safariAllowPopups'
+, 'safariInitialUrl'
 , 'safariIgnoreFraudWarning'
 , 'safariOpenLinksInBackground'
 , 'keepKeyChains'

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -807,6 +807,11 @@ exports.asyncScriptTimeout = function (req, res) {
   req.device.asyncScriptTimeout(ms, getResponseHandler(req, res));
 };
 
+exports.pageLoadTimeout = function (req, res) {
+  var ms = req.body.ms;
+  req.device.pageLoadTimeout(ms, getResponseHandler(req, res));
+};
+
 exports.timeouts = function (req, res) {
   var timeoutType = req.body.type
     , ms = req.body.ms;
@@ -818,6 +823,8 @@ exports.timeouts = function (req, res) {
     } else if (timeoutType === "command") {
       var secs = parseInt(ms, 10) / 1000;
       req.appium.setCommandTimeout(secs, getResponseHandler(req, res));
+    } else if (timeoutType === "page load") {
+      exports.pageLoadTimeout(req, res);
     } else {
       respondError(req, res, status.codes.UnknownCommand.code,
         new Error("Invalid timeout '" + timeoutType + "'"));
@@ -1191,24 +1198,32 @@ exports.crash = function () {
 };
 
 exports.guineaPig = function (req, res) {
-  var params = {
-    serverTime: parseInt(new Date().getTime() / 1000, 10)
-  , userAgent: req.headers['user-agent']
-  , comment: "None"
-  };
-  if (req.method === "POST") {
-    params.comment = req.body.comments || params.comment;
-  }
-  safely(req, function () {
-    res.set('Content-Type', 'text/html');
-    res.cookie('guineacookie1', 'i am a cookie value', {path: '/'});
-    res.cookie('guineacookie2', 'cookié2', {path: '/'});
-    res.cookie('guineacookie3', 'cant access this', {
-      domain: '.blargimarg.com',
-      path: '/'
+  var delay = req.param('delay') ? parseInt(req.param('delay'), 10) : 0;
+  setTimeout(function () {
+   var params = {
+      serverTime: parseInt(new Date().getTime() / 1000, 10)
+    , userAgent: req.headers['user-agent']
+    , comment: "None"
+    };
+    if (req.method === "POST") {
+      params.comment = req.body.comments || params.comment;
+    }
+    safely(req, function () {
+      res.set('Content-Type', 'text/html');
+      res.cookie('guineacookie1', 'i am a cookie value', {path: '/'});
+      res.cookie('guineacookie2', 'cookié2', {path: '/'});
+      res.cookie('guineacookie3', 'cant access this', {
+        domain: '.blargimarg.com',
+        path: '/'
+      });
+      res.send(exports.getTemplate('guinea-pig')(params));
     });
-    res.send(exports.getTemplate('guinea-pig')(params));
-  });
+  }, delay);
+};
+
+exports.welcome = function (req, res) {
+  var params = { message: 'Let\'s browse!' };
+  res.send(exports.getTemplate('welcome')(params));
 };
 
 exports.getTemplate = function (templateName) {

--- a/lib/server/routing.js
+++ b/lib/server/routing.js
@@ -89,6 +89,10 @@ module.exports = function (appium) {
 
   // allow appium to receive async response
   rest.post('/wd/hub/session/:sessionId?/receive_async_response', controller.receiveAsyncResponse);
+
+  //welcome page
+  rest.all('/welcome', controller.welcome);
+
   // these are for testing purposes only
   rest.post('/wd/hub/produce_error', controller.produceError);
   rest.post('/wd/hub/crash', controller.crash);

--- a/lib/server/templates/welcome.html
+++ b/lib/server/templates/welcome.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Appium/welcome</title>
+</head>
+  <body>
+    <h1>{{message}}</h1>
+  </body>
+</html>

--- a/test/functional/ios/safari/basics-specs.js
+++ b/test/functional/ios/safari/basics-specs.js
@@ -1,0 +1,38 @@
+"use strict";
+
+var env = require('../../../helpers/env'),
+    setup = require("../../common/setup-base");
+
+describe('safari - basics @skip-ios6', function () {
+  if (env.IOS81) {
+    describe('default init' ,function () {
+      var driver;
+      setup(this, {browserName: 'safari'}).then(function (d) { driver = d; });
+      it('it should use appium default init page', function (done) {
+        driver
+          .source().should.eventually.include('Let\'s browse!')
+          .nodeify(done);
+      });
+    });
+
+    describe('init with safariInitialUrl', function () {
+      var driver;
+      setup(this, {browserName: 'safari', safariInitialUrl: env.GUINEA_TEST_END_POINT})
+        .then(function (d) { driver = d; });
+      it('should go to the requested page', function () {
+        return driver
+          .source().should.eventually.include('I am some page content');
+      });
+    });
+  } else {
+    describe('default init' ,function () {
+      var driver;
+      setup(this, {browserName: 'safari'}).then(function (d) { driver = d; });
+      it('it should use appium default init page', function (done) {
+        driver
+          .source().should.eventually.include('Apple')
+          .nodeify(done);
+      });
+    });
+  }
+});

--- a/test/functional/ios/safari/page-load-timeout-specs.js
+++ b/test/functional/ios/safari/page-load-timeout-specs.js
@@ -1,0 +1,39 @@
+"use strict";
+
+var env = require('../../../helpers/env'),
+    setup = require("../../common/setup-base");
+
+describe('safari - page load timeout @skip-ios6', function () {
+  if (env.IOS81) {
+    describe('small timeout, slow page load', function () {
+      var driver;
+      setup(this, {browserName: 'safari'})
+        .then(function (d) { driver = d; });
+      it('should go to the requested page', function () {
+        return driver
+          .setPageLoadTimeout(5000)
+          .get(env.GUINEA_TEST_END_POINT + '?delay=30000')
+          // the page should not have time to load
+          .source().should.eventually.include('Let\'s browse!');
+      });
+    });
+
+    describe('no timeout, very slow page', function () {
+      var startMs = Date.now();
+      var driver;
+      setup(this, {browserName: 'safari'})
+        .then(function (d) { driver = d; });
+      it('should go to the requested page', function () {
+        return driver
+          .setCommandTimeout(120000)
+          .setPageLoadTimeout(-1)
+          .get(env.GUINEA_TEST_END_POINT + '?delay=70000')
+          // the page should load after 70000
+          .source().should.eventually.include('I am some page content')
+          .then(function () {
+            (Date.now() -startMs).should.be.above(70000);
+          });
+      });
+    });
+  }
+});


### PR DESCRIPTION
With slow connection there is a race condition between the initial Apple page and the first page requested, this fixes it by waiting for the Apple page to finish loading before the new session request returns.
