### PR TITLE
making checkSelendroidCerts series operation instead of parallel one

### DIFF
--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -220,32 +220,24 @@ Selendroid.prototype.checkInternetPermissionForApp = function (cb) {
 };
 
 Selendroid.prototype.checkSelendroidCerts = function (cb) {
-  var alreadyReturned = false
-    , checks = 0;
-
-  var onDoneSigning = function () {
-    checks++;
-    if (checks === 2 && !alreadyReturned) {
-      cb();
-    }
-  };
-
-  // these run in parallel
   var apks = [this.selendroidServerPath, this.args.app];
-  _.each(apks, function (apk) {
+    
+  async.eachSeries(apks, function(apk, done){
     logger.debug("Checking signed status of " + apk);
     this.adb.checkApkCert(apk, this.args.appPackage, function (err, isSigned) {
-      if (err) return cb(err);
-      if (isSigned) return onDoneSigning();
+      if (err) return done(err);
+      if (isSigned) return done();
       this.adb.sign(apk, function (err) {
-        if (err && !alreadyReturned) {
-          alreadyReturned = true;
-          return cb(err);
-        }
-        onDoneSigning();
+        if (err) return done(err);
+		done();
       });
     }.bind(this));
-  }.bind(this));
+  }.bind(this), 
+    function (err){
+       if (err) return cb(err);
+       logger.debug("SelendroidCerts signing is completed");
+	   cb();
+    });
 };
 
 Selendroid.prototype.stop = function (ocb) {


### PR DESCRIPTION
It looks like test hangs due to race condition while signing apk. So, making checkSelendroidCerts series operation instead of parallel 
