### PR TITLE
Support the sessionOverride flag

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -96,11 +96,28 @@ class AppiumDriver extends BaseDriver {
     for (let [cap, value] of _.toPairs(caps)) {
       log.info(`  ${cap}: ${util.inspect(value)}`);
     }
+
+    // sessionOverride server flag check
+    // this will need to be re-thought when we go to multiple session support
+    if (this.args.sessionOverride && !!this.sessions && _.keys(this.sessions).length > 0) {
+      log.info('Session override is on. Deleting other sessions.');
+      for (let id of _.keys(this.sessions)) {
+        log.info(`    Deleting session '${id}'`);
+        try {
+          await this.deleteSession(id);
+        } catch (ign) {
+          // the error has already been logged in AppiumDriver.deleteSession
+          // continue
+        }
+      }
+    }
+
     try {
       curSessions = this.curSessionDataForDriver(InnerDriver);
     } catch (e) {
       throw new errors.SessionNotCreatedError(e.message);
     }
+
     let d = new InnerDriver(this.args);
     let [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, curSessions);
     this.sessions[innerSessionId] = d;


### PR DESCRIPTION
## Proposed changes

We still have the `--session-override` server argument, but it does nothing. Until we support multiple sessions, this should kill any existing sessions.

See #6442
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
### Reviewers: @scottdixon, @jlipps
