### PR TITLE
Fix appium-doctor for OS X 10.11

### DIFF
--- a/lib/doctor/ios.js
+++ b/lib/doctor/ios.js
@@ -3,6 +3,7 @@ var path = require('path')
   , fs = require('fs')
   , env = process.env
   , exec = require('child_process').exec
+  , _s = require('underscore.string')
   , async = require('async');
 
 require("./common.js");
@@ -27,15 +28,18 @@ IOSChecker.prototype.runAllChecks = function (cb) {
 IOSChecker.prototype.getMacOSXVersion = function (cb) {
   exec("sw_vers -productVersion", function (err, stdout) {
     if (err === null) {
-      if (stdout.match('10.8') !== null) {
+      if (_s.startsWith(stdout, '10.8')) {
         this.osVersion = '10.8';
         cb(null, "Mac OS X 10.8 is installed.");
-      } else if (stdout.match('10.9') !== null) {
+      } else if (_s.startsWith(stdout, '10.9')) {
         this.osVersion = '10.9';
         cb(null, "Mac OS X 10.9 is installed.");
-      } else if ((stdout.match('10.10') !== null) || (stdout.match('10.10.1') !== null)) {
+      } else if (_s.startsWith(stdout, '10.10')) {
         this.osVersion = '10.10';
         cb(null, "Mac OS X 10.10 is installed.");
+      } else if (_s.startsWith(stdout, '10.11')) {
+        this.osVersion = '10.11';
+        cb(null, "Mac OS X 10.11 is installed.");
       } else {
         this.log.fail("Could not detect Mac OS X Version", cb);
       }


### PR DESCRIPTION
```
$ bin/appium-doctor.js
Running iOS Checks
✖ Could not detect Mac OS X Version
Appium-Doctor detected problems. Please fix and rerun Appium-Doctor.
$
$ sw_vers -productVersion
10.11
```
