### PR TITLE
don't proxy chromedriver requests for /wd/hub/:session_id/appium/*

### DIFF
--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -38,7 +38,9 @@ ChromeAndroid.prototype.setChromedriverMode = function () {
     ['POST', new RegExp('^/wd/hub/session/[^/]+/touch/perform')],
     ['POST', new RegExp('^/wd/hub/session/[^/]+/touch/multi/perform')],
     ['POST', new RegExp('^/wd/hub/session/[^/]+/orientation')],
-    ['GET', new RegExp('^/wd/hub/session/[^/]+/orientation')]
+    ['GET', new RegExp('^/wd/hub/session/[^/]+/orientation')],
+    ['POST', new RegExp('^/wd/hub/session/[^/]+/appium')],
+    ['GET', new RegExp('^/wd/hub/session/[^/]+/appium')]
   ];
 };
 


### PR DESCRIPTION
At my company we're testing an applinks feature (launching the app from links in the browser) and I needed the ability to install/remove apps while running a browser session on Android - I was sad to find out they 404'd

This is my first PR to appium, I'm happy to change things as needed just please help me bring it up to standards.  I wanted to write a test to cover it but sadly my experience with Mocha is pretty limited (I'm normally a ruby developer) and I couldn't find existing tests for ChromeAndroid I could hopefully learn from.
