### PR TITLE
Using appium-adb for installApp and removeApp

### DIFF
--- a/lib/devices/android/android-controller.js
+++ b/lib/devices/android/android-controller.js
@@ -779,21 +779,25 @@ androidController.isAppInstalled = function (appPackage, cb) {
 };
 
 androidController.removeApp = function (appPackage, cb) {
-  if (this.adb.curDeviceId) {
-    var removeCommand = 'adb -s ' + this.adb.curDeviceId + ' uninstall ' + appPackage;
-    deviceCommon.removeApp(removeCommand, this.adb.curDeviceId, appPackage, cb);
-  } else {
-    cb(new Error('Unable to un-install [' + appPackage + '] from undefined device id'));
-  }
+  var deviceId = this.adb.curDeviceId;
+  this.adb.uninstallApk(appPackage, function (err) {
+    if (err) {
+      cb(err, 'Unable to un-install [' + appPackage + '] from device with id [' + deviceId + ']. Error [' + err + ']');
+    } else {
+      cb(null, 'Successfully un-installed [' + appPackage + '] from device with id [' + deviceId + ']');
+    }
+  });
 };
 
 androidController.installApp = function (appPath, cb) {
-  if (this.adb.curDeviceId) {
-    var installationCommand = 'adb -s ' + this.adb.curDeviceId + ' install ' + appPath;
-    deviceCommon.installApp(installationCommand, this.adb.curDeviceId, appPath, cb);
-  } else {
-    cb(new Error('Unable to install [' + appPath + '] to undefined device id'));
-  }
+  var deviceId = this.adb.curDeviceId;
+  this.adb.install(appPath, false, function (err) {
+    if (err) {
+      cb(err, 'Unable to install [' + appPath + '] to device with id [' + deviceId + ']. Error [' + err + ']');
+    } else {
+      cb(null, 'Successfully unzipped and installed [' + appPath + '] to device with id [' + deviceId + ']');
+    }
+  });
 };
 
 androidController.unpackApp = function (req, cb) {

--- a/lib/devices/common.js
+++ b/lib/devices/common.js
@@ -129,28 +129,6 @@ exports.isAppInstalled = function (isInstalledCommand, cb) {
   });
 };
 
-exports.removeApp = function (removeCommand, udid, bundleId, cb) {
-  logger.debug("Removing app using cmd: " + removeCommand);
-  exec(removeCommand, function (error) {
-    if (error !== null) {
-      cb(new Error('Unable to un-install [' + bundleId + '] from device with id [' + udid + ']. Error [' + error + ']'));
-    } else {
-      cb(error, 'Successfully un-installed [' + bundleId + '] from device with id [' + udid + ']');
-    }
-  });
-};
-
-exports.installApp = function (installationCommand, udid, unzippedAppPath, cb) {
-  logger.debug("Installing app using cmd: " + installationCommand);
-  exec(installationCommand, { maxBuffer: 524288 }, function (error) {
-    if (error !== null) {
-      cb(new Error('Unable to install [' + unzippedAppPath + '] to device with id [' + udid + ']. Error [' + error + ']'));
-    } else {
-      cb(error, 'Successfully unzipped and installed [' + unzippedAppPath + '] to device with id [' + udid + ']');
-    }
-  });
-};
-
 exports.unpackApp = function (req, packageExtension, cb) {
   var reqAppPath = req.body.appPath;
   if (reqAppPath.toLowerCase().substring(0, 4) === "http") {


### PR DESCRIPTION
When trying to use install_app or remove_app, Appium fails to execute the adb commands on OS X:

```
info: --> POST /wd/hub/session/04ba7d06-65c1-4167-8ecf-ecf3adfb8012/appium/device/install_app {"appPath":"/var/folders/8n/wksz2lp943q043yf9nxr2y9x2qkb7w/T/AndroidChromeAppFetcher2354111942119848933.apk"}

info: [debug] Installing app using cmd: adb install /var/folders/8n/wksz2lp943q043yf9nxr2y9x2qkb7w/T/AndroidChromeAppFetcher2354111942119848933.apk

info: [debug] Responding to client with error: {"status":1,"value":{"message":"Unable to install [/var/folders/8n/wksz2lp943q043yf9nxr2y9x2qkb7w/T/AndroidChromeAppFetcher2354111942119848933.apk] to device with id [null]. Error [Error: Command failed: /bin/sh -c adb install /var/folders/8n/wksz2lp943q043yf9nxr2y9x2qkb7w/T/AndroidChromeAppFetcher2354111942119848933.apk\n/bin/sh: adb: command not found\n]"},"sessionId":"04ba7d06-65c1-4167-8ecf-ecf3adfb8012"}
info: <-- POST /wd/hub/session/04ba7d06-65c1-4167-8ecf-ecf3adfb8012/appium/device/install_app 500 13.649 ms - 412 
```

Appium appears to be assuming that adb is present in the PATH on OS X, however this will not work (it is supposed to find it from $ANDROID_HOME). This change is analogous to [this one](https://github.com/appium/appium/commit/f14c5c9108d5c600d373d37388c3984d2531950e) previously made.

I noticed [this commit](https://github.com/appium/appium/commit/5e5f5ded366c5e8f69d5896abb74e88c9d13e6bb) recently alleged that these methods did work correctly, however that may have been on a non-POSIX platform and appium-adb appears to support using adb on all platforms. Note that this PR preserves the device ID behavior of the aforementioned change since appium-adb takes care of that in a more sophisticated fashion.

I also removed the now-uncalled methods from `lib/device/common.js` since they didn't work for me and couldn't find any other references to those methods.
