### PR TITLE
For iOS get home path from environment, not by guessing

### DIFF
--- a/lib/devices/ios/simulator.js
+++ b/lib/devices/ios/simulator.js
@@ -59,13 +59,13 @@ var safeRimRafSync = function (delPath, tries) {
 };
 
 Simulator.prototype.getRootDir = function () {
-  var u = process.env.USER;
+  var home = process.env.HOME;
   if (parseFloat(this.sdkVer) >= 8) {
-    return path.resolve("/Users", u, "Library", "Developer",
+    return path.resolve(home, "Library", "Developer",
       "CoreSimulator", "Devices");
   }
 
-  return path.resolve("/Users", u, "Library", "Application Support",
+  return path.resolve(home, "Library", "Application Support",
     "iPhone Simulator");
 };
 
@@ -578,8 +578,8 @@ Simulator.prototype.setLocale = function (language, locale, calendar) {
 };
 
 Simulator.getSimAppPrefsFile = function () {
-  var u = process.env.USER;
-  return path.resolve("/Users", u, "Library", "Preferences",
+  var home = process.env.HOME;
+  return path.resolve(home, "Library", "Preferences",
                       "com.apple.iphonesimulator.plist");
 };
 


### PR DESCRIPTION
In `simulator.js` there are some paths that are resolved by concatenating `"/Users"`, `username`, etc., but this fails when running under users with nonstandard home directories (like Jenkins).

The correct home directory is provided in the environment, so it would be better to use that.
