### PR TITLE
Docs Proposal: Move client docs into client table

### DIFF
--- a/commands-yml/parse.js
+++ b/commands-yml/parse.js
@@ -8,6 +8,8 @@ import replaceExt from 'replace-ext';
 import _ from 'lodash';
 import { asyncify } from 'asyncbox';
 import validator from './validator';
+import url from 'url';
+
 
 // What range of platforms do the driver's support
 const platformRanges = {
@@ -93,6 +95,11 @@ Handlebars.registerHelper('if_eq', function (a, b, opts) {
   } else {
     return opts.inverse(this);
   }
+});
+
+Handlebars.registerHelper('base_url', function (fullUrl) {
+  const baseUrl = url.parse(fullUrl);
+  return baseUrl.hostname;
 });
 
 async function main () {

--- a/commands-yml/template.md
+++ b/commands-yml/template.md
@@ -77,16 +77,6 @@
 {{description}}
 {{/if}}
 
-## Client Docs
-
-{{#if client_docs.java}} * [Java]({{client_docs.java}}) {{/if}}
-{{#if client_docs.python}} * [Python]({{client_docs.python}}) {{/if}}
-{{#if client_docs.javascript_wdio}} * [Javascript (WebdriverIO)]({{client_docs.javascript_wdio}}) {{/if}}
-{{#if client_docs.javascript_wd}} * [Javascript (WD)]({{client_docs.javascript_wd}}) {{/if}}
-{{#if client_docs.ruby}} * [Ruby]({{client_docs.ruby}}) {{/if}}
-{{#if client_docs.php}} * [PHP]({{client_docs.php}}) {{/if}}
-{{#if client_docs.csharp}} * [C#]({{client_docs.csharp}}) {{/if}}
-
 ## Support
 
 ### Appium Server
@@ -108,15 +98,15 @@
 
 ### Appium Clients
 
-|Language|Support|
-|--------|-------|
-|[Java](https://github.com/appium/java-client/releases/latest)| {{versions client_support.java}} |
-|[Python](https://github.com/appium/python-client/releases/latest)| {{versions client_support.python}} |
-|[Javascript (WebdriverIO)](http://webdriver.io/index.html)| {{versions client_support.javascript_wdio}} |
-|[Javascript (WD)](https://github.com/admc/wd/releases/latest)| {{versions client_support.javascript_wd}} |
-|[Ruby](https://github.com/appium/ruby_lib/releases/latest)| {{versions client_support.ruby}} |
-|[PHP](https://github.com/appium/php-client/releases/latest)| {{versions client_support.php}} |
-|[C#](https://github.com/appium/appium-dotnet-driver/releases/latest)| {{versions client_support.csharp}} |
+|Language|Support|Documentation|
+|--------|-------|-------------|
+|[Java](https://github.com/appium/java-client/releases/latest)| {{versions client_support.java}} | {{#if client_docs.java}} [{{base_url client_docs.java}}]({{client_docs.java}}) {{/if}} |
+|[Python](https://github.com/appium/python-client/releases/latest)| {{versions client_support.python}} | {{#if client_docs.python}} [{{base_url client_docs.python}}]({{client_docs.python}}) {{/if}} |
+|[Javascript (WebdriverIO)](http://webdriver.io/index.html)| {{versions client_support.javascript_wdio}} | {{#if client_docs.javascript_wdio}} [{{base_url client_docs.javascript_wdio}}]({{client_docs.javascript_wdio}}) {{/if}} |
+|[Javascript (WD)](https://github.com/admc/wd/releases/latest)| {{versions client_support.javascript_wd}} | {{#if client_docs.javascript_wd}} [{{base_url client_docs.javascript_wd}}]({{client_docs.javascript_wd}}) {{/if}} |
+|[Ruby](https://github.com/appium/ruby_lib/releases/latest)| {{versions client_support.ruby}} | {{#if client_docs.ruby}} [{{base_url client_docs.ruby}}]({{client_docs.ruby}}) {{/if}} |
+|[PHP](https://github.com/appium/php-client/releases/latest)| {{versions client_support.php}} | {{#if client_docs.php}} [{{base_url client_docs.php}}]({{client_docs.php}}) {{/if}} |
+|[C#](https://github.com/appium/appium-dotnet-driver/releases/latest)| {{versions client_support.csharp}} | {{#if client_docs.csharp}} [{{base_url client_docs.csharp}}]({{client_docs.csharp}}) {{/if}} |
 
 ## HTTP API Specifications
 


### PR DESCRIPTION
## Proposed changes

Instead of having a dedicated area for client docs, add them to the existing client compatibility table, which is sparsely populated anyway.

Old layout:
<img width="1348" alt="screenshot 2017-10-03 12 08 19" src="https://user-images.githubusercontent.com/2614354/31139103-875df1c2-a83e-11e7-997a-203c39b2a30a.png">




With this move:
<img width="1327" alt="screenshot 2017-10-03 12 46 31" src="https://user-images.githubusercontent.com/2614354/31139126-91df495c-a83e-11e7-95dc-9c951d9072f8.png">


## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
