### PR TITLE
Add support to set directory on android device to save screenshots

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -60,6 +60,7 @@
 |`chromeOptions`| Allows passing chromeOptions capability for ChromeDriver. For more information see [chromeOptions](https://sites.google.com/a/chromium.org/chromedriver/capabilities) | `chromeOptions: {args: ['--disable-popup-blocking']}` |
 |`recreateChromeDriverSessions`| Kill ChromeDriver session when moving to a non-ChromeDriver webview. Defaults to `false` | `true` or `false`|
 |`nativeWebScreenshot`| In a web context, use native (adb) method for taking a screenshot, rather than proxying to ChromeDriver. Defaults to `false` | `true` or `false`|
+|`androidScreenshotPath`| The name of the directory on the device in which the screenshot will be put. Defaults to `/data/local/tmp` |e.g. `/sdcard/screenshots/`|
 
 ### iOS Only
 


### PR DESCRIPTION
## Proposed changes

Currently for getScreenshot method on Android devices, appium puts the screenshot in /data/local/tmp/screenshot.png. This forces appium to use device diskpace. This PR gives user to mention the directory in which he would want to store the screenshot file in the form of a capability.
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [`x` ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist
- [`x` ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ `x`] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [ `x`] Lint and unit tests pass locally with my changes
- [ `x`] I have added tests that prove my fix is effective or that my feature works
- [`x` ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
## Further comments

Also made changes to appium-android-driver node module in this [PR](https://github.com/appium/appium-android-driver/pull/165)
### Reviewers: @imurchie, @jlipps, ...
