### PR TITLE
Fix for #3942: Removed fruitstrap (use node-idevice everywhere).

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "submodules/selendroid"]
 	path = submodules/selendroid
 	url = https://github.com/selendroid/selendroid.git
-[submodule "submodules/fruitstrap"]
-	path = submodules/fruitstrap
-	url = https://github.com/tborys/fruitstrap.git
 [submodule "submodules/io.appium.gappium.sampleapp"]
 	path = submodules/io.appium.gappium.sampleapp
 	url = https://github.com/appium/io.appium.gappium.sampleapp.git

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -24,7 +24,6 @@ var path = require('path')
   , iOSHybrid = require('./ios-hybrid.js')
   , settings = require('./settings.js')
   , Simulator = require('./simulator.js')
-  , fruitstrap = path.resolve(__dirname, '../../../build/fruitstrap/fruitstrap')
   , prepareBootstrap = require('./uiauto').prepareBootstrap
   , CommandProxy = require('./uiauto').CommandProxy
   , UnknownError = errors.UnknownError
@@ -855,8 +854,8 @@ IOS.prototype.installToRealDevice = function (cb) {
       } catch (e) {
         return cb(e);
       }
-      this.isAppInstalled(this.args.bundleId, function (err) {
-        if (err) {
+      this.isAppInstalled(this.args.bundleId, function (err, installed) {
+        if (err || !installed) {
           logger.debug("App is not installed. Will try to install the app.");
         } else {
           logger.debug("App is installed.");
@@ -1469,8 +1468,7 @@ IOS.prototype.push = function (elem) {
 
 IOS.prototype.isAppInstalled = function (bundleId, cb) {
   if (this.args.udid) {
-    var isInstalledCommand = fruitstrap + ' isInstalled --id ' + this.args.udid + ' --bundle ' + bundleId;
-    deviceCommon.isAppInstalled(isInstalledCommand, cb);
+    this.realDevice.isInstalled(bundleId, cb);
   } else {
     cb(new Error("You can not call isInstalled for the iOS simulator!"));
   }
@@ -1478,8 +1476,7 @@ IOS.prototype.isAppInstalled = function (bundleId, cb) {
 
 IOS.prototype.removeApp = function (bundleId, cb) {
   if (this.args.udid) {
-    var removeCommand = fruitstrap + ' uninstall --id ' + this.args.udid + ' --bundle ' + bundleId;
-    deviceCommon.removeApp(removeCommand, this.args.udid, bundleId, cb);
+    this.realDevice.remove(bundleId, cb);
   } else {
     cb(new Error("You can not call removeApp for the iOS simulator!"));
   }
@@ -1487,9 +1484,7 @@ IOS.prototype.removeApp = function (bundleId, cb) {
 
 IOS.prototype.installApp = function (unzippedAppPath, cb) {
   if (this.args.udid) {
-    var installQuietFlag = this.args.quiet ? ' -q' : '';
-    var installationCommand = fruitstrap + installQuietFlag + ' install --id ' + this.args.udid + ' --bundle "' + unzippedAppPath + '"';
-    deviceCommon.installApp(installationCommand, this.args.udid, unzippedAppPath, cb);
+    this.realDevice.install(unzippedAppPath, cb);
   } else {
     cb(new Error("You can not call installApp for the iOS simulator!"));
   }

--- a/reset.sh
+++ b/reset.sh
@@ -205,16 +205,6 @@ reset_ios() {
         echo "* Cleaning/rebuilding iOS test app: WebViewApp"
         run_cmd "$grunt" buildApp:WebViewApp:iphonesimulator$sdk_ver
     fi
-    echo "* Cloning/updating fruitstrap"
-    run_cmd git submodule update --init submodules/fruitstrap
-    echo "* Making fruitstrap"
-    run_cmd pushd "$appium_home"/submodules/fruitstrap/
-    run_cmd make fruitstrap
-    run_cmd popd
-    echo "* Copying fruitstrap to build"
-    run_cmd rm -rf build/fruitstrap
-    run_cmd mkdir -p build/fruitstrap
-    run_cmd cp submodules/fruitstrap/fruitstrap build/fruitstrap
     if $should_reset_realsafari; then
         echo "* Cloning/updating SafariLauncher"
         run_cmd git submodule update --init submodules/SafariLauncher


### PR DESCRIPTION
Fix for #3942. Let's get rid of `fruitstrap` for good.
I've tested it on device with both .ipa and .app and it works fine.
Also added a pr to allow for spaces in app path here: https://github.com/OniOni/node-idevice/pull/4
