### PR TITLE
Fix to use udid option with idevicesyslog

### DIFF
--- a/lib/devices/ios/ios-log.js
+++ b/lib/devices/ios/ios-log.js
@@ -47,7 +47,7 @@ IosLog.prototype.startCapture = function (cb) {
     which("idevicesyslog", function (err) {
       if (!err) {
         try {
-          this.proc = spawn("idevicesyslog", {env: spawnEnv});
+          this.proc = spawn("idevicesyslog", ["-u", this.udid], {env: spawnEnv});
         } catch (e) {
           cb(e);
         }


### PR DESCRIPTION
Without -u option idevicesyslog shows logs from any connected iOS device.
