### PR TITLE
iOS9+ about:blank fix

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1619,10 +1619,10 @@ IOS.prototype.getLatestWebviewContextForTitle = function (titleRegex, cb) {
     _(contexts).each(function (ctx) {
       if (ctx.view && (ctx.view.title || "").match(titleRegex)) {
         if (ctx.view.url === "about:blank") {
-          // in the case of Xcode  < 5 (i.e., iOS SDK Version less than 7)
-          // and in the case of iOS 7.1 in a webview (not in Safari)
+          // in the cases of Xcode < 5 (i.e., iOS SDK Version less than 7)
+          // iOS 7.1, iOS 9.0 & iOS 9.1 in a webview (not in Safari)
           // we can have the url be `about:blank`
-          if (parseFloat(this.iOSSDKVersion) < 7 ||
+          if (parseFloat(this.iOSSDKVersion) < 7 || parseFloat(this.iOSSDKVersion) >= 9 ||
               (this.args.platformVersion === '7.1' && this.args.app && this.args.app.toLowerCase() !== 'safari')) {
             matchingCtx = ctx;
           }


### PR DESCRIPTION
When a page can't load, `getContextsAndViews` returns different information depending on SDK version.

8.4 returns:

```
{ id: 'WEBVIEW_1',
  view:
   { id: 1,
     title: 'Cannot Open Page',
     url: 'x-appbundle:///StandardError.html',
     isKey: false } }`
```

Where as 9.0 & 9.1 return:

```
{ id: 'WEBVIEW_1',
  view:
   { id: 1,
     title: 'Cannot Open Page',
     url: 'about:blank',
     isKey: false } }
```

In 9.0 & 9.1 this results in the refresh button being repeatedly tapped. The bug can be reproduced by running prelaunch specs on iOS9.0 or iOS9.1.

The same fix was used for iOS7.1 (I think @sebv created the original fix)

@moizjv @imurchie
