### PR TITLE
Pin fake-driver to 0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "appium-android-driver": "1.x",
     "appium-base-driver": "2.x",
     "appium-espresso-driver": "^1.0.0-beta.3",
-    "appium-fake-driver": "0.x",
+    "appium-fake-driver": "^0.2.x",
     "appium-ios-driver": "1.x",
     "appium-mac-driver": "1.x",
     "appium-selendroid-driver": "1.x",


### PR DESCRIPTION
* FakeDriver 0.3 is incompatible because it has an arity of 4 for `createSession` (W3C compliance reasons)
* Pin it to 0.2 until 1.7.2 is released and then we'll switch over