### PR TITLE
Fix iOS device string for iOS 9 SDK

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -990,7 +990,9 @@ IOS.getDeviceStringFromOpts = function (opts) {
       (isiPhone ? "iPhone Simulator" : "iPad Simulator");
   }
   var reqVersion = opts.platformVersion || opts.iOSSDKVersion;
-  if (opts.iOSSDKVersion >= 8) {
+  if (opts.iOSSDKVersion >= 9) {
+    iosDeviceString += " (" + reqVersion + ")";
+  } else if (opts.iOSSDKVersion >= 8) {
     iosDeviceString += " (" + reqVersion + " Simulator)";
   } else if (opts.iOSSDKVersion >= 7.1) {
     iosDeviceString += " - Simulator - iOS " + reqVersion;


### PR DESCRIPTION
With Xcode 7 beta 5 the format of the device names understood by Instruments appears to have changed from `$DEVICE ($IOS_VERSION Simulator)` to simply `$DEVICE ($IOS_VERSION)`:

```
$ instruments -s devices
Known Devices:
Aaron’s MacBook Pro [UDID redacted]
iPad 2 (7.1) [UDID redacted]
iPad 2 (8.1) [UDID redacted]
iPad 2 (8.2) [UDID redacted]
iPad 2 (8.3) [UDID redacted]
iPad 2 (8.4) [UDID redacted]
iPad 2 (9.0) [UDID redacted]
iPad Air (7.1) [UDID redacted]
...
```

I have not investigated what exactly happens to device names when upgrading from older Xcode, etc., so if my changes are not robust enough then please simply treat this as an issue ticket and ignore my code.
