### PR TITLE
remove deprecated ANDROID_ADB_SERVER_PORT flag and use adbPort cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ tests.
   --chromedriver-version="$VER"
 - `driver.closeApp` no longer runs through the shutdown routine; it simply
   force-stops the app
+- The `ANDROID_ADB_SERVER_PORT` environment variable has been removed in favor
+  of the `adbPort` desired capability, which does the same thing.
 
 CHANGES IN VERSION 1.4.16 (from 1.4.15)
 ===================================

--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -33,6 +33,7 @@
 |`androidCoverage`| Fully qualified instrumentation class. Passed to -w in adb shell am instrument -e coverage true -w | `com.my.Pkg/com.my.Pkg.instrumentation.MyInstrumentation`|
 |`enablePerformanceLogging`| (Chrome and webview only) Enable Chromedriver's performance logging (default `false`)| `true`, `false`|
 |`androidDeviceReadyTimeout`|Timeout in seconds used to wait for a device to become ready after booting|e.g., `30`|
+|`adbPort`|Port used to connect to the ADB server (default `5037`)|`5037`|
 |`androidDeviceSocket`|Devtools socket name. Needed only when tested app is a Chromium embedding browser. The socket is open by the browser and Chromedriver connects to it as a devtools client.|e.g., `chrome_devtools_remote`|
 |`avd`| Name of avd to launch|e.g., `api19`|
 |`avdLaunchTimeout`| How long to wait in milliseconds for an avd to launch and connect to ADB (default `120000`)| `300000`|

--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
     "doc": "./docs"
   },
   "dependencies": {
-    "appium-android-driver": "^1.6.7",
+    "appium-android-driver": "^1.6.11",
     "appium-base-driver": "^1.3.0",
     "appium-express": "^1.2.0",
     "appium-fake-driver": "^0.1.9",
     "appium-ios-driver": "^1.8.4",
     "appium-logger": "^2.1.0",
-    "appium-selendroid-driver": "^1.1.1",
+    "appium-selendroid-driver": "^1.2.1",
     "appium-support": "^2.0.9",
     "argparse": "^1.0.2",
     "asyncbox": "^2.3.1",


### PR DESCRIPTION
## Proposed changes

We don't want a mix of env vars and caps determining server behavior. Get rid of this env var and use the cap instead. Changes made in downstream appium-adb, appium-android-driver, and appium-selendroid-driver.
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Breaking change, however we can release it in 1.5
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
### Reviewers: @imurchie
