### PR TITLE
updated request promise to fix explicit CLS dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "^3.9.1",
     "mobile-json-wire-protocol": "^1.2.0",
     "npmlog": "^2.0.1",
-    "request-promise": "^1.0.2",
+    "request-promise": "^2.0.0",
     "source-map-support": "^0.3.2",
     "teen_process": "^1.5.1",
     "winston": "^1.0.0"


### PR DESCRIPTION
Unable to install appium dependency as npm install throws "npm WARN EPEERINVALID cls-bluebird@1.0.1 requires a peer of continuation-local-storage@~3 but none was installed"

This has been fixed in reuest promise recently and that enabled support for node version 5.0 as well. 

https://github.com/request/request-promise/commit/05b6314748941c29c811b7023d120ccf04bdf137
https://github.com/request/request-promise/pull/75
https://github.com/request/request-promise/issues/70

@imurchie @moizjv please review
