### PR TITLE
Keep track of the correct app id for safari webview

### DIFF
--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -77,9 +77,11 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
       if (this.remoteAppKey === null) {
         return cb(new Error("remote debug app key must be set"));
       }
-      this.remote.selectApp(this.remoteAppKey, function (res) {
+      this.remote.selectApp(this.remoteAppKey, function (err, perhapsModifiedAppKey, res) {
+        if (err) return onDone(err);
+        this.remoteAppKey = perhapsModifiedAppKey;
         onDone(null, res);
-      });
+      }.bind(this));
     }
   } else {
     if (this.args.udid !== null) {
@@ -107,9 +109,11 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
         }
         logger.debug("Using remote debugger app key: " + appKey);
         this.remoteAppKey = appKey;
-        this.remote.selectApp(appKey, function (res) {
+        this.remote.selectApp(appKey, function (err, perhapsModifiedAppKey, res) {
+          if (err) return onDone(err);
+          this.remoteAppKey = perhapsModifiedAppKey;
           onDone(null, res);
-        });
+        }.bind(this));
       }.bind(this), this.onPageChange.bind(this));
       var loopCloseRuns = 0;
       var loopClose = function () {

--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -151,7 +151,7 @@ RemoteDebugger.prototype.selectApp = function (appIdKey, cb, tries) {
     }
     if (responded) return;
     responded = true;
-    cb(this.pageArrayFromDict(pageDict));
+    cb(null, appIdKey, this.pageArrayFromDict(pageDict));
     this.specialCbs['_rpc_forwardGetListing:'] = this.onPageChange.bind(this);
   }.bind(this);
 


### PR DESCRIPTION
We sometimes get a redirect message from Safari, but it only happens once. If we don't keep track of it between retries then after the first time through there is no chance of getting the page.

Also, allow error to move through.

Resolves #4865 (and others?).
