### PR TITLE
Adding disableAndroidWatcher cap to reduce cpu cycles on android device/emulator #4698

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -55,6 +55,7 @@
 |`resetKeyboard`| Reset keyboard to its original state, after running Unicode tests with `unicodeKeyboard` capability. Ignored if used alone. Default `false`| `true` or `false`|
 |`noSign`| Skip checking and signing of app with debug keys, will work only with UiAutomator and not with selendroid, default `false`| `true` or `false`|
 |`ignoreUnimportantViews`| Calls the `setCompressedLayoutHierarchy()` uiautomator function. This capability can speed up test execution, since Accessibility commands will run faster ignoring some elements. The ignored elements will not be findable, which is why this capability has also been implemented as a toggle-able *setting* as well as a capability. Defaults to `false` | `true` or `false`
+|`disableAndroidWatchers`| Disables android watchers that watch for application not responding and application crash, this will reduce cpu usage on android device/emulator. This capability will work only with UiAutomator and not with selendroid, default `false`| `true` or `false`|
 
 ### iOS Only
 

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
@@ -6,17 +6,18 @@ import io.appium.android.bootstrap.handler.Find;
 
 /**
  * The Bootstrap class runs the socket server.
- * 
+ *
  */
 public class Bootstrap extends UiAutomatorTestCase {
 
   public void testRunServer() {
     Find.params = getParams();
+    boolean disableAndroidWatchers = Boolean.parseBoolean(getParams().getString("disableAndroidWatchers"));
 
     SocketServer server;
     try {
       server = new SocketServer(4724);
-      server.listenForever();
+      server.listenForever(disableAndroidWatchers);
     } catch (final SocketServerException e) {
       Logger.error(e.getError());
       System.exit(1);

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
@@ -109,10 +109,14 @@ class SocketServer {
    *
    * @throws SocketServerException
    */
-  public void listenForever() throws SocketServerException {
+  public void listenForever(boolean disableAndroidWatchers) throws SocketServerException {
     Logger.debug("Appium Socket Server Ready");
     UpdateStrings.loadStringsJson();
-    dismissCrashAlerts();
+    if (disableAndroidWatchers) {
+      Logger.debug("Skipped registering crash watchers.");
+    } else {
+      dismissCrashAlerts();
+    }
     final TimerTask updateWatchers = new TimerTask() {
       @Override
       public void run() {

--- a/lib/devices/android/uiautomator.js
+++ b/lib/devices/android/uiautomator.js
@@ -21,6 +21,7 @@ var UiAutomator = function (adb, opts) {
   this.systemPort = opts.systemPort;
   this.resendLastCommand = function () {};
   this.appPackage = opts.appPackage;
+  this.disableAndroidWatchers = !!opts.disableAndroidWatchers;
 };
 
 UiAutomator.prototype.start = function (readyCb) {
@@ -29,7 +30,7 @@ UiAutomator.prototype.start = function (readyCb) {
     if (err) return readyCb(err);
     logger.debug("Running bootstrap");
     var args = ["shell", "uiautomator", "runtest", "AppiumBootstrap.jar", "-c",
-        "io.appium.android.bootstrap.Bootstrap", "-e", "pkg", this.appPackage];
+        "io.appium.android.bootstrap.Bootstrap", "-e", "pkg", this.appPackage, "-e", "disableAndroidWatchers", this.disableAndroidWatchers];
 
     this.alreadyExited = false;
     this.onSocketReady = readyCb;

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -68,6 +68,7 @@ var androidCaps = [
 , 'noSign'
 , 'ignoreUnimportantViews'
 , 'dontStopAppOnReset'
+, 'disableAndroidWatchers'
 ];
 
 var iosCaps = [


### PR DESCRIPTION
- One of the reasons for #4698 
- Cap to disableAndroidWatchers which can reduce cpu cycles on android device/emulator
- Users will loose ability of appium handling crash/application not responding. 
