### PR TITLE
Add 'org.chromium.chrome' as a browser target

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -198,7 +198,7 @@ Appium.prototype.isSelendroidAutomation = function (automation) {
 };
 
 Appium.prototype.isChromeBrowser = function (browser) {
-  return _.contains(["chrome", "chromium", "chromebeta", "browser"], browser);
+  return _.contains(["chrome", "chromium", "chromebeta", "chromium-browser", "browser"], browser);
 };
 
 Appium.prototype.isChromePackage = function (pkg) {
@@ -206,6 +206,7 @@ Appium.prototype.isChromePackage = function (pkg) {
     "com.android.chrome"
   , "com.chrome.beta"
   , "org.chromium.chrome.shell"
+  , "org.chromium.chrome"
   , "com.android.browser"
   ];
   return _.contains(chromePkgs, pkg);

--- a/lib/devices/android/chrome.js
+++ b/lib/devices/android/chrome.js
@@ -60,6 +60,9 @@ ChromeAndroid.prototype.configure = function (args, caps, cb) {
   if (app === "chromium") {
     this.args.androidPackage = "org.chromium.chrome.shell";
     this.args.androidActivity = ".ChromeShellActivity";
+  } else if (app === "chromium-browser") {
+    this.args.androidPackage = "org.chromium.chrome";
+    this.args.androidActivity = "com.google.android.apps.chrome.Main";
   } else if (app === "chromebeta") {
     this.args.androidPackage = "com.chrome.beta";
     this.args.androidActivity = "com.google.android.apps.chrome.Main";
@@ -142,6 +145,7 @@ ChromeAndroid.prototype.createSession = function (cb) {
   }
 
   var knownPackages = ["org.chromium.chrome.shell",
+                       "org.chromium.chrome",
                        "com.android.chrome",
                        "com.chrome.beta"];
 


### PR DESCRIPTION
Allow the developer to specify 'chromium-browser' for the 'browserName'
capability. This will launch the 'org.chromium.chrome' app as a Chrome
browser.
