### PR TITLE
PlistBuddy fails to get Xcode version when there are spaces in path

### DIFF
--- a/lib/devices/ios/xcode.js
+++ b/lib/devices/ios/xcode.js
@@ -5,7 +5,9 @@ var logger = require('../../server/logger.js').get('appium')
   , async = require('async')
   , exec = require('child_process').exec
   , util = require('appium-support').util
-  , env = process.env;
+  , env = process.env
+  , helpers = require('../../helpers.js')
+  , escapeSpace = helpers.escapeSpace;
 
 var XCODE_SUBDIR = "/Contents/Developer";
 var xcode = {};
@@ -86,7 +88,12 @@ xcode.getVersion = function (cb) {
     if (!fs.existsSync(plistPath)) {
       return cb(new Error("Could not get Xcode version: " + plistPath + " does not exist on disk."), null);
     } else {
-      var cmd = "/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' " + plistPath;
+      try {
+        var cmd = "/usr/libexec/PlistBuddy -c 'Print CFBundleShortVersionString' " + 
+                  escapeSpace(plistPath);
+      } catch(e) {
+        return cb(e);
+      }
       exec(cmd, { maxBuffer: 524288, timeout: 3000 }, function (err, stdout) {
         if (err !== null) return cb(err, null);
         var versionPattern = /\d\.\d\.*\d*/;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,7 +10,9 @@ var logger = require('./server/logger.js').get('appium')
   , isWindows = support.system.isWindows
   , isMac = support.system.isMac
   , tempDir = support.tempDir
-  , AdmZip = require('adm-zip');
+  , AdmZip = require('adm-zip')
+  , ESCAPE_SPACE_RE = '\\ '
+  , SPACE = / /;
 
 
 exports.downloadFile = function (fileUrl, suffix, cb) {
@@ -338,4 +340,7 @@ exports.truncateDecimals = function (number, digits) {
   return truncatedNum / multiplier;
 };
 
+exports.escapeSpace = function (str) {
+  return str.split(SPACE).join(ESCAPE_SPACE_RE);
+};  
 

--- a/test/unit/helper-specs.js
+++ b/test/unit/helper-specs.js
@@ -89,4 +89,11 @@ describe("Helpers", function () {
       logger.warn.called.should.equal(false);
     });
   });
+  describe('xcode version', function () {
+    it('parses xcode version with space', function () {
+      var actual = "/Applications/ Xcode 6.1.1.app/Contents/Developer";
+      var expected = "/Applications/\\ Xcode\\ 6.1.1.app/Contents/Developer"
+      helpers.escapeSpace(actual).should.equal(expected);
+    });
+  });
 });


### PR DESCRIPTION
#4809 added a method to handle spaces in path
