### PR TITLE
Fix logging of args and caps

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -9,6 +9,7 @@ import { SelendroidDriver } from 'appium-selendroid-driver';
 import { routeConfiguringFunction, errors,
          isSessionCommand } from 'mobile-json-wire-protocol';
 import B from 'bluebird';
+import util from 'util';
 
 
 class AppiumDriver extends BaseDriver {
@@ -79,6 +80,11 @@ class AppiumDriver extends BaseDriver {
     let InnerDriver = this.getDriverForCaps(caps);
     let curSessions;
     log.info(`Creating new ${InnerDriver.name} session`);
+    log.info('Capabilities:');
+    util.inspect(caps);
+    for (let [cap, value] of _.pairs(caps)) {
+      log.info(`  ${cap}: ${util.inspect(value)}`);
+    }
     try {
       curSessions = this.curSessionDataForDriver(InnerDriver);
     } catch (e) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -18,4 +18,5 @@ function fixCaps (originalCaps) {
   return caps;
 }
 
+
 export { fixCaps };

--- a/lib/main.js
+++ b/lib/main.js
@@ -12,6 +12,7 @@ import { showConfig, checkNodeOk, validateServerArgs,
          getDeprecatedArgs, getGitRev, APPIUM_VER } from './config';
 import getAppiumRouter from './appium';
 import registerNode from './grid-register';
+import util from 'util';
 
 
 async function preflightChecks (parser, args) {
@@ -38,7 +39,23 @@ async function preflightChecks (parser, args) {
 function logDeprecationWarning (deprecatedArgs) {
   logger.warn('Deprecated server args:');
   for (let [arg, realArg] of _.pairs(deprecatedArgs)) {
-    logger.warn(`    ${arg.red} => ${realArg}`);
+    logger.warn(`  ${arg.red} => ${realArg}`);
+  }
+}
+
+function logNonDefaultArgsWarning (args) {
+  logger.info('Non-default server args:');
+  for (let [arg, value] of _.pairs(args)) {
+    logger.info(`  ${arg}: ${util.inspect(value)}`);
+  }
+}
+
+function logDefaultCapabilitiesWarning (caps) {
+  logger.info('Default capabilities, which will be added to each request ' +
+              'unless overridden by desired capabilities:');
+  util.inspect(caps);
+  for (let [cap, value] of _.pairs(caps)) {
+    logger.info(`  ${cap}: ${util.inspect(value)}`);
   }
 }
 
@@ -54,19 +71,14 @@ async function logStartupInfo (parser, args) {
   logger.info(logMessage);
   let showArgs = getNonDefaultArgs(parser, args);
   if (_.size(showArgs)) {
-    logger.info(`Non-default server args:`);
-    for (let [arg, value] of _.pairs(showArgs)) {
-      logger.info(`    ${arg.red}: ${value}`);
-    }
+    logNonDefaultArgsWarning(showArgs);
   }
   let deprecatedArgs = getDeprecatedArgs(parser, args);
   if (_.size(deprecatedArgs)) {
     logDeprecationWarning(deprecatedArgs);
   }
   if (!_.isEmpty(args.defaultCapabilities)) {
-    logger.info(`Default capabilities, which will be added to each request ` +
-                `unless overridden by desired capabilities: ` +
-                `${JSON.stringify(args.defaultCapabilities)}`);
+    logDefaultCapabilitiesWarning(args.defaultCapabilities);
   }
   // TODO: bring back loglevel reporting below once logger is flushed out
   //logger.info('Console LogLevel: ' + logger.transports.console.level);


### PR DESCRIPTION
Clean up logging of non-default server arguments and default capabilities. Also add logging of capabilities upon create session request.

Output:

``` shell
isaac@isaac: ~/code/appium-repos/appium isaac-logs
👻 ➤ node . --default-capabilities '{"showIosLog":"true", "launchTimeout":4000}' --ipa /path/to/it.ipa
[Appium] Welcome to Appium v1.5.0-beta9 (REV 558bee17bfadf13c741e800f1616cfa6c75f9c99)
[Appium] Appium REST http interface listener started on 0.0.0.0:4723
[Appium] Non-default server args:
[Appium]   ipa: /path/to/it.ipa
[Appium]   defaultCapabilities:
[Appium]     showIosLog: "true"
[Appium]     launchTimeout: 4000
[Appium] Default capabilities, which will be added to each request unless overridden by desired capabilities:
[Appium]   showIosLog: true
[Appium]   launchTimeout: 4000
[HTTP] --> POST /wd/hub/session
[MJSONWP] Calling AppiumDriver.createSession() with args: [{"app":"/Users/isaac/code/appium-repos/appium-test-suite/node_modules/sample-apps/node_modules/ios-uicatalog/build/Release-iphonesimulator/UICatal...
[Appium] Creating new IosDriver session
[Appium] Capabilities:
[Appium]   app: /Users/isaac/code/appium-repos/appium-test-suite/node_modules/sample-apps/node_modules/ios-uicatalog/build/Release-iphonesimulator/UICatalog-iphonesimulator.app
[Appium]   appName: UICatalog
[Appium]   browserName:
[Appium]   deviceName: iPhone 6
[Appium]   launchTimeout:
[Appium]     global: 60000
[Appium]     afterSimLaunch: 10000
[Appium]   platformName: iOS
[Appium]   platformVersion: 9.2
[Appium]   showIosLog: true
[debug] [Appium] Capability 'showIosLog' changed from string to boolean. This may cause unexpected behavior
[BaseDriver] The following capabilities were provided, but are not recognized by appium: showIosLog.
[BaseDriver] Session created with session id: a813092e-f97b-4d37-9929-83c6ff3ef64c
[debug] [iOS] Not auto-detecting udid.
...
```

Output with log timestamps on:

``` shell
isaac@isaac: ~/code/appium-repos/appium isaac-logs
👻 ➤ node . --default-capabilities '{"showIosLog":"true", "launchTimeout":4000}' --ipa /path/to/it.ipa --log-timestamp
2016-01-05 17:50:29:120 - [Appium] Welcome to Appium v1.5.0-beta9 (REV 558bee17bfadf13c741e800f1616cfa6c75f9c99)
2016-01-05 17:50:29:122 - [Appium] Appium REST http interface listener started on 0.0.0.0:4723
2016-01-05 17:50:29:123 - [Appium] Non-default server args:
2016-01-05 17:50:29:124 - [Appium]   ipa: /path/to/it.ipa
2016-01-05 17:50:29:124 - [Appium]   logTimestamp: true
2016-01-05 17:50:29:125 - [Appium]   defaultCapabilities:
2016-01-05 17:50:29:125 - [Appium]     showIosLog: "true"
2016-01-05 17:50:29:125 - [Appium]     launchTimeout: 4000
2016-01-05 17:50:29:126 - [Appium] Default capabilities, which will be added to each request unless overridden by desired capabilities:
2016-01-05 17:50:29:127 - [Appium]   showIosLog: true
2016-01-05 17:50:29:128 - [Appium]   launchTimeout: 4000
2016-01-05 17:50:33:495 - [HTTP] --> POST /wd/hub/session
2016-01-05 17:50:33:521 - [MJSONWP] Calling AppiumDriver.createSession() with args: [{"app":"/Users/isaac/code/appium-repos/appium-test-suite/node_modules/sample-apps/node_modules/ios-uicatalog/build/Release-iphonesimulator/UICatal...
2016-01-05 17:50:33:524 - [Appium] Creating new IosDriver session
2016-01-05 17:50:33:524 - [Appium] Capabilities:
2016-01-05 17:50:33:525 - [Appium]   app: /Users/isaac/code/appium-repos/appium-test-suite/node_modules/sample-apps/node_modules/ios-uicatalog/build/Release-iphonesimulator/UICatalog-iphonesimulator.app
2016-01-05 17:50:33:525 - [Appium]   appName: UICatalog
2016-01-05 17:50:33:525 - [Appium]   browserName:
2016-01-05 17:50:33:526 - [Appium]   deviceName: iPhone 6
2016-01-05 17:50:33:526 - [Appium]   launchTimeout:
2016-01-05 17:50:33:526 - [Appium]     global: 60000
2016-01-05 17:50:33:526 - [Appium]     afterSimLaunch: 10000
2016-01-05 17:50:33:527 - [Appium]   platformName: iOS
2016-01-05 17:50:33:527 - [Appium]   platformVersion: 9.2
2016-01-05 17:50:33:527 - [Appium]   showIosLog: true
2016-01-05 17:50:33:531 - [debug] [Appium] Capability 'showIosLog' changed from string to boolean. This may cause unexpected behavior
2016-01-05 17:50:33:535 - [BaseDriver] The following capabilities were provided, but are not recognized by appium: showIosLog.
2016-01-05 17:50:33:536 - [BaseDriver] Session created with session id: dd90e721-e50d-4a2b-a28a-9816c4262516
2016-01-05 17:50:33:538 - [debug] [iOS] Not auto-detecting udid.
...
```
