### PR TITLE
Add a new mobile command for iOS background issue

### DIFF
--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -26,6 +26,7 @@ var uuid = require('uuid-js')
   , NotImplementedError = errors.NotImplementedError
   , NotYetImplementedError = errors.NotYetImplementedError
   , Parser = require('../../server/parser.js')
+  , backgroundOSA = path.resolve(__dirname, "./osa/background.scpt")
   , url = require('url');
 
 var iOSController = {};
@@ -1231,6 +1232,17 @@ iOSController.lock = function (secs, cb) {
 iOSController.isLocked = function (cb) {
   cb(new NotYetImplementedError(), null);
 };
+
+iOSController.osaBackground = function (appName, secs, cb) {
+  logger.debug("Execute background osa: '" + appName + "'," + secs);
+  exec ('osascript ' + backgroundOSA + ' \'' + appName + '\' \'' + secs + '\'', function (error, stdout, stderr) {
+    if (error !== null) {
+      cb (error);
+    } else {
+      cb (null, {status:0, result: "" + stderr + ";" + stdout});
+    }
+  })
+}
 
 iOSController.background = function (secs, cb) {
   this.proxy(["au.background(", secs, ")"].join(''), cb);

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1233,7 +1233,7 @@ iOSController.isLocked = function (cb) {
   cb(new NotYetImplementedError(), null);
 };
 
-iOSController.osaBackground = function (appName, secs, cb) {
+var osaBackground = function (appName, secs, cb) {
   logger.debug("Execute background osa: '" + appName + "'," + secs);
   exec ('osascript ' + backgroundOSA + ' \'' + appName + '\' \'' + secs + '\'', function (error, stdout, stderr) {
     if (error !== null) {
@@ -1245,7 +1245,22 @@ iOSController.osaBackground = function (appName, secs, cb) {
 }
 
 iOSController.background = function (secs, cb) {
-  this.proxy(["au.background(", secs, ")"].join(''), cb);
+  var v = (this.args.platformVersion || this.iOSSDKVersion);
+  if (v >= 9) {
+    if (!this.args.appName) {
+      this.getAppNameFromApp (function(err, appName) {
+        if (err) {
+          cb (err);
+        } else {
+          osaBackground (appName, secs, cb);
+        }
+      });
+    } else {
+      osaBackground (this.args.appName, secs, cb);
+    }
+  } else {
+    this.proxy(["au.background(", secs, ")"].join(''), cb);
+  }
 };
 
 iOSController.getOrientation = function (cb) {

--- a/lib/devices/ios/ios-controller.js
+++ b/lib/devices/ios/ios-controller.js
@@ -1235,28 +1235,22 @@ iOSController.isLocked = function (cb) {
 
 var osaBackground = function (appName, secs, cb) {
   logger.debug("Execute background osa: '" + appName + "'," + secs);
-  exec ('osascript ' + backgroundOSA + ' \'' + appName + '\' \'' + secs + '\'', function (error, stdout, stderr) {
-    if (error !== null) {
-      cb (error);
-    } else {
-      cb (null, {status:0, result: "" + stderr + ";" + stdout});
-    }
-  })
-}
+  exec('osascript ' + backgroundOSA + ' \'' + appName + '\' \'' + secs + '\'', function (error, stdout, stderr) {
+    if (error) return cb(error);
+    cb(null, {status:0, result: "" + stderr + ";" + stdout});
+  });
+};
 
 iOSController.background = function (secs, cb) {
   var v = (this.args.platformVersion || this.iOSSDKVersion);
   if (v >= 9) {
     if (!this.args.appName) {
-      this.getAppNameFromApp (function(err, appName) {
-        if (err) {
-          cb (err);
-        } else {
-          osaBackground (appName, secs, cb);
-        }
+      this.getAppNameFromApp(function (err, appName) {
+        if (err) return cb(err);
+        osaBackground(appName, secs, cb);
       });
     } else {
-      osaBackground (this.args.appName, secs, cb);
+      osaBackground(this.args.appName, secs, cb);
     }
   } else {
     this.proxy(["au.background(", secs, ")"].join(''), cb);

--- a/lib/devices/ios/osa/background.scpt
+++ b/lib/devices/ios/osa/background.scpt
@@ -8,6 +8,7 @@ on run argv
         set frontmost to true
         keystroke "h" using {shift down, command down} # background app
         delay delayInSec
+        set frontmost to true
         keystroke "h" using {shift down, command down} # go to home screen, page 1
         delay 1
         tell slider 1 of window 1

--- a/lib/devices/ios/osa/background.scpt
+++ b/lib/devices/ios/osa/background.scpt
@@ -1,0 +1,30 @@
+on run argv
+    if (count of argv) > 1 then
+        set appName to item 1 of argv
+        set delayInSec to item 2 of argv as integer
+    end if
+    tell application "System Events" to tell process "Simulator"
+        activate
+        set frontmost to true
+        keystroke "h" using {shift down, command down} # background app
+        delay delayInSec
+        keystroke "h" using {shift down, command down} # go to home screen, page 1
+        delay 1
+        tell slider 1 of window 1
+            set pos to position
+            set s to size
+        end tell
+        set sliderTitle to title of slider 1 of window 1
+        set pageTotalText to text ((offset of "of " in sliderTitle) + 2) thru -1 in sliderTitle
+        set numCount to count of characters in pageTotalText
+        set pageTotal to pageTotalText as integer
+        
+        repeat while pageTotal > 0 and appName is not in title of UI elements of window 1
+            click at {((item 1 of pos) + (item 1 of s) * 0.7), ((item 2 of pos) + (item 2 of s) / 2)}
+            delay 1
+            set pageTotal to pageTotal - 1
+        end repeat
+        click UI element appName of window 1
+        delay 1 # give it a few moment to launch
+    end tell
+end run

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -70,6 +70,19 @@ exports.getStatus = function (req, res) {
   respondSuccess(req, res, data);
 };
 
+exports.osaBackground = function (req, res) {
+  req.body = _.defaults(req.body, {
+    appName: "",
+    timeout: 5
+  });
+  if (req.device.osaBackground) {
+    req.device.osaBackground (req.body.appName, req.body.timeout, 
+          getResponseHandler (req, res));
+  } else {
+    notYetImplemented(req, res);
+  }
+}
+
 exports.installApp = function (req, res) {
   var install = function (appPath) {
     req.device.installApp(appPath, function (error, response) {
@@ -1198,6 +1211,7 @@ var mobileCmdMap = {
 , 'move' : exports.touchMove
 , 'pinchClose': exports.mobilePinchClose
 , 'pinchOpen': exports.mobilePinchOpen
+, 'osaBackground': exports.osaBackground
 };
 
 exports.produceError = function (req, res) {

--- a/lib/server/controller.js
+++ b/lib/server/controller.js
@@ -70,19 +70,6 @@ exports.getStatus = function (req, res) {
   respondSuccess(req, res, data);
 };
 
-exports.osaBackground = function (req, res) {
-  req.body = _.defaults(req.body, {
-    appName: "",
-    timeout: 5
-  });
-  if (req.device.osaBackground) {
-    req.device.osaBackground (req.body.appName, req.body.timeout, 
-          getResponseHandler (req, res));
-  } else {
-    notYetImplemented(req, res);
-  }
-}
-
 exports.installApp = function (req, res) {
   var install = function (appPath) {
     req.device.installApp(appPath, function (error, response) {
@@ -1211,7 +1198,6 @@ var mobileCmdMap = {
 , 'move' : exports.touchMove
 , 'pinchClose': exports.mobilePinchClose
 , 'pinchOpen': exports.mobilePinchOpen
-, 'osaBackground': exports.osaBackground
 };
 
 exports.produceError = function (req, res) {


### PR DESCRIPTION
The workaround script, (written in AppleScript so it needs Accessiblity permission), to communicate Simulator using Apple Events to mimic background and foreground by clicking the home button and finding the app icon to open it

this depends on #5971 so it would be able to get the correct appName
