### PR TITLE
Cancel commands queueing for the umbrella driver

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -31,6 +31,13 @@ class AppiumDriver extends BaseDriver {
     this.pendingDrivers = {};
   }
 
+  /**
+   * Cancel commands queueing for the umbrella Appium driver
+   */
+  get isCommandsQueueEnabled () {
+    return false;
+  }
+
   sessionExists (sessionId) {
     return _.includes(_.keys(this.sessions), sessionId) &&
            this.sessions[sessionId].sessionId !== null;


### PR DESCRIPTION
## Proposed changes

Commands queueing is not needed for AppiumDriver, since it only slows down execution for parallel sessions.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

The change has been tested locally and confirmed by @saikrishna321 with parallel iOS and iOS/Android sessions