### PR TITLE
Fix to redirect appium to call the selendroid 'actions'

### DIFF
--- a/lib/devices/android/selendroid.js
+++ b/lib/devices/android/selendroid.js
@@ -54,6 +54,7 @@ Selendroid.prototype.init = function () {
     , 'toggleWiFi'
     , 'toggleLocationServices'
     , 'getStrings'
+    , 'performMultiAction'
   ];
   this.proxyHost = this.selendroidHost;
   this.avoidProxy = [
@@ -71,6 +72,7 @@ Selendroid.prototype.init = function () {
     , ['POST', new RegExp('^/wd/hub/session/[^/]+/ime')]
     , ['GET', new RegExp('^/wd/hub/session/[^/]+/ime')]
     , ['POST', new RegExp('^/wd/hub/session/[^/]+/keys')]
+    , ['POST', new RegExp('^/wd/hub/session/[^/]+/touch/multi/perform')]
   ];
   this.curContext = this.defaultContext();
 };
@@ -577,6 +579,25 @@ Selendroid.prototype.keys = function (value, cb) {
 
 Selendroid.prototype.back = function (cb) {
   this.keyevent(4, null, cb);
+};
+
+Selendroid.prototype.performMultiAction = function (elementId, actions, cb) {
+  logger.debug("Sending multi touch action to Selendroid"+ actions);
+  var reqUrl = this.proxyHost + ':' + this.proxyPort +
+      '/wd/hub/session/' + this.proxySessionId +
+      '/actions';
+  //selendroid expects the actions to be in 'payload' object
+  var payload = {
+    "payload" : actions
+  };
+
+  doRequest(reqUrl, 'POST', payload, null, function (err) {
+    if (err) return cb(err);
+    cb(null, {
+      status: status.codes.Success.code,
+      value: ''
+    });
+  });
 };
 
 module.exports = Selendroid;


### PR DESCRIPTION
Fix to redirect appium to call the selendroid 'actions' instead of 'touch/multi/perform' which throws 404 undefined exception  Related to issue https://github.com/appium/appium/issues/4195
