### PR TITLE
delegate ios simulator app installation/removal/launching to simctl

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1494,7 +1494,7 @@ IOS.prototype.removeApp = function (bundleId, cb) {
   if (this.args.udid) {
     this.realDevice.remove(bundleId, cb);
   } else {
-    cb(new Error("You can not call removeApp for the iOS simulator!"));
+    this.sim.remove(bundleId, cb);
   }
 };
 
@@ -1502,7 +1502,15 @@ IOS.prototype.installApp = function (unzippedAppPath, cb) {
   if (this.args.udid) {
     this.realDevice.install(unzippedAppPath, cb);
   } else {
-    cb(new Error("You can not call installApp for the iOS simulator!"));
+    this.sim.install(unzippedAppPath, cb);
+  }
+};
+
+IOS.prototype.startApp = function (args, cb) {
+  if (this.args.udid) {
+    cb(new Error("You can not call startApp for a real device!"));
+  } else {
+    this.sim.launch(args.appPackage, cb);
   }
 };
 

--- a/lib/devices/ios/simulator.js
+++ b/lib/devices/ios/simulator.js
@@ -648,4 +648,45 @@ Simulator.prototype.deleteOtherSims = function (cb) {
   }.bind(this));
 };
 
+Simulator.prototype.getBootedDevice = function (cb) {
+  simctl.getDevices(function (err, devices) {
+    if (err) return cb(err);
+
+    var booted = null;
+
+    _.detect(devices, function (sdkDevices) {
+      booted = _.findWhere(sdkDevices, {state: "Booted"});
+
+      return !!booted;
+    });
+
+    if (booted) {
+      cb(null, booted.udid);
+    } else {
+      cb("Simctl couldn't find any booted device");
+    }
+  });
+};
+
+Simulator.prototype.remove = function (bundleId, cb) {
+  this.getBootedDevice(function (err, udid) {
+    if (err) return cb(err);
+    simctl.removeApp(udid, bundleId, cb);
+  });
+};
+
+Simulator.prototype.install = function (appPath, cb) {
+  this.getBootedDevice(function (err, udid) {
+    if (err) return cb(err);
+    simctl.installApp(udid, appPath, cb);
+  });
+};
+
+Simulator.prototype.launch = function (bundleId, cb) {
+  this.getBootedDevice(function (err, udid) {
+    if (err) return cb(err);
+    simctl.launch(udid, bundleId, cb);
+  });
+};
+
 module.exports = Simulator;


### PR DESCRIPTION
This PR introduces the installApp, removeApp and startActivity endpoint for the iOS simulator.  I haven't gotten startActivity on a real device working yet because I'm not even sure if libidevice can support that (I will look into it soon).

This work depends upon appium/node-simctl#4 so there will probably need to be some updates done to ensure that dependency is properly pulled in once it gets merged.

Please help me bring this PR up to spec - I'm happy to write some tests but I think I might need some direction here.
