### PR TITLE
Don't url encode cookie value

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -19,10 +19,6 @@ module.exports = function (cookieString) {
     return decodeURIComponent(s);
   }
 
-  function stringifyCookieValue(value) {
-    return encode(String(value));
-  }
-
   function parseCookieValue(s) {
     if (s.indexOf('"') === 0) {
       // This is a quoted cookie as according to RFC2068, unescape...
@@ -50,7 +46,7 @@ module.exports = function (cookieString) {
       options = _.extend({}, options);
 
       var ret = [
-        encode(key), '=', stringifyCookieValue(value),
+        encode(key), '=', value,
         options.expires ? '; expires=' + options.expires : '', // use expires attribute, max-age is not supported by IE
         options.path    ? '; path=' + options.path : '',
         options.domain  ? '; domain=' + options.domain : '',


### PR DESCRIPTION
This change is to ensure we stay consistent with other selenium driver
implementation.

This is a follow PR on #4727
