### PR TITLE
Only catch signals once

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -133,12 +133,12 @@ async function main (args = null) {
     throw err;
   }
 
-  process.on('SIGINT', async function () {
+  process.once('SIGINT', async function () {
     logger.info(`Received SIGINT - shutting down`);
     await server.close();
   });
 
-  process.on('SIGTERM', async function () {
+  process.once('SIGTERM', async function () {
     logger.info(`Received SIGTERM - shutting down`);
     await server.close();
   });


### PR DESCRIPTION
## Proposed changes

Currently we catch every SIGINT and SIGTERM signal coming in and try to stop the http server. Unfortunately, if there are connections, it has to wait for them to be closed on both ends before Appium actually stops. 

This is a quick solution, only adding a one-time event listener for the signals. So if someone cares that the connections are closed etc. they can wait, otherwise another signal will terminate the whole thing.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

### Reviewers: @jlipps
