### PR TITLE
graceful handling of SIGTERM and SIGINT such that return codes are mo…

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -132,6 +132,17 @@ async function main (args = null) {
     await server.close();
     throw err;
   }
+
+  process.on('SIGINT', async function () {
+    logger.info(`Received SIGINT - shutting down`);
+    await server.close();
+  });
+
+  process.on('SIGTERM', async function () {
+    logger.info(`Received SIGTERM - shutting down`);
+    await server.close();
+  });
+
   logServerPort(args.address, args.port);
 
   return server;


### PR DESCRIPTION
## Proposed changes

Upon receiving SIGTERM appium exits with code 143 which is line with the documentation presented [here](https://nodejs.org/api/process.html#process_signal_events). However it is not an expected result from the point of view of many existing system tools. A SIGTERM would usually result in a graceful shutdown and an exit code of 0. 

I've installed basic signal handers for SIGTERM and SIGINT that shutdown express when they are met. The code then exits gracefully with an exit code of 0.

The specific problem I encountered was met when managing appium using launchctl on OSX which I use to manage appium process life. Shutdown is performed via SIGTERM and launchctl expects an exit code of 0 as is typical. 
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
## Further comments

NA
### Reviewers: @imurchie, @jlipps
