### PR TITLE
bring in new appium-chromedriver with chromedriver 2.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "adm-zip": "~0.4.7",
     "appium-adb": "=1.7.5",
     "appium-atoms": "=0.0.5",
-    "appium-chromedriver": "^2.0.0",
+    "appium-chromedriver": "^2.1.0",
     "appium-instruments": "^2.0.4",
     "appium-support": "=1.0.5",
     "appium-uiauto": "=1.10.8",


### PR DESCRIPTION
cc @bayandin. I tried to run chrome specs with this, but got some failures. I'm not sure if this chromedriver actually works very well. Have you used it much @bayandin?

I was testing against the Browser app in api 21
