### PR TITLE
Added option to specify webkit debug proxy port

### DIFF
--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -86,3 +86,4 @@ All flags are optional, but some are required in conjunction with certain others
 |`--dont-stop-app-on-reset`|false|(Android-only) When included, refrains from stopping the app before restart||
 |`--debug-log-spacing`|false|Add exaggerated spacing in logs to help with visual inspection||
 |`--suppress-adb-kill-server`|false|(Android-only) If set, prevents Appium from killing the adb server instance||
+|`--webkit-debug-proxy-port`|false|((IOS-only) Local port used for communication with ios-webkit-debug-proxy|`--webkit-debug-proxy-port 27753`|

--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -85,7 +85,7 @@ iOSHybrid.listWebFrames = function (cb, exitCb) {
     }
   } else {
     if (this.args.udid !== null) {
-      this.remote = wkrd.init(exitCb);
+      this.remote = wkrd.init(exitCb, this.args.webkitDebugProxyPort);
       this.remote.pageArrayFromJson(onDone);
     } else {
       this.remote = rd.init(exitCb);

--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -10,10 +10,11 @@ var _ = require('underscore')
 // CONFIG
 // ====================================
 
-var WebKitRemoteDebugger = function (onDisconnect) {
+var WebKitRemoteDebugger = function (onDisconnect, webkitDebugProxyPort) {
   this.dataMethods = {};
   this.host = 'localhost';
-  this.port = process.env.REMOTE_DEBUGGER_PORT || 27753;
+  //this.port = process.env.REMOTE_DEBUGGER_PORT || 27753;
+  this.port = webkitDebugProxyPort || 27753;
   this.socketDisconnectCb = null;
   this.init(1, onDisconnect);
 };
@@ -182,6 +183,6 @@ WebKitRemoteDebugger.prototype.receive = function (data) {
   this.handleMessage(data, method);
 };
 
-exports.init = function (onDisconnect) {
-  return new WebKitRemoteDebugger(onDisconnect);
+exports.init = function (onDisconnect, webkitDebugProxyPort) {
+  return new WebKitRemoteDebugger(onDisconnect, webkitDebugProxyPort);
 };

--- a/lib/devices/ios/webkit-remote-debugger.js
+++ b/lib/devices/ios/webkit-remote-debugger.js
@@ -13,7 +13,10 @@ var _ = require('underscore')
 var WebKitRemoteDebugger = function (onDisconnect, webkitDebugProxyPort) {
   this.dataMethods = {};
   this.host = 'localhost';
-  //this.port = process.env.REMOTE_DEBUGGER_PORT || 27753;
+  if (process.env.REMOTE_DEBUGGER_PORT) {
+    this.logger.debug('Found remote debugger port through REMOTE_DEBUGGER_PORT environment variable. This is deprecated, use `--webkit-debug-proxy-port` server argument');
+    webkitDebugProxyPort = webkitDebugProxyPort || process.env.REMOTE_DEBUGGER_PORT;
+  }
   this.port = webkitDebugProxyPort || 27753;
   this.socketDisconnectCb = null;
   this.init(1, onDisconnect);

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -93,6 +93,7 @@ var iosCaps = [
 , 'sendKeyStrategy'
 , 'waitForAppScript'
 , 'webviewConnectRetries'
+, 'webkitDebugProxyPort'
 ];
 
 var Capabilities = function (capabilities) {

--- a/lib/server/parser.js
+++ b/lib/server/parser.js
@@ -649,7 +649,17 @@ var args = [
   , required: false
   , action: 'storeTrue'
   , help: 'Add long stack traces to log entries. Recommended for debugging only.'
+  }],
+
+  [['--webkit-debug-proxy-port'], {
+    defaultValue: 27753
+  , dest: 'webkitDebugProxyPort'
+  , required: false
+  , type: 'int'
+  , example: "27753"
+  , help: '(IOS-only) Local port used for communication with ios-webkit-debug-proxy'
   }]
+
 ];
 
 // Setup all the command line argument parsing


### PR DESCRIPTION
Additional option to run appium with specified webkit debug proxy port. Removed use of system env REMOTE_DEBUGGER_PORT for hybrid iOS apps in webkit-remote-debugger.js.
