### PR TITLE
Real device suite

### DIFF
--- a/bin/test.sh
+++ b/bin/test.sh
@@ -72,10 +72,19 @@ run_ios_tests() {
     echo "RUNNING IOS $1 TESTS"
     echo "---------------------"
 
+    tag_regex=$3
+    if $real_device; then
+        tag_regex="$3|@skip-real-device"
+    fi
 
-    DEVICE=$2 time $appium_mocha -g $3 -i \
-        test/functional/common \
-        test/functional/ios
+    if $real_device; then
+        DEVICE=$2 REAL_DEVICE=true time $appium_mocha -g $tag_regex -i \
+           test/functional/ios
+    else
+       DEVICE=$2 time $appium_mocha -g $3 -i \
+           test/functional/common \
+           test/functional/ios
+    fi
 }
 
 if $ios6_only || $ios_only || $all_tests; then

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -22,8 +22,11 @@ var uuid = require('uuid-js')
   , IOSPerfLog = require('./ios-perf-log')
   , errors = require('../../server/errors.js')
   , isWindows = require('appium-support').system.isWindows
+  , localIp = require('appium-support').util.localIp
   , NotImplementedError = errors.NotImplementedError
-  , NotYetImplementedError = errors.NotYetImplementedError;
+  , NotYetImplementedError = errors.NotYetImplementedError
+  , Parser = require('../../server/parser.js')
+  , url = require('url');
 
 var iOSController = {};
 var FLICK_MS = 3000;
@@ -39,6 +42,13 @@ var logTypesSupported = {
   'syslog': 'Logs for iOS applications on real devices and simulators',
   'crashlog': 'Crash logs for iOS applications on real devices and simulators',
   'performance': 'Performance Logs - Debug Timelines on real devices and simulators'
+};
+
+var getDefaultCallbackAddress = function () {
+  var parser = new Parser();
+  return parser.rawArgs.filter(function (a) {
+    return a[0][1] === '--address';
+  })[0][1].defaultValue;
 };
 
 iOSController.getStatusExtensions = function () {
@@ -1892,6 +1902,21 @@ iOSController.execute = function (script, args, cb) {
 
 iOSController.executeAsync = function (script, args, responseUrl, cb) {
   if (this.isWebContext()) {
+    if (this.args.udid) {
+      var defaultHost = getDefaultCallbackAddress();
+      var urlObject = url.parse(responseUrl);
+      if (urlObject.hostname === defaultHost) {
+        logger.debug('Real device safari test and no custom ' +
+                     'callback address set, ' +
+                     'changing callback address to local ip.');
+        urlObject.hostname = localIp();
+        urlObject.host = null; // set to null, otherwise hostname is ignored
+        responseUrl = url.format(urlObject);
+      } else {
+        logger.debug('Custom callback address set, leaving as is.');
+      }
+    }
+
     logger.debug("Response url for executeAsync is " + responseUrl);
     this.convertElementForAtoms(args, function (err, res) {
       if (err) {

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1587,8 +1587,11 @@ IOS.prototype.useNewSafari = function () {
 
 IOS.prototype.navToInitialWebview = function (cb) {
   var timeout = 0;
-  if (this.args.udid) timeout = parseInt(this.iOSSDKVersion, 10) >= 8 ? 4000 : 6000;
-  if (timeout > 0) logger.debug('Waiting for ' + timeout + ' ms before navigating to view.');
+  if (this.args.udid) {
+    timeout = 3000;
+    logger.debug('Waiting for ' + timeout + ' ms before navigating to view.');
+  }
+
   setTimeout(function () {
     if (this.useNewSafari()) {
       return this.typeAndNavToUrl(cb);

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -61,7 +61,7 @@ var args = [
   , dest: 'callbackAddress'
   , defaultValue: null
   , example: "127.0.0.1"
-  , help: 'callback IP Address (default: same as address)'
+  , help: 'callback IP Address (default: same as --address)'
   }],
 
   [['-cp', '--callback-port'], {

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "promisepipe": "^1.0.1",
     "rewire": "^2.3.1",
     "run-sequence": "^1.0.2",
+    "sample-apps": "=2.0.1",
     "saucelabs": "~0.1.1",
     "sinon": "~1.12.2",
     "sinon-chai": "~2.7.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "appium-atoms": "=0.0.5",
     "appium-chromedriver": "^1.1.0",
     "appium-instruments": "=2.0.2",
-    "appium-support": "=1.0.4",
+    "appium-support": "=1.0.5",
     "appium-uiauto": "=1.10.8",
     "appium-xcode": "=2.0.4",
     "argparse": "~1.0.1",

--- a/reset.sh
+++ b/reset.sh
@@ -186,24 +186,6 @@ reset_ios() {
             echo "* Cloning/npm linking appium-uiauto"
             run_cmd ./bin/npmlink.sh -l appium-uiauto
         fi
-        if $ios7_active || $ios8_active ; then
-            if $hardcore ; then
-                echo "* Clearing out old UICatalog download"
-                run_cmd rm -rf ./sample-code/apps/UICatalog/
-            fi
-            if [ ! -d "./sample-code/apps/UICatalog" ]; then
-                echo "* Unzipping UICatalog app source"
-                run_cmd pushd ./sample-code/apps
-                run_cmd unzip UICatalog.zip
-                run_cmd popd
-            fi
-            echo "* Cleaning/rebuilding iOS test app: UICatalog"
-            run_cmd "$grunt" buildApp:UICatalog:iphonesimulator:$sdk_ver
-        fi
-        echo "* Cleaning/rebuilding iOS test app: TestApp"
-        run_cmd "$grunt" buildApp:TestApp:iphonesimulator:$sdk_ver
-        echo "* Cleaning/rebuilding iOS test app: WebViewApp"
-        run_cmd "$grunt" buildApp:WebViewApp:iphonesimulator$sdk_ver
     fi
     if $should_reset_realsafari; then
         echo "* Building SafariLauncher for real devices"

--- a/test/functional/ios/file-movement-specs.js
+++ b/test/functional/ios/file-movement-specs.js
@@ -12,7 +12,7 @@ var setup = require("../common/setup-base")
   , getSimUdid = require('../../helpers/sim-udid.js').getSimUdid
   , Unzip = require('unzip');
 
-describe('file movements - pullFile and pushFile', function () {
+describe('file movements - pullFile and pushFile @skip-real-device', function () {
   var driver;
   var desired = {
     app: getAppPath('TestApp')

--- a/test/functional/ios/prefs/autocomplete-settings-specs.js
+++ b/test/functional/ios/prefs/autocomplete-settings-specs.js
@@ -10,7 +10,7 @@ var desired = {
   app: 'settings'
 };
 
-describe("prefs @skip-ios6", function () {
+describe("prefs @skip-ios6 @skip-real-device", function () {
   // TODO: cannot install settings app on ios6
   describe('settings app', function () {
     var driver;
@@ -33,4 +33,3 @@ describe("prefs @skip-ios6", function () {
   });
 
 });
-

--- a/test/functional/ios/prefs/bundleid-specs.js
+++ b/test/functional/ios/prefs/bundleid-specs.js
@@ -9,7 +9,7 @@ var desired = {
   bundleId: 'com.apple.Preferences'
 };
 
-describe('settings app @skip-ios6 @skip-ios7', function () {
+describe('settings app @skip-ios6 @skip-ios7 @skip-real-device', function () {
   var driver;
   setup(this, desired).then(function (d) { driver = d; });
 

--- a/test/functional/ios/prefs/location-settings-specs.js
+++ b/test/functional/ios/prefs/location-settings-specs.js
@@ -10,7 +10,7 @@ var desired = {
   app: 'settings'
 };
 
-describe("prefs @skip-ios6", function () {
+describe("prefs @skip-ios6 @skip-real-device", function () {
   // TODO: cannot install settings app on ios6
 
   var checkLocServ = function (driver, expected, cb) {
@@ -44,4 +44,3 @@ describe("prefs @skip-ios6", function () {
     });
   });
 });
-

--- a/test/functional/ios/safari/basics-specs.js
+++ b/test/functional/ios/safari/basics-specs.js
@@ -3,7 +3,7 @@
 var env = require('../../../helpers/env'),
     setup = require("../../common/setup-base");
 
-describe('safari - basics @skip-ios6', function () {
+describe('safari - basics @skip-ios6 @skip-real-device', function () {
   if (env.IOS8 && !env.IOS80) {
     describe('default init' ,function () {
       var driver;
@@ -28,7 +28,7 @@ describe('safari - basics @skip-ios6', function () {
     describe('default init' ,function () {
       var driver;
       setup(this, {browserName: 'safari'}).then(function (d) { driver = d; });
-      it('it should use appium default init page', function (done) {
+      it('it should use safari default init page', function (done) {
         driver
           .source().should.eventually.include('Apple')
           .nodeify(done);

--- a/test/functional/ios/safari/webview/alerts-specs.js
+++ b/test/functional/ios/safari/webview/alerts-specs.js
@@ -1,6 +1,6 @@
 "use strict";
 var desired = require('./desired');
 
-describe("safari - webview @skip-ios6", function () {
+describe("safari - webview @skip-ios6 @skip-real-device", function () {
   require('../../../common/webview/alerts-base')(desired);
 });

--- a/test/functional/ios/testapp/desired.js
+++ b/test/functional/ios/testapp/desired.js
@@ -1,7 +1,8 @@
 "use strict";
 
-var getAppPath = require('../../../helpers/app').getAppPath;
+var getAppPath = require('sample-apps');
+var env = require('../../../helpers/env.js');
 
 module.exports = {
-  app: getAppPath('TestApp')
+  app: getAppPath('TestApp', env.REAL_DEVICE)
 };

--- a/test/functional/ios/uicatalog/desired.js
+++ b/test/functional/ios/uicatalog/desired.js
@@ -1,7 +1,8 @@
 "use strict";
 
-var getAppPath = require('../../../helpers/app').getAppPath;
+var getAppPath = require('sample-apps');
+var env = require('../../../helpers/env.js');
 
 module.exports = {
-  app: getAppPath('UICatalog')
+  app: getAppPath('UICatalog', env.REAL_DEVICE)
 };

--- a/test/functional/ios/webview/desired.js
+++ b/test/functional/ios/webview/desired.js
@@ -1,8 +1,13 @@
 "use strict";
 
-var env = require('../../../helpers/env')
-  , getAppPath = require('../../../helpers/app').getAppPath;
+var getAppPath = require('sample-apps');
+var env = require('../../../helpers/env.js');
 
 module.exports = {
-  app: env.IOS6 ? "assets/WebViewApp6.1.app.zip" : getAppPath('WebViewApp')
+  app: getAppPath('TestApp', env.REAL_DEVICE)
+};
+
+module.exports = {
+  app: env.IOS6 ? "assets/WebViewApp6.1.app.zip" :
+                 getAppPath('WebViewApp', env.REAL_DEVICE)
 };

--- a/test/helpers/env.js
+++ b/test/helpers/env.js
@@ -265,7 +265,11 @@ env.localIP = function () {
 };
 
 env.LOCAL_APPIUM_PORT = env.SAUCE ? 4443 : env.APPIUM_PORT;
-env.TEST_END_POINT = 'http://localhost:' + env.LOCAL_APPIUM_PORT + '/test/';
+if (env.REAL_DEVICE) {
+  env.TEST_END_POINT = 'http://' + env.localIP() + ':' + env.LOCAL_APPIUM_PORT + '/test/';
+} else {
+  env.TEST_END_POINT = 'http://localhost:' + env.LOCAL_APPIUM_PORT + '/test/';
+}
 env.GUINEA_TEST_END_POINT = env.TEST_END_POINT + 'guinea-pig';
 if (env.REAL_DEVICE) {
   env.CHROME_TEST_END_POINT = 'http://' + env.localIP() + ':' + env.LOCAL_APPIUM_PORT + '/test/';

--- a/test/helpers/env.js
+++ b/test/helpers/env.js
@@ -1,8 +1,7 @@
 "use strict";
 
 var path = require('path')
-  , _ = require('underscore')
-  , os = require('os');
+  , localIp = require('appium-support').util.localIp;
 
 var env = {};
 
@@ -251,28 +250,15 @@ if (env.SAUCE && env.TARBALL) {
   env.CAPS.tags = [env.DEVICE];
 }
 
-// rest enf points
-env.localIP = function () {
-  var ip = _.chain(os.networkInterfaces())
-    .values()
-    .flatten()
-    .filter(function (val) {
-      return (val.family === 'IPv4' && val.internal === false);
-    })
-    .pluck('address')
-    .first().value();
-  return ip;
-};
-
 env.LOCAL_APPIUM_PORT = env.SAUCE ? 4443 : env.APPIUM_PORT;
 if (env.REAL_DEVICE) {
-  env.TEST_END_POINT = 'http://' + env.localIP() + ':' + env.LOCAL_APPIUM_PORT + '/test/';
+  env.TEST_END_POINT = 'http://' + localIp() + ':' + env.LOCAL_APPIUM_PORT + '/test/';
 } else {
   env.TEST_END_POINT = 'http://localhost:' + env.LOCAL_APPIUM_PORT + '/test/';
 }
 env.GUINEA_TEST_END_POINT = env.TEST_END_POINT + 'guinea-pig';
 if (env.REAL_DEVICE) {
-  env.CHROME_TEST_END_POINT = 'http://' + env.localIP() + ':' + env.LOCAL_APPIUM_PORT + '/test/';
+  env.CHROME_TEST_END_POINT = 'http://' + localIp() + ':' + env.LOCAL_APPIUM_PORT + '/test/';
 } else {
   env.CHROME_TEST_END_POINT = 'http://10.0.2.2:' + env.LOCAL_APPIUM_PORT + '/test/';
 }


### PR DESCRIPTION
These changes establish our iOS real device test suite (via `bin.test.sh --real-device --ios83`), begins the task of marking tests with `@skip-real-device`.

This PR also changes the iOS test apps to be loaded by way of the `sample-apps` repo instead of through `submodules/sample-code`.

This PR also fixes #5061 execute_asynce on safari real device
