### PR TITLE
Add androidInstallTimeout cap, update Android dep

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -33,6 +33,7 @@
 |`androidCoverage`| Fully qualified instrumentation class. Passed to -w in adb shell am instrument -e coverage true -w | `com.my.Pkg/com.my.Pkg.instrumentation.MyInstrumentation`|
 |`enablePerformanceLogging`| (Chrome and webview only) Enable Chromedriver's performance logging (default `false`)| `true`, `false`|
 |`androidDeviceReadyTimeout`|Timeout in seconds used to wait for a device to become ready after booting|e.g., `30`|
+|`androidInstallTimeout`|Timeout in milliseconds used to wait for an apk to install to the device. Defaults to `90000` |e.g., `90000`|
 |`adbPort`|Port used to connect to the ADB server (default `5037`)|`5037`|
 |`androidDeviceSocket`|Devtools socket name. Needed only when tested app is a Chromium embedding browser. The socket is open by the browser and Chromedriver connects to it as a devtools client.|e.g., `chrome_devtools_remote`|
 |`avd`| Name of avd to launch|e.g., `api19`|

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "doc": "./docs"
   },
   "dependencies": {
-    "appium-android-driver": "^1.10.6",
+    "appium-android-driver": "^1.10.12",
     "appium-base-driver": "^2.0.3",
     "appium-fake-driver": "^0.1.10",
     "appium-ios-driver": "^1.12.2",


### PR DESCRIPTION
## Proposed changes

Document androidInstallTimeout capability which is new to appium-android-driver 1.10.12
Bump appium-android-driver dependency to 1.10.12

The androidInstallTimeout capability will allow appium users to modify the amount of time allowed to install an apk to the android device. The previous, default adb push timeout of 90 seconds is not sufficient for apks with total size over ~500MB

Directly addresses: https://github.com/appium/appium-adb/issues/147 
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
## Further comments

The appium-android-driver update from 1.10.6 to 1.10.12 contains the following fixes:
- Fix 'release' touch action
- Unlock helper deflake
- Add device udid to android session information
- Improve text clear command
- Allow fast reset without 'app' capability
- Add 'androidInstallTimeout' capability

which should fix:
https://github.com/appium/appium-android-driver/issues/146
https://github.com/appium/appium/issues/6489
https://github.com/appium/appium/issues/6433
https://github.com/appium/appium/issues/6262
https://github.com/appium/appium/issues/6254
### Reviewers: @imurchie, @jlipps, ...

Add android-install-timeout capability to docs

Android driver dependency updates from 1.10.6 > 1.10.12:
- Fix 'release' touch action
- Unlock helper deflake
- Add device udid to android session information
- Improve text clear command
- Allow fast reset without 'app' capability
- Add 'androidInstallTimeout' capability
