### PR TITLE
rm old.apk--> rm -f old.apk

### DIFF
--- a/lib/devices/android/android-common.js
+++ b/lib/devices/android/android-common.js
@@ -609,7 +609,7 @@ androidCommon.removeTempApks = function (exceptMd5s, cb) {
           }
         });
         if (noMd5Matched) {
-          removes.push('rm "' + path + '"');
+          removes.push('rm -f "' + path + '"');
         } else {
           logger.debug("Found an apk we want to keep at " + path);
           matchingApkFound = true;


### PR DESCRIPTION
Some stricter phone's /local/data/ dir is not accessible to generally user.(Moto XT1085 etc.)

```
rm /data/local/tmp/a60..1de.apk
```

will lead to:

```
override r--r--r-- shell:shell for '/data/local/tmp/a60...1de.apk'? ^C
```
- appium cannot  deal with this **interactive prompt** then will get freezed forever<br>
  So **rm -f** may be better.
