### PR TITLE
Fix formatting of default capabilities

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -48,9 +48,32 @@ function logDeprecationWarning (deprecatedArgs) {
 }
 
 function logNonDefaultArgsWarning (args) {
+  // cleanly print out the default arguments, allowing for prefix and timestamp
+  function getValueArray (obj, indent = '  ') {
+    if (!_.isObject(obj)) {
+      return [obj];
+    }
+
+    let strArr = ['{'];
+    for (let [arg, value] of _.toPairs(obj)) {
+      if (!_.isObject(value)) {
+        strArr.push(`${indent}  ${arg}: ${value}`);
+      } else {
+        value = getValueArray(value, `${indent}  `);
+        strArr.push(`${indent}  ${arg}: ${value.shift()}`);
+        strArr.push(...value);
+      }
+    }
+    strArr.push(`${indent}}`);
+    return strArr;
+  }
   logger.info('Non-default server args:');
   for (let [arg, value] of _.toPairs(args)) {
-    logger.info(`  ${arg}: ${util.inspect(value)}`);
+    value = getValueArray(value);
+    logger.info(`  ${arg}: ${value.shift()}`);
+    for (let val of value) {
+      logger.info(val);
+    }
   }
 }
 


### PR DESCRIPTION
## Proposed changes

Call me irrational, but I _hate_ how the default capabilities get printed within the server args section of the Appium startup logging.

How it currently is:
```
$ node . --log-timestamp --default-capabilities '{"showIOSLog": true, "nativeInstrumentsLib": true, "platformName": "Android", "timeouts": {"global": 10000}}'
2017-02-14 16:22:15:233 - [Appium] Welcome to Appium v1.6.4-beta (REV b57d1a3171355c791a7f0024cfcdc797ce89d56a)
2017-02-14 16:22:15:235 - [Appium] Non-default server args:
2017-02-14 16:22:15:236 - [Appium]   logTimestamp: true
2017-02-14 16:22:15:249 - [Appium]   defaultCapabilities: { showIOSLog: true,
  nativeInstrumentsLib: true,
  platformName: 'Android',
  timeouts: { global: 10000 } }
2017-02-14 16:22:15:250 - [Appium] Default capabilities, which will be added to each request unless overridden by desired capabilities:
2017-02-14 16:22:15:252 - [Appium]   showIOSLog: true
2017-02-14 16:22:15:252 - [Appium]   nativeInstrumentsLib: true
2017-02-14 16:22:15:252 - [Appium]   platformName: 'Android'
2017-02-14 16:22:15:253 - [Appium]   timeouts: { global: 10000 }
2017-02-14 16:22:15:295 - [Appium] Appium REST http interface listener started on 0.0.0.0:4723
```

How it should be (and is, with this PR):
```
$ node . --log-timestamp --default-capabilities '{"showIOSLog": true, "nativeInstrumentsLib": true, "platformName": "Android", "timeouts": {"global": 10000}}'
2017-02-14 16:16:31:567 - [Appium] Welcome to Appium v1.6.4-beta (REV b57d1a3171355c791a7f0024cfcdc797ce89d56a)
2017-02-14 16:16:31:569 - [Appium] Non-default server args:
2017-02-14 16:16:31:570 - [Appium]   logTimestamp: true
2017-02-14 16:16:31:570 - [Appium]   defaultCapabilities: {
2017-02-14 16:16:31:570 - [Appium]     showIOSLog: true
2017-02-14 16:16:31:571 - [Appium]     nativeInstrumentsLib: true
2017-02-14 16:16:31:571 - [Appium]     platformName: Android
2017-02-14 16:16:31:571 - [Appium]     timeouts: {
2017-02-14 16:16:31:572 - [Appium]       global: 10000
2017-02-14 16:16:31:572 - [Appium]     }
2017-02-14 16:16:31:573 - [Appium]   }
2017-02-14 16:16:31:574 - [Appium] Default capabilities, which will be added to each request unless overridden by desired capabilities:
2017-02-14 16:16:31:585 - [Appium]   showIOSLog: true
2017-02-14 16:16:31:585 - [Appium]   nativeInstrumentsLib: true
2017-02-14 16:16:31:586 - [Appium]   platformName: 'Android'
2017-02-14 16:16:31:586 - [Appium]   timeouts: { global: 10000 }
2017-02-14 16:16:31:634 - [Appium] Appium REST http interface listener started on 0.0.0.0:4723
```

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This is minor but bugs me every time I see the logs.

### Reviewers: @dpgraham , @jlipps, ...
