### PR TITLE
add systemPort capability for uiautomator2

### DIFF
--- a/docs/en/appium-setup/parallel_tests.md
+++ b/docs/en/appium-setup/parallel_tests.md
@@ -22,6 +22,8 @@ As long as your Appium and Appium bootstrap ports are between 0 and 65536, all t
 
 If you are using chromedriver or selendroid, set a different port for each server.
 
+If you are using [appium-uiautomator2-server](https://github.com/appium/appium-uiautomator2-server), set a different system port with `systemPort` capability since sometimes the same ports is conflictted such as [this issue](https://github.com/appium/appium/issues/7745).
+
 ### Parallel iOS Tests
 
 Unfortunately, running local parallel iOS tests isn't currently possible. Unlike Android, only one version of the iOS simulator can be launched at a time, making it run multiple tests at once.

--- a/docs/en/appium-setup/parallel_tests.md
+++ b/docs/en/appium-setup/parallel_tests.md
@@ -22,7 +22,7 @@ As long as your Appium and Appium bootstrap ports are between 0 and 65536, all t
 
 If you are using chromedriver or selendroid, set a different port for each server.
 
-If you are using [appium-uiautomator2-server](https://github.com/appium/appium-uiautomator2-server), set a different system port with `systemPort` capability since sometimes the same ports is conflictted such as [this issue](https://github.com/appium/appium/issues/7745).
+If you are using [appium-uiautomator2-driver](https://github.com/appium/appium-uiautomator2-driver), set a different system port for each Appium instanceset with `systemPort` capability since sometimes there can be a port conflict if different ports aren't used, such as in [this issue](https://github.com/appium/appium/issues/7745).
 
 ### Parallel iOS Tests
 


### PR DESCRIPTION
## Proposed changes

Sometimes, we should set `systemPort` to run parallel tests with uiautomator2 since without the capability, [Not able to run parallel tests using uiautomator2](https://github.com/appium/appium/issues/7745) is caused.

So, I've added the capability and the issue in `parallel_tests.md`. What do you think to add the description here?

## Types of changes

Update documentations.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

### Reviewers: @imurchie, @jlipps, ...
