### PR TITLE
Pass capability acceptSslCerts to AndroidDriver

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -146,7 +146,8 @@ class AppiumDriver extends BaseDriver {
       throw new errors.SessionNotCreatedError(e.message);
     }
 
-    let d = new InnerDriver(this.args);
+    let driverOpts = _.assign({}, this.args, {acceptSslCerts: !!caps.acceptSslCerts});
+    let d = new InnerDriver(driverOpts);
     let [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, curSessions);
     this.sessions[innerSessionId] = d;
 


### PR DESCRIPTION
## Proposed changes

Fix ```acceptSslCerts``` capability for android browser

PR for https://github.com/appium/appium/issues/7326

Linked PR: https://github.com/appium/appium-android-driver/pull/194

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

### Reviewers: @imurchie, @jlipps, ...

```AndroidDriver``` looks for capability ```acceptSslCerts``` in the first parameter of constructor.