### PR TITLE
Fixing ambiguous device issue for iPhone 6 (9.0) #5619

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1039,7 +1039,9 @@ IOS.getDeviceStringFromOpts = function (opts) {
       // correctly starts iPhone 6 [udid] and not the iPhone 6 (9.0) + Apple Watch
       // for ios9.0 and above; see #5619
       'iPhone Simulator (9.0)': 'iPhone 6 (9.0) [',
-      'iPhone Simulator (9.1)': 'iPhone 6 (9.1) ['
+      'iPhone Simulator (9.1)': 'iPhone 6 (9.1) [',
+      'iPhone 6 (9.0)': 'iPhone 6 (9.0) [',
+      'iPhone 6 (9.1)': 'iPhone 6 (9.1) ['
     };
     var configFix = xcodeMajorVer === 7 ? CONFIG_FIX__XCODE_7 : CONFIG_FIX;
     if (configFix[iosDeviceString]) {


### PR DESCRIPTION
- @imurchie I realize that my earlier fix only fixes issue when caps have simulator in them, now this fix code change will also fix for iPhone 6 cap
