### PR TITLE
Add window/:windowhandle/maximize route as noop

### DIFF
--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -701,6 +701,11 @@ exports.getWindowSize = function (req, res) {
   req.device.getWindowSize(windowHandle, getResponseHandler(req, res));
 };
 
+exports.maximizeWindow = function (req, res) {
+  // noop
+  respondSuccess(req, res);
+};
+
 exports.getPageIndex = function (req, res) {
   var elementId = req.params.elementId;
   req.device.getPageIndex(elementId, getResponseHandler(req, res));

--- a/lib/server/routing.js
+++ b/lib/server/routing.js
@@ -64,6 +64,7 @@ module.exports = function (appium) {
   rest.post('/wd/hub/session/:sessionId?/window', controller.setWindow);
   rest.delete('/wd/hub/session/:sessionId?/window', controller.closeWindow);
   rest.get('/wd/hub/session/:sessionId?/window/:windowhandle?/size', controller.getWindowSize);
+  rest.post('/wd/hub/session/:sessionId?/window/:windowhandle/maximize', controller.maximizeWindow);
   rest.post('/wd/hub/session/:sessionId?/execute', controller.execute);
   rest.post('/wd/hub/session/:sessionId?/execute_async', controller.executeAsync);
   rest.get('/wd/hub/session/:sessionId?/title', controller.title);
@@ -156,7 +157,6 @@ var routeNotYetImplemented = function (rest) {
   rest.post('/wd/hub/session/:sessionId?/window/:windowhandle/size', controller.notYetImplemented);
   rest.post('/wd/hub/session/:sessionId?/window/:windowhandle/position', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/window/:windowhandle/position', controller.notYetImplemented);
-  rest.post('/wd/hub/session/:sessionId?/window/:windowhandle/maximize', controller.notYetImplemented);
   rest.get('/wd/hub/session/:sessionId?/element/:elementId?', controller.notYetImplemented);
   rest.post('/wd/hub/session/:sessionId?/buttondown', controller.notYetImplemented);
   rest.post('/wd/hub/session/:sessionId?/buttonup', controller.notYetImplemented);


### PR DESCRIPTION
Mobile browsers are always fullscreen. Make this endpoint a noop.
