### PR TITLE
Support w3c createSession

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import log from './logger';
 import { getAppiumConfig } from './config';
 import { BaseDriver, routeConfiguringFunction, errors,
-         isSessionCommand } from 'appium-base-driver';
+         isSessionCommand, processCapabilities } from 'appium-base-driver';
 import { FakeDriver } from 'appium-fake-driver';
 import { AndroidDriver } from 'appium-android-driver';
 import { IosDriver } from 'appium-ios-driver';
@@ -172,10 +172,13 @@ class AppiumDriver extends BaseDriver {
     inspectObject(caps);
   }
 
-  async createSession (caps, reqCaps) {
-    caps = _.defaults(_.clone(caps), this.args.defaultCapabilities);
-    let InnerDriver = this.getDriverForCaps(caps);
-    this.printNewSessionAnnouncement(InnerDriver, caps);
+  async createSession (desiredCaps, reqCaps, capabilities) {
+    if (capabilities) {
+      desiredCaps = processCapabilities(capabilities, null, false);
+    }
+    desiredCaps = _.defaults(_.clone(desiredCaps), this.args.defaultCapabilities);
+    let InnerDriver = this.getDriverForCaps(desiredCaps);
+    this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
 
     if (this.args.sessionOverride) {
       const sessionIdsToDelete = await sessionsListGuard.acquire(AppiumDriver.name, () => _.keys(this.sessions));
@@ -201,7 +204,7 @@ class AppiumDriver extends BaseDriver {
     });
     let innerSessionId, dCaps;
     try {
-      [innerSessionId, dCaps] = await d.createSession(caps, reqCaps, [...runningDriversData, ...otherPendingDriversData]);
+      [innerSessionId, dCaps] = await d.createSession(desiredCaps, reqCaps, [...runningDriversData, ...otherPendingDriversData]);
       await sessionsListGuard.acquire(AppiumDriver.name, () => {
         this.sessions[innerSessionId] = d;
       });

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -5,6 +5,7 @@ import B from 'bluebird';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import wd from 'wd';
+import request from 'request-promise';
 import { main as appiumServer } from '../lib/main';
 import { TEST_FAKE_APP, TEST_HOST, TEST_PORT } from './helpers';
 
@@ -74,6 +75,43 @@ describe('FakeDriver - via HTTP', () => {
 
       await B.delay(250);
       await driver.source().should.eventually.be.rejectedWith(/terminated/);
+    });
+
+    it('should accept W3C capabilities', async () => {
+      // Try with valid capabilities and check that it returns a session ID
+      const w3cCaps = {
+        capabilities: {
+          alwaysMatch: {platformName: 'Fake'},
+          firstMatch: [{'appium:deviceName': 'Fake', 'appium:app': TEST_FAKE_APP}],
+        }
+      };
+
+      const { status, value, sessionId } = await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, form: w3cCaps, json: true});
+      status.should.equal(0);
+      sessionId.should.be.a.string;
+      value.should.exist;
+
+      // Now use that sessionId to call /screenshot
+      const { status:screenshotStatus, value:screenshotValue } = await request({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}/screenshot`, json: true});
+      screenshotValue.should.equal('hahahanotreallyascreenshot');
+      screenshotStatus.should.equal(0);
+
+      // Now use that sessionID to call an arbitrary W3C-only endpoint that isn't implemented to see if it throws correct error
+      await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}/execute/async`, form: {script: '', args: ['a']}, json: true}).should.eventually.be.rejectedWith(/not yet been implemented/);
+
+      // Now try with invalid capabilities and check that it returns 500 status
+      const badW3Ccaps = {
+        capabilities: {
+          alwaysMatch: {},
+          firstMatch: [{'appium:deviceName': 'Fake', 'appium:app': TEST_FAKE_APP}],
+        }
+      };
+
+      try {
+        await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, form: badW3Ccaps});
+      } catch (e) {
+        e.statusCode.should.equal(500);
+      }
     });
   });
 });

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -86,7 +86,7 @@ describe('FakeDriver - via HTTP', () => {
         }
       };
 
-      const { status, value, sessionId } = await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, form: w3cCaps, json: true});
+      const { status, value, sessionId } = await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, json: w3cCaps});
       status.should.equal(0);
       sessionId.should.be.a.string;
       value.should.exist;
@@ -97,7 +97,7 @@ describe('FakeDriver - via HTTP', () => {
       screenshotStatus.should.equal(0);
 
       // Now use that sessionID to call an arbitrary W3C-only endpoint that isn't implemented to see if it throws correct error
-      await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}/execute/async`, form: {script: '', args: ['a']}, json: true}).should.eventually.be.rejectedWith(/not yet been implemented/);
+      await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}/execute/async`, json: {script: '', args: ['a']}}).should.eventually.be.rejectedWith(/not yet been implemented/);
 
       // Now try with invalid capabilities and check that it returns 500 status
       const badW3Ccaps = {
@@ -108,7 +108,7 @@ describe('FakeDriver - via HTTP', () => {
       };
 
       try {
-        await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, form: badW3Ccaps});
+        await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, json: badW3Ccaps});
       } catch (e) {
         e.statusCode.should.equal(500);
       }


### PR DESCRIPTION
* In 'createSession', process w3c caps using 'processCapabilities' method exposed by base-driver
* Add tests that run W3C requests on server to verify that it's accepting w3c format