### PR TITLE
Keep track of updated remote debugger app

### DIFF
--- a/lib/devices/ios/remote-debugger.js
+++ b/lib/devices/ios/remote-debugger.js
@@ -152,6 +152,11 @@ RemoteDebugger.prototype.selectApp = function (appIdKey, cb, maxTries, tries) {
       return onRequiresRetry(this.appIdKey, msg);
     }
     if (responded) return;
+
+    if (this.appIdKey !== appIdKey) {
+      this.logger.debug('Received altered app id, updating from \'' + this.appIdKey + '\' to \'' + appIdKey + '\'');
+      this.appIdKey = appIdKey;
+    }
     this.logger.debug('Connected to app ' + appIdKey + ' [' + JSON.stringify(this.pageArrayFromDict(pageDict)) + ']');
     responded = true;
     cb(null, appIdKey, this.pageArrayFromDict(pageDict));


### PR DESCRIPTION
We have had some issues with iOS 9+ and webviews connecting then hanging. Fix this by remembering the actually connected app.
