### PR TITLE
Deprecate --command-timeout server arg

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -259,16 +259,6 @@ const args = [
     help: 'Bypass Appium\'s checks to ensure we can read/write necessary files',
   }],
 
-  [['--command-timeout'], {
-    defaultValue: 60,
-    dest: 'defaultCommandTimeout',
-    type: 'int',
-    required: false,
-    help: 'The default command timeout for the server to use for all ' +
-          'sessions (in seconds and should be less than 2147483). ' +
-          'Will still be overridden by newCommandTimeout cap',
-  }],
-
   [['--strict-caps'], {
     defaultValue: false,
     dest: 'enforceStrictCaps',
@@ -356,6 +346,16 @@ const args = [
 ];
 
 const deprecatedArgs = [
+  [['--command-timeout'], {
+    defaultValue: 60,
+    dest: 'defaultCommandTimeout',
+    type: 'int',
+    required: false,
+    help: '[DEPRECATED] No effect. This used to be the default command ' +
+          'timeout for the server to use for all sessions (in seconds and ' +
+          'should be less than 2147483). Use newCommandTimeout cap instead'
+  }],
+
   [['-k', '--keep-artifacts'], {
     defaultValue: false,
     dest: 'keepArtifacts',


### PR DESCRIPTION
## Proposed changes

The `--command-timeout` server argument no longer does anything. Deprecate.

Resolves #6351
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
### Reviewers: @scottdixon , @jlipps
