### PR TITLE
add support to set UiAutomator Congfigurator values

### DIFF
--- a/docs/en/advanced-concepts/settings.md
+++ b/docs/en/advanced-concepts/settings.md
@@ -38,3 +38,17 @@ Settings are implemented via the following API endpoints:
 ### Supported Settings
 
 **"ignoreUnimportantViews"** - Boolean which sets whether Android devices should use `setCompressedLayoutHeirarchy()` which ignores all views which are marked IMPORTANT_FOR_ACCESSIBILITY_NO or IMPORTANT_FOR_ACCESSIBILITY_AUTO (and have been deemed not important by the system), in an attempt to make things less confusing or faster.
+
+#### Android UiAutomator Configurator
+
+sets [UiAutomator Configurator](https://developer.android.com/reference/android/support/test/uiautomator/Configurator.html) timeouts and delays in Android devices. only works in Android API 18 and above.
+
+**"actionAcknowledgmentTimeout"** - Int which is the same as [setActionAcknowledgmentTimeout](https://developer.android.com/reference/android/support/test/uiautomator/Configurator.html#setActionAcknowledgmentTimeout(long)). If a negative value is given, it would set to default(3 * 1000 milliseconds)
+
+**"keyInjectionDelay"** - Int which is the same as [setKeyInjectionDelay](https://developer.android.com/reference/android/support/test/uiautomator/Configurator.html#setKeyInjectionDelay(long)). If a negative value is given, it would set to default(0 milliseconds)
+
+**"scrollAcknowledgmentTimeout"** - Int which is the same as [setScrollAcknowledgmentTimeout](https://developer.android.com/reference/android/support/test/uiautomator/Configurator.html#setScrollAcknowledgmentTimeout(long)). If a negative value is given, it would set to default(200 milliseconds)
+
+**"waitForIdleTimeout"** - Int which is the same as [setWaitForIdleTimeout](https://developer.android.com/reference/android/support/test/uiautomator/Configurator.html#setWaitForIdleTimeout(long)). If a negative value is given, it would set to default(10 * 1000 milliseconds)
+
+**"waitForSelectorTimeout"** - Int which is the same as [setWaitForSelectorTimeout](https://developer.android.com/reference/android/support/test/uiautomator/Configurator.html#setWaitForSelectorTimeout(long)). If a negative value is given, it would set to default(10 * 1000 milliseconds)


### PR DESCRIPTION
## Proposed changes

[UiAutomator Configurator](https://developer.android.com/reference/android/support/test/uiautomator/Configurator.html) provides several methods to change its the configurations.
I have implemented them in appium using [appium settings api](https://github.com/appium/appium/tree/master/docs/en/advanced-concepts/settings.md)

This is the overall PR for all other three PRs:
[appium-android-driver](https://github.com/appium/appium-android-driver/pull/153)
[appium-android-bootstrap](https://github.com/appium/appium-android-bootstrap/pull/25)
[java-client](https://github.com/appium/java-client/pull/410)

I know there would be `appium-uiautomator2-server` and `appium-uiautomator2-driver` in upcoming versions. Since I used existing API, It would be OK for me to merge this feature to the new android server and driver
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
## Further comments

But according to [android uiautomator fixed timeout bug in UiAutomatorBridge](https://code.google.com/p/android/issues/detail?id=73297), the timeout in dynamic page still cannot be changed.
Maybe we need to recompile `uiautomator.jar` to change the static final field [`TOTAL_TIME_TO_WAIT_FOR_IDLE_STATE`](https://android.googlesource.com/platform/frameworks/uiautomator/+/master/src/com/android/uiautomator/core/UiAutomatorBridge.java#39) from `10 * 1000` to `Configurator.getInstance().getWaitForIdleTimeout()`.
That's a little more complexed, I have not tried that.
### Reviewers:
