### PR TITLE
Fix ios crash log retrieval

### DIFF
--- a/lib/devices/ios/ios-crash-log.js
+++ b/lib/devices/ios/ios-crash-log.js
@@ -56,7 +56,7 @@ IosCrashLog.prototype.startCapture = function (cb) {
 IosCrashLog.prototype.getLogs = function () {
   var crashFiles = glob.sync(this.crashDir + "/*.crash");
   var diff = _.difference(crashFiles, this.prevLogs, this.logsSinceLastRequest);
-  this.logsSinceLastRequest = diff;
+  this.logsSinceLastRequest = _.union(this.logsSinceLastRequest, diff);
 
   return this.filesToJSON(diff);
 };

--- a/test/functional/ios/testapp/basics/calc-app-2-specs.js
+++ b/test/functional/ios/testapp/basics/calc-app-2-specs.js
@@ -3,7 +3,8 @@
 var setup = require("../../../common/setup-base")
   , desired = require('../desired')
   , fs = require('fs')
-  , path = require('path');
+  , path = require('path')
+  , _ = require('underscore');
 
 describe('testapp - basics - calc app 2', function () {
   var driver;
@@ -69,18 +70,20 @@ describe('testapp - basics - calc app 2', function () {
   it('should be able to get crashlog logs @skip-ci', function (done) {
     var dir = path.resolve(process.env.HOME, "Library", "Logs", "DiagnosticReports");
     var msg = 'boom';
-    var numBeforeLogs;
     driver
-      .log('crashlog').then(function (logsBefore) {
-        numBeforeLogs = logsBefore.length;
+      .log('crashlog').then(function (/* logs */) {
         fs.writeFileSync(dir + '/myApp_' + Date.parse(new Date()) + '_rocksauce.crash', msg);
-      }).log('crashlog').then(function (logsAfter) {
-        logsAfter.length.should.be.above(0);
-        logsAfter.length.should.not.equal(numBeforeLogs);
-        logsAfter[0].message.should.not.include("\n");
-        logsAfter[0].message.should.equal(msg);
-        logsAfter[0].level.should.equal("ALL");
-        logsAfter[0].timestamp.should.exist;
-      }).nodeify(done);
+      })
+      .log('crashlog').then(function (logs) {
+        logs.length.should.equal(1);
+        _.last(logs).message.should.not.include("\n");
+        _.last(logs).message.should.equal(msg);
+        _.last(logs).level.should.equal("ALL");
+        _.last(logs).timestamp.should.exist;
+      })
+      .log('crashlog').then(function (logs) {
+        logs.length.should.equal(0);
+      })
+      .nodeify(done);
   });
 });


### PR DESCRIPTION
Logs [should](https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/log) have buffer reset after each request. We were trying to do this, but not quite making it.
