### PR TITLE
Fixes sessionExists and command timeout issues.

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -6,6 +6,7 @@ import { AndroidDriver } from 'appium-android-driver';
 import { IosDriver } from 'appium-ios-driver';
 import { routeConfiguringFunction, errors,
          isSessionCommand } from 'mobile-json-wire-protocol';
+import B from 'bluebird';
 
 class AppiumDriver extends BaseDriver {
 
@@ -61,6 +62,18 @@ class AppiumDriver extends BaseDriver {
     let d = new InnerDriver(this.args);
     let [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, curSessions);
     this.sessions[innerSessionId] = d;
+
+    // Remove the session on unexpected shutdown, so that we are in a position
+    // to open another session later on.
+    // TODO: this should be removed and replaced by a onShutdown callback.
+    d.onUnexpectedShutdown
+      .then(() => { throw new Error('Unexpected shutdown'); })
+      .catch(B.CancellationError, () => {})
+      .catch((err) => {
+        log.warn('Closing session, cause was', err.message);
+        delete this.sessions[innerSessionId];
+      }).done();
+
     log.info(`New ${InnerDriver.name} session created successfully, session ` +
              `${innerSessionId} added to master session list`);
     return [innerSessionId, dCaps];

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -16,7 +16,8 @@ class AppiumDriver extends BaseDriver {
   }
 
   sessionExists (sessionId) {
-    return _.contains(_.keys(this.sessions), sessionId);
+    return _.contains(_.keys(this.sessions), sessionId) &&
+           this.sessions[sessionId].sessionId !== null;
   }
 
   getDriverForCaps (caps) {

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -98,6 +98,11 @@ class AppiumDriver extends BaseDriver {
     if (isAppiumDriverCommand(cmd)) {
       return super.executeCommand(cmd, ...args);
     }
+
+    // since we don't call super.executeCommand, we need
+    // to clear the appium driver timeout manually
+    this.clearNewCommandTimeout();
+
     let sessionId = args[args.length - 1];
     return this.sessions[sessionId].executeCommand(cmd, ...args);
   }


### PR DESCRIPTION
Handles the following cases:
- When we reset sessionId is null in the session object, but not in the sessionCache.
- There is a command timeout running after the session starts, which is not cleared by the internal drivers. 

ping @jlipps.
