### PR TITLE
Fix reporting of url in logs

### DIFF
--- a/lib/devices/device.js
+++ b/lib/devices/device.js
@@ -123,7 +123,7 @@ Device.prototype.configureDownloadedApp = function (cb) {
       }.bind(this));
     } catch (e) {
       var err = e.toString();
-      logger.error("Failed downloading app from appUrl " + appUrl);
+      logger.error("Failed downloading app from appUrl " + appUrl.href);
       cb(err);
     }
   } else if (ext === ".zip" || ext === ".ipa") {
@@ -137,10 +137,10 @@ Device.prototype.configureDownloadedApp = function (cb) {
           cb();
         }
       }.bind(this));
-      logger.debug("Using downloadable app from " + origin + ": " + appUrl);
+      logger.debug("Using downloadable app from " + origin + ": " + appUrl.href);
     } catch (e) {
       var err = e.toString();
-      logger.error("Failed downloading app from appUrl " + appUrl);
+      logger.error("Failed downloading app from appUrl " + appUrl.href);
       cb(err);
     }
   } else {


### PR DESCRIPTION
A few places where we get `[object Object]` in the logs, rather than something useful (in this case, the url from which we are downloading the app).
