### PR TITLE
Update to allow safari on iOS 7.1 when xcode is 6+

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -30,8 +30,7 @@ var path = require('path')
   , UnknownError = errors.UnknownError
   , binaryPlist = true
   , Args = require("vargs").Constructor
-  , logCustomDeprecationWarning = require('../../helpers.js').logCustomDeprecationWarning
-  ;
+  , logCustomDeprecationWarning = require('../../helpers.js').logCustomDeprecationWarning;
 
 // XML Plist library helper
 var parseXmlPlistFile = function (plistFilename, cb) {
@@ -725,9 +724,9 @@ IOS.prototype.instantLaunchAndQuit = function (needSafariDirs, cb) {
   var condition = function () {
     var simDirsExist = this.sim.dirsExist();
     var locServicesExist = settings.locServicesDirsExist(this.sim);
-    var safariDirsExist = this.iOSSDKVersion < 7.0 ||
+    var safariDirsExist = this.args.platformVersion < 7.0 ||
                           (this.sim.safariDirsExist() &&
-                           (this.iOSSDKVersion < 8.0 ||
+                           (this.args.platformVersion < 8.0 ||
                             this.sim.userSettingsPlistExists())
                           );
     var okToGo = simDirsExist && locServicesExist &&
@@ -1572,10 +1571,18 @@ IOS.prototype.getLatestWebviewContextForTitle = function (titleRegex, cb) {
     if (err) return cb(err);
     var matchingCtx;
     _(contexts).each(function (ctx) {
-      if (ctx.view &&
-          (parseFloat(this.iOSSDKVersion) < 7 || ctx.view.url !== "about:blank") &&
-          (ctx.view.title || "").match(titleRegex)) {
-        matchingCtx = ctx;
+      if (ctx.view && (ctx.view.title || "").match(titleRegex)) {
+        if (ctx.view.url === "about:blank") {
+          // in the case of Xcode  < 5 (i.e., iOS SDK Version less than 7)
+          // and in the case of iOS 7.1 in a webview (not in Safari)
+          // we can have the url be `about:blank`
+          if (parseFloat(this.iOSSDKVersion) < 7 ||
+              (this.args.platformVersion === '7.1' && this.args.app && this.args.app.toLowerCase() !== 'safari')) {
+            matchingCtx = ctx;
+          }
+        } else {
+          matchingCtx = ctx;
+        }
       }
     }.bind(this));
     cb(null, matchingCtx ? matchingCtx.id : undefined);

--- a/lib/devices/ios/simulator.js
+++ b/lib/devices/ios/simulator.js
@@ -450,6 +450,7 @@ Simulator.prototype.cleanSim = function (keepKeychains, tempDir, cb) {
 };
 
 Simulator.prototype.moveBuiltInApp = function (appPath, appName, newAppDir, cb) {
+  safeRimRafSync(newAppDir);
   ncp(appPath, newAppDir, function (err) {
     if (err) return cb(err);
     logger.debug("Copied " + appName + " to " + newAppDir);
@@ -496,7 +497,7 @@ Simulator.prototype.prepareBuiltInApp = function (appName, tmpDir, cb) {
       fs.stat(newAppDir, function (err, s) {
         if (err) {
           logger.warn("App is also not at " + newAppDir);
-          return cb(new Error("Couldn't find built in app in its home " +
+          return cb(new Error("Couldn't find built in app " + appName + " in its home " +
                               "or temp dir!"));
         }
         if (checkApp(s, appPath, cb)) {


### PR DESCRIPTION
Safari was not working for iOS 7.1 when using a version of Xcode above 5.1.1. Partly this was due to the use of SDK version rather than platform version, and partly because there was a problem with deleting the temporary mobile safari folder.
