### PR TITLE
Allow access to element content description attribute directly

### DIFF
--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/AndroidElement.java
@@ -41,7 +41,7 @@ public class AndroidElement {
   public boolean click() throws UiObjectNotFoundException {
     return el.click();
   }
-  
+
   public boolean exists() {
     return el.exists();
   }
@@ -65,13 +65,13 @@ public class AndroidElement {
       return false;
     }
   }
-  
+
   public Point getAbsolutePosition(final Point point)
       throws UiObjectNotFoundException, InvalidCoordinatesException {
     final Rect rect = this.getBounds();
-    
+
     Logger.debug("Element bounds: " + rect.toShortString());
-    
+
     return PositionHelper.getAbsolutePosition(point, rect, new Point(rect.left, rect.top), false);
   }
 
@@ -171,6 +171,8 @@ public class AndroidElement {
       if (res.equals("")) {
         res = getText();
       }
+    } else if (attr.equals("contentDescription")) {
+      res = getContentDesc();
     } else if (attr.equals("text")) {
       res = getText();
     } else if (attr.equals("className")) {

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/handler/GetAttribute.java
@@ -33,8 +33,9 @@ public class GetAttribute extends CommandHandler {
       try {
         final AndroidElement el = command.getElement();
         final String attr = params.get("attribute").toString();
-        if (attr.equals("name") || attr.equals("text")
-            || attr.equals("className") || attr.equals("resourceId")) {
+        if (attr.equals("name") || attr.equals("contentDescription")
+            || attr.equals("text") || attr.equals("className")
+            || attr.equals("resourceId")) {
           return getSuccessResult(el.getStringAttribute(attr));
         } else {
           return getSuccessResult(String.valueOf(el.getBoolAttribute(attr)));

--- a/test/functional/android/apidemos/attributes-specs.js
+++ b/test/functional/android/apidemos/attributes-specs.js
@@ -34,6 +34,11 @@ describe("apidemos - attributes", function () {
       .back()
       .nodeify(done);
   });
+  it('should be able to find content description attribute', function (done) {
+    driver.elementByName('Animation').getAttribute('contentDescription')
+        .should.become("Animation")
+      .nodeify(done);
+  });
   it('should be able to find displayed attribute', function (done) {
     driver
       .elementByName('Animation').getAttribute('displayed')


### PR DESCRIPTION
It is confusing to users (see #5142) to not be able to get the content description directly, but to have to get the `name` attribute. Add `contentDescription` attribute.
