### PR TITLE
issue/kill spawn process ios_webkit_debug_proxy

### DIFF
--- a/bin/ios-webkit-debug-proxy-launcher.js
+++ b/bin/ios-webkit-debug-proxy-launcher.js
@@ -28,11 +28,18 @@ var RESTART_ON_MESSAGES = [
   'Invalid message _rpc_applicationSentListing'];
 
 var PROXY_CMD = 'ios_webkit_debug_proxy';
+var proxy;
 
-function startProxy() {
+var handleKillProcess = function (exitCode) {
+  console.log('\nKilling proxy process!');
+  proxy.kill('SIGTERM');
+  process.exit((exitCode || 0));
+};
+
+var startProxy = function () {
   console.log('RUNNING:', PROXY_CMD, args.join(' '));
 
-  var proxy = spawn(PROXY_CMD, args);
+  proxy = spawn(PROXY_CMD, args);
 
   proxy.stdout.on('data', function (data) {
     console.log('stdout: ' + data);
@@ -54,7 +61,10 @@ function startProxy() {
   proxy.on('close', function (code) {
     console.log('child process exited with code ' + code);
   });
-}
+};
+
+process.on('SIGINT', handleKillProcess);
+process.on('SIGTERM', handleKillProcess);
 
 startProxy();
 


### PR DESCRIPTION
fix for fork process ios-webkit-debug-proxy-lauchner.js, when kill process with not kill child process ios_webkit_debug_proxy

example code fork_process.js

``` javascript
let childProcess = child.fork(process.env.APPIUM_HOME + '/bin/ios-webkit-debug-proxy-launcher.js', [
   '-c',
   idDevice + ':' + port,
   '-d'
], {
   cwd: process.cwd(),
   execArgv: ['--harmony'],
   silent: true
});

[...]

setTimeout(() => {
 childProcess.kill('SIGTERM');
}, 10000);
```
