### PR TITLE
Add method to get a driver for a particular session

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -21,6 +21,10 @@ class AppiumDriver extends BaseDriver {
            this.sessions[sessionId].sessionId !== null;
   }
 
+  driverForSession (sessionId) {
+    return this.sessions[sessionId];
+  }
+
   getDriverForCaps (caps) {
     // TODO if this logic ever becomes complex, should probably factor out
     // into its own file


### PR DESCRIPTION
We need to sometimes get access to the internal driver (for instance, when proxying commands to the driver from the protocol layer).
