### PR TITLE
add reboot option for android emulator

### DIFF
--- a/docs/en/writing-running-appium/default-capabilities-arg.md
+++ b/docs/en/writing-running-appium/default-capabilities-arg.md
@@ -52,3 +52,4 @@ Appium 1.5 does away with most CLI flags; the remainder can be converted into JS
 | --keep-keychains          | keepKeyChains           |
 | --localizable-strings-dir | localizableStringsDir   |
 | --show-ios-log            | showIOSLog              |
+| --reboot                  | reboot                  |

--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -52,6 +52,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--async-trace`|false|Add long stack traces to log entries. Recommended for debugging only.||
 |`--webkit-debug-proxy-port`|27753|(IOS-only) Local port used for communication with ios-webkit-debug-proxy|`--webkit-debug-proxy-port 27753`|
 |`-dc`, `--default-capabilities`|{}|Set the default desired capabilities, which will be set on each session unless overridden by received capabilities.|`--default-capabilities [ '{"app": "myapp.app", "deviceName": "iPhone Simulator"}' | /path/to/caps.json ]`|
+|`--reboot`|false| - (Android-only) reboot emulator after each session and kill it at the end||
 |`--command-timeout`|60|[DEPRECATED] No effect. This used to be the default command timeout for the server to use for all sessions (in seconds and should be less than 2147483). Use newCommandTimeout cap instead||
 |`-k`, `--keep-artifacts`|false|[DEPRECATED] - no effect, trace is now in tmp dir by default and is cleared before each run. Please also refer to the --trace-dir flag.||
 |`--platform-name`|null|[DEPRECATED] - Name of the mobile platform: iOS, Android, or FirefoxOS|`--platform-name iOS`|

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -14,6 +14,15 @@ const args = [
     dest: 'shell',
   }],
 
+  [['--reboot'], {
+    defaultValue: false,
+    dest: 'reboot',
+    action: 'storeTrue',
+    required: false,
+    help: '(Android-only) reboot emulator after each session and kill it at the end',
+    nargs: 0,
+  }],
+   
   [['--ipa'], {
     required: false,
     defaultValue: null,


### PR DESCRIPTION
## Proposed changes

If reboot option activated, it will always wipe data of emulator on start, and close emulator at the end. it is required for [support reboot parameter for android](https://github.com/appium/appium-android-driver/pull/180)
## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
### Reviewers: @imurchie, @jlipps, ...
