### PR TITLE
Sanitize the deviceOrientation

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -168,9 +168,9 @@ IOS.prototype.configure = function (args, caps, cb) {
 IOS.prototype.setIOSArgs = function () {
   this.args.withoutDelay = !this.args.nativeInstrumentsLib;
   this.args.reset = !this.args.noReset;
-  this.args.initialOrientation = this.capabilities.deviceOrientation ||
-                                 this.args.orientation ||
-                                 "PORTRAIT";
+  this.args.initialOrientation = (this.capabilities.deviceOrientation ||
+                                  this.args.orientation ||
+                                  "PORTRAIT").toUpperCase();
   this.useRobot = this.args.robotPort > 0;
   this.args.robotUrl = this.useRobot ?
     "http://" + this.args.robotAddress + ":" + this.args.robotPort + "" :

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -844,7 +844,7 @@ exports.timeouts = function (req, res) {
 };
 
 exports.setOrientation = function (req, res) {
-  var orientation = req.body.orientation;
+  var orientation = (req.body.orientation || "").toUpperCase();
   req.device.setOrientation(orientation, getResponseHandler(req, res));
 };
 


### PR DESCRIPTION
Throughout the code we check if `deviceOrientation` is either `LANDSCAPE` or `PORTRAIT` (case sensitive), but the user can pass those strings in any case. While the iOS Simulators have the correct orientation, it returns the orientation in the original case as it was passed by user. This causes our screenshot rotation code to break as it checks for `LANDSCAPE` in uppercase.

It's better to sanitize the orientation whenever we get it.
