### PR TITLE
Update appium-bindings.md

### DIFF
--- a/docs/en/writing-running-appium/appium-bindings.md
+++ b/docs/en/writing-running-appium/appium-bindings.md
@@ -1052,7 +1052,7 @@ driver.PullFile("Library/AddressBook/AddressBook.sqlitedb");
 
 ### Push File
 
-Pushes a file to the device.
+Pushes a file to the device. *Android only*
 
 ```ruby
 # ruby


### PR DESCRIPTION
Saw in the javadoc that PushesFiles is only implemented by AndroidDriver currently. Should update this doc to reflect.
