### PR TITLE
Update to new name for xcuitest driver

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -7,7 +7,7 @@ import { FakeDriver } from 'appium-fake-driver';
 import { AndroidDriver } from 'appium-android-driver';
 import { IosDriver } from 'appium-ios-driver';
 import { SelendroidDriver } from 'appium-selendroid-driver';
-import { WebDriverAgentDriver } from 'appium-xcuitest-driver';
+import { XCUITestDriver } from 'appium-xcuitest-driver';
 import { YouiEngineDriver } from 'appium-youiengine-driver';
 import B from 'bluebird';
 import util from 'util';
@@ -48,7 +48,7 @@ class AppiumDriver extends BaseDriver {
         return SelendroidDriver;
       } else if (caps.automationName.toLowerCase() === 'xcuitest') {
         // but if we do and it is 'XCUITest', act on it
-        return WebDriverAgentDriver;
+        return XCUITestDriver;
       } else if (caps.automationName.toLowerCase() === 'youiengine') {
         // but if we do and it is 'YouiEngine', act on it
         return YouiEngineDriver;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "appium-logger": "^2.1.0",
     "appium-selendroid-driver": "^1.3.4",
     "appium-support": "^2.3.0",
-    "appium-xcuitest-driver": "^1.0.4",
+    "appium-xcuitest-driver": "^2.0.0",
     "appium-youiengine-driver": "^1.0.3",
     "argparse": "^1.0.7",
     "asyncbox": "^2.3.1",

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -7,7 +7,7 @@ import _ from 'lodash';
 import sinon from 'sinon';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { WebDriverAgentDriver } from 'appium-xcuitest-driver';
+import { XCUITestDriver } from 'appium-xcuitest-driver';
 
 
 chai.use(chaiAsPromised);
@@ -176,14 +176,14 @@ describe('AppiumDriver', () => {
         let appium = new AppiumDriver({});
         (() => { appium.getDriverForCaps({}); }).should.throw(/platformName/);
       });
-      it('should get WebDriverAgentDriver driver for automationName of XCUITest', () => {
+      it('should get XCUITestDriver driver for automationName of XCUITest', () => {
         let appium = new AppiumDriver({});
         let driver = appium.getDriverForCaps({
           platformName: 'iOS',
           automationName: 'XCUITest'
         });
         driver.should.be.an.instanceof(Function);
-        driver.should.equal(WebDriverAgentDriver);
+        driver.should.equal(XCUITestDriver);
       });
     });
   });


### PR DESCRIPTION
## Proposed changes

The name of the driver exported by `appium-xcuitest-driver` was changed from `WebDriverAgentDriver` to `XCUITestDriver` so as not to encode underlying technology (i.e., Facebook's `WebDriverAgent`) into the driver's name. It also gets rid of the awful double-driver moniker.
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
### Reviewers: @jlipps
