### PR TITLE
Pass the list of running sessions to deleteSession

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -239,9 +239,11 @@ class AppiumDriver extends BaseDriver {
   async deleteSession (sessionId) {
     try {
       if (this.sessions[sessionId]) {
-        const curSessionsData = this.curSessionDataForDriver(this.sessions[sessionId].constructor);
-        const curDriverData = this.sessions[sessionId].driverData;
-        await this.sessions[sessionId].deleteSession(sessionId, _.filter(curSessionsData, (x) => x !== curDriverData));
+        const curConstructorName = this.sessions[sessionId].constructor.name;
+        const otherSessionsData = _.toPairs(this.sessions)
+                .filter(([key, value]) => value.constructor.name === curConstructorName && key !== sessionId)
+                .map(([key, value]) => value.driverData);
+        await this.sessions[sessionId].deleteSession(sessionId, otherSessionsData);
       }
     } catch (e) {
       log.error(`Had trouble ending session ${sessionId}: ${e.message}`);

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -239,7 +239,9 @@ class AppiumDriver extends BaseDriver {
   async deleteSession (sessionId) {
     try {
       if (this.sessions[sessionId]) {
-        await this.sessions[sessionId].deleteSession();
+        const curSessionsData = this.curSessionDataForDriver(this.sessions[sessionId].constructor);
+        const curDriverData = this.sessions[sessionId].driverData;
+        await this.sessions[sessionId].deleteSession(sessionId, _.filter(curSessionsData, (x) => x !== curDriverData));
       }
     } catch (e) {
       log.error(`Had trouble ending session ${sessionId}: ${e.message}`);

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -242,7 +242,7 @@ class AppiumDriver extends BaseDriver {
         const curConstructorName = this.sessions[sessionId].constructor.name;
         const otherSessionsData = _.toPairs(this.sessions)
                 .filter(([key, value]) => value.constructor.name === curConstructorName && key !== sessionId)
-                .map(([key, value]) => value.driverData);
+                .map(([, value]) => value.driverData);
         await this.sessions[sessionId].deleteSession(sessionId, otherSessionsData);
       }
     } catch (e) {

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -130,9 +130,9 @@ describe('AppiumDriver', () => {
         sessions.should.have.length(0);
       });
       it('should call inner driver\'s deleteSession method', async () => {
-        let [sessionId] = await appium.createSession(BASE_CAPS);
+        const [sessionId] = await appium.createSession(BASE_CAPS);
         mockFakeDriver.expects("deleteSession")
-          .once().withExactArgs()
+          .once().withExactArgs(sessionId, [])
           .returns();
         await appium.deleteSession(sessionId);
         mockFakeDriver.verify();


### PR DESCRIPTION
## Proposed changes

We already provide the list of active sessions for the current driver class in _createSession_ method. This list will be also useful for _deleteSession_ method if we want parallel sessions handling to work properly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Reviewers: @imurchie, @jlipps, ...