### PR TITLE
Allow for a - in iOS app name

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -519,13 +519,12 @@ iOSController._getFullPath = function (remotePath, cb) {
   var appName = null;
 
   if (this.args.app) {
-    var appNameRegex = new RegExp("\\" + path.sep + "(\\w+\\.app)");
+    var appNameRegex = new RegExp("\\" + path.sep + "([\\w-]+\\.app)");
     var appNameMatches = appNameRegex.exec(this.args.app);
     if (appNameMatches) {
       appName = appNameMatches[1];
     }
   }
-
   // de-absolutize the path
   if (isWindows()) {
     if (remotePath.indexof("://") === 1) {


### PR DESCRIPTION
Sometimes an iOS application has a hyphen in the name, and tests that need the full path will fail.
