### PR TITLE
Add server parameter for WebDriverAgent local port

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -351,6 +351,15 @@ const args = [
     help: '(IOS-only) Local port used for communication with ios-webkit-debug-proxy'
   }],
 
+  [['--webdriveragent-port'], {
+    defaultValue: 8100,
+    dest: 'wdaLocalPort',
+    required: false,
+    type: 'int',
+    example: "8100",
+    help: '(IOS-only, XCUITest-only) Local port used for communication with WebDriverAgent'
+  }],
+
   [['-dc', '--default-capabilities'], {
     dest: 'defaultCapabilities',
     defaultValue: {},


### PR DESCRIPTION
## Proposed changes

Enable specifying the WebDriverAgent port as a server parameter, so multiple Appium XCUI tests can be run concurrently.
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
### Reviewers: @imurchie, @jlipps, ...
