### PR TITLE
Docs: --default-capabilities additional info + Windows note

### DIFF
--- a/docs/en/writing-running-appium/default-capabilities-arg.md
+++ b/docs/en/writing-running-appium/default-capabilities-arg.md
@@ -6,6 +6,10 @@ Appium 1.5 does away with most CLI flags; the remainder can be converted into JS
 --default-capabilities '{"app": "myapp.app", "deviceName": "iPhone Simulator"}'
 ```
 
+**Windows users** will need to escape the quotes: `--default-capabilities "{\"app\": \"myapp.app\"}"`
+
+
+
 | Flag                      | JSON key                |
 |---------------------------|-------------------------|
 | --keep-artifacts          | keepArtifacts           |

--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -52,7 +52,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--suppress-adb-kill-server`|false|(Android-only) If set, prevents Appium from killing the adb server instance||
 |`--async-trace`|false|Add long stack traces to log entries. Recommended for debugging only.||
 |`--webkit-debug-proxy-port`|27753|(IOS-only) Local port used for communication with ios-webkit-debug-proxy|`--webkit-debug-proxy-port 27753`|
-|`--default-capabilities`|{}|Set the default desired capabilities, which will be set on each session unless overridden by received capabilities.|`--default-capabilities {"app": "myapp.app", "deviceName": "iPhone Simulator"}`|
+|`--default-capabilities`|{}|Set the default desired capabilities, which will be set on each session unless overridden by received capabilities. [More infomation](/docs/en/writing-running-appium/default-capabilities-arg.md). |`--default-capabilities '{"app": "myapp.app", "deviceName": "iPhone Simulator"}'`|
 |`-k`, `--keep-artifacts`|false|[DEPRECATED] - no effect, trace is now in tmp dir by default and is cleared before each run. Please also refer to the --trace-dir flag.||
 |`--platform-name`|null|[DEPRECATED] - Name of the mobile platform: iOS, Android, or FirefoxOS|`--platform-name iOS`|
 |`--platform-version`|null|[DEPRECATED] - Version of the mobile platform|`--platform-version 7.1`|


### PR DESCRIPTION
Update to `--default-capabilities` docs:
- Note to Windows users
- Link to more information from server arguments page
- Fixed example

Reference: https://github.com/appium/appium/issues/6133

@imurchie - is this sufficient Windows info? No other arguments expect JSON.
## Types of changes

Docs only.
