### PR TITLE
Reset current URL when all iOS webviews have closed

### DIFF
--- a/lib/devices/ios/ios-hybrid.js
+++ b/lib/devices/ios/ios-hybrid.js
@@ -172,6 +172,7 @@ iOSHybrid.onPageChange = function (pageArray) {
     } else {
       logger.error("Don't have our current window anymore, and there " +
                    "aren't any more to load! Doing nothing...");
+      this.setCurrentUrl(undefined);
     }
     this.curContext = keyId;
     this.remote.pageIdKey = parseInt(keyId, 10);


### PR DESCRIPTION
I am testing an app that uses webviews to implement one particular feature, and the way it is implemented the user may enter the webview, close out back to native land, and then enter a new webview later.

Since v1.4.15 (specifically commit 3b71a7261a22164f1d82fbcdcf2f315886004539) this is broken for me. Specifically what I'm seeing is (Python bindings):
1. Start appium, launch app, do stuff in `NATIVE_CONTEXT`.
2. Open web view. At this point `driver.contexts` returns `[u'NATIVE_APP', u'WEBVIEW_3']` as expected.
3. Switch to `WEBVIEW_3` context. Do stuff.
4. Close web view. At this point `driver.contexts` returns `[u'NATIVE_APP']` as expected.
5. Open separate web view that starts with different initial URL. Now `driver.contexts` still returns only `[u'NATIVE_APP']` and I am unable to reenter a web context so the test fails.

I did some debugging and found the cause to be the following:
1. The changes in 3b71a7261a22164f1d82fbcdcf2f315886004539 add some state to `ios-hybrid.js` that stores the current webview's current URL.
2. This state is not cleared when the webview is closed.
3. When opening a different webview with a different URL, logic in `remote-debugger.js` searches the `pageDict` for an entry with matching current URL, but does not find one, leading to a retry loop and then failure.

I don't know if my patch is sufficient for a complete fix, but it resolves the issue as I am experiencing it. Perhaps @imurchie can confirm.
