### PR TITLE
Fix for git pre-commit hook fail on Android.

### DIFF
--- a/test/unit/ios-device-specs.js
+++ b/test/unit/ios-device-specs.js
@@ -10,6 +10,7 @@ var path = require('path')
   , chai = require('chai')
   , expect = chai.expect
   , fs = require('fs')
+  , os = require('os')
   , env = process.env;
 
 chai.should();
@@ -113,37 +114,42 @@ describe('IOS', function () {
     });
   });
 
-  describe('xcode#getpath', function () {
-    it('should always return a valid path', function (done) {
-      this.timeout(5000);
-      // getPath failures have been intermittent, so try a few times
-      var iterations = 100;
-      var nextTest = function () {
-        XCODE.getPath(function (err, path) {
-          expect(err).to.be.null;
-          expect(path).not.to.be.empty;
-          expect(fs.existsSync(path)).to.be.true;
-          if (--iterations > 0) {
-            nextTest();
-          } else {
-            done();
-          }
+  if (os.platform() === 'darwin') {
+
+    describe('xcode#getpath', function () {
+      it('should always return a valid path', function (done) {
+        this.timeout(5000);
+        // getPath failures have been intermittent, so try a few times
+        var iterations = 100;
+        var nextTest = function () {
+          XCODE.getPath(function (err, path) {
+            expect(err).to.be.null;
+            expect(path).not.to.be.empty;
+            expect(fs.existsSync(path)).to.be.true;
+            if (--iterations > 0) {
+              nextTest();
+            } else {
+              done();
+            }
+          });
+        };
+        nextTest();
+      });
+
+      // careful, there's a bug in mocha so if you call this before
+      // 'should always return a valid path', then the other test
+      // will get passed this test's `err` object.
+      it('should fail with a bad path', function (done) {
+        env.DEVELOPER_DIR = "/foo/bar";
+
+        XCODE.getPath(function (err) {
+          env.DEVELOPER_DIR = "";
+          expect(err).not.to.be.null;
+          done();
         });
-      };
-      nextTest();
-    });
-
-    // careful, there's a bug in mocha so if you call this before
-    // 'should always return a valid path', then the other test
-    // will get passed this test's `err` object.
-    it('should fail with a bad path', function (done) {
-      env.DEVELOPER_DIR = "/foo/bar";
-
-      XCODE.getPath(function (err) {
-        env.DEVELOPER_DIR = "";
-        expect(err).not.to.be.null;
-        done();
       });
     });
-  });
+
+  } // end if
+
 });


### PR DESCRIPTION
iOS-specific tests should only be run on iOS.

Committing on Android fails since the pre-commit hooks fails. Bug was introduced here: https://github.com/appium/appium/commit/54f9b3af226374329fbf0bec903de6fbad4550a6
