### PR TITLE
update bplist-creator version to 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "async": "~0.9.0",
     "binary-cookies": "~0.1.1",
     "body-parser": "~1.12.0",
-    "bplist-creator": "~0.0.4",
+    "bplist-creator": "~0.0.5",
     "bplist-parser": "~0.0.6",
     "bufferpack": "0.0.6",
     "bytes": "~1.0.0",


### PR DESCRIPTION
Hi guys.
I update bplist-creator to 0.0.5 in package.json.
The update solve [Non-ASCII strings not handled properly](https://github.com/joeferner/node-bplist-creator/issues/11) against ios plist.

Could you merge this after reviewing ?
