### PR TITLE
create sessionRemain server flag and controller-specs unit test

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -40,6 +40,7 @@ var Appium = function (args) {
   this.session = null;
   this.preLaunched = false;
   this.sessionOverride = this.args.sessionOverride;
+  this.sessionRemain = this.args.sessionRemain;
   this.resetting = false;
   this.defCommandTimeoutMs = this.args.defaultCommandTimeout * 1000;
   this.commandTimeoutMs = this.defCommandTimeoutMs;

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -241,7 +241,13 @@ exports.background = function (req, res) {
 };
 
 exports.deleteSession = function (req, res) {
-  req.appium.stop(getResponseHandler(req, res));
+  if (req.appium.sessionRemain === true) {
+    safely(req, function () {
+      res.status(200).send("sessionRemain flag is set - Not killing session.");
+    });
+  } else {
+      req.appium.stop(getResponseHandler(req, res));
+  }
 };
 
 exports.equalsElement = function (req, res) {

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -111,6 +111,17 @@ var args = [
   , nargs: 0
   }],
 
+  [['--session-remain'], {
+    defaultValue: false
+  , dest: 'sessionRemain'
+  , action: 'storeTrue'
+  , required: false
+  , help: 'Allows creation of a new session without deleting ' +
+          'the old session. By using this feature, registering ' +
+          'and switching between multiple devices in a single test is possible.'
+  , nargs: 0
+  }],
+
   [['--full-reset'], {
     defaultValue: false
   , dest: 'fullReset'

--- a/test/unit/controller-specs.js
+++ b/test/unit/controller-specs.js
@@ -1,0 +1,39 @@
+var sinon = require('sinon')
+  , sinonChai = require('sinon-chai')
+  , chai = require('chai')
+  , controller = require('../../lib/server/controller.js');
+
+chai.use(sinonChai);
+chai.should();
+
+describe('deleteSession', function () {
+  "use strict";
+  describe('sessionRemain', function () {
+    var req = {
+      appium : {
+        stop : sinon.spy()
+      }
+    };
+    var res = {
+      status : function () {
+        return {
+          send : function () {
+          }
+        };
+      }
+    };
+
+    it('should respond 200 OK when set', function () {
+      sinon.spy(res, 'status');
+      req.appium.sessionRemain = true;
+      controller.deleteSession(req, res);
+      res.status.should.have.been.calledWith(200);
+    });
+
+    it('should stop the appium session when not set', function () {
+      req.appium.sessionRemain = false;
+      controller.deleteSession(req, res);
+      req.appium.stop.should.have.been.called;
+    });
+  });
+});


### PR DESCRIPTION
I have added a server flag called 'sessionRemain'. This allows anyone who sets it to instantiate multiple driver objects and switch between them in a single test without deleteSession killing the original session. This idea came about due to a use case at my company which involves multiple iOS devices communicating with each other in a single test. Without this inclusion, we simply cannot switch between iOS devices in the same test. I have also added a file called 'controller-specs.js' which includes the unit test for the change to the deleteSession function. I did not know exactly where in the project to place this file so as of now its just in the test/unit directory. 
