### PR TITLE
Fix Android keys by finding focused element

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -202,15 +202,15 @@ androidController.getPageIndex = function (elementId, cb) {
   cb(new NotYetImplementedError(), null);
 };
 
-androidController.keys = function (elementId, keys, cb) {
+androidController.keys = function (keys, cb) {
   var params = {
-    elementId: elementId,
-    text: keys
+    text: keys,
+    replace: false
   };
   if (this.args.unicodeKeyboard) {
     params.unicodeKeyboard = true;
   }
-  this.proxy(["element:setText", params], cb);
+  this.proxy(['setText', params], cb);
 };
 
 androidController.frame = function (frame, cb) {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/SetText.java
@@ -2,7 +2,10 @@ package io.appium.android.bootstrap.handler;
 
 import com.android.uiautomator.core.UiDevice;
 import com.android.uiautomator.core.UiObjectNotFoundException;
+import com.android.uiautomator.core.UiSelector;
 import io.appium.android.bootstrap.*;
+import io.appium.android.bootstrap.exceptions.ElementNotFoundException;
+import io.appium.android.bootstrap.handler.Find;
 import org.json.JSONException;
 
 import java.util.Hashtable;
@@ -26,51 +29,60 @@ public class SetText extends CommandHandler {
   @Override
   public AndroidCommandResult execute(final AndroidCommand command)
       throws JSONException {
+
+    AndroidElement el = null;
     if (command.isElementCommand()) {
-      // Only makes sense on an element
-      try {
-        final Hashtable<String, Object> params = command.params();
-        final AndroidElement el = command.getElement();
-        boolean replace = Boolean.parseBoolean(params.get("replace").toString());
-        String text = params.get("text").toString();
-        boolean pressEnter = false;
-        if (text.endsWith("\\n")) {
-          pressEnter = true;
-          text = text.replace("\\n", "");
-          Logger.debug("Will press enter after setting text");
-        }
-        boolean unicodeKeyboard = false;
-        if (params.get("unicodeKeyboard") != null) {
-          unicodeKeyboard = Boolean.parseBoolean(params.get("unicodeKeyboard").toString());
-        }
-        String currText = el.getText();
-        new Clear().execute(command);
-        if (!el.getText().isEmpty()) {
-          // clear could have failed, or we could have a hint in the field
-          // we'll assume it is the latter
-          Logger.debug("Text not cleared. Assuming remainder is hint text.");
-          currText = "";
-        }
-        if (!replace) {
-          text = currText + text;
-        }
-        final boolean result = el.setText(text, unicodeKeyboard);
-        if (!result) {
-          return getErrorResult("el.setText() failed!");
-        }
-        if (pressEnter) {
-          final UiDevice d = UiDevice.getInstance();
-          d.pressEnter();
-        }
-        return getSuccessResult(result);
-      } catch (final UiObjectNotFoundException e) {
-        return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
-            e.getMessage());
-      } catch (final Exception e) { // handle NullPointerException
-        return getErrorResult("Unknown error");
-      }
+      Logger.debug("Using element passed in.");
+      el = command.getElement();
     } else {
-      return getErrorResult("Unable to set text without an element.");
+      try {
+        Logger.debug("Using currently-focused element.");
+        AndroidElementsHash  elements = AndroidElementsHash.getInstance();
+        el = elements.getElement(new UiSelector().focused(true), "");
+      } catch (ElementNotFoundException e) {
+        Logger.debug("Error retrieving focused element: " + e);
+        return getErrorResult("Unable to set text without a focused element.");
+      }
+    }
+    try {
+      final Hashtable<String, Object> params = command.params();
+      boolean replace = Boolean.parseBoolean(params.get("replace").toString());
+      String text = params.get("text").toString();
+      boolean pressEnter = false;
+      if (text.endsWith("\\n")) {
+        pressEnter = true;
+        text = text.replace("\\n", "");
+        Logger.debug("Will press enter after setting text");
+      }
+      boolean unicodeKeyboard = false;
+      if (params.get("unicodeKeyboard") != null) {
+        unicodeKeyboard = Boolean.parseBoolean(params.get("unicodeKeyboard").toString());
+      }
+      String currText = el.getText();
+      new Clear().execute(command);
+      if (!el.getText().isEmpty()) {
+        // clear could have failed, or we could have a hint in the field
+        // we'll assume it is the latter
+        Logger.debug("Text not cleared. Assuming remainder is hint text.");
+        currText = "";
+      }
+      if (!replace) {
+        text = currText + text;
+      }
+      final boolean result = el.setText(text, unicodeKeyboard);
+      if (!result) {
+        return getErrorResult("el.setText() failed!");
+      }
+      if (pressEnter) {
+        final UiDevice d = UiDevice.getInstance();
+        d.pressEnter();
+      }
+      return getSuccessResult(result);
+    } catch (final UiObjectNotFoundException e) {
+      return new AndroidCommandResult(WDStatus.NO_SUCH_ELEMENT,
+          e.getMessage());
+    } catch (final Exception e) { // handle NullPointerException
+      return getErrorResult("Unknown error");
     }
   }
 }

--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -70,6 +70,7 @@ Selendroid.prototype.init = function () {
     , ['POST', new RegExp('^/wd/hub/session/[^/]+/network_connection')]
     , ['POST', new RegExp('^/wd/hub/session/[^/]+/ime')]
     , ['GET', new RegExp('^/wd/hub/session/[^/]+/ime')]
+    , ['POST', new RegExp('^/wd/hub/session/[^/]+/keys')]
   ];
   this.curContext = this.defaultContext();
 };
@@ -525,12 +526,11 @@ Selendroid.prototype.defaultWebviewName = function () {
   return this.WEBVIEW_WIN + "_0";
 };
 
-Selendroid.prototype.setValue = function (elementId, value, cb) {
-  logger.debug('Setting text on element \'' + elementId + '\': \'' + value + '\'');
+var encodeString = function (value, unicode) {
   for (var i = 0; i < value.length; i++) {
     var c = value.charCodeAt(i);
     // if we're using the unicode keyboard, and this is unicode, maybe encode
-    if (this.args.unicodeKeyboard && (c > 127 || c === 38)) {
+    if (unicode && (c > 127 || c === 38)) {
       // this is not simple ascii, or it is an ampersand (`&`)
       if (c >= parseInt("E000", 16) && c <= parseInt("E040", 16)) {
         // Selenium uses a Unicode PUA to cover certain special characters
@@ -542,9 +542,30 @@ Selendroid.prototype.setValue = function (elementId, value, cb) {
       }
     }
   }
+  return value;
+};
+
+Selendroid.prototype.setValue = function (elementId, value, cb) {
+  logger.debug('Setting text on element \'' + elementId + '\': \'' + value + '\'');
+  value = encodeString(value, this.args.unicodeKeyboard);
   var reqUrl = this.proxyHost + ':' + this.proxyPort +
       '/wd/hub/session/' + this.proxySessionId +
       '/element/' + elementId + '/value';
+  doRequest(reqUrl, 'POST', { value: [value] }, null, function (err) {
+    if (err) return cb(err);
+    cb(null, {
+      status: status.codes.Success.code,
+      value: ''
+    });
+  });
+};
+
+Selendroid.prototype.keys = function (value, cb) {
+  logger.debug('Setting text: \'' + value + '\'');
+  value = encodeString(value, this.args.unicodeKeyboard);
+  var reqUrl = this.proxyHost + ':' + this.proxyPort +
+      '/wd/hub/session/' + this.proxySessionId +
+      '/keys';
   doRequest(reqUrl, 'POST', { value: [value] }, null, function (err) {
     if (err) return cb(err);
     cb(null, {


### PR DESCRIPTION
For Android we had the incorrect `keys` method. This fixes it by leveraging the ability to set text, but using the currently focused element rather than sending in an element.

Addresses #4981
