### PR TITLE
Allow Java version parsing to match OpenJDK

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -1048,7 +1048,7 @@ androidCommon.parseJavaVersion = function (stderr) {
   var lines = stderr.split("\n");
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i];
-    if (new RegExp("java version").test(line)) {
+    if (new RegExp("java|openjdk version").test(line)) {
       return line.split(" ")[2].replace(/"/g, '');
     }
   }

--- a/test/unit/android-common-specs.js
+++ b/test/unit/android-common-specs.js
@@ -43,5 +43,9 @@ describe('devices/android/android-common.js', function () {
       testDouble.value().should.be.equal('1.8.0_22');
     });
 
+    it('parses OpenJDK versioning', function () {
+      androidCommon.parseJavaVersion('openjdk version 1.8').should.be.equal('1.8');
+    });
+
   });
 });


### PR DESCRIPTION
When an Android device is connected to Appium, the `android-common` class attempts to get the version of Java installed on the system by calling `java -version`. If a user has an alternative version of the JDK installed on their machine (e.g. OpenJDK), the Java version parsing in android-common will fail due to the RegExp expecting 'java version' as opposed to what will be output ('openjdk version').

This pull request solves the issue by matching on java and openjdk in the RegExp matcher inside `androidCommon.parseJavaVersion`.
