### PR TITLE
Add handling of boolean caps

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import log from './logger';
+import { fixCaps } from './helpers';
 import { BaseDriver } from 'appium-base-driver';
 import { FakeDriver } from 'appium-fake-driver';
 import { AndroidDriver } from 'appium-android-driver';
@@ -84,7 +85,7 @@ class AppiumDriver extends BaseDriver {
       throw new errors.SessionNotCreatedError(e.message);
     }
     let d = new InnerDriver(this.args);
-    let [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, curSessions);
+    let [innerSessionId, dCaps] = await d.createSession(fixCaps(caps), reqCaps, curSessions);
     this.sessions[innerSessionId] = d;
 
     // Remove the session on unexpected shutdown, so that we are in a position

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,21 @@
+import _ from 'lodash';
+import log from './logger';
+
+
+function fixCaps (originalCaps) {
+  let caps = _.clone(originalCaps);
+  // boolean capabilities can be passed in as strings 'false' and 'true'
+  // which we want to translate into boolean values
+  for (let [cap, value] of _.pairs(caps)) {
+    if (_.isString(value)) {
+      value = value.toLowerCase();
+      if (value === 'true' || value === 'false') {
+        log.debug(`Capability '${cap}' changed from string to boolean. This may cause unexpected behavior`);
+        caps[cap] = (value === 'true');
+      }
+    }
+  }
+  return caps;
+}
+
+export { fixCaps };

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -71,6 +71,15 @@ describe('AppiumDriver', () => {
         await appium.createSession(BASE_CAPS);
         mockFakeDriver.verify();
       });
+      it('should call inner driver\'s createSession with desired capabilities with string booleans transformed to booleans', async () => {
+        let sentCaps = _.extend({autoAcceptAlerts: 'false', autoDismissAlerts: 'true'}, BASE_CAPS);
+        let expectedCaps = _.extend({autoAcceptAlerts: false, autoDismissAlerts: true}, BASE_CAPS);
+        mockFakeDriver.expects("createSession")
+          .once().withExactArgs(expectedCaps, undefined, [])
+          .returns([1, expectedCaps]);
+        await appium.createSession(sentCaps);
+        mockFakeDriver.verify();
+      });
     });
     describe('deleteSession', () => {
       let appium


### PR DESCRIPTION
In the previous version of Appium we changed caps that were boolean, but sent in as strings, into booleans. This adds that to 1.5.
