### PR TITLE
Return false if SpringBoard loads instead of app

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -429,6 +429,15 @@ IOS.prototype.setInitialOrientation = function (cb) {
   }
 };
 
+IOS.isSpringBoard = function (uiAppObj) {
+// Test for iOS homescreen (SpringBoard). AUT occassionally start the sim, but fails to load
+// the app. If that occurs, getSourceForElementFoXML will return a doc object that meets our
+// app-check conditions, resulting in a false positive. This function tests the UiApplication
+// property's meta data to ensure that the Appium doesn't confuse SpringBoard with the app
+// under test.
+  return _.propertyOf(uiAppObj['@'])('name') === 'SpringBoard';
+};
+
 IOS.prototype.waitForAppLaunched = function (cb) {
   // on iOS8 in particular, we can get a working session before the app
   // is ready to respond to commands; in that case the source will be empty
@@ -456,7 +465,8 @@ IOS.prototype.waitForAppLaunched = function (cb) {
         try {
           sourceObj = JSON.parse(res.value);
           appEls = sourceObj.UIAApplication['>'];
-          if (appEls.length > 0) {
+
+          if (appEls.length > 0 && !IOS.isSpringBoard(sourceObj.UIAApplication)) {
             return cb(true);
           } else {
             return cb(false, new Error("App did not have elements"));

--- a/test/unit/ios-device-specs.js
+++ b/test/unit/ios-device-specs.js
@@ -83,6 +83,15 @@ describe('IOS', function () {
     });
   });
 
+  describe('ios#isSpringBoard', function () {
+    it('should return true if uiApp object name == SpringBoard and false if it is not', function () {
+      var uiApp = {"@":{"name":"SpringBoard","label":" ","value":null,"dom":null,"enabled":true,"valid":true,"visible":true,"hint":null,"path":"/0","x":0,"y":20,"width":320,"height":548},">":[{"UIAWindow":{"@":{"name":null,"label":null,"value":null,"dom":null,"enabled":true}}}]};
+      expect(IOS.isSpringBoard(uiApp)).to.be.true;
+      uiApp["@"].name = "foo";
+      expect(IOS.isSpringBoard(uiApp)).to.be.false;
+    });
+  });
+
   describe('io#configure', function () {
     var getCaps = function () {
       return {platformName: 'iOS', platformVersion: '7.1',


### PR DESCRIPTION
Prophylactic for false-App-start positives reported in "Restart instruments if AUT does not start #4653".
