### PR TITLE
Add appName cap

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -87,3 +87,4 @@
 |`screenshotWaitTimeout`| Max timeout in sec to wait for a screenshot to be generated. default: 10 |e.g., `5`|
 |`waitForAppScript`| The ios automation script used to determined if the app has been launched, by default the system wait for the page source not to be empty. The result must be a boolean |e.g. `true;`, `target.elements().length > 0;`, `$.delay(5000); true;` |
 |`webviewConnectRetries`| Number of times to send connection message to remote debugger, to get webview. Default: `8` |e.g., `12`|
+|`appName`| The display name of the application under test. Used to automate backgrounding the app in iOS 9+.|e.g., `UICatalog`|

--- a/lib/devices/ios/ios.js
+++ b/lib/devices/ios/ios.js
@@ -1119,6 +1119,19 @@ IOS.prototype.getBundleIdFromApp = function (cb) {
   }.bind(this));
 };
 
+IOS.prototype.getAppNameFromApp = function (cb) {
+  logger.debug("Getting application name from app");
+  var plist = path.resolve(this.args.app, "Info.plist");
+  parsePlistFile(plist, function (err, obj) {
+    if (err) {
+      logger.error("Could not get the application name from app.");
+      cb(err, null);
+    } else {
+      cb(null, obj.CFBundleDisplayName);
+    }
+  }.bind(this));
+};
+
 IOS.getSimForDeviceString = function (dString, availDevices) {
   var matchedDevice = null;
   var matchedUdid = null;

--- a/lib/server/capabilities.js
+++ b/lib/server/capabilities.js
@@ -94,6 +94,7 @@ var iosCaps = [
 , 'sendKeyStrategy'
 , 'waitForAppScript'
 , 'webviewConnectRetries'
+, 'appName'
 ];
 
 var Capabilities = function (capabilities) {


### PR DESCRIPTION
Add the ability to pass in the iOS `appName` as a capability, and also to pull it from the app's plist. This is wiring needed for #5950
