### PR TITLE
Remove default ChromeDriver port in arg parse

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -236,12 +236,12 @@ const args = [
   }],
 
   [['--chromedriver-port'], {
-    defaultValue: 9515,
+    defaultValue: null,
     dest: 'chromeDriverPort',
     required: false,
     type: 'int',
     example: '9515',
-    help: 'Port upon which ChromeDriver will run',
+    help: 'Port upon which ChromeDriver will run. If not given, Android driver will pick a random available port.',
   }],
 
   [['--chromedriver-executable'], {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "doc": "./docs"
   },
   "dependencies": {
-    "appium-android-driver": "^1.10.12",
+    "appium-android-driver": "^1.10.19",
     "appium-base-driver": "^2.0.8",
     "appium-fake-driver": "^0.1.10",
     "appium-ios-driver": "^1.12.2",


### PR DESCRIPTION
## Proposed changes

Let lower level Android driver pick a random free port for Chrome driver if the user doesn't give an explicit port. This will allow parallel browser-based Android tests on the same machine.

WRT https://github.com/appium/appium-android-driver/issues/176
## Types of changes

What types of changes does your code introduce to Appium?
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
