### PR TITLE
added link to roadmap in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Gecko-based platforms.
 Please take a look at our [contribution documentation](CONTRIBUTING.md)
 for instructions on how to build, test and run Appium from source.
 
+### Roadmap
+
+Interested in where Appium is heading in the future? Check out the [Roadmap](ROADMAP.md)
+
 ### Project Credits & Inspiration
 
 [Credits](/docs/en/contributing-to-appium/credits.md)


### PR DESCRIPTION
From commit https://github.com/appium/appium/commit/4057a81731ab34375ae134261538f108af5fb9c8
Actual Roadmap.md is already ported.
