### PR TITLE
Wrap java versions in brackets for Regex matching

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -1048,7 +1048,7 @@ androidCommon.parseJavaVersion = function (stderr) {
   var lines = stderr.split("\n");
   for (var i = 0; i < lines.length; i++) {
     var line = lines[i];
-    if (new RegExp("java|openjdk version").test(line)) {
+    if (new RegExp("(java|openjdk) version").test(line)) {
       return line.split(" ")[2].replace(/"/g, '');
     }
   }


### PR DESCRIPTION
Previously, we were matching the java/openjdk version without wrapping
the words in brackets, meaning it would only match 'java' and not 'java
version'.

This commit addresses the issue.
