### PR TITLE
Force MJSONWP protocol

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -17,6 +17,8 @@ import B from 'bluebird';
 import AsyncLock from 'async-lock';
 import { inspectObject } from './utils';
 
+// Force protocol to be MJSONWP until we start accepting W3C capabilities
+BaseDriver.determineProtocol = () => 'MJSONWP';
 
 const sessionsListGuard = new AsyncLock();
 const pendingDriversGuard = new AsyncLock();
@@ -218,6 +220,7 @@ class AppiumDriver extends BaseDriver {
     });
     let innerSessionId, dCaps;
     try {
+      // TODO: When we support W3C pass in capabilities object
       [innerSessionId, dCaps] = await d.createSession(desiredCaps, reqCaps, [...runningDriversData, ...otherPendingDriversData]);
       await sessionsListGuard.acquire(AppiumDriver.name, () => {
         this.sessions[innerSessionId] = d;

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -95,9 +95,8 @@ describe('FakeDriver - via HTTP', () => {
       const { status:screenshotStatus, value:screenshotValue } = await request({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}/screenshot`, json: true});
       screenshotValue.should.equal('hahahanotreallyascreenshot');
       screenshotStatus.should.equal(0);
-
       // Now use that sessionID to call an arbitrary W3C-only endpoint that isn't implemented to see if it throws correct error
-      await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}/execute/async`, json: {script: '', args: ['a']}}).should.eventually.be.rejectedWith(/not yet been implemented/);
+      await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}/execute/async`, json: {script: '', args: ['a']}}).should.eventually.be.rejectedWith(/501/);
 
       // Now try with invalid capabilities and check that it returns 500 status
       const badW3Ccaps = {


### PR DESCRIPTION
* The 'executeCommand' on appium-base-driver checks the protocol by looking for the w3c 'capabilities' object and is called before 'createSession' is
* Right now it's finding the 'capabilities' object and then appium is merging it into desiredCapabilities and running an MJSONWP session
* Because of this, session is being misidentified as W3C
* Fix for this upcoming release is just to monkey-patch the method that determines the protocol to return MJSONWP
* Next release we'll remove this and start fully accepting W3C sessions
