### PR TITLE
Check if a non default server argument is passed as a string True / Fals...

### DIFF
--- a/lib/server/helpers.js
+++ b/lib/server/helpers.js
@@ -191,6 +191,17 @@ var getNonDefaultArgs = function (parser, args) {
   _.each(parser.rawArgs, function (rawArg) {
     var arg = rawArg[1].dest;
     if (args[arg] !== rawArg[1].defaultValue) {
+      var value = args[arg];
+      if (typeof value === "string") {
+       // handle the case where users send in "true" or "false" as a string
+       // instead of a boolean
+       var tempValue = value.trim().toLowerCase();
+       if (tempValue === "false" || tempValue === "true") {
+         logger.warn("Converting cap " + arg  + " from string to boolean. " +
+                    "This might cause unexpected behavior.");
+          args[arg] = (tempValue === "true");
+        }
+      }
       nonDefaults[arg] = args[arg];
     }
   });


### PR DESCRIPTION
Check if a non default server argument is passed as a string True / False and convert it to boolean

This check is made for the desired server capabilities and not for the non default arguments, causing the checking of non default arguments to fail.
