### PR TITLE
Remove date-utils library and use node-dateformat

### DIFF
--- a/lib/logsink.js
+++ b/lib/logsink.js
@@ -1,9 +1,8 @@
 import npmlog from 'npmlog';
 import winston  from 'winston';
 import { fs, logger } from 'appium-support';
-import 'date-utils';
+import dateformat from 'dateformat';
 import _ from 'lodash';
-
 
 // set up distributed logging before everything else
 logger.patchLogger(npmlog);
@@ -43,7 +42,7 @@ function timestamp () {
   if (!timeZone) {
     date = new Date(date.valueOf() + date.getTimezoneOffset() * 60000);
   }
-  return date.toFormat("YYYY-MM-DD HH24:MI:SS:LL");
+  return dateformat(date, "yyyy-mm-dd HH:MM:ss:l");
 }
 
 // Strip the color marking within messages.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-runtime": "=5.8.24",
     "bluebird": "2.x",
     "continuation-local-storage": "3.x",
-    "date-utils": "1.x",
+    "dateformat": "^2.0.0",
     "lodash": "4.x",
     "npmlog": "2.x",
     "request": "^2.81.0",


### PR DESCRIPTION
* Removed date-utils and removed require
* Replaced `call to date.toFormat(...)` with `dateformat(date, '...')` in `timestamp` function in `logsink.js`
* Couldn't write any tests because timestamp is a private method, so did a quick sanity check from the command line to confirm that the behaviour is the same

```
Daniels-MacBook-Pro:appium danielgraham$ node --version
v4.1.2
Daniels-MacBook-Pro:appium danielgraham$ node
> require('date-utils')
{ language: [Function: language] }
> var date = new Date()
undefined
> date = new Date(date.valueOf() + date.getTimezoneOffset() * 60000)
2017-04-26T06:24:09.224Z
> date.toFormat("YYYY-MM-DD HH24:MI:SS:LL")
'2017-04-25 23:24:09:224'
> var dateformat = require('dateformat')
undefined
> dateformat(date, "yyyy-mm-dd H:M:ss:l")
'2017-04-25 23:24:09:224'
```

(reviewers
