### PR TITLE
Make sure realdevice object is initialized

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -846,17 +846,19 @@ IOS.prototype.setBundleIdFromApp = function (cb) {
 };
 
 IOS.prototype.installToRealDevice = function (cb) {
+  // get a real device object to deal with incoming queries
+  try {
+    this.realDevice = this.getIDeviceObj();
+  } catch (e) {
+    return cb(e);
+  }
+
   // if user has passed in desiredCaps.autoLaunch = false
   // meaning they will manage app install / launching
   if (this.args.autoLaunch === false) {
     cb();
   } else {
     if (this.args.udid) {
-      try {
-        this.realDevice = this.getIDeviceObj();
-      } catch (e) {
-        return cb(e);
-      }
       this.isAppInstalled(this.args.bundleId, function (err, installed) {
         if (err || !installed) {
           logger.debug("App is not installed. Will try to install the app.");
@@ -914,7 +916,11 @@ IOS.prototype.getIDeviceObj = function () {
 IOS.prototype.installIpa = function (cb) {
   logger.debug("Installing ipa found at " + this.args.ipa);
   if (!this.realDevice) {
-    this.realDevice = this.getIDeviceObj();
+    try {
+      this.realDevice = this.getIDeviceObj();
+    } catch (e) {
+      return cb(e);
+    }
   }
   var d = this.realDevice;
   async.waterfall([
@@ -1484,6 +1490,13 @@ IOS.prototype.push = function (elem) {
 
 IOS.prototype.isAppInstalled = function (bundleId, cb) {
   if (this.args.udid) {
+    if (!this.realDevice) {
+      try {
+        this.realDevice = this.getIDeviceObj();
+      } catch (e) {
+        return cb(e);
+      }
+    }
     this.realDevice.isInstalled(bundleId, cb);
   } else {
     cb(new Error("You can not call isInstalled for the iOS simulator!"));
@@ -1492,6 +1505,13 @@ IOS.prototype.isAppInstalled = function (bundleId, cb) {
 
 IOS.prototype.removeApp = function (bundleId, cb) {
   if (this.args.udid) {
+    if (!this.realDevice) {
+      try {
+        this.realDevice = this.getIDeviceObj();
+      } catch (e) {
+        return cb(e);
+      }
+    }
     this.realDevice.remove(bundleId, cb);
   } else {
     this.sim.remove(bundleId, cb);
@@ -1500,6 +1520,13 @@ IOS.prototype.removeApp = function (bundleId, cb) {
 
 IOS.prototype.installApp = function (unzippedAppPath, cb) {
   if (this.args.udid) {
+    if (!this.realDevice) {
+      try {
+        this.realDevice = this.getIDeviceObj();
+      } catch (e) {
+        return cb(e);
+      }
+    }
     this.realDevice.install(unzippedAppPath, cb);
   } else {
     this.sim.install(unzippedAppPath, cb);


### PR DESCRIPTION
When Fruitstrap [was removed](https://github.com/appium/appium/commit/8b40589571cf2708ba6174eada555916a983395a) the `realDevice` property of the iOS object became the way to interact with real devices, and it is not always initialized. This is particularly the case when `autoLaunch` is `false`.

Resolves #5392
