### PR TITLE
Fix removeApp and installApp not providing deviceId to ADB.

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -779,23 +779,21 @@ androidController.isAppInstalled = function (appPackage, cb) {
 };
 
 androidController.removeApp = function (appPackage, cb) {
-  var removeCommand = null;
-  if (this.args.udid) {
-    removeCommand = 'adb -s ' + this.args.udid + ' uninstall ' + appPackage;
+  if (this.adb.curDeviceId) {
+    var removeCommand = 'adb -s ' + this.adb.curDeviceId + ' uninstall ' + appPackage;
+    deviceCommon.removeApp(removeCommand, this.adb.curDeviceId, appPackage, cb);
   } else {
-    removeCommand = 'adb uninstall ' + appPackage;
+    cb(new Error('Unable to un-install [' + appPackage + '] from undefined device id'));
   }
-  deviceCommon.removeApp(removeCommand, this.args.udid, appPackage, cb);
 };
 
 androidController.installApp = function (appPath, cb) {
-  var installationCommand = null;
-  if (this.args.udid) {
-    installationCommand = 'adb -s ' + this.args.udid + ' install ' + appPath;
+  if (this.adb.curDeviceId) {
+    var installationCommand = 'adb -s ' + this.adb.curDeviceId + ' install ' + appPath;
+    deviceCommon.installApp(installationCommand, this.adb.curDeviceId, appPath, cb);
   } else {
-    installationCommand = 'adb install ' + appPath;
+    cb(new Error('Unable to install [' + appPath + '] to undefined device id'));
   }
-  deviceCommon.installApp(installationCommand, this.args.udid, appPath, cb);
 };
 
 androidController.unpackApp = function (req, cb) {


### PR DESCRIPTION
When multiple devices are attached to ADB, `adb uninstall <package>` will hang waiting for only a single device to remain connected.  `adb install <apk>` will fail immediately.

Always provide the current device ID for ADB using the `-s <deviceId>` argument.

`this.args.udid` was always null, for any circumstance.
