### PR TITLE
add help information for command-timeout option

### DIFF
--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -531,7 +531,8 @@ var args = [
   , type: 'int'
   , required: false
   , help: 'The default command timeout for the server to use for all ' +
-          'sessions. Will still be overridden by newCommandTimeout cap'
+          'sessions (in seconds and should be less than 2147483). ' + 
+          'Will still be overridden by newCommandTimeout cap'
   }],
 
   [['--keep-keychains'], {


### PR DESCRIPTION
add help information for command-timeout option: 
- the option is in seconds 
- the value should be less than 2147483 since setTimeout using a 32 bit int to store the delay
