### PR TITLE
Update parser and logging to handle log spy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,9 @@
 "use strict";
 
+// turn all logging on since we have tests that rely on npmlog logs actually
+// getting sent to the handler
+process.env._FORCE_LOGS="1";
+
 var gulp = require('gulp'),
     boilerplate = require('appium-gulp-plugins').boilerplate.use(gulp),
     path = require('path'),

--- a/lib/config.js
+++ b/lib/config.js
@@ -62,7 +62,7 @@ function getNonDefaultArgs (parser, args) {
   let nonDefaults = {};
   for (let rawArg of parser.rawArgs) {
     let arg = rawArg[1].dest;
-    if (args[arg] !== rawArg[1].defaultValue) {
+    if (args[arg] && args[arg] !== rawArg[1].defaultValue) {
       nonDefaults[arg] = args[arg];
     }
   }
@@ -77,7 +77,7 @@ function getDeprecatedArgs (parser, args) {
     let arg = rawArg[1].dest;
     let defaultValue = rawArg[1].defaultValue;
     let isDeprecated = !!rawArg[1].deprecatedFor;
-    if (args[arg] !== defaultValue && isDeprecated) {
+    if (args[arg] && args[arg] !== defaultValue && isDeprecated) {
       deprecated[rawArg[0]] = rawArg[1].deprecatedFor;
     }
   }

--- a/lib/logsink.js
+++ b/lib/logsink.js
@@ -81,6 +81,7 @@ function _createConsoleTransport (args, logLvl) {
   if (args.logNoColors) {
     applyStripColorPatch(transport);
   }
+
   return transport;
 }
 

--- a/lib/logsink.js
+++ b/lib/logsink.js
@@ -179,6 +179,10 @@ async function init (args) {
     winston.addColors(colors);
   }
 
+  // clean up in case we have initted before since npmlog is a global
+  // object
+  clear();
+
   logger = new (winston.Logger)({
     transports: await _createTransports(args)
   });
@@ -192,6 +196,10 @@ async function init (args) {
       msg = `${prefix.magenta} ${msg}`;
     }
     logger[winstonLevel](msg);
+    if (args.logHandler && typeof args.logHandler === "function") {
+      args.logHandler(logObj.level, msg);
+    }
+
   });
 
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -6,7 +6,7 @@ import logger from './logger'; // logger needs to remain first of imports
 import _ from 'lodash';
 import { server as baseServer } from 'appium-base-driver';
 import { asyncify } from 'asyncbox';
-import getParser from './parser';
+import { default as getParser, getDefaultArgs } from './parser';
 import { showConfig, checkNodeOk, validateServerArgs,
          warnNodeDeprecations, validateTmpDir, getNonDefaultArgs,
          getDeprecatedArgs, getGitRev, APPIUM_VER } from './config';
@@ -93,7 +93,12 @@ function logServerPort (address, port) {
 
 async function main (args = null) {
   let parser = getParser();
-  if (!args) {
+  if (args) {
+    // a containing package passed in their own args, let's fill them out
+    // with defaults
+    args = Object.assign({}, getDefaultArgs(), args);
+  } else {
+    // otherwise parse from CLI
     args = parser.parseArgs();
   }
   await logsinkInit(args);

--- a/lib/main.js
+++ b/lib/main.js
@@ -15,7 +15,7 @@ import registerNode from './grid-register';
 import util from 'util';
 
 
-async function preflightChecks (parser, args) {
+async function preflightChecks (parser, args, throwInsteadOfExit = false) {
   try {
     checkNodeOk();
     if (args.asyncTrace) {
@@ -32,6 +32,10 @@ async function preflightChecks (parser, args) {
     }
   } catch (err) {
     logger.error(err.message.red);
+    if (throwInsteadOfExit) {
+      throw err;
+    }
+
     process.exit(1);
   }
 }
@@ -93,16 +97,26 @@ function logServerPort (address, port) {
 
 async function main (args = null) {
   let parser = getParser();
+  let throwInsteadOfExit = false;
   if (args) {
     // a containing package passed in their own args, let's fill them out
     // with defaults
     args = Object.assign({}, getDefaultArgs(), args);
+
+    // if we have a containing package instead of running as a CLI process,
+    // that package might not appreciate us calling 'process.exit' willy-
+    // nilly, so give it the option to have us throw instead of exit
+    if (args.throwInsteadOfExit) {
+      throwInsteadOfExit = true;
+      // but remove it since it's not a real server arg per se
+      delete args.throwInsteadOfExit;
+    }
   } else {
     // otherwise parse from CLI
     args = parser.parseArgs();
   }
   await logsinkInit(args);
-  await preflightChecks(parser, args);
+  await preflightChecks(parser, args, throwInsteadOfExit);
   await logStartupInfo(parser, args);
   let router = getAppiumRouter(args);
   let server = await baseServer(router, args.port, args.address);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -11,6 +11,7 @@ const args = [
     defaultValue: null,
     help: 'Enter REPL mode',
     nargs: 0,
+    dest: 'shell',
   }],
 
   [['--ipa'], {
@@ -18,6 +19,7 @@ const args = [
     defaultValue: null,
     help: '(IOS-only) abs path to compiled .ipa file',
     example: '/abs/path/to/my.ipa',
+    dest: 'ipa',
   }],
 
   [['-a', '--address'], {
@@ -25,6 +27,7 @@ const args = [
     required: false,
     example: '0.0.0.0',
     help: 'IP Address to listen on',
+    dest: 'address',
   }],
 
   [['-p', '--port'], {
@@ -33,6 +36,7 @@ const args = [
     type: 'int',
     example: '4723',
     help: 'port to listen on',
+    dest: 'port',
   }],
 
   [['-ca', '--callback-address'], {
@@ -141,12 +145,14 @@ const args = [
     defaultValue: null,
     required: false,
     example: 'localhost:9876',
+    dest: 'webhook',
     help: 'Also send log output to this HTTP listener',
   }],
 
   [['--safari'], {
     defaultValue: false,
     action: 'storeTrue',
+    dest: 'safari',
     required: false,
     help: '(IOS-Only) Use the safari app',
     nargs: 0,
@@ -198,6 +204,7 @@ const args = [
   [['--nodeconfig'], {
     required: false,
     defaultValue: null,
+    dest: 'nodeconfig',
     help: 'Configuration JSON file to register appium with selenium grid',
     example: '/abs/path/to/nodeconfig.json',
   }],


### PR DESCRIPTION
The new appium desktop will import Appium and run it in memory, so we need a way to attach a log spy method.

Some other cleanup as well along the way.

This is the branch that is currently supporting the work in progress at https://github.com/jlipps/appium-desktop (using `npm link`)
