### PR TITLE
Accept SSL certs

### DIFF
--- a/lib/devices/android/bootstrap/src/com/android/uiautomator/common/UiWatchers.java
+++ b/lib/devices/android/bootstrap/src/com/android/uiautomator/common/UiWatchers.java
@@ -122,6 +122,27 @@ public class UiWatchers {
     Log.i(LOG_TAG, "Registed GUI Exception watchers");
   }
 
+  public void registerAcceptSSLCertWatcher() {
+    UiDevice.getInstance().registerWatcher("SSLCERTERROR", new UiWatcher() {
+      @Override
+      public boolean checkForCondition() {
+        UiObject continueButton = new UiObject(new UiSelector()
+          .className("android.widget.Button").packageName("com.android.browser").text("Continue"));
+        if (continueButton.exists()) {
+          try {
+            continueButton.click();
+            return true; // triggered
+          } catch (UiObjectNotFoundException e) {
+            Log.e(LOG_TAG, "Exception", e);
+          }
+        }
+        return false; // no trigger
+      }
+    });
+
+    Log.i(LOG_TAG, "Registered SSL Certificate Error Watchers");
+  }
+
   public void onAnrDetected(String errorText) {
     mErrors.add(errorText);
   }

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/Bootstrap.java
@@ -13,11 +13,12 @@ public class Bootstrap extends UiAutomatorTestCase {
   public void testRunServer() {
     Find.params = getParams();
     boolean disableAndroidWatchers = Boolean.parseBoolean(getParams().getString("disableAndroidWatchers"));
+    boolean acceptSSLCerts = Boolean.parseBoolean(getParams().getString("acceptSslCerts"));
 
     SocketServer server;
     try {
       server = new SocketServer(4724);
-      server.listenForever(disableAndroidWatchers);
+      server.listenForever(disableAndroidWatchers, acceptSSLCerts);
     } catch (final SocketServerException e) {
       Logger.error(e.getError());
       System.exit(1);

--- a/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
+++ b/lib/devices/android/bootstrap/src/io/appium/android/bootstrap/SocketServer.java
@@ -109,7 +109,7 @@ class SocketServer {
    *
    * @throws SocketServerException
    */
-  public void listenForever(boolean disableAndroidWatchers) throws SocketServerException {
+  public void listenForever(boolean disableAndroidWatchers, boolean acceptSSLCerts) throws SocketServerException {
     Logger.debug("Appium Socket Server Ready");
     UpdateStrings.loadStringsJson();
     if (disableAndroidWatchers) {
@@ -117,6 +117,12 @@ class SocketServer {
     } else {
       dismissCrashAlerts();
     }
+
+    if (acceptSSLCerts) {
+      Logger.debug("Accepting SSL certificate errors.");
+      acceptSSLCertificates();
+    }
+
     final TimerTask updateWatchers = new TimerTask() {
       @Override
       public void run() {
@@ -151,6 +157,15 @@ class SocketServer {
       Logger.debug("Registered crash watchers.");
     } catch (Exception e) {
       Logger.debug("Unable to register crash watchers.");
+    }
+  }
+
+  public void acceptSSLCertificates() {
+    try {
+      new UiWatchers().registerAcceptSSLCertWatcher();
+      Logger.debug("Registered SSL certificate error watcher.");
+    } catch (Exception e) {
+      Logger.debug("Unable to register SSL certificate error watcher.");
     }
   }
 

--- a/lib/devices/android/uiautomator.js
+++ b/lib/devices/android/uiautomator.js
@@ -22,6 +22,7 @@ var UiAutomator = function (adb, opts) {
   this.resendLastCommand = function () {};
   this.appPackage = opts.appPackage;
   this.disableAndroidWatchers = !!opts.disableAndroidWatchers;
+  this.acceptSslCerts = !!opts.acceptSslCerts;
 };
 
 UiAutomator.prototype.start = function (readyCb) {
@@ -30,7 +31,9 @@ UiAutomator.prototype.start = function (readyCb) {
     if (err) return readyCb(err);
     logger.debug("Running bootstrap");
     var args = ["shell", "uiautomator", "runtest", "AppiumBootstrap.jar", "-c",
-        "io.appium.android.bootstrap.Bootstrap", "-e", "pkg", this.appPackage, "-e", "disableAndroidWatchers", this.disableAndroidWatchers];
+        "io.appium.android.bootstrap.Bootstrap", "-e", "pkg", this.appPackage,
+        "-e", "disableAndroidWatchers", this.disableAndroidWatchers,
+        "-e", "acceptSslCerts", this.acceptSslCerts];
 
     this.alreadyExited = false;
     this.onSocketReady = readyCb;

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -69,6 +69,7 @@ var androidCaps = [
 , 'ignoreUnimportantViews'
 , 'dontStopAppOnReset'
 , 'disableAndroidWatchers'
+, 'acceptSslCerts'
 ];
 
 var iosCaps = [


### PR DESCRIPTION
This enables the `acceptSslCerts` capability as found in the desktop browsers for Selenium in Android. I have also submitted https://github.com/appium/appium-android-bootstrap/pull/10 which is a part of this change.
