### PR TITLE
Added support for iPhone 6s, iPhone 6s Plus and iPhone 6plus

### DIFF
--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1044,7 +1044,16 @@ IOS.getDeviceStringFromOpts = function (opts) {
       'iPhone Simulator (9.2)': 'iPhone 6 (9.2) [',
       'iPhone 6 (9.0)': 'iPhone 6 (9.0) [',
       'iPhone 6 (9.1)': 'iPhone 6 (9.1) [',
-      'iPhone 6 (9.2)': 'iPhone 6 (9.2) ['
+      'iPhone 6 (9.2)': 'iPhone 6 (9.2) [',
+      'iPhone 6s (9.0)': 'iPhone 6s (9.0) [',
+      'iPhone 6s (9.1)': 'iPhone 6s (9.1) [',
+      'iPhone 6s (9.2)': 'iPhone 6s (9.2) [',
+      'iPhone 6 Plus (9.0)': 'iPhone 6 Plus (9.0) [',
+      'iPhone 6 Plus (9.1)': 'iPhone 6 Plus (9.1) [',
+      'iPhone 6 Plus (9.2)': 'iPhone 6 Plus (9.2) [',
+      'iPhone 6s Plus (9.0)': 'iPhone 6s Plus (9.0) [',
+      'iPhone 6s Plus (9.1)': 'iPhone 6s Plus (9.1) [',
+      'iPhone 6s Plus (9.2)': 'iPhone 6s Plus (9.2) ['
     };
     var configFix = xcodeMajorVer === 7 ? CONFIG_FIX__XCODE_7 : CONFIG_FIX;
     if (configFix[iosDeviceString]) {


### PR DESCRIPTION
Added support for iPhone 6s, iPhone 6s Plus and iPhone 6plus to fix https://github.com/appium/appium-dot-app/issues/514. please review the same.
