### PR TITLE
Add ability to tweak remote debugger retries

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -86,3 +86,4 @@
 |`sendKeyStrategy`| strategy to use to type test into a test field. Simulator default: `oneByOne`. Real device default: `grouped` |`oneByOne`, `grouped` or `setValue`|
 |`screenshotWaitTimeout`| Max timeout in sec to wait for a screenshot to be generated. default: 10 |e.g., `5`|
 |`waitForAppScript`| The ios automation script used to determined if the app has been launched, by default the system wait for the page source not to be empty. The result must be a boolean |e.g. `true;`, `target.elements().length > 0;`, `$.delay(5000); true;` |
+|`webviewConnectRetries`| Number of times to send connection message to remote debugger, to get webview. Default: `8` |e.g., `12`|

--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -81,7 +81,7 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
         if (err) return onDone(err);
         this.remoteAppKey = perhapsModifiedAppKey;
         onDone(null, res);
-      }.bind(this));
+      }.bind(this), this.args.webviewConnectRetries);
     }
   } else {
     if (this.args.udid !== null) {
@@ -113,7 +113,7 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
           if (err) return onDone(err);
           this.remoteAppKey = perhapsModifiedAppKey;
           onDone(null, res);
-        }.bind(this));
+        }.bind(this), this.args.webviewConnectRetries);
       }.bind(this), this.onPageChange.bind(this));
       var loopCloseRuns = 0;
       var loopClose = function () {

--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -18,6 +18,7 @@ var net = require('net')
 // CONFIG
 // ====================================
 
+var CONNECTION_RETRIES = 8;
 
 var RemoteDebugger = function (onDisconnect) {
   this.init(2, onDisconnect);
@@ -131,12 +132,13 @@ RemoteDebugger.prototype.setConnectionKey = function (cb) {
   });
 };
 
-RemoteDebugger.prototype.selectApp = function (appIdKey, cb, tries) {
+RemoteDebugger.prototype.selectApp = function (appIdKey, cb, maxTries, tries) {
+  if (_.isUndefined(maxTries)) maxTries = CONNECTION_RETRIES;
   if (_.isUndefined(tries)) tries = 1;
   try { assert.ok(this.connId); } catch (err) { return cb(err); }
   this.appIdKey = appIdKey;
   var connectToApp = messages.connectToApp(this.connId, this.appIdKey);
-  this.logger.debug("Selecting app " + this.appIdKey + " (try #" + tries + ")");
+  this.logger.debug("Selecting app " + this.appIdKey + " (try #" + tries + " of " + maxTries + ")");
   var responded = false;
 
   var onConnect = function (appIdKey, pageDict) {
@@ -150,6 +152,7 @@ RemoteDebugger.prototype.selectApp = function (appIdKey, cb, tries) {
       return onRequiresRetry(this.appIdKey, msg);
     }
     if (responded) return;
+    this.logger.debug('Connected to app ' + appIdKey + ' [' + JSON.stringify(this.pageArrayFromDict(pageDict)) + ']');
     responded = true;
     cb(null, appIdKey, this.pageArrayFromDict(pageDict));
     this.specialCbs['_rpc_forwardGetListing:'] = this.onPageChange.bind(this);
@@ -158,17 +161,17 @@ RemoteDebugger.prototype.selectApp = function (appIdKey, cb, tries) {
   var onRequiresRetry = function (correctAppIdKey, msg) {
     if (responded) return;
     responded = true;
-    if (tries < 4) {
+    if (tries < maxTries) {
       if (!msg) {
         msg = "We were notified we connected to possibly the wrong " +
               "app. Using the id key suggested and trying again";
       }
       this.logger.info(msg);
-      this.selectApp(correctAppIdKey, cb, tries + 1);
+      this.selectApp(correctAppIdKey, cb, maxTries, tries + 1);
     } else {
-      msg = "Could not connect to a valid app after " + tries + " tries.";
-      this.logger.error(msg);
-      cb(new Error(msg));
+      this.logger.debug(msg);
+      this.logger.debug("Could not connect to a valid app after " + tries + " tries.");
+      cb();
     }
   }.bind(this);
 
@@ -592,7 +595,6 @@ RemoteDebugger.prototype.send = function (data, cb, cb2) {
     if (data.__selector === '_rpc_reportIdentifier:') {
       this.specialCbs.connect = cb2;
     } else if (data.__selector === '_rpc_forwardGetListing:') {
-      this.logger.debug(cb2);
       this.specialCbs.connectedToBadApp = cb2;
     }
   } else if (data.__argument && data.__argument.WIRSocketDataKey) {

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -92,6 +92,7 @@ var iosCaps = [
 , 'loggingPrefs'
 , 'sendKeyStrategy'
 , 'waitForAppScript'
+, 'webviewConnectRetries'
 ];
 
 var Capabilities = function (capabilities) {


### PR DESCRIPTION
Cherry pick addition of `webviewConnectRetries` into `1.4` branch. This will hopefully allow iOS webview startup to be less flakey.
