### PR TITLE
ios-webkit-debug-proxy-launcher fix: replace underscore with lodash

### DIFF
--- a/bin/ios-webkit-debug-proxy-launcher.js
+++ b/bin/ios-webkit-debug-proxy-launcher.js
@@ -19,7 +19,7 @@
 "use strict";
 
 var spawn = require('child_process').spawn,
-    _ = require('underscore');
+    _ = require('lodash');
 
 var args = process.argv.slice(2);
 


### PR DESCRIPTION
In porting `bin/ios-webkit-debug-proxy-launcher.js` we didn't update the underscore reference.

lodash has the same method available: https://lodash.com/docs#find
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
### Reviewers: @imurchie
