### PR TITLE
Renaming forgotten pairs to toPairs

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -54,7 +54,7 @@ function logDefaultCapabilitiesWarning (caps) {
   logger.info('Default capabilities, which will be added to each request ' +
               'unless overridden by desired capabilities:');
   util.inspect(caps);
-  for (let [cap, value] of _.pairs(caps)) {
+  for (let [cap, value] of _.toPairs(caps)) {
     logger.info(`  ${cap}: ${util.inspect(value)}`);
   }
 }


### PR DESCRIPTION
## Types of changes

In the commits introduced in the PR https://github.com/appium/appium/pull/6296, which constituted upgrading `lodash` module, all occurrences of `pairs` function was renamed to `toPairs`. But, there was one place where it was not done in [lib/main.js](https://github.com/appium/appium/blob/master/lib/main.js#L57). This PR fixes that. 
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
### Reviewers: @imurchie, @jlipps, ...
