### PR TITLE
Don't allow undefined process.argv[1] in parser

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -782,7 +782,8 @@ function getParser () {
   let parser = new ArgumentParser({
     version: pkgObj.version,
     addHelp: true,
-    description: 'A webdriver-compatible server for use with native and hybrid iOS and Android applications.'
+    description: 'A webdriver-compatible server for use with native and hybrid iOS and Android applications.',
+    prog: process.argv[1] || 'Appium'
   });
   let allArgs = _.union(args, deprecatedArgs);
   parser.rawArgs = allArgs;

--- a/test/config-specs.js
+++ b/test/config-specs.js
@@ -194,6 +194,30 @@ describe('Config', () => {
     });
   });
 
+  describe('parsing args with empty argv[1]', () => {
+    let argv1;
+
+    before(() => {
+      argv1 = process.argv[1];
+    });
+
+    after(() => {
+      process.argv[1] = argv1;
+    });
+
+    it('should not fail if process.argv[1] is undefined', () => {
+      process.argv[1] = undefined;
+      let args = getParser();
+      args.prog.should.be.equal('Appium');
+    });
+
+    it('should set "prog" to process.argv[1]', () => {
+      process.argv[1] = 'Hello World';
+      let args = getParser();
+      args.prog.should.be.equal('Hello World');
+    });
+  });
+
   describe('validateServerArgs', () => {
     let parser = getParser();
     parser.debug = true; // throw instead of exit on error; pass as option instead?


### PR DESCRIPTION
argParse breaks if process.argv[1] is undefined, which is a problem when Appium is being run as a binary (because there's only one arg). Added check so that if process.argv[1] is undefined, set the prog name to 'Appium'.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

### Reviewers: @imurchie, @jlipps, ...
