### PR TITLE
Include the information about pending drivers being currently at creation stage into createSession argument

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -27,6 +27,8 @@ class AppiumDriver extends BaseDriver {
     this.args = args;
 
     this.sessions = {};
+
+    this.pendingDrivers = {};
   }
 
   sessionExists (sessionId) {
@@ -176,15 +178,26 @@ class AppiumDriver extends BaseDriver {
       }
     }
 
-    let curSessions;
+    let runningDriversData;
     try {
-      curSessions = this.curSessionDataForDriver(InnerDriver);
+      runningDriversData = this.curSessionDataForDriver(InnerDriver);
     } catch (e) {
       throw new errors.SessionNotCreatedError(e.message);
     }
 
+    let innerSessionId, dCaps;
     let d = new InnerDriver(this.args);
-    let [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, curSessions);
+    try {
+      if (_.isArray(this.pendingDrivers[InnerDriver.name])) {
+        this.pendingDrivers[InnerDriver.name].push(d);
+      } else {
+        this.pendingDrivers[InnerDriver.name] = [d];
+      }
+      const otherPendingDriversData = this.pendingDrivers[InnerDriver.name].filter((drv) => d !== drv).map((drv) => drv.driverData);
+      [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, [...runningDriversData, ...otherPendingDriversData]);
+    } finally {
+      _.pull(this.pendingDrivers[InnerDriver.name], d);
+    }
     this.sessions[innerSessionId] = d;
 
     // this is an async function but we don't await it because it handles

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -188,12 +188,9 @@ class AppiumDriver extends BaseDriver {
     let innerSessionId, dCaps;
     let d = new InnerDriver(this.args);
     try {
-      if (_.isArray(this.pendingDrivers[InnerDriver.name])) {
-        this.pendingDrivers[InnerDriver.name].push(d);
-      } else {
-        this.pendingDrivers[InnerDriver.name] = [d];
-      }
-      const otherPendingDriversData = this.pendingDrivers[InnerDriver.name].filter((drv) => d !== drv).map((drv) => drv.driverData);
+      this.pendingDrivers[InnerDriver.name] = this.pendingDrivers[InnerDriver.name] || [];
+      const otherPendingDriversData = this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData);
+      this.pendingDrivers[InnerDriver.name].push(d);
       [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, [...runningDriversData, ...otherPendingDriversData]);
     } finally {
       _.pull(this.pendingDrivers[InnerDriver.name], d);


### PR DESCRIPTION
## Proposed changes

Current algorithm only passes the information for drivers that already have sessions, but this does not work as expected for the case when several drivers are being created at the same time and we are trying to figure out which of them is the first one in the pipeline. That is why I also include the data of other pending drivers, whose state is 'session creation'.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Reviewers: @imurchie, @jlipps, ...