### PR TITLE
Fix handling real device object in Safari

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -910,7 +910,9 @@ IOS.prototype.getIDeviceObj = function () {
 
 IOS.prototype.installIpa = function (cb) {
   logger.debug("Installing ipa found at " + this.args.ipa);
-  this.realDevice = this.getIDeviceObj();
+  if (!this.realDevice) {
+    this.realDevice = this.getIDeviceObj();
+  }
   var d = this.realDevice;
   async.waterfall([
     function (cb) { d.isInstalled(this.args.bundleId, cb); }.bind(this),

--- a/lib/devices/ios/safari.js
+++ b/lib/devices/ios/safari.js
@@ -115,8 +115,15 @@ Safari.prototype.configureBootstrap = function (cb) {
 
 Safari.prototype.installToRealDevice = function (cb) {
   if (this.args.udid) {
-    this.isAppInstalled("com.bytearc.SafariLauncher", function (err) {
-      if (err) {
+    try {
+      if (!this.realDevice) {
+        this.realDevice = this.getIDeviceObj();
+      }
+    } catch (e) {
+      return cb(e);
+    }
+    this.isAppInstalled("com.bytearc.SafariLauncher", function (err, installed) {
+      if (err || !installed) {
         this.installApp(this.args.app, cb);
       } else {
         cb();


### PR DESCRIPTION
When using Safari on real devices there is a problem with the ideviceinstaller interface not being initialized.

The specific error is:

``` shell
error: Unhandled error: TypeError: Cannot call method 'isInstalled' of undefined
    at IOS.isAppInstalled (/Users/isaac/code/appium/lib/devices/ios/ios.js:1475:21)
    at Safari.installToRealDevice (/Users/isaac/code/appium/lib/devices/ios/safari.js:123:10)
    at /Users/isaac/code/appium/node_modules/async/lib/async.js:610:21
    at /Users/isaac/code/appium/node_modules/async/lib/async.js:249:17
    at iterate (/Users/isaac/code/appium/node_modules/async/lib/async.js:149:13)
    at /Users/isaac/code/appium/node_modules/async/lib/async.js:160:25
    at /Users/isaac/code/appium/node_modules/async/lib/async.js:251:21
    at /Users/isaac/code/appium/node_modules/async/lib/async.js:615:34
    at IOS.prelaunchSimulator (/Users/isaac/code/appium/lib/devices/ios/ios.js:1193:12)
    at /Users/isaac/code/appium/node_modules/async/lib/async.js:610:21 context: [POST /wd/hub/session {"desiredCapabilities":{"browserName":"safari","platformVersion":"8.2","deviceName":"iPhone 5s","app":"","launchTimeout":60000,"platformName":"iOS"}}]
```

Fixes #4819
