### PR TITLE
Add helpers for checking proxy status

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -127,9 +127,34 @@ class AppiumDriver extends BaseDriver {
     // since we don't call super.executeCommand, we need
     // to clear the appium driver timeout manually
     this.clearNewCommandTimeout();
-
     let sessionId = args[args.length - 1];
     return this.sessions[sessionId].executeCommand(cmd, ...args);
+  }
+
+  proxyActive (sessionId) {
+    let driver = this.sessions[sessionId];
+
+    // drivers need to explicitly say when the proxy is active
+    if (!driver || !driver.jwpProxyActive) {
+      return false;
+    }
+
+    return true;
+  }
+
+  getProxyAvoidList (sessionId) {
+    let driver = this.sessions[sessionId];
+    let proxyAvoid = driver.jwpProxyAvoid || [];
+    if (!_.isArray(proxyAvoid)) {
+      throw new Error('Proxy avoidance must be a list of pairs');
+    }
+
+    return proxyAvoid;
+  }
+
+  canProxy (sessionId) {
+    let driver = this.sessions[sessionId];
+    return _.isFunction(driver.proxyReqRes);
   }
 }
 


### PR DESCRIPTION
Proxying currently requires much too much knowledge of the internals of our drivers. This PR adds some helpers so that the dependency can be reduced.
