### PR TITLE
Fix #5408: Prep device and set actual caps during Android noLaunchSetup.

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -319,6 +319,10 @@ androidCommon.toggleLocationServices = function (ocb) {
 };
 
 androidCommon.prepareDevice = function (onReady) {
+  if (this.adb.logcat !== null) {
+    logger.debug("Device already prepared for session");
+    return onReady();
+  }
   logger.debug("Using fast reset? " + this.args.fastReset);
   logger.debug("Preparing device for session");
   async.series([

--- a/lib/devices/android/android.js
+++ b/lib/devices/android/android.js
@@ -89,6 +89,8 @@ Android.prototype.noLaunchSetup = function (cb) {
   async.series([
     this.initJavaVersion.bind(this),
     this.initAdb.bind(this),
+    this.prepareDevice.bind(this),
+    this.setActualCapabilities.bind(this)
   ], function (err) { cb(err); });
 };
 


### PR DESCRIPTION
When setting the `autoLaunch` capability to false, the device was not prepared and actual capabilities was not set.  Therefore, the driver was not able to retrieve the device ID or install/remove apps prior to invoking launchApp.

Add `prepareDevice` and `setActualCapabilities` to `noLaunchSetup`.  Add check to prepareDevice for initialized ADB Logcat to prevent `start` (launchApp) from attempting to prepare the device a second time when using `autoLaunch=false`.
