### PR TITLE
Allow android drag and drop with absolute coordinates

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -668,7 +668,7 @@ androidController.drag = function (startX, startY, endX, endY, duration, touchCo
   , steps: Math.round(duration * this.dragStepsPerSec)
   };
 
-  if (elementId !== null) {
+  if (elementId) {
     this.proxy(["element:drag", dragOpts], cb);
   } else {
     this.proxy(["drag", dragOpts], cb);
@@ -867,31 +867,52 @@ androidController.performTouch = function (gestures, cb) {
   // drag is *not* press-move-release, so we need to translate
   // drag works fine for scroll, as well
   var doTouchDrag = function (gestures, cb) {
-    var longPress = gestures[0];
-    var elementId = longPress.options.element;
-    this.getLocation(elementId, function (err, res) {
-      if (err) return cb(err);
+    var getStartLocation = function (elementId, x, y, ncb) {
+      var startX = x || 0
+        , startY = y || 0;
+      if (elementId) {
+        this.getLocation(elementId, function (err, res) {
+          if (err) return ncb(err);
 
-      var startX = res.value.x;
-      var startY = res.value.y;
+          startX += res.value.x || 0;
+          startY += res.value.y || 0;
 
-      var moveTo = gestures[1];
-      var destElId = moveTo.options.element;
-      var endX = moveTo.options.x;
-      var endY = moveTo.options.y;
-
-      if (typeof destElId !== 'undefined' && destElId) {
-        this.getLocation(destElId, function (err, res) {
-          if (err) return cb(err);
-
-          endX = res.value.x + (endX || 0);
-          endY = res.value.y + (endY || 0);
-
-          return this.drag(startX, startY, endX, endY, 1, 1, elementId, destElId, cb);
+          return ncb(null, startX, startY);
         }.bind(this));
       } else {
-        return this.drag(startX, startY, endX, endY, 1, 1, elementId, destElId, cb);
+        return ncb(null, startX, startY);
       }
+    }.bind(this);
+    var getEndLocation = function (elementId, x, y, ncb) {
+      var endX = x || 0
+        , endY = y || 0;
+      if (elementId) {
+        this.getLocation(elementId, function (err, res) {
+          if (err) return ncb(err);
+
+          endX += res.value.x || 0;
+          endY += res.value.y || 0;
+
+          return ncb(null, endX, endY);
+        }.bind(this));
+      } else {
+        return ncb(null, endX, endY);
+      }
+    }.bind(this);
+
+    var longPress = gestures[0];
+    getStartLocation(longPress.options.element, longPress.options.x, longPress.options.y, function (err, startX, startY) {
+      if (err) return cb(err);
+
+      var moveTo = gestures[1];
+      getEndLocation(moveTo.options.element, moveTo.options.x, moveTo.options.y, function (err, endX, endY) {
+        this.adb.getApiLevel(function (err, apiLevel) {
+          // lollipop takes a little longer to get things rolling
+          var duration = apiLevel >= 5 ? 2 : 1;
+          // `drag` will take care of whether there is an element or not at that level
+          return this.drag(startX, startY, endX, endY, duration, 1, longPress.options.element, moveTo.options.element, cb);
+        }.bind(this));
+      }.bind(this));
     }.bind(this));
   }.bind(this);
 

--- a/test/functional/android/apidemos/touch/drag-specs.js
+++ b/test/functional/android/apidemos/touch/drag-specs.js
@@ -3,6 +3,7 @@
 var setup = require("../../../common/setup-base")
   , desired = require("../desired")
   , wd = require("wd")
+  , asserters = wd.asserters
   , TouchAction = wd.TouchAction
   , _ = require('underscore');
 
@@ -14,6 +15,13 @@ describe("apidemo - touch - drag", function () {
   }, desired)).then(function (d) { driver = d; });
 
   describe('drag', function () {
+    var last = false;
+    afterEach(function () {
+      if (!last) {
+        return driver.resetApp();
+      }
+    });
+
     it('should drag by element', function (done) {
       driver
         .elementById("io.appium.android.apis:id/drag_dot_3")
@@ -25,9 +33,81 @@ describe("apidemo - touch - drag", function () {
               return action.longPress({el: dd3}).moveTo({ el: dd2 }).release().perform();
             });
         })
-        .sleep(500)
-        .elementById("io.appium.android.apis:id/drag_result_text").text()
-          .should.become("Dropped!")
+        .waitForElementById("io.appium.android.apis:id/drag_result_text", asserters.textInclude('Dropped'), 2000)
+        .nodeify(done);
+    });
+
+    it('should drag by element with an offset', function (done) {
+      driver
+        .elementById("io.appium.android.apis:id/drag_dot_3")
+        .then(function (dd3) {
+          return driver
+            .elementById("io.appium.android.apis:id/drag_dot_2")
+            .then(function (dd2) {
+              var action = new TouchAction(driver);
+              return action.longPress({
+                el: dd3,
+                x: 5,
+                y: 5
+              }).moveTo({
+                el: dd2,
+                x: 5,
+                y: 5
+              }).release().perform();
+            });
+        })
+        .waitForElementById("io.appium.android.apis:id/drag_result_text", asserters.textInclude('Dropped'), 2000)
+        .nodeify(done);
+    });
+
+    it('should drag by absolute position', function (done) {
+      last = true;
+      var startEl
+        , startLoc
+        , startSize
+        , endEl
+        , endLoc
+        , endSize;
+      driver
+        .elementById("io.appium.android.apis:id/drag_dot_3")
+          .then(function (_el) {
+            startEl = _el;
+            return startEl;
+          })
+        .getLocationInView()
+          .then(function (_startLoc) {
+            startLoc = _startLoc;
+            return startEl;
+          })
+        .getSize()
+          .then(function (_startSize) {
+            startSize = _startSize;
+          })
+        .elementById("io.appium.android.apis:id/drag_dot_2")
+          .then(function (_el) {
+            endEl = _el;
+            return endEl;
+          })
+        .getLocationInView()
+          .then(function (_endLoc) {
+            endLoc = _endLoc;
+            return endEl;
+          })
+        .getSize()
+          .then(function (_endSize) {
+            endSize = _endSize;
+          })
+        .then(function () {
+          var action = new TouchAction(driver);
+          return action.longPress({
+            x: startLoc.x + (startSize.width / 2),
+            y: startLoc.y + (startSize.height / 2)
+          }).moveTo({
+            x: endLoc.x + (endSize.width / 2),
+            y: endLoc.y + (endSize.height / 2)
+          }).release().perform();
+        })
+        .waitForElementById("io.appium.android.apis:id/drag_result_text", asserters.textInclude('Dropped'), 2000)
         .nodeify(done);
     });
   });


### PR DESCRIPTION
Our current implementation of drag and drop in Android only works if you have an element as a starting point. This adds support for offsets and absolute coordinates. 

Resolves #4686
