### PR TITLE
Re-install Selendroid server only on file changes.

### DIFF
--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -15,6 +15,7 @@ var Device = require('../device.js')
   , androidCommon = require('./android-common.js')
   , androidHybrid = require('./android-hybrid.js')
   , path = require('path')
+  , md5 = require('md5calculator')
   , utf7 = require('utf7').imap;
 
 var Selendroid = function () {
@@ -93,32 +94,30 @@ Selendroid.prototype.start = function (cb) {
 
   var modServerExists = false
     , modAppPkg = null
-    , modServerTimestamp = null;
+    , resignedServerMd5Hash = null;
 
   var checkModServerExists = function (cb) {
     this.selendroidServerPath = path.resolve(this.args.tmpDir,
         'selendroid.' + this.args.appPackage + '.apk');
     modAppPkg = this.args.appPackage + '.selendroid';
-    fs.stat(this.selendroidServerPath, function (err, stat) {
-      modServerExists = !err;
-      if (stat) {
-        modServerTimestamp = stat.mtime.getTime();
-      }
+    fs.exists(this.selendroidServerPath, function (exists) {
+      modServerExists = exists;
       cb();
     });
   }.bind(this);
 
   var checkServerResigned = function (cb) {
     if (modServerExists) {
-      fs.stat(this.selendroidServerPath, function (err, stat) {
-        if (stat && stat.mtime.getTime() > modServerTimestamp) {
+      md5(this.selendroidServerPath, function (err, md5Hash) {
+        if (err) return cb(err);
+        logger.debug("MD5 for selendroid server is " + md5Hash);
+        if (resignedServerMd5Hash !== md5Hash) {
+          resignedServerMd5Hash = md5Hash;
           modServerExists = false;
         }
-        cb();
-      });
-    } else {
-      cb();
+      }.bind(this));
     }
+    cb();
   }.bind(this);
 
   var conditionalUninstallSelendroid = function (cb) {


### PR DESCRIPTION
Currently, we look at the timestamp (mtime) of the Selendroid server
file to determine if we need to re-install it. Since we are creating it
every time, this means that we re-install it every single time!
This fix checks the MD5 hash of the server file, so that we re-install
only when the binary is different.
