### PR TITLE
Fix simulator launch for Xcode 7

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -941,9 +941,10 @@ IOS.getDeviceStringFromOpts = function (opts) {
     deviceName: opts.deviceName,
     platformVersion: opts.platformVersion
   }));
+  var xcodeVersionMajor = parseInt(opts.xcodeVersion.substr(0, opts.xcodeVersion.indexOf('.')), 10);
   var isiPhone = opts.forceIphone || opts.forceIpad === null || (opts.forceIpad !== null && !opts.forceIpad);
   var isTall = isiPhone;
-  var isRetina = opts.xcodeVersion[0] !== '4';
+  var isRetina = xcodeVersionMajor != 4;
   var is64bit = false;
   var deviceName = opts.deviceName;
   var fixDevice = true;
@@ -966,13 +967,13 @@ IOS.getDeviceStringFromOpts = function (opts) {
   }
 
   var iosDeviceString = isiPhone ? "iPhone" : "iPad";
-  if (opts.xcodeVersion[0] === '4') {
+  if (xcodeVersionMajor == 4) {
     if (isiPhone && isRetina) {
       iosDeviceString += isTall ? " (Retina 4-inch)" : " (Retina 3.5-inch)";
     } else {
       iosDeviceString += isRetina ? " (Retina)" : "";
     }
-  } else if (opts.xcodeVersion[0] === '5') {
+  } else if (xcodeVersionMajor == 5) {
     iosDeviceString += isRetina ? " Retina" : "";
     if (isiPhone) {
       if (isRetina && isTall) {
@@ -983,7 +984,7 @@ IOS.getDeviceStringFromOpts = function (opts) {
     } else {
       iosDeviceString += is64bit ? " (64-bit)" : "";
     }
-  } else if (opts.xcodeVersion[0] === '6') {
+  } else if (xcodeVersionMajor >= 6) {
     iosDeviceString = opts.deviceName ||
       (isiPhone ? "iPhone Simulator" : "iPad Simulator");
   }


### PR DESCRIPTION
Fix error with Xcode 7 (beta 3).

I specified caps:

```
platformName = "iOS"
deviceName = "iPhone 5s"
```

But got error:

```
Could not find a device to launch. You requested 'iPhone (8.1 Simulator)', but the available devices were: [...]
```
