### PR TITLE
Replace IOSDriver with WindowsDriver

### DIFF
--- a/docs/en/writing-running-appium/windows-app-testing.md
+++ b/docs/en/writing-running-appium/windows-app-testing.md
@@ -26,7 +26,7 @@ To test a UWP app, you can use any Selenium supported language and simply specif
 // Launch the AlarmClock app
 DesiredCapabilities appCapabilities = new DesiredCapabilities();
 appCapabilities.SetCapability("app", "Microsoft.WindowsAlarms_8wekyb3d8bbwe!App");
-AlarmClockSession = new IOSDriver<IOSElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
+AlarmClockSession = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
 // Control the AlarmClock app
 AlarmClockSession.FindElementByAccessibilityId("AddAlarmButton").Click();
 AlarmClockSession.FindElementByAccessibilityId("AlarmNameTextBox").Clear();
@@ -38,7 +38,7 @@ To test a classic Windows app, you can also use any Selenium supported language 
 // Launch Notepad
 DesiredCapabilities appCapabilities = new DesiredCapabilities();
 appCapabilities.SetCapability("app", @"C:\Windows\System32\notepad.exe");
-NotepadSession = new IOSDriver<IOSElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
+NotepadSession = new WindowsDriver<WindowsElement>(new Uri("http://127.0.0.1:4723"), appCapabilities);
 // Control the AlarmClock app
 NotepadSession.FindElementByClassName("Edit").SendKeys("This is some text");
 ```


### PR DESCRIPTION
## Proposed changes

The [3.0.0.1 release of the Appium.WebDriver package](https://github.com/appium/appium-dotnet-driver/blob/master/RELEASE_NOTES.md#3001) provides a WindowsDriver class which can be used in place of IOSDriver when testing against Windows devices.  This PR replaces IOSDriver/IOSElement with WindowsDriver/WindowsElement in the `windows-app-testing.md` document.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://docs.google.com/forms/d/1lOfXRw_0VCk7gYzjj4WLetGu7yelDVo5LWh0z7pGftE/viewform)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

### Reviewers: @imurchie, @jlipps, ...
