### PR TITLE
copyLocalZip doesn't check all possible errors

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -40,6 +40,7 @@ exports.copyLocalZip = function (localZipPath, cb) {
   fs.stat(localZipPath, function (err) {
     if (err) return cb(err);
     tempDir.open({prefix: 'appium-app', suffix: '.zip'}).nodeify(function (err, info) {
+      if (err) return cb(err);
       var infile = fs.createReadStream(localZipPath);
       var outfile = fs.createWriteStream(info.path);
       infile.pipe(outfile).on('close', function () {


### PR DESCRIPTION
One error wasn't reported, which made for a very confusing failure.  Adding this line helped us dig deeper into the actual issue we have.
