### PR TITLE
Handle `node-idevice` callback parameter types for `isInstalled`.

### DIFF
--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -108,15 +108,21 @@ exports.removeApp = function (req, res) {
   }
 };
 
-// TODO: fix this method so it expects a callback with a boolean value, not
-// some weird stdout thing
 exports.isAppInstalled = function (req, res) {
   if (checkMissingParams(req, res, {bundleId: req.body.bundleId}, true)) {
     req.device.isAppInstalled(req.body.bundleId, function (error, stdout) {
       if (error !== null) {
         respondSuccess(req, res, false);
       } else {
-        if ((req.appium.args.udid && req.appium.args.udid.length === 40) || (typeof stdout[0] !== "undefined")) {
+        // We're examining the type of stdout because `isAppInstalled` uses
+        // node-idevice for real iOS devices.  node-idevice passes a boolean
+        // value in the second parameter of the callback function.  Other
+        // functions pass back an array.  Changing the parameter type of the
+        // other functions is a deeper and more dangerous change than just
+        // type-checking here.
+        if ((req.appium.args.udid && req.appium.args.udid.length === 40) ||
+            (typeof stdout === "boolean" && stdout) ||
+            (typeof stdout[0] !== "undefined")) {
           respondSuccess(req, res, true);
         } else {
           respondSuccess(req, res, false);


### PR DESCRIPTION
This handles #4915.

Node package `node-idevice` has a method on the `IDevice` class
that checks to see if a given app is installed: `isInstalled`.
This method passes a boolean value as the second argument in the
callback function, but `isAppInstalled` expects an array.

The array support appears to be necessary for some other opaque
types so it cannot be removed.  Instead, we check the type of the
second parameter.  If it's `boolean` and `true` then we execute
the positive portion of the if block.
