### PR TITLE
Move authorize-ios to a global program only

### DIFF
--- a/docs/en/appium-setup/running-on-osx.md
+++ b/docs/en/appium-setup/running-on-osx.md
@@ -31,21 +31,16 @@ Appium on OS X supports iOS and Android testing.
 ### Authorizing iOS on the computer
 
 You need to authorize use of the iOS Simulator by running the `authorize-ios`
-binary made available through `npm`. If you installed globally, by running
-`npm install -g appium`, use
+binary made available through `npm`. Install the program by running
+
+```
+npm install -g authorize-ios
+```
+
+And the invoke the program using
 
 ```
 sudo authorize-ios
-```
-
-If you installed locally, the binary will be installed within the `node_modules/.bin`
-directory, so use
-
-```
-sudo node_modules/.bin/authorize-ios
-
-# alternatively
-sudo $(npm bin)/authorize-ios
 ```
 
 If you are running [Appium.app](https://github.com/appium/appium-dot-app), you can
@@ -81,7 +76,7 @@ those on Linux. See the [Android setup docs](/docs/en/appium-setup/android-setup
 
 ### Running iOS tests on OS X using Jenkins
 
-First download the jenkins-cli.jar and verify the Mac successfully connects to Jenkins master. Ensure you've run the `authorize_ios` command mentioned above.
+First download the jenkins-cli.jar and verify the Mac successfully connects to Jenkins master. Ensure you've run the `authorize-ios` command mentioned above.
 
 `wget https://jenkins.ci.cloudbees.com/jnlpJars/jenkins-cli.jar`
 

--- a/docs/en/contributing-to-appium/appium-from-source.md
+++ b/docs/en/contributing-to-appium/appium-from-source.md
@@ -22,9 +22,8 @@ git clone https://github.com/appium/appium.git
 cd appium
 npm install
 gulp transpile # requires gulp, see below
-sudo node_modules/.bin/authorize-ios # for ios only
-# alternatively
-sudo $(npm bin)/authorize-ios
+npm install -g authorize-ios # for ios only
+authorize-ios                # for ios only
 node .
 ```
 
@@ -83,7 +82,7 @@ have to modify your `/etc/authorization` file in one of two ways:
 
     ```center
     sudo node_modules/.bin/authorize-ios.js
-    
+
     # alternatively
 	sudo $(npm bin)/authorize-ios
 	```

--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -94,6 +94,21 @@
 |`webviewConnectRetries`| Number of times to send connection message to remote debugger, to get webview. Default: `8` |e.g., `12`|
 |`appName`| The display name of the application under test. Used to automate backgrounding the app in iOS 9+.|e.g., `UICatalog`|
 
+### iOS Only, using XCUITest
+
+<expand_table>
+
+|Capability|Description|Values|
+|----------|-----------|------|
+|`processArguments`|Process arguments and environment which will be sent to the WebDriverAgent server.|`{ args: ["a", "b", "c"] , env: { "a": "b", "c": "d" } }` or `'{"args": ["a", "b", "c"], "env": { "a": "b", "c": "d" }}'`|
+|`wdaLocalPort`|This value if specified, will be used to forward traffic from Mac host to real ios devices over USB. Default value is same as port number used by WDA on device.|e.g., `8100`|
+|`showXcodeLog`|Whether to display the output of the Xcode command used to run the tests. If this is `true`, there will be **lots** of extra logging at startup. Defaults to `false`|e.g., `true`|
+|`realDeviceLogger`|Device logger for real devices. It could be path to `deviceconsole` (installed with `npm install deviceconsole`, a compiled binary named `deviceconsole` will be added to `./node_modules/deviceconsole/`) or `idevicesyslog` (comes with libimobiledevice). Defaults to `idevicesyslog`|`idevicesyslog`, `/abs/path/to/deviceconsole`|
+|`iosInstallPause`|Time in milliseconds to pause between installing the application and starting WebDriverAgent on the device. Used particularly for larger applications. Defaults to `0`|e.g., `8000`|
+|`xcodeConfigFile`|Full path to an optional Xcode configuration file that specifies the code signing identity and team for running the WebDriverAgent on the real device.|e.g., `/path/to/myconfig.xcconfig`|
+|`keychainPath`|Full path to the private development key exported from the system keychain. Used in conjunction with `keychainPassword` when testing on real devices.|e.g., `/path/to/MyPrivateKey.p12`|
+|`keychainPassword`|Password for unlocking keychain specified in `keychainPath`.|e.g., `super awesome password`|
+
 ### You.i Engine Only
 
 <expand_table>

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   },
   "main": "./build/lib/main.js",
   "bin": {
-    "appium": "./build/lib/main.js",
-    "authorize-ios": "./node_modules/.bin/authorize-ios"
+    "appium": "./build/lib/main.js"
   },
   "directories": {
     "lib": "./lib",
@@ -48,7 +47,6 @@
     "appium-windows-driver": "^0.x",
     "argparse": "^1.0.7",
     "asyncbox": "^2.3.1",
-    "authorize-ios": "^1.0.4",
     "babel-runtime": "=5.8.24",
     "bluebird": "^2.10.2",
     "continuation-local-storage": "^3.1.7",


### PR DESCRIPTION
## Proposed changes

With newer npm versions we run into a problem installing locally, where the system fails to install Appium when doing a local install, because authorize-ios can't be linked.

It is already a global package, so just change instructions to manually install and run.
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
### Reviewers: @imurchie, @jlipps, ...
