### PR TITLE
Add basic synchonization to session creation and deletion

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -19,7 +19,7 @@ import AsyncLock from 'async-lock';
 
 
 const sessionsListGuard = new AsyncLock();
-const pendindDriversGuard = new AsyncLock();
+const pendingDriversGuard = new AsyncLock();
 
 class AppiumDriver extends BaseDriver {
   constructor (args) {
@@ -30,12 +30,12 @@ class AppiumDriver extends BaseDriver {
 
     this.args = args;
 
-    // Access to sessions list must be guarded with a Sepamphore, because
+    // Access to sessions list must be guarded with a Semaphore, because
     // it might be changed by other async calls at any time
     // It is not recommended to access this property directly from the outside
     this.sessions = {};
 
-    // Access to pending drivers list must be guarded with a Sepamphore, because
+    // Access to pending drivers list must be guarded with a Semaphore, because
     // it might be changed by other async calls at any time
     // It is not recommended to access this property directly from the outside
     this.pendingDrivers = {};
@@ -198,7 +198,7 @@ class AppiumDriver extends BaseDriver {
     } catch (e) {
       throw new errors.SessionNotCreatedError(e.message);
     }
-    await pendindDriversGuard.acquire(AppiumDriver.name, () => {
+    await pendingDriversGuard.acquire(AppiumDriver.name, () => {
       this.pendingDrivers[InnerDriver.name] = this.pendingDrivers[InnerDriver.name] || [];
       otherPendingDriversData = this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData);
       this.pendingDrivers[InnerDriver.name].push(d);
@@ -206,14 +206,12 @@ class AppiumDriver extends BaseDriver {
     let innerSessionId, dCaps;
     try {
       [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, [...runningDriversData, ...otherPendingDriversData]);
-    } finally {
-      await pendindDriversGuard.acquire(AppiumDriver.name, () => {
-        _.pull(this.pendingDrivers[InnerDriver.name], d);
-      });
       await sessionsListGuard.acquire(AppiumDriver.name, () => {
-        if (innerSessionId) {
-          this.sessions[innerSessionId] = d;
-        }
+        this.sessions[innerSessionId] = d;
+      });
+    } finally {
+      await pendingDriversGuard.acquire(AppiumDriver.name, () => {
+        _.pull(this.pendingDrivers[InnerDriver.name], d);
       });
     }
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -15,7 +15,11 @@ import { MacDriver } from 'appium-mac-driver';
 import { EspressoDriver } from 'appium-espresso-driver';
 import B from 'bluebird';
 import util from 'util';
+import AsyncLock from 'async-lock';
 
+
+const sessionsListGuard = new AsyncLock();
+const pendindDriversGuard = new AsyncLock();
 
 class AppiumDriver extends BaseDriver {
   constructor (args) {
@@ -26,14 +30,20 @@ class AppiumDriver extends BaseDriver {
 
     this.args = args;
 
+    // Access to sessions list must be guarded with a Sepamphore, because
+    // it might be changed by other async calls at any time
+    // It is not recommended to access this property directly from the outside
     this.sessions = {};
 
+    // Access to pending drivers list must be guarded with a Sepamphore, because
+    // it might be changed by other async calls at any time
+    // It is not recommended to access this property directly from the outside
     this.pendingDrivers = {};
   }
 
   sessionExists (sessionId) {
-    return _.includes(_.keys(this.sessions), sessionId) &&
-           this.sessions[sessionId].sessionId !== null;
+    const dstSession = this.sessions[sessionId];
+    return dstSession && dstSession.sessionId !== null;
   }
 
   driverForSession (sessionId) {
@@ -138,11 +148,11 @@ class AppiumDriver extends BaseDriver {
   }
 
   async getSessions () {
-    let sessions = [];
-    for (let [id, driver] of _.toPairs(this.sessions)) {
-      sessions.push({id, capabilities: driver.caps});
-    }
-    return sessions;
+    const sessions = await sessionsListGuard.acquire(AppiumDriver.name, () => this.sessions);
+    return _.toPairs(sessions)
+        .map(([id, driver]) => {
+          return {id, capabilities: driver.caps};
+        });
   }
 
   printNewSessionAnnouncement (driver, caps) {
@@ -165,37 +175,47 @@ class AppiumDriver extends BaseDriver {
 
     // sessionOverride server flag check
     // this will need to be re-thought when we go to multiple session support
-    if (this.args.sessionOverride && !!this.sessions && _.keys(this.sessions).length > 0) {
-      log.info('Session override is on. Deleting other sessions.');
-      for (let id of _.keys(this.sessions)) {
-        log.info(`    Deleting session '${id}'`);
-        try {
-          await this.deleteSession(id);
-        } catch (ign) {
-          // the error has already been logged in AppiumDriver.deleteSession
-          // continue
+    if (this.args.sessionOverride) {
+      const sessionIdsToDelete = await sessionsListGuard.acquire(AppiumDriver.name, () => _.keys(this.sessions));
+      if (sessionIdsToDelete.length) {
+        log.info(`Session override is on. Deleting other ${sessionIdsToDelete.length} active session${sessionIdsToDelete.length ? '' : 's'}.`);
+        for (const id of sessionIdsToDelete) {
+          log.info(`\tDeleting session '${id}'`);
+          try {
+            await this.deleteSession(id);
+          } catch (ign) {
+            // the error has already been logged in AppiumDriver.deleteSession
+            // continue
+          }
         }
       }
     }
 
-    let runningDriversData;
+    let runningDriversData, otherPendingDriversData;
+    let d = new InnerDriver(this.args);
     try {
-      runningDriversData = this.curSessionDataForDriver(InnerDriver);
+      runningDriversData = await this.curSessionDataForDriver(InnerDriver);
     } catch (e) {
       throw new errors.SessionNotCreatedError(e.message);
     }
-
-    let innerSessionId, dCaps;
-    let d = new InnerDriver(this.args);
-    try {
+    await pendindDriversGuard.acquire(AppiumDriver.name, () => {
       this.pendingDrivers[InnerDriver.name] = this.pendingDrivers[InnerDriver.name] || [];
-      const otherPendingDriversData = this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData);
+      otherPendingDriversData = this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData);
       this.pendingDrivers[InnerDriver.name].push(d);
+    });
+    let innerSessionId, dCaps;
+    try {
       [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, [...runningDriversData, ...otherPendingDriversData]);
     } finally {
-      _.pull(this.pendingDrivers[InnerDriver.name], d);
+      await pendindDriversGuard.acquire(AppiumDriver.name, () => {
+        _.pull(this.pendingDrivers[InnerDriver.name], d);
+      });
+      await sessionsListGuard.acquire(AppiumDriver.name, () => {
+        if (innerSessionId) {
+          this.sessions[innerSessionId] = d;
+        }
+      });
     }
-    this.sessions[innerSessionId] = d;
 
     // this is an async function but we don't await it because it handles
     // an out-of-band promise which is fulfilled if the inner driver
@@ -228,14 +248,17 @@ class AppiumDriver extends BaseDriver {
       }
       log.warn(`Closing session, cause was '${e.message}'`);
       log.info(`Removing session ${innerSessionId} from our master session list`);
-      delete this.sessions[innerSessionId];
+      await sessionsListGuard.acquire(AppiumDriver.name, () => {
+        delete this.sessions[innerSessionId];
+      });
     }
   }
 
-  curSessionDataForDriver (InnerDriver) {
-    let data = _.values(this.sessions)
-                .filter((s) => s.constructor.name === InnerDriver.name)
-                .map((s) => s.driverData);
+  async curSessionDataForDriver (InnerDriver) {
+    const sessions = await sessionsListGuard.acquire(AppiumDriver.name, () => this.sessions);
+    const data = _.values(sessions)
+                   .filter((s) => s.constructor.name === InnerDriver.name)
+                   .map((s) => s.driverData);
     for (let datum of data) {
       if (!datum) {
         throw new Error(`Problem getting session data for driver type ` +
@@ -248,13 +271,18 @@ class AppiumDriver extends BaseDriver {
 
   async deleteSession (sessionId) {
     try {
-      if (this.sessions[sessionId]) {
-        const curConstructorName = this.sessions[sessionId].constructor.name;
-        const otherSessionsData = _.toPairs(this.sessions)
+      let otherSessionsData = null;
+      let dstSession = null;
+      await sessionsListGuard.acquire(AppiumDriver.name, () => {
+        if (this.sessions[sessionId]) {
+          const curConstructorName = this.sessions[sessionId].constructor.name;
+          otherSessionsData = _.toPairs(this.sessions)
                 .filter(([key, value]) => value.constructor.name === curConstructorName && key !== sessionId)
                 .map(([, value]) => value.driverData);
-        await this.sessions[sessionId].deleteSession(sessionId, otherSessionsData);
-      }
+          dstSession = this.sessions[sessionId];
+        }
+      });
+      await dstSession.deleteSession(sessionId, otherSessionsData);
     } catch (e) {
       log.error(`Had trouble ending session ${sessionId}: ${e.message}`);
       throw e;
@@ -263,7 +291,9 @@ class AppiumDriver extends BaseDriver {
       // make the session unavailable, because who knows what state it might
       // be in otherwise
       log.info(`Removing session ${sessionId} from our master session list`);
-      delete this.sessions[sessionId];
+      await sessionsListGuard.acquire(AppiumDriver.name, () => {
+        delete this.sessions[sessionId];
+      });
     }
   }
 
@@ -277,25 +307,27 @@ class AppiumDriver extends BaseDriver {
       return super.executeCommand(cmd, ...args);
     }
 
-    let sessionId = args[args.length - 1];
-    return this.sessions[sessionId].executeCommand(cmd, ...args);
+    const sessionId = _.last(args);
+    const dstSession = await sessionsListGuard.acquire(AppiumDriver.name, () => this.sessions[sessionId]);
+    if (!dstSession) {
+      throw new Error(`The session with id '${sessionId}' does not exist`);
+    }
+    return dstSession.executeCommand(cmd, ...args);
   }
 
   proxyActive (sessionId) {
-    return this.sessions[sessionId] &&
-           _.isFunction(this.sessions[sessionId].proxyActive) &&
-           this.sessions[sessionId].proxyActive(sessionId);
+    const dstSession = this.sessions[sessionId];
+    return dstSession && _.isFunction(dstSession.proxyActive) && dstSession.proxyActive(sessionId);
   }
 
   getProxyAvoidList (sessionId) {
-    if (!this.sessions[sessionId]) {
-      return [];
-    }
-    return this.sessions[sessionId].getProxyAvoidList();
+    const dstSession = this.sessions[sessionId];
+    return dstSession ? dstSession.getProxyAvoidList() : [];
   }
 
   canProxy (sessionId) {
-    return this.sessions[sessionId] && this.sessions[sessionId].canProxy(sessionId);
+    const dstSession = this.sessions[sessionId];
+    return dstSession && dstSession.canProxy(sessionId);
   }
 }
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -264,18 +264,19 @@ class AppiumDriver extends BaseDriver {
       let otherSessionsData = null;
       let dstSession = null;
       await sessionsListGuard.acquire(AppiumDriver.name, () => {
-        if (this.sessions[sessionId]) {
-          const curConstructorName = this.sessions[sessionId].constructor.name;
-          otherSessionsData = _.toPairs(this.sessions)
-                .filter(([key, value]) => value.constructor.name === curConstructorName && key !== sessionId)
-                .map(([, value]) => value.driverData);
-          dstSession = this.sessions[sessionId];
-          log.info(`Removing session ${sessionId} from our master session list`);
-          // regardless of whether the deleteSession completes successfully or not
-          // make the session unavailable, because who knows what state it might
-          // be in otherwise
-          delete this.sessions[sessionId];
+        if (!this.sessions[sessionId]) {
+          return;
         }
+        const curConstructorName = this.sessions[sessionId].constructor.name;
+        otherSessionsData = _.toPairs(this.sessions)
+              .filter(([key, value]) => value.constructor.name === curConstructorName && key !== sessionId)
+              .map(([, value]) => value.driverData);
+        dstSession = this.sessions[sessionId];
+        log.info(`Removing session ${sessionId} from our master session list`);
+        // regardless of whether the deleteSession completes successfully or not
+        // make the session unavailable, because who knows what state it might
+        // be in otherwise
+        delete this.sessions[sessionId];
       });
       await dstSession.deleteSession(sessionId, otherSessionsData);
     } catch (e) {

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -173,21 +173,13 @@ class AppiumDriver extends BaseDriver {
     let InnerDriver = this.getDriverForCaps(caps);
     this.printNewSessionAnnouncement(InnerDriver, caps);
 
-    // sessionOverride server flag check
-    // this will need to be re-thought when we go to multiple session support
     if (this.args.sessionOverride) {
       const sessionIdsToDelete = await sessionsListGuard.acquire(AppiumDriver.name, () => _.keys(this.sessions));
       if (sessionIdsToDelete.length) {
         log.info(`Session override is on. Deleting other ${sessionIdsToDelete.length} active session${sessionIdsToDelete.length ? '' : 's'}.`);
-        for (const id of sessionIdsToDelete) {
-          log.info(`\tDeleting session '${id}'`);
-          try {
-            await this.deleteSession(id);
-          } catch (ign) {
-            // the error has already been logged in AppiumDriver.deleteSession
-            // continue
-          }
-        }
+        try {
+          await B.map(sessionIdsToDelete, (id) => this.deleteSession(id));
+        } catch (ign) {}
       }
     }
 
@@ -278,20 +270,17 @@ class AppiumDriver extends BaseDriver {
                 .filter(([key, value]) => value.constructor.name === curConstructorName && key !== sessionId)
                 .map(([, value]) => value.driverData);
           dstSession = this.sessions[sessionId];
+          log.info(`Removing session ${sessionId} from our master session list`);
+          // regardless of whether the deleteSession completes successfully or not
+          // make the session unavailable, because who knows what state it might
+          // be in otherwise
+          delete this.sessions[sessionId];
         }
       });
       await dstSession.deleteSession(sessionId, otherSessionsData);
     } catch (e) {
       log.error(`Had trouble ending session ${sessionId}: ${e.message}`);
       throw e;
-    } finally {
-      // regardless of whether the deleteSession completes successfully or not
-      // make the session unavailable, because who knows what state it might
-      // be in otherwise
-      log.info(`Removing session ${sessionId} from our master session list`);
-      await sessionsListGuard.acquire(AppiumDriver.name, () => {
-        delete this.sessions[sessionId];
-      });
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "appium-xcuitest-driver": "2.x",
     "appium-youiengine-driver": "1.x",
     "argparse": "1.x",
+    "async-lock": "^1.0.0",
     "asyncbox": "2.x",
     "babel-runtime": "=5.8.24",
     "bluebird": "2.x",


### PR DESCRIPTION
## Proposed changes

Our functional tests demonstrated that session creation is done in parallel, which means that each driver does not know about other driver executed at the same time, since the list of pending sessions is being created exactly at the same time for each instance. Synchronization solves this problem, so they wait for each other to update the shared list of pending and active sessions. Same thing with session deletion.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
