### PR TITLE
Remove duplicate trailing in jshintrc for test

### DIFF
--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -5,7 +5,6 @@
   "trailing": true,
   "node": true,
   "eqeqeq": true,
-  "trailing": true,
   "expr": true,
   "white": true,
   "indent": 2,


### PR DESCRIPTION
## Proposed changes

This is very minor fix for duplicate entry in `test/.jshintrc`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

### Reviewers: @imurchie, @jlipps, ...

