### PR TITLE
Deprecate server args that are also desired caps

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -32,12 +32,13 @@ class AppiumDriver extends BaseDriver {
   async getSessions () {
     let sessions = [];
     for (let [id, driver] of _.pairs(this.sessions)) {
-      sessions.push(Object.assign({id}, driver.caps));
+      sessions.push({id: id, capabilities: driver.caps});
     }
     return sessions;
   }
 
   async createSession (caps, reqCaps) {
+    caps = _.defaults(_.clone(caps), this.args.defaultCapabilities);
     let InnerDriver = this.getDriverForCaps(caps);
     let curSessions;
     log.info(`Creating new ${InnerDriver.name} session`);

--- a/lib/config.js
+++ b/lib/config.js
@@ -77,7 +77,7 @@ function getDeprecatedArgs (parser, args) {
     let defaultValue = rawArg[1].defaultValue;
     let isDeprecated = !!rawArg[1].deprecatedFor;
     if (args[arg] !== defaultValue && isDeprecated) {
-      deprecated[rawArg[0]] = `use instead: ${rawArg[1].deprecatedFor}`;
+      deprecated[rawArg[0]] = rawArg[1].deprecatedFor;
     }
   }
   return deprecated;

--- a/lib/main.js
+++ b/lib/main.js
@@ -32,6 +32,13 @@ async function preflightChecks (parser, args) {
   }
 }
 
+function logDeprecationWarning (deprecatedArgs) {
+  logger.warn('Deprecated server args: ');
+  for (let [arg, realArg] of _.pairs(deprecatedArgs)) {
+    logger.warn(`        ${arg} => ${realArg}`);
+  }
+}
+
 async function logStartupInfo (parser, args) {
   let welcome = `Welcome to Appium v${APPIUM_VER}`;
   let appiumRev = await getGitRev();
@@ -39,16 +46,21 @@ async function logStartupInfo (parser, args) {
     welcome += ` (REV ${appiumRev})`;
   }
   logger.info(welcome);
-  let logMessage = "Appium REST http interface listener started on " +
-                   args.address + ":" + args.port;
+  let logMessage = `Appium REST http interface listener started on ` +
+                   `${args.address}:${args.port}`;
   logger.info(logMessage);
   let showArgs = getNonDefaultArgs(parser, args);
   if (_.size(showArgs)) {
-    logger.debug("Non-default server args: " + JSON.stringify(showArgs));
+    logger.debug(`Non-default server args: ${JSON.stringify(showArgs)}`);
   }
   let deprecatedArgs = getDeprecatedArgs(parser, args);
   if (_.size(deprecatedArgs)) {
-    logger.warn("Deprecated server args: " + JSON.stringify(deprecatedArgs));
+    logDeprecationWarning(deprecatedArgs);
+  }
+  if (!_.isEmpty(args.defaultCapabilities)) {
+    logger.debug(`Default capabilities, which will be added to each request ` +
+                 `unless overridden by desired capabilities: ` +
+                 `${JSON.stringify(args.defaultCapabilities)}`);
   }
   // TODO: bring back loglevel reporting below once logger is flushed out
   //logger.info('Console LogLevel: ' + logger.transports.console.level);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,653 +1,722 @@
 import path from 'path';
+import _ from 'lodash';
 import { ArgumentParser } from 'argparse';
 import pkgObj from '../../package.json';
 
 const args = [
   [['--shell'], {
-    required: false
-  , defaultValue: null
-  , help: 'Enter REPL mode'
-  , nargs: 0
-  }],
-
-  [['--localizable-strings-dir'], {
-    required: false
-  , dest: 'localizableStringsDir'
-  , defaultValue: 'en.lproj'
-  , help: 'IOS only: the relative path of the dir where Localizable.strings file resides '
-  , example: "en.lproj"
-  }],
-
-  [['--app'], {
-    required: false
-  , defaultValue: null
-  , help: 'IOS: abs path to simulator-compiled .app file or the bundle_id of the desired target on device; Android: abs path to .apk file'
-  , example: "/abs/path/to/my.app"
+    required: false,
+    defaultValue: null,
+    help: 'Enter REPL mode',
+    nargs: 0,
   }],
 
   [['--ipa'], {
-    required: false
-  , defaultValue: null
-  , help: '(IOS-only) abs path to compiled .ipa file'
-  , example: "/abs/path/to/my.ipa"
-  }],
-
-  [['-U', '--udid'], {
-    required: false
-  , defaultValue: null
-  , example: "1adsf-sdfas-asdf-123sdf"
-  , help: 'Unique device identifier of the connected physical device'
+    required: false,
+    defaultValue: null,
+    help: '(IOS-only) abs path to compiled .ipa file',
+    example: '/abs/path/to/my.ipa',
   }],
 
   [['-a', '--address'], {
-    defaultValue: '0.0.0.0'
-  , required: false
-  , example: "0.0.0.0"
-  , help: 'IP Address to listen on'
+    defaultValue: '0.0.0.0',
+    required: false,
+    example: '0.0.0.0',
+    help: 'IP Address to listen on',
   }],
 
   [['-p', '--port'], {
-    defaultValue: 4723
-  , required: false
-  , type: 'int'
-  , example: "4723"
-  , help: 'port to listen on'
+    defaultValue: 4723,
+    required: false,
+    type: 'int',
+    example: '4723',
+    help: 'port to listen on',
   }],
 
   [['-ca', '--callback-address'], {
-    required: false
-  , dest: 'callbackAddress'
-  , defaultValue: null
-  , example: "127.0.0.1"
-  , help: 'callback IP Address (default: same as --address)'
+    required: false,
+    dest: 'callbackAddress',
+    defaultValue: null,
+    example: '127.0.0.1',
+    help: 'callback IP Address (default: same as --address)',
   }],
 
   [['-cp', '--callback-port'], {
-    required: false
-  , dest: 'callbackPort'
-  , defaultValue: null
-  , type: 'int'
-  , example: "4723"
-  , help: 'callback port (default: same as port)'
+    required: false,
+    dest: 'callbackPort',
+    defaultValue: null,
+    type: 'int',
+    example: '4723',
+    help: 'callback port (default: same as port)',
   }],
 
   [['-bp', '--bootstrap-port'], {
-    defaultValue: 4724
-  , dest: 'bootstrapPort'
-  , required: false
-  , type: 'int'
-  , example: "4724"
-  , help: '(Android-only) port to use on device to talk to Appium'
-  }],
-
-  [['-k', '--keep-artifacts'], {
-    defaultValue: false
-  , dest: 'keepArtifacts'
-  , action: 'storeTrue'
-  , required: false
-  , help: '[DEPRECATED] no effect, trace is now in tmp dir by default and is ' +
-  ' cleared before each run. Please also refer to the --trace-dir flag.'
-  , nargs: 0
+    defaultValue: 4724,
+    dest: 'bootstrapPort',
+    required: false,
+    type: 'int',
+    example: '4724',
+    help: '(Android-only) port to use on device to talk to Appium',
   }],
 
   [['-r', '--backend-retries'], {
-    defaultValue: 3
-  , dest: 'backendRetries'
-  , required: false
-  , type: 'int'
-  , example: "3"
-  , help: '(iOS-only) How many times to retry launching Instruments ' +
-          'before saying it crashed or timed out'
+    defaultValue: 3,
+    dest: 'backendRetries',
+    required: false,
+    type: 'int',
+    example: '3',
+    help: '(iOS-only) How many times to retry launching Instruments ' +
+          'before saying it crashed or timed out',
   }],
 
   [['--session-override'], {
-    defaultValue: false
-  , dest: 'sessionOverride'
-  , action: 'storeTrue'
-  , required: false
-  , help: 'Enables session override (clobbering)'
-  , nargs: 0
-  }],
-
-  [['--full-reset'], {
-    defaultValue: false
-  , dest: 'fullReset'
-  , action: 'storeTrue'
-  , required: false
-  , help: '(iOS) Delete the entire simulator folder. (Android) Reset app ' +
-          'state by uninstalling app instead of clearing app data. On ' +
-          'Android, this will also remove the app after the session is complete.'
-  , nargs: 0
-  }],
-
-  [['--no-reset'], {
-    defaultValue: false
-  , dest: 'noReset'
-  , action: 'storeTrue'
-  , required: false
-  , help: "Don't reset app state between sessions (IOS: don't delete app " +
-          "plist files; Android: don't uninstall app before new session)"
-  , nargs: 0
+    defaultValue: false,
+    dest: 'sessionOverride',
+    action: 'storeTrue',
+    required: false,
+    help: 'Enables session override (clobbering)',
+    nargs: 0,
   }],
 
   [['-l', '--pre-launch'], {
-    defaultValue: false
-  , dest: 'launch'
-  , action: 'storeTrue'
-  , required: false
-  , help: 'Pre-launch the application before allowing the first session ' +
-          '(Requires --app and, for Android, --app-pkg and --app-activity)'
-  , nargs: 0
-  }],
-
-  [['-lt', '--launch-timeout'], {
-    defaultValue: 90000
-  , dest: 'launchTimeout'
-  , required: false
-  , help: '(iOS-only) how long in ms to wait for Instruments to launch'
+    defaultValue: false,
+    dest: 'launch',
+    action: 'storeTrue',
+    required: false,
+    help: 'Pre-launch the application before allowing the first session ' +
+          '(Requires --app and, for Android, --app-pkg and --app-activity)',
+    nargs: 0,
   }],
 
   [['-g', '--log'], {
-    defaultValue: null
-  , dest: 'log'
-  , required: false
-  , example: "/path/to/appium.log"
-  , help: 'Also send log output to this file'
+    defaultValue: null,
+    dest: 'log',
+    required: false,
+    example: '/path/to/appium.log',
+    help: 'Also send log output to this file',
   }],
 
   [['--log-level'], {
-    choices: [  'info', 'info:debug', 'info:info', 'info:warn', 'info:error'
-              , 'warn', 'warn:debug', 'warn:info', 'warn:warn', 'warn:error'
-              , 'error', 'error:debug', 'error:info', 'error:warn', 'error:error'
-              , 'debug', 'debug:debug', 'debug:info', 'debug:warn', 'debug:error']
-  , defaultValue: 'debug'
-  , dest: 'loglevel'
-  , required: false
-  , example: "debug"
-  , help: 'log level; default (console[:file]): debug[:debug]'
+    choices: ['info', 'info:debug', 'info:info', 'info:warn', 'info:error',
+              'warn', 'warn:debug', 'warn:info', 'warn:warn', 'warn:error',
+              'error', 'error:debug', 'error:info', 'error:warn', 'error:error',
+              'debug', 'debug:debug', 'debug:info', 'debug:warn', 'debug:error'],
+    defaultValue: 'debug',
+    dest: 'loglevel',
+    required: false,
+    example: 'debug',
+    help: 'log level; default (console[:file]): debug[:debug]',
   }],
 
   [['--log-timestamp'], {
-    defaultValue: false
-  , required: false
-  , help: 'Show timestamps in console output'
-  , nargs: 0
-  , action: 'storeTrue'
-  , dest: 'logTimestamp'
+    defaultValue: false,
+    required: false,
+    help: 'Show timestamps in console output',
+    nargs: 0,
+    action: 'storeTrue',
+    dest: 'logTimestamp',
   }],
 
   [['--local-timezone'], {
-    defaultValue: false
-  , required: false
-  , help: 'Use local timezone for timestamps'
-  , nargs: 0
-  , action: 'storeTrue'
-  , dest: 'localTimezone'
+    defaultValue: false,
+    required: false,
+    help: 'Use local timezone for timestamps',
+    nargs: 0,
+    action: 'storeTrue',
+    dest: 'localTimezone',
   }],
 
   [['--log-no-colors'], {
-    defaultValue: false
-  , required: false
-  , help: "Don't use colors in console output"
-  , nargs: 0
-  , action: 'storeTrue'
-  , dest: 'logNoColors'
+    defaultValue: false,
+    required: false,
+    help: 'Do not use colors in console output',
+    nargs: 0,
+    action: 'storeTrue',
+    dest: 'logNoColors',
   }],
 
   [['-G', '--webhook'], {
-    defaultValue: null
-  , required: false
-  , example: "localhost:9876"
-  , help: 'Also send log output to this HTTP listener'
-  }],
-
-  [['--native-instruments-lib'], {
-    defaultValue: false
-  , dest: 'nativeInstrumentsLib'
-  , action: 'storeTrue'
-  , required: false
-  , help: '(IOS-only) IOS has a weird built-in unavoidable ' +
-          'delay. We patch this in appium. If you do not want it patched, ' +
-          'pass in this flag.'
-  , nargs: 0
-  }],
-
-  [['--app-pkg'], {
-    dest: 'androidPackage'
-  , defaultValue: null
-  , required: false
-  , example: "com.example.android.myApp"
-  , help: "(Android-only) Java package of the Android app you want to run " +
-          "(e.g., com.example.android.myApp)"
-  }],
-
-  [['--app-activity'], {
-    dest: 'androidActivity'
-  , defaultValue: null
-  , required: false
-  , example: "MainActivity"
-  , help: "(Android-only) Activity name for the Android activity you want " +
-          "to launch from your package (e.g., MainActivity)"
-  }],
-
-  [['--app-wait-package'], {
-    dest: 'androidWaitPackage'
-  , defaultValue: false
-  , required: false
-  , example: "com.example.android.myApp"
-  , help: "(Android-only) Package name for the Android activity you want " +
-          "to wait for (e.g., com.example.android.myApp)"
-  }],
-
-  [['--app-wait-activity'], {
-    dest: 'androidWaitActivity'
-  , defaultValue: false
-  , required: false
-  , example: "SplashActivity"
-  , help: "(Android-only) Activity name for the Android activity you want " +
-          "to wait for (e.g., SplashActivity)"
-  }],
-
-  [['--android-coverage'], {
-    dest: 'androidCoverage'
-  , defaultValue: false
-  , required: false
-  , example: 'com.my.Pkg/com.my.Pkg.instrumentation.MyInstrumentation'
-  , help: "(Android-only) Fully qualified instrumentation class. Passed to -w in " +
-      "adb shell am instrument -e coverage true -w "
-  }],
-
-  [['--avd'], {
-    defaultValue: null
-  , required: false
-  , example: "@default"
-  , help: "(Android-only) Name of the avd to launch"
-  }],
-
-  [['--avd-args'], {
-    dest: 'avdArgs'
-  , defaultValue: null
-  , required: false
-  , example: "-no-snapshot-load"
-  , help: "(Android-only) Additional emulator arguments to launch the avd"
-  }],
-
-  [['--device-ready-timeout'], {
-    dest: 'androidDeviceReadyTimeout'
-  , defaultValue: '5'
-  , required: false
-  , example: "5"
-  , help: "(Android-only) Timeout in seconds while waiting for device to become ready"
+    defaultValue: null,
+    required: false,
+    example: 'localhost:9876',
+    help: 'Also send log output to this HTTP listener',
   }],
 
   [['--safari'], {
-    defaultValue: false
-  , action: 'storeTrue'
-  , required: false
-  , help: "(IOS-Only) Use the safari app"
-  , nargs: 0
-  }],
-
-  [['--device-name'], {
-    dest: 'deviceName'
-  , defaultValue: null
-  , required: false
-  , example: "iPhone Retina (4-inch), Android Emulator"
-  , help: "Name of the mobile device to use"
-  }],
-
-  [['--platform-name'], {
-    dest: 'platformName'
-  , defaultValue: null
-  , required: false
-  , example: "iOS"
-  , help: "Name of the mobile platform: iOS, Android, or FirefoxOS"
-  }],
-
-  [['--platform-version'], {
-    dest: 'platformVersion'
-  , defaultValue: null
-  , required: false
-  , example: "7.1"
-  , help: "Version of the mobile platform"
-  }],
-
-  [['--automation-name'], {
-    dest: 'automationName'
-  , defaultValue: null
-  , required: false
-  , example: "Appium"
-  , help: "Name of the automation tool: Appium or Selendroid"
-  }],
-
-  [['--browser-name'], {
-    dest: 'browserName'
-  , defaultValue: null
-  , required: false
-  , example: "Safari"
-  , help: "Name of the mobile browser: Safari or Chrome"
+    defaultValue: false,
+    action: 'storeTrue',
+    required: false,
+    help: '(IOS-Only) Use the safari app',
+    nargs: 0,
   }],
 
   [['--default-device', '-dd'], {
-    dest: 'defaultDevice'
-  , defaultValue: false
-  , action: 'storeTrue'
-  , required: false
-  , help: "(IOS-Simulator-only) use the default simulator that instruments " +
-          "launches on its own"
+    dest: 'defaultDevice',
+    defaultValue: false,
+    action: 'storeTrue',
+    required: false,
+    help: '(IOS-Simulator-only) use the default simulator that instruments ' +
+          'launches on its own',
   }],
 
   [['--force-iphone'], {
-    defaultValue: false
-  , dest: 'forceIphone'
-  , action: 'storeTrue'
-  , required: false
-  , help: "(IOS-only) Use the iPhone Simulator no matter what the app wants"
-  , nargs: 0
+    defaultValue: false,
+    dest: 'forceIphone',
+    action: 'storeTrue',
+    required: false,
+    help: '(IOS-only) Use the iPhone Simulator no matter what the app wants',
+    nargs: 0,
   }],
 
   [['--force-ipad'], {
-    defaultValue: false
-  , dest: 'forceIpad'
-  , action: 'storeTrue'
-  , required: false
-  , help: "(IOS-only) Use the iPad Simulator no matter what the app wants"
-  , nargs: 0
-  }],
-
-  [['--language'], {
-    defaultValue: null
-  , dest: 'language'
-  , required: false
-  , example: "en"
-  , help: 'Language for the iOS simulator / Android Emulator'
-  }],
-
-  [['--locale'], {
-    defaultValue: null
-  , dest: 'locale'
-  , required: false
-  , example: "en_US"
-  , help: 'Locale for the iOS simulator / Android Emulator'
-  }],
-
-  [['--calendar-format'], {
-    defaultValue: null
-  , dest: 'calendarFormat'
-  , required: false
-  , example: "gregorian"
-  , help: '(IOS-only) calendar format for the iOS simulator'
-  }],
-
-  [['--orientation'], {
-    defaultValue: null
-  , required: false
-  , example: "LANDSCAPE"
-  , help: "(IOS-only) use LANDSCAPE or PORTRAIT to initialize all requests " +
-          "to this orientation"
+    defaultValue: false,
+    dest: 'forceIpad',
+    action: 'storeTrue',
+    required: false,
+    help: '(IOS-only) Use the iPad Simulator no matter what the app wants',
+    nargs: 0,
   }],
 
   [['--tracetemplate'], {
-    defaultValue: null
-  , dest: 'automationTraceTemplatePath'
-  , required: false
-  , example: "/Users/me/Automation.tracetemplate"
-  , help: "(IOS-only) .tracetemplate file to use with Instruments"
+    defaultValue: null,
+    dest: 'automationTraceTemplatePath',
+    required: false,
+    example: '/Users/me/Automation.tracetemplate',
+    help: '(IOS-only) .tracetemplate file to use with Instruments',
   }],
 
   [['--instruments'], {
-    defaultValue: null
-  , dest: 'instrumentsPath'
-  , require: false
-  , example: "/path/to/instruments"
-  , help: "(IOS-only) path to instruments binary"
-  }],
-
-  [['--show-sim-log'], {
-    defaultValue: false
-  , dest: 'showSimulatorLog'
-  , action: 'storeTrue'
-  , required: false
-  , deprecatedFor: '--show-ios-log'
-  , help: "(IOS-only) if set, the iOS simulator log will be written to the console"
-  , nargs: 0
-  }],
-
-  [['--show-ios-log'], {
-    defaultValue: false
-  , dest: 'showIOSLog'
-  , action: 'storeTrue'
-  , required: false
-  , help: "(IOS-only) if set, the iOS system log will be written to the console"
-  , nargs: 0
+    defaultValue: null,
+    dest: 'instrumentsPath',
+    require: false,
+    example: '/path/to/instruments',
+    help: '(IOS-only) path to instruments binary',
   }],
 
   [['--nodeconfig'], {
-    required: false
-  , defaultValue: null
-  , help: 'Configuration JSON file to register appium with selenium grid'
-  , example: "/abs/path/to/nodeconfig.json"
+    required: false,
+    defaultValue: null,
+    help: 'Configuration JSON file to register appium with selenium grid',
+    example: '/abs/path/to/nodeconfig.json',
   }],
 
   [['-ra', '--robot-address'], {
-    defaultValue: '0.0.0.0'
-  , dest: 'robotAddress'
-  , required: false
-  , example: "0.0.0.0"
-  , help: 'IP Address of robot'
+    defaultValue: '0.0.0.0',
+    dest: 'robotAddress',
+    required: false,
+    example: '0.0.0.0',
+    help: 'IP Address of robot',
   }],
 
   [['-rp', '--robot-port'], {
-    defaultValue: -1
-  , dest: 'robotPort'
-  , required: false
-  , type: 'int'
-  , example: "4242"
-  , help: 'port for robot'
+    defaultValue: -1,
+    dest: 'robotPort',
+    required: false,
+    type: 'int',
+    example: '4242',
+    help: 'port for robot',
   }],
 
   [['--selendroid-port'], {
-    defaultValue: 8080
-  , dest: 'selendroidPort'
-  , required: false
-  , type: 'int'
-  , example: "8080"
-  , help: 'Local port used for communication with Selendroid'
+    defaultValue: 8080,
+    dest: 'selendroidPort',
+    required: false,
+    type: 'int',
+    example: '8080',
+    help: 'Local port used for communication with Selendroid',
   }],
 
   [['--chromedriver-port'], {
-    defaultValue: 9515
-  , dest: 'chromeDriverPort'
-  , required: false
-  , type: 'int'
-  , example: '9515'
-  , help: 'Port upon which ChromeDriver will run'
+    defaultValue: 9515,
+    dest: 'chromeDriverPort',
+    required: false,
+    type: 'int',
+    example: '9515',
+    help: 'Port upon which ChromeDriver will run',
   }],
 
   [['--chromedriver-executable'], {
-    defaultValue: null
-  , dest: 'chromedriverExecutable'
-  , required: false
-  , help: 'ChromeDriver executable full path'
-  }],
-
-  [['--use-keystore'], {
-    defaultValue: false
-  , dest: 'useKeystore'
-  , action: 'storeTrue'
-  , required: false
-  , help: '(Android-only) When set the keystore will be used to sign apks.'
-  }],
-
-  [['--keystore-path'], {
-    defaultValue: path.resolve(process.env.HOME || process.env.USERPROFILE || '', '.android', 'debug.keystore')
-  , dest: 'keystorePath'
-  , required: false
-  , help: '(Android-only) Path to keystore'
-  }],
-
-  [['--keystore-password'], {
-    defaultValue: 'android'
-  , dest: 'keystorePassword'
-  , required: false
-  , help: '(Android-only) Password to keystore'
-  }],
-
-  [['--key-alias'], {
-    defaultValue: 'androiddebugkey'
-  , dest: 'keyAlias'
-  , required: false
-  , help: '(Android-only) Key alias'
-  }],
-
-  [['--key-password'], {
-    defaultValue: 'android'
-  , dest: 'keyPassword'
-  , required: false
-  , help: '(Android-only) Key password'
+    defaultValue: null,
+    dest: 'chromedriverExecutable',
+    required: false,
+    help: 'ChromeDriver executable full path',
   }],
 
   [['--show-config'], {
-    defaultValue: false
-  , dest: 'showConfig'
-  , action: 'storeTrue'
-  , required: false
-  , help: 'Show info about the appium server configuration and exit'
+    defaultValue: false,
+    dest: 'showConfig',
+    action: 'storeTrue',
+    required: false,
+    help: 'Show info about the appium server configuration and exit',
   }],
 
   [['--no-perms-check'], {
-    defaultValue: false
-  , dest: 'noPermsCheck'
-  , action: 'storeTrue'
-  , required: false
-  , help: "Bypass Appium's checks to ensure we can read/write necessary files"
+    defaultValue: false,
+    dest: 'noPermsCheck',
+    action: 'storeTrue',
+    required: false,
+    help: 'Bypass Appium\'s checks to ensure we can read/write necessary files',
   }],
 
   [['--command-timeout'], {
-    defaultValue: 60
-  , dest: 'defaultCommandTimeout'
-  , type: 'int'
-  , required: false
-  , help: 'The default command timeout for the server to use for all ' +
-          'sessions. Will still be overridden by newCommandTimeout cap'
-  }],
-
-  [['--keep-keychains'], {
-    defaultValue: false
-  , dest: 'keepKeyChains'
-  , action: 'storeTrue'
-  , required: false
-  , help: "(iOS) Whether to keep keychains (Library/Keychains) when reset app between sessions"
-  , nargs: 0
+    defaultValue: 60,
+    dest: 'defaultCommandTimeout',
+    type: 'int',
+    required: false,
+    help: 'The default command timeout for the server to use for all ' +
+          'sessions. Will still be overridden by newCommandTimeout cap',
   }],
 
   [['--strict-caps'], {
-    defaultValue: false
-  , dest: 'enforceStrictCaps'
-  , action: 'storeTrue'
-  , required: false
-  , help: "Cause sessions to fail if desired caps are sent in that Appium " +
-          "does not recognize as valid for the selected device"
-  , nargs: 0
+    defaultValue: false,
+    dest: 'enforceStrictCaps',
+    action: 'storeTrue',
+    required: false,
+    help: 'Cause sessions to fail if desired caps are sent in that Appium ' +
+          'does not recognize as valid for the selected device',
+    nargs: 0,
   }],
 
   [['--isolate-sim-device'], {
-    defaultValue: false
-  , dest: 'isolateSimDevice'
-  , action: 'storeTrue'
-  , required: false
-  , help: "Xcode 6 has a bug on some platforms where a certain simulator " +
-          "can only be launched without error if all other simulator devices " +
-          "are first deleted. This option causes Appium to delete all " +
-          "devices other than the one being used by Appium. Note that this " +
-          "is a permanent deletion, and you are responsible for using simctl " +
-          "or xcode to manage the categories of devices used with Appium."
-  , nargs: 0
+    defaultValue: false,
+    dest: 'isolateSimDevice',
+    action: 'storeTrue',
+    required: false,
+    help: 'Xcode 6 has a bug on some platforms where a certain simulator ' +
+          'can only be launched without error if all other simulator devices ' +
+          'are first deleted. This option causes Appium to delete all ' +
+          'devices other than the one being used by Appium. Note that this ' +
+          'is a permanent deletion, and you are responsible for using simctl ' +
+          'or xcode to manage the categories of devices used with Appium.',
+    nargs: 0,
   }],
 
   [['--tmp'], {
-    defaultValue: null
-  , dest: 'tmpDir'
-  , required: false
-  , help: 'Absolute path to directory Appium can use to manage temporary ' +
+    defaultValue: null,
+    dest: 'tmpDir',
+    required: false,
+    help: 'Absolute path to directory Appium can use to manage temporary ' +
           'files, like built-in iOS apps it needs to move around. On *nix/Mac ' +
-          'defaults to /tmp, on Windows defaults to C:\\Windows\\Temp'
+          'defaults to /tmp, on Windows defaults to C:\\Windows\\Temp',
   }],
 
   [['--trace-dir'], {
-    defaultValue: null
-  , dest: 'traceDir'
-  , required: false
-  , help: 'Absolute path to directory Appium use to save ios instruments ' +
-          'traces, defaults to <tmp dir>/appium-instruments'
-  }],
-
-  [['--intent-action'], {
-    dest: 'intentAction'
-  , defaultValue: "android.intent.action.MAIN"
-  , required: false
-  , example: "android.intent.action.MAIN"
-  , help: "(Android-only) Intent action which will be used to start activity"
-  }],
-
-  [['--intent-category'], {
-    dest: 'intentCategory'
-  , defaultValue: "android.intent.category.LAUNCHER"
-  , required: false
-  , example: "android.intent.category.APP_CONTACTS"
-  , help: "(Android-only) Intent category which will be used to start activity"
-  }],
-
-  [['--intent-flags'], {
-    dest: 'intentFlags'
-  , defaultValue: "0x10200000"
-  , required: false
-  , example: "0x10200000"
-  , help: "(Android-only) Flags that will be used to start activity"
-  }],
-
-  [['--intent-args'], {
-    dest: 'optionalIntentArguments'
-  , defaultValue: null
-  , required: false
-  , example: "0x10200000"
-  , help: "(Android-only) Additional intent arguments that will be used to " +
-          "start activity"
-  }],
-
-  [['--dont-stop-app-on-reset'], {
-    dest: 'dontStopAppOnReset'
-  , defaultValue: false
-  , action: 'storeTrue'
-  , required: false
-  , help: "(Android-only) When included, refrains from stopping the app before restart"
+    defaultValue: null,
+    dest: 'traceDir',
+    required: false,
+    help: 'Absolute path to directory Appium use to save ios instruments ' +
+          'traces, defaults to <tmp dir>/appium-instruments',
   }],
 
   [['--debug-log-spacing'], {
-    dest: 'debugLogSpacing'
-  , defaultValue: false
-  , action: 'storeTrue'
-  , required: false
-  , help: "Add exaggerated spacing in logs to help with visual inspection"
+    dest: 'debugLogSpacing',
+    defaultValue: false,
+    action: 'storeTrue',
+    required: false,
+    help: 'Add exaggerated spacing in logs to help with visual inspection',
   }],
 
   [['--suppress-adb-kill-server'], {
-    dest: 'suppressAdbKillServer'
-  , defaultValue: false
-  , action: 'storeTrue'
-  , required: false
-  , help: "(Android-only) If set, prevents Appium from killing the adb server instance"
-  , nargs: 0
+    dest: 'suppressAdbKillServer',
+    defaultValue: false,
+    action: 'storeTrue',
+    required: false,
+    help: '(Android-only) If set, prevents Appium from killing the adb server instance',
+    nargs: 0,
   }],
 
   [['--async-trace'], {
-    dest: 'asyncTrace'
-  , defaultValue: false
-  , required: false
-  , action: 'storeTrue'
-  , help: 'Add long stack traces to log entries. Recommended for debugging only.'
+    dest: 'asyncTrace',
+    defaultValue: false,
+    required: false,
+    action: 'storeTrue',
+    help: 'Add long stack traces to log entries. Recommended for debugging only.',
+  }],
+
+  [['--default-capabilities'], {
+    dest: 'defaultCapabilities',
+    defaultValue: {},
+    type: JSON.parse,
+    required: false,
+    example: '{"app": "myapp.app", "deviceName": "iPhone Simulator"}',
+    help: 'Set the default desired capabilities, which will be set on each ' +
+          'session unless overridden by recieved capabilities.'
+  }],
+];
+
+const deprecatedArgs = [
+  [['-k', '--keep-artifacts'], {
+    defaultValue: false,
+    dest: 'keepArtifacts',
+    action: 'storeTrue',
+    required: false,
+    help: '[DEPRECATED] no effect, trace is now in tmp dir by default and is ' +
+          'cleared before each run. Please also refer to the --trace-dir flag.',
+    nargs: 0,
+  }],
+
+  [['--platform-name'], {
+    dest: 'platformName',
+    defaultValue: null,
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    example: 'iOS',
+    help: 'Name of the mobile platform: iOS, Android, or FirefoxOS',
+  }],
+
+  [['--platform-version'], {
+    dest: 'platformVersion',
+    defaultValue: null,
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    example: '7.1',
+    help: 'Version of the mobile platform',
+  }],
+
+  [['--automation-name'], {
+    dest: 'automationName',
+    defaultValue: null,
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    example: 'Appium',
+    help: 'Name of the automation tool: Appium or Selendroid',
+  }],
+
+  [['--device-name'], {
+    dest: 'deviceName',
+    defaultValue: null,
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    example: 'iPhone Retina (4-inch), Android Emulator',
+    help: 'Name of the mobile device to use',
+  }],
+
+  [['--browser-name'], {
+    dest: 'browserName',
+    defaultValue: null,
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    example: 'Safari',
+    help: 'Name of the mobile browser: Safari or Chrome',
+  }],
+
+  [['--app'], {
+    dest: 'app',
+    required: false,
+    defaultValue: null,
+    deprecatedFor: '--default-capabilities',
+    help: 'IOS: abs path to simulator-compiled .app file or the bundle_id of the desired target on device; Android: abs path to .apk file',
+    example: '/abs/path/to/my.app',
+  }],
+
+  [['-lt', '--launch-timeout'], {
+    defaultValue: 90000,
+    dest: 'launchTimeout',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(iOS-only) how long in ms to wait for Instruments to launch',
+  }],
+
+  [['--language'], {
+    defaultValue: null,
+    dest: 'language',
+    required: false,
+    example: 'en',
+    deprecatedFor: '--default-capabilities',
+    help: 'Language for the iOS simulator / Android Emulator',
+  }],
+
+  [['--locale'], {
+    defaultValue: null,
+    dest: 'locale',
+    required: false,
+    example: 'en_US',
+    deprecatedFor: '--default-capabilities',
+    help: 'Locale for the iOS simulator / Android Emulator',
+  }],
+
+  [['-U', '--udid'], {
+    dest: 'udid',
+    required: false,
+    defaultValue: null,
+    example: '1adsf-sdfas-asdf-123sdf',
+    deprecatedFor: '--default-capabilities',
+    help: 'Unique device identifier of the connected physical device',
+  }],
+
+  [['--orientation'], {
+    dest: 'orientation',
+    defaultValue: null,
+    required: false,
+    example: 'LANDSCAPE',
+    deprecatedFor: '--default-capabilities',
+    help: '(IOS-only) use LANDSCAPE or PORTRAIT to initialize all requests ' +
+          'to this orientation',
+  }],
+
+  [['--no-reset'], {
+    defaultValue: false,
+    dest: 'noReset',
+    action: 'storeTrue',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: 'Do not reset app state between sessions (IOS: do not delete app ' +
+          'plist files; Android: do not uninstall app before new session)',
+    nargs: 0,
+  }],
+
+  [['--full-reset'], {
+    defaultValue: false,
+    dest: 'fullReset',
+    action: 'storeTrue',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(iOS) Delete the entire simulator folder. (Android) Reset app ' +
+          'state by uninstalling app instead of clearing app data. On ' +
+          'Android, this will also remove the app after the session is complete.',
+    nargs: 0,
+  }],
+
+  [['--app-pkg'], {
+    dest: 'appPackage',
+    defaultValue: null,
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    example: 'com.example.android.myApp',
+    help: '(Android-only) Java package of the Android app you want to run ' +
+          '(e.g., com.example.android.myApp)',
+  }],
+
+  [['--app-activity'], {
+    dest: 'appActivity',
+    defaultValue: null,
+    required: false,
+    example: 'MainActivity',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Activity name for the Android activity you want ' +
+          'to launch from your package (e.g., MainActivity)',
+  }],
+
+  [['--app-wait-package'], {
+    dest: 'appWaitPackage',
+    defaultValue: false,
+    required: false,
+    example: 'com.example.android.myApp',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Package name for the Android activity you want ' +
+          'to wait for (e.g., com.example.android.myApp)',
+  }],
+
+  [['--app-wait-activity'], {
+    dest: 'appWaitActivity',
+    defaultValue: false,
+    required: false,
+    example: 'SplashActivity',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Activity name for the Android activity you want ' +
+          'to wait for (e.g., SplashActivity)',
+  }],
+
+  [['--device-ready-timeout'], {
+    dest: 'deviceReadyTimeout',
+    defaultValue: '5',
+    required: false,
+    example: '5',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Timeout in seconds while waiting for device to become ready',
+  }],
+
+  [['--android-coverage'], {
+    dest: 'androidCoverage',
+    defaultValue: false,
+    required: false,
+    example: 'com.my.Pkg/com.my.Pkg.instrumentation.MyInstrumentation',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Fully qualified instrumentation class. Passed to -w in ' +
+          'adb shell am instrument -e coverage true -w ',
+  }],
+
+  [['--avd'], {
+    dest: 'avd',
+    defaultValue: null,
+    required: false,
+    example: '@default',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Name of the avd to launch',
+  }],
+
+  [['--avd-args'], {
+    dest: 'avdArgs',
+    defaultValue: null,
+    required: false,
+    example: '-no-snapshot-load',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Additional emulator arguments to launch the avd',
+  }],
+
+  [['--use-keystore'], {
+    defaultValue: false,
+    dest: 'useKeystore',
+    action: 'storeTrue',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) When set the keystore will be used to sign apks.',
+  }],
+
+  [['--keystore-path'], {
+    defaultValue: path.resolve(process.env.HOME || process.env.USERPROFILE || '', '.android', 'debug.keystore'),
+    dest: 'keystorePath',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Path to keystore',
+  }],
+
+  [['--keystore-password'], {
+    defaultValue: 'android',
+    dest: 'keystorePassword',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Password to keystore',
+  }],
+
+  [['--key-alias'], {
+    defaultValue: 'androiddebugkey',
+    dest: 'keyAlias',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Key alias',
+  }],
+
+  [['--key-password'], {
+    defaultValue: 'android',
+    dest: 'keyPassword',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Key password',
+  }],
+
+  [['--intent-action'], {
+    dest: 'intentAction',
+    defaultValue: 'android.intent.action.MAIN',
+    required: false,
+    example: 'android.intent.action.MAIN',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Intent action which will be used to start activity',
+  }],
+
+  [['--intent-category'], {
+    dest: 'intentCategory',
+    defaultValue: 'android.intent.category.LAUNCHER',
+    required: false,
+    example: 'android.intent.category.APP_CONTACTS',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Intent category which will be used to start activity',
+  }],
+
+  [['--intent-flags'], {
+    dest: 'intentFlags',
+    defaultValue: '0x10200000',
+    required: false,
+    example: '0x10200000',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Flags that will be used to start activity',
+  }],
+
+  [['--intent-args'], {
+    dest: 'optionalIntentArguments',
+    defaultValue: null,
+    required: false,
+    example: '0x10200000',
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) Additional intent arguments that will be used to ' +
+          'start activity',
+  }],
+
+  [['--dont-stop-app-on-reset'], {
+    dest: 'dontStopAppOnReset',
+    defaultValue: false,
+    action: 'storeTrue',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(Android-only) When included, refrains from stopping the app before restart',
+  }],
+
+  [['--calendar-format'], {
+    defaultValue: null,
+    dest: 'calendarFormat',
+    required: false,
+    example: 'gregorian',
+    deprecatedFor: '--default-capabilities',
+    help: '(IOS-only) calendar format for the iOS simulator',
+  }],
+
+  [['--native-instruments-lib'], {
+    defaultValue: false,
+    dest: 'nativeInstrumentsLib',
+    action: 'storeTrue',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(IOS-only) IOS has a weird built-in unavoidable ' +
+          'delay. We patch this in appium. If you do not want it patched, ' +
+          'pass in this flag.',
+    nargs: 0,
+  }],
+
+  [['--keep-keychains'], {
+    defaultValue: false,
+    dest: 'keepKeyChains',
+    action: 'storeTrue',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(iOS) Whether to keep keychains (Library/Keychains) when reset app between sessions',
+    nargs: 0,
+  }],
+
+  [['--localizable-strings-dir'], {
+    required: false,
+    dest: 'localizableStringsDir',
+    defaultValue: 'en.lproj',
+    deprecatedFor: '--default-capabilities',
+    help: 'IOS only: the relative path of the dir where Localizable.strings file resides ',
+    example: 'en.lproj',
+  }],
+
+  [['--show-ios-log'], {
+    defaultValue: false,
+    dest: 'showIOSLog',
+    action: 'storeTrue',
+    required: false,
+    deprecatedFor: '--default-capabilities',
+    help: '(IOS-only) if set, the iOS system log will be written to the console',
+    nargs: 0,
   }]
 ];
+
+function updateParseArgsForDefaultCapabilities (parser) {
+  // here we want to update the parser.parseArgs() function
+  // in order to bring together all the args that are actually
+  // default caps.
+  // once those deprecated args are actually removed, this
+  // can also be removed
+  parser._parseArgs = parser.parseArgs;
+  parser.parseArgs = function (args) {
+    let parsedArgs = parser._parseArgs(args);
+    parsedArgs.defaultCapabilities = parsedArgs.defaultCapabilities || {};
+    for (let argEntry of deprecatedArgs) {
+      let arg = argEntry[1].dest;
+      if (argEntry[1].deprecatedFor === '--default-capabilities') {
+        if (arg in parsedArgs && parsedArgs[arg] !== argEntry[1].defaultValue) {
+          parsedArgs.defaultCapabilities[arg] = parsedArgs[arg];
+          // j s h i n t can't handle complex interpolated strings
+          let capDict = {[arg]: parsedArgs[arg]};
+          argEntry[1].deprecatedFor = `--default-capabilities ` +
+                                      `'${JSON.stringify(capDict)}'`;
+        }
+      }
+    }
+    return parsedArgs;
+  };
+}
 
 function getParser () {
   let parser = new ArgumentParser({
@@ -655,12 +724,13 @@ function getParser () {
     addHelp: true,
     description: 'A webdriver-compatible server for use with native and hybrid iOS and Android applications.'
   });
-
-  for (let arg of args) {
+  let allArgs = _.union(args, deprecatedArgs);
+  parser.rawArgs = allArgs;
+  for (let arg of allArgs) {
     parser.addArgument(arg[0], arg[1]);
   }
+  updateParseArgsForDefaultCapabilities(parser);
 
-  parser.rawArgs = args;
   return parser;
 }
 

--- a/test/config-specs.js
+++ b/test/config-specs.js
@@ -131,12 +131,12 @@ describe('Config', () => {
         _.keys(deprecatedArgs).length.should.equal(0);
       });
       it('should catch a deprecated argument', () => {
-        args.showSimulatorLog = true;
+        args.showIOSLog = true;
         let deprecatedArgs = getDeprecatedArgs(parser, args);
         _.keys(deprecatedArgs).length.should.equal(1);
-        should.exist(deprecatedArgs['--show-sim-log']);
+        should.exist(deprecatedArgs['--show-ios-log']);
       });
-      it.skip('should catch a non-boolean deprecated argument', () => {
+      it('should catch a non-boolean deprecated argument', () => {
         args.calendarFormat = 'orwellian';
         let deprecatedArgs = getDeprecatedArgs(parser, args);
         _.keys(deprecatedArgs).length.should.equal(1);

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -1,0 +1,127 @@
+// transpile:mocha
+
+import { AppiumDriver, getAppiumRouter } from '../lib/appium';
+import { FakeDriver } from 'appium-fake-driver';
+import { TEST_FAKE_APP } from './helpers';
+import _ from 'lodash';
+import sinon from 'sinon';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);
+
+const BASE_CAPS = {platformName: 'Fake', app: TEST_FAKE_APP};
+
+describe('AppiumDriver', () => {
+  describe('getAppiumRouter', () => {
+    it('should return a route configuring function', async () => {
+      let routeConfiguringFunction = getAppiumRouter({});
+      routeConfiguringFunction.should.be.a.function;
+    });
+  });
+
+  describe('AppiumDriver', () => {
+    function getDriverAndFakeDriver () {
+      let appium = new AppiumDriver({});
+      let fakeDriver = new FakeDriver();
+      let mockFakeDriver = sinon.mock(fakeDriver);
+      appium.getDriverForCaps = function (/*args*/) {
+        return () => {
+          return fakeDriver;
+        };
+      };
+      return [appium, mockFakeDriver];
+    }
+    describe('createSession', () => {
+      let appium
+        , mockFakeDriver;
+      beforeEach(() => {
+        [appium, mockFakeDriver] = getDriverAndFakeDriver();
+      });
+      afterEach(() => {
+        mockFakeDriver.restore();
+        appium.args.defaultCapabilities = {};
+      });
+
+      it('should call inner driver\'s createSession with desired capabilities', async () => {
+        mockFakeDriver.expects("createSession")
+          .once().withExactArgs(BASE_CAPS, undefined, [])
+          .returns([1, BASE_CAPS]);
+        await appium.createSession(BASE_CAPS);
+        mockFakeDriver.verify();
+      });
+      it('should call inner driver\'s createSession with desired and default capabilities', async () => {
+        let defaultCaps = {deviceName: 'Emulator'}
+          , allCaps = _.extend(_.clone(defaultCaps), BASE_CAPS);
+        appium.args.defaultCapabilities = defaultCaps;
+        mockFakeDriver.expects("createSession")
+          .once().withArgs(allCaps)
+          .returns([1, allCaps]);
+        await appium.createSession(BASE_CAPS);
+        mockFakeDriver.verify();
+      });
+      it('should call inner driver\'s createSession with desired and default capabilities without overriding caps', async () => {
+        // a default capability with the same key as a desired capability
+        // should do nothing
+        let defaultCaps = {platformName: 'Ersatz'};
+        appium.args.defaultCapabilities = defaultCaps;
+        mockFakeDriver.expects("createSession")
+          .once().withArgs(BASE_CAPS)
+          .returns([1, BASE_CAPS]);
+        await appium.createSession(BASE_CAPS);
+        mockFakeDriver.verify();
+      });
+    });
+    describe('deleteSession', () => {
+      let appium
+        , mockFakeDriver;
+      beforeEach(() => {
+        [appium, mockFakeDriver] = getDriverAndFakeDriver();
+      });
+      afterEach(() => {
+        mockFakeDriver.restore();
+        appium.args.defaultCapabilities = {};
+      });
+      it('should remove the session if it is found', async () => {
+        let [sessionId] = await appium.createSession(BASE_CAPS);
+        let sessions = await appium.getSessions();
+        sessions.should.have.length(1);
+        await appium.deleteSession(sessionId);
+        sessions = await appium.getSessions();
+        sessions.should.have.length(0);
+      });
+      it('should call inner driver\'s deleteSession method', async () => {
+        let [sessionId] = await appium.createSession(BASE_CAPS);
+        mockFakeDriver.expects("deleteSession")
+          .once().withExactArgs()
+          .returns();
+        await appium.deleteSession(sessionId);
+        mockFakeDriver.verify();
+      });
+    });
+    describe('getSessions', () => {
+      let appium;
+      before(() => {
+        appium = new AppiumDriver({});
+      });
+      it('should return an empty array of sessions', async () => {
+        let sessions = await appium.getSessions();
+        sessions.should.be.an.array;
+        sessions.should.be.empty;
+      });
+      it('should return sessions created', async () => {
+        let session1 = await appium.createSession(_.extend(_.clone(BASE_CAPS), {cap: 'value'}));
+        let session2 = await appium.createSession(_.extend(_.clone(BASE_CAPS), {cap: 'other value'}));
+        let sessions = await appium.getSessions();
+        sessions.should.be.an.array;
+        sessions.should.have.length(2);
+        sessions[0].id.should.equal(session1[0]);
+        sessions[0].capabilities.should.eql(session1[1]);
+        sessions[1].id.should.equal(session2[0]);
+        sessions[1].capabilities.should.eql(session2[1]);
+      });
+    });
+    describe('sessionExists', () => {
+    });
+  });
+});

--- a/test/parser-specs.js
+++ b/test/parser-specs.js
@@ -1,32 +1,36 @@
 // transpile:mocha
 
-import _ from 'lodash';
 import getParser from '../lib/parser';
 import chai from 'chai';
 
 const should = chai.should();
-const oldArgv = _.clone(process.argv);
 
 describe('Parser', () => {
-  before(() => {
-    process.argv = [];
-  });
-  after(() => {
-    process.argv = oldArgv;
-  });
+  let p = getParser();
   it('should return an arg parser', () => {
-    let p = getParser();
     should.exist(p.parseArgs);
-    p.parseArgs().should.have.property('port');
+    p.parseArgs([]).should.have.property('port');
   });
   it('should keep the raw server flags array', () => {
-    let p = getParser();
     should.exist(p.rawArgs);
   });
   it('should have help for every arg', () => {
-    let p = getParser();
     for (let arg of p.rawArgs) {
       arg[1].should.have.property('help');
     }
+  });
+  it('should throw an error with unknown argument', () => {
+    (() => {p.parseArgs(['--apple']);}).should.throw;
+  });
+  it('should parse default capabilities correctly', () => {
+    let defaultCapabilities = {a: 'b'};
+    let args = p.parseArgs(['--default-capabilities',
+                            JSON.stringify(defaultCapabilities)]);
+    args.defaultCapabilities.should.eql(defaultCapabilities);
+  });
+  it('should parse args that are caps into default capabilities', () => {
+    let defaultCapabilities = {localizableStringsDir: '/my/dir'};
+    let args = p.parseArgs(['--localizable-strings-dir', '/my/dir']);
+    args.defaultCapabilities.should.eql(defaultCapabilities);
   });
 });


### PR DESCRIPTION
Appium has a number of server arguments that are also desired capabilities. They should be deprecated in favor of a `--default-capabilities` argument, which takes a JSON string of desired capabilities to be used as defaults for each new session.

Also, the deprecated server arguments are mapped to the desired capabilities, so that even if we pass in `--show-ios-log` we will get, internally, `defaultCapabilities = {showIOSLog: true}`.

Also, finally remove the deprecated `--show-sim-log` in favor of `--show-ios-log`.
