### PR TITLE
W3C Full Implementation

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -17,9 +17,6 @@ import B from 'bluebird';
 import AsyncLock from 'async-lock';
 import { inspectObject } from './utils';
 
-// Force protocol to be MJSONWP until we start accepting W3C capabilities
-BaseDriver.determineProtocol = () => 'MJSONWP';
-
 const sessionsListGuard = new AsyncLock();
 const pendingDriversGuard = new AsyncLock();
 
@@ -268,7 +265,7 @@ class AppiumDriver extends BaseDriver {
     let {defaultCapabilities} = this.args;
 
     // Get copies of the capabilities that reconcile any discrepancies between JSONWP and W3C
-    let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = this.getCaps(jsonwpCaps, w3cCapabilities, {}, defaultCapabilities); // TODO: Set the constraints
+    let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = this.getCaps(jsonwpCaps, w3cCapabilities, this.desiredCapConstraints, defaultCapabilities);
     let InnerDriver = this.getDriverForCaps(desiredCaps);
     this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -182,7 +182,11 @@ class AppiumDriver extends BaseDriver {
     let {defaultCapabilities} = this.args;
 
     // Parse the caps into a format that the InnerDriver will accept
-    let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, w3cCapabilities, this.desiredCapConstraints, defaultCapabilities);
+    let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(
+      jsonwpCaps,
+      w3cCapabilities,
+      this.desiredCapConstraints, defaultCapabilities
+    );
     let InnerDriver = this.getDriverForCaps(desiredCaps);
     this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
 
@@ -215,7 +219,12 @@ class AppiumDriver extends BaseDriver {
 
     let innerSessionId, dCaps;
     try {
-      [innerSessionId, dCaps] = await d.createSession(newJsonwpCaps, reqCaps, newW3CCapabilities, [...runningDriversData, ...otherPendingDriversData]);
+      [innerSessionId, dCaps] = await d.createSession(
+        processedJsonwpCaps,
+        reqCaps,
+        processedW3CCapabilities,
+        [...runningDriversData, ...otherPendingDriversData]
+      );
       await sessionsListGuard.acquire(AppiumDriver.name, () => {
         this.sessions[innerSessionId] = d;
       });

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import log from './logger';
 import { getAppiumConfig } from './config';
 import { BaseDriver, routeConfiguringFunction, errors,
-         isSessionCommand, processCapabilities } from 'appium-base-driver';
+         isSessionCommand } from 'appium-base-driver';
 import { FakeDriver } from 'appium-fake-driver';
 import { AndroidDriver } from 'appium-android-driver';
 import { IosDriver } from 'appium-ios-driver';
@@ -15,7 +15,7 @@ import { MacDriver } from 'appium-mac-driver';
 import { EspressoDriver } from 'appium-espresso-driver';
 import B from 'bluebird';
 import AsyncLock from 'async-lock';
-import { inspectObject } from './utils';
+import { inspectObject, parseCapsForInnerDriver } from './utils';
 
 const sessionsListGuard = new AsyncLock();
 const pendingDriversGuard = new AsyncLock();
@@ -172,117 +172,6 @@ class AppiumDriver extends BaseDriver {
   }
 
   /**
-   * Takes a capabilities objects and prefixes capabilities with `appium:`
-   * @param {*} caps {Object} Desired capabilities object
-   */
-  insertAppiumPrefixes (caps) {
-
-    // Standard, non-prefixed capabilities (see https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities)
-    const STANDARD_CAPS = [
-      'browserName',
-      'browserVersion',
-      'platformName',
-      'acceptInsecureCerts',
-      'pageLoadStrategy',
-      'proxy',
-      'setWindowRect',
-      'timeouts',
-      'unhandledPromptBehavior'
-    ];
-
-    let prefixedCaps = {};
-    for (let [name, value] of _.toPairs(caps)) {
-      if (STANDARD_CAPS.includes(name) || name.includes(':')) {
-        prefixedCaps[name] = value;
-      } else {
-        prefixedCaps[`appium:${name}`] = value;
-      }
-    }
-    return prefixedCaps;
-  }
-
-  /**
-   * Takes the caps that were provided in the request and translates them
-   * into caps that can be used by the inner drivers.
-   * @param {*} jsonwpCaps
-   * @param {*} w3cCapabilities
-   * @param {*} constraints
-   * @param {*} defaultCapabilities
-   */
-  getCaps (jsonwpCaps, w3cCapabilities, constraints={}, defaultCapabilities={}) {
-    // Check if the caller sent JSONWP caps, W3C caps, or both
-    const hasW3CCaps = _.isObject(w3cCapabilities);
-    const hasJSONWPCaps = _.isObject(jsonwpCaps);
-
-    // Make copies of the capabilities that include the default capabilities
-    if (hasW3CCaps) {
-      w3cCapabilities = {
-        ...w3cCapabilities,
-        alwaysMatch: {
-          ...defaultCapabilities,
-          ...w3cCapabilities.alwaysMatch,
-        },
-      };
-    }
-
-    if (hasJSONWPCaps) {
-      jsonwpCaps = {
-        ...defaultCapabilities,
-        ...jsonwpCaps,
-      };
-    }
-
-    // Get MJSONWP caps
-    let desiredCaps = {};
-    if (hasJSONWPCaps) {
-      desiredCaps = jsonwpCaps;
-    }
-
-    // Get W3C caps
-    if (hasW3CCaps) {
-      // Call the process capabilities algorithm to find matching caps on the W3C (https://github.com/jlipps/simple-wd-spec#processing-capabilities)
-      let matchingW3CCaps = processCapabilities(w3cCapabilities, constraints, true);
-
-      if (hasJSONWPCaps) {
-        let jsonwpKeys = _.keys(desiredCaps);
-        let matchingW3CCapsKeys = _.keys(matchingW3CCaps);
-
-        // If JSONWP has keys that W3C doesn't have, log a warning message
-        let differingKeys = _.differenceWith(jsonwpKeys, matchingW3CCapsKeys);
-        if (differingKeys.length > 0) {
-          log.warn(`The following capabilities were provided in the JSONWP desired capabilities but not the W3C capabilities: ${JSON.stringify(differingKeys)}`);
-        }
-      }
-
-      // If JSONWP caps and W3C caps were provided and there are discrepancies between them
-      // we'll be forgiving for now and just merge the two. But in the future, the clients
-      // should not be sending discrepant caps and Appium should ignore the extraneous MJSONWP caps
-      desiredCaps = {
-        ...desiredCaps, // TODO: This line should be removed once we decide to not allow discrepent caps
-        ...matchingW3CCaps,
-      };
-    }
-
-    let newJsonwpCaps, newW3CCapabilities;
-
-    // Create new JSONWP desired capabilities and W3C 'capabilities' objects that have the reconciled attributes
-    if (hasJSONWPCaps) {
-      newJsonwpCaps = {...desiredCaps};
-    }
-
-    // Translate the matched W3C caps back into W3C capabilities object so that it
-    // can be proxied to the inner driver
-    if (hasW3CCaps) {
-      newW3CCapabilities = {
-        alwaysMatch: {...this.insertAppiumPrefixes(desiredCaps)}, // Insert 'appium:' prefix to non-prefixed caps so that the Inner Driver doesn't complain about bad W3C prefixes
-        firstMatch: [{}],
-      };
-    }
-
-    return {desiredCaps, newJsonwpCaps, newW3CCapabilities};
-  }
-
-  /**
    * Create a new session
    * @param {Object} jsonwpCaps JSONWP formatted desired capabilities
    * @param {Object} reqCaps Required capabilities (JSONWP standard)
@@ -293,7 +182,7 @@ class AppiumDriver extends BaseDriver {
     let {defaultCapabilities} = this.args;
 
     // Get copies of the capabilities that reconcile any discrepancies between JSONWP and W3C
-    let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = this.getCaps(jsonwpCaps, w3cCapabilities, this.desiredCapConstraints, defaultCapabilities);
+    let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, w3cCapabilities, this.desiredCapConstraints, defaultCapabilities);
     let InnerDriver = this.getDriverForCaps(desiredCaps);
     this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -181,7 +181,7 @@ class AppiumDriver extends BaseDriver {
   async createSession (jsonwpCaps, reqCaps, w3cCapabilities) {
     let {defaultCapabilities} = this.args;
 
-    // Get copies of the capabilities that reconcile any discrepancies between JSONWP and W3C
+    // Parse the caps into a format that the InnerDriver will accept
     let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, w3cCapabilities, this.desiredCapConstraints, defaultCapabilities);
     let InnerDriver = this.getDriverForCaps(desiredCaps);
     this.printNewSessionAnnouncement(InnerDriver, desiredCaps);

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -175,20 +175,100 @@ class AppiumDriver extends BaseDriver {
   }
 
   /**
+   * Takes the caps that were provided in the request and translates them
+   * into caps that can be used by inner drivers
+   * @param {*} jsonwpCaps
+   * @param {*} w3cCapabilities
+   * @param {*} constraints
+   * @param {*} defaultCapabilities
+   */
+  getCaps (jsonwpCaps, w3cCapabilities, constraints={}, defaultCapabilities={}) {
+    // Check if the caller sent JSONWP caps, W3C caps, or both
+    const hasW3CCaps = _.isObject(w3cCapabilities);
+    const hasJSONWPCaps = _.isObject(jsonwpCaps);
+
+    // Make copies of the capabilities that include the default capabilities
+    if (hasW3CCaps) {
+      w3cCapabilities = {
+        ...w3cCapabilities,
+        alwaysMatch: {
+          ...defaultCapabilities,
+          ...w3cCapabilities.alwaysMatch,
+        },
+      };
+    }
+
+    if (hasJSONWPCaps) {
+      jsonwpCaps = {
+        ...defaultCapabilities,
+        ...jsonwpCaps,
+      };
+    }
+
+    // Get MJSONWP caps
+    let desiredCaps = {};
+    if (hasJSONWPCaps) {
+      desiredCaps = jsonwpCaps;
+    }
+
+    // Get W3C caps
+    if (hasW3CCaps) {
+      // Call the process capabilities algorithm to find matching caps on the W3C (https://github.com/jlipps/simple-wd-spec#processing-capabilities)
+      let matchingW3CCaps = processCapabilities(w3cCapabilities, constraints, true);
+
+      if (hasJSONWPCaps) {
+        let jsonwpKeys = _.keys(desiredCaps);
+        let matchingW3CCapsKeys = _.keys(matchingW3CCaps);
+
+        // If JSONWP has keys that W3C doesn't have, log a warning message
+        let differingKeys = _.differenceWith(jsonwpKeys, matchingW3CCapsKeys);
+        if (differingKeys.length > 0) {
+          log.warn(`The following capabilities were provided in the JSONWP desired capabilities but not the W3C capabilities: ${JSON.stringify(differingKeys)}`);
+        }
+
+        // If JSONWP caps and W3C caps were provided and there are discrepancies between them
+        // we'll be forgiving for now and just merge the two. But in the future, the clients
+        // should not be sending discrepant caps and Appium shouldn't be handling that case
+        desiredCaps = {
+          ...desiredCaps, // TODO: This line should be removed once we decide to not allow discrepent caps
+          ...matchingW3CCaps,
+        };
+      } else {
+        desiredCaps = matchingW3CCaps;
+      }
+    }
+
+    let newJsonwpCaps, newW3CCapabilities;
+
+    // Create new JSONWP desired capabilities and W3C 'capabilities' objects that have the reconciled attributes
+    if (hasJSONWPCaps) {
+      newJsonwpCaps = {...desiredCaps};
+    }
+
+    // Translate the matched W3C caps back into W3C capabilities object so that it
+    // can be proxied to the inner driver
+    if (hasW3CCaps) {
+      newW3CCapabilities = {
+        alwaysMatch: {...desiredCaps},
+        firstMatch: [{}],
+      };
+    }
+
+    return {desiredCaps, newJsonwpCaps, newW3CCapabilities};
+  }
+
+  /**
    * Create a new session
-   * @param {Object} desiredCaps JSONWP formatted desired capabilities
-   * @param {Object} reqCaps Required capabilities
-   * @param {Object} capabilities W3C capabilities
+   * @param {Object} jsonwpCaps JSONWP formatted desired capabilities
+   * @param {Object} reqCaps Required capabilities (JSONWP standard)
+   * @param {Object} w3cCapabilities W3C capabilities
    * @return {Array} Unique session ID and capabilities
    */
-  async createSession (desiredCaps={}, reqCaps, capabilities) {
-    if (capabilities) {
-      // Merging W3C caps into desiredCaps is a stop-gap until all the clients and drivers become fully W3C compliant
-      log.info(`Merged W3C capabilities ${_.truncate(JSON.stringify(capabilities), {length: 50})} into desiredCapabilities object ${_.truncate(JSON.stringify(desiredCaps), {length: 50})}`);
-      let w3cCaps = processCapabilities(capabilities, null, false);
-      desiredCaps = _.merge(desiredCaps, w3cCaps);
-    }
-    desiredCaps = _.defaults(_.clone(desiredCaps), this.args.defaultCapabilities);
+  async createSession (jsonwpCaps, reqCaps, w3cCapabilities) {
+    let {defaultCapabilities} = this.args;
+
+    // Get copies of the capabilities that reconcile any discrepancies between JSONWP and W3C
+    let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = this.getCaps(jsonwpCaps, w3cCapabilities, {}, defaultCapabilities); // TODO: Set the constraints
     let InnerDriver = this.getDriverForCaps(desiredCaps);
     this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
 
@@ -218,10 +298,10 @@ class AppiumDriver extends BaseDriver {
       otherPendingDriversData = this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData);
       this.pendingDrivers[InnerDriver.name].push(d);
     });
+
     let innerSessionId, dCaps;
     try {
-      // TODO: When we support W3C pass in capabilities object
-      [innerSessionId, dCaps] = await d.createSession(desiredCaps, reqCaps, [...runningDriversData, ...otherPendingDriversData]);
+      [innerSessionId, dCaps] = await d.createSession(newJsonwpCaps, reqCaps, newW3CCapabilities, [...runningDriversData, ...otherPendingDriversData]);
       await sessionsListGuard.acquire(AppiumDriver.name, () => {
         this.sessions[innerSessionId] = d;
       });

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -172,8 +172,38 @@ class AppiumDriver extends BaseDriver {
   }
 
   /**
+   * Takes a capabilities objects and prefixes capabilities with `appium:`
+   * @param {*} caps {Object} Desired capabilities object
+   */
+  insertAppiumPrefixes (caps) {
+
+    // Standard, non-prefixed capabilities (see https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities)
+    const STANDARD_CAPS = [
+      'browserName',
+      'browserVersion',
+      'platformName',
+      'acceptInsecureCerts',
+      'pageLoadStrategy',
+      'proxy',
+      'setWindowRect',
+      'timeouts',
+      'unhandledPromptBehavior'
+    ];
+
+    let prefixedCaps = {};
+    for (let [name, value] of _.toPairs(caps)) {
+      if (STANDARD_CAPS.includes(name) || name.includes(':')) {
+        prefixedCaps[name] = value;
+      } else {
+        prefixedCaps[`appium:${name}`] = value;
+      }
+    }
+    return prefixedCaps;
+  }
+
+  /**
    * Takes the caps that were provided in the request and translates them
-   * into caps that can be used by inner drivers
+   * into caps that can be used by the inner drivers.
    * @param {*} jsonwpCaps
    * @param {*} w3cCapabilities
    * @param {*} constraints
@@ -222,17 +252,15 @@ class AppiumDriver extends BaseDriver {
         if (differingKeys.length > 0) {
           log.warn(`The following capabilities were provided in the JSONWP desired capabilities but not the W3C capabilities: ${JSON.stringify(differingKeys)}`);
         }
-
-        // If JSONWP caps and W3C caps were provided and there are discrepancies between them
-        // we'll be forgiving for now and just merge the two. But in the future, the clients
-        // should not be sending discrepant caps and Appium shouldn't be handling that case
-        desiredCaps = {
-          ...desiredCaps, // TODO: This line should be removed once we decide to not allow discrepent caps
-          ...matchingW3CCaps,
-        };
-      } else {
-        desiredCaps = matchingW3CCaps;
       }
+
+      // If JSONWP caps and W3C caps were provided and there are discrepancies between them
+      // we'll be forgiving for now and just merge the two. But in the future, the clients
+      // should not be sending discrepant caps and Appium should ignore the extraneous MJSONWP caps
+      desiredCaps = {
+        ...desiredCaps, // TODO: This line should be removed once we decide to not allow discrepent caps
+        ...matchingW3CCaps,
+      };
     }
 
     let newJsonwpCaps, newW3CCapabilities;
@@ -246,7 +274,7 @@ class AppiumDriver extends BaseDriver {
     // can be proxied to the inner driver
     if (hasW3CCaps) {
       newW3CCapabilities = {
-        alwaysMatch: {...desiredCaps},
+        alwaysMatch: {...this.insertAppiumPrefixes(desiredCaps)}, // Insert 'appium:' prefix to non-prefixed caps so that the Inner Driver doesn't complain about bad W3C prefixes
         firstMatch: [{}],
       };
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import logger from './logger';
+import { processCapabilities } from 'appium-base-driver';
 
 
 function inspectObject (args) {
@@ -30,4 +31,116 @@ function inspectObject (args) {
   }
 }
 
-export { inspectObject };
+/**
+ * Takes the caps that were provided in the request and translates them
+ * into caps that can be used by the inner drivers.
+ * @param {*} jsonwpCaps
+ * @param {*} w3cCapabilities
+ * @param {*} constraints
+ * @param {*} defaultCapabilities
+ */
+function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, defaultCapabilities={}) {
+  // Check if the caller sent JSONWP caps, W3C caps, or both
+  const hasW3CCaps = _.isObject(w3cCapabilities);
+  const hasJSONWPCaps = _.isObject(jsonwpCaps);
+
+  // Make copies of the capabilities that include the default capabilities
+  if (hasW3CCaps) {
+    w3cCapabilities = {
+      ...w3cCapabilities,
+      alwaysMatch: {
+        ...defaultCapabilities,
+        ...w3cCapabilities.alwaysMatch,
+      },
+    };
+  }
+
+  if (hasJSONWPCaps) {
+    jsonwpCaps = {
+      ...defaultCapabilities,
+      ...jsonwpCaps,
+    };
+  }
+
+  // Get MJSONWP caps
+  let desiredCaps = {};
+  if (hasJSONWPCaps) {
+    desiredCaps = jsonwpCaps;
+  }
+
+  // Get W3C caps
+  if (hasW3CCaps) {
+    // Call the process capabilities algorithm to find matching caps on the W3C (https://github.com/jlipps/simple-wd-spec#processing-capabilities)
+    let matchingW3CCaps = processCapabilities(w3cCapabilities, constraints, true);
+
+    if (hasJSONWPCaps) {
+      let jsonwpKeys = _.keys(desiredCaps);
+      let matchingW3CCapsKeys = _.keys(matchingW3CCaps);
+
+      // If JSONWP has keys that W3C doesn't have, log a warning message
+      let differingKeys = _.differenceWith(jsonwpKeys, matchingW3CCapsKeys);
+      if (differingKeys.length > 0) {
+        logger.warn(`The following capabilities were provided in the JSONWP desired capabilities but not the W3C capabilities: ${JSON.stringify(differingKeys)}`);
+      }
+    }
+
+    // If JSONWP caps and W3C caps were provided and there are discrepancies between them
+    // we'll be forgiving for now and just merge the two. But in the future, the clients
+    // should not be sending discrepant caps and Appium should ignore the extraneous MJSONWP caps
+    desiredCaps = {
+      ...desiredCaps, // TODO: This line should be removed once we decide to not allow discrepent caps
+      ...matchingW3CCaps,
+    };
+  }
+
+  let newJsonwpCaps, newW3CCapabilities;
+
+  // Create new JSONWP desired capabilities and W3C 'capabilities' objects that have the reconciled attributes
+  if (hasJSONWPCaps) {
+    newJsonwpCaps = {...desiredCaps};
+  }
+
+  // Translate the matched W3C caps back into W3C capabilities object so that it
+  // can be proxied to the inner driver
+  if (hasW3CCaps) {
+    newW3CCapabilities = {
+      alwaysMatch: {...insertAppiumPrefixes(desiredCaps)}, // Insert 'appium:' prefix to non-prefixed caps so that the Inner Driver doesn't complain about bad W3C prefixes
+      firstMatch: [{}],
+    };
+  }
+
+  return {desiredCaps, newJsonwpCaps, newW3CCapabilities};
+}
+
+
+/**
+ * Takes a capabilities objects and prefixes capabilities with `appium:`
+ * @param {*} caps {Object} Desired capabilities object
+ */
+function insertAppiumPrefixes (caps) {
+
+  // Standard, non-prefixed capabilities (see https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities)
+  const STANDARD_CAPS = [
+    'browserName',
+    'browserVersion',
+    'platformName',
+    'acceptInsecureCerts',
+    'pageLoadStrategy',
+    'proxy',
+    'setWindowRect',
+    'timeouts',
+    'unhandledPromptBehavior'
+  ];
+
+  let prefixedCaps = {};
+  for (let [name, value] of _.toPairs(caps)) {
+    if (STANDARD_CAPS.includes(name) || name.includes(':')) {
+      prefixedCaps[name] = value;
+    } else {
+      prefixedCaps[`appium:${name}`] = value;
+    }
+  }
+  return prefixedCaps;
+}
+
+export { inspectObject, parseCapsForInnerDriver, insertAppiumPrefixes };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,15 +34,15 @@ function inspectObject (args) {
 /**
  * Takes the caps that were provided in the request and translates them
  * into caps that can be used by the inner drivers.
- * @param {*} jsonwpCaps
- * @param {*} w3cCapabilities
- * @param {*} constraints
- * @param {*} defaultCapabilities
+ * @param {Object} jsonwpCaps
+ * @param {Object} w3cCapabilities
+ * @param {Object} constraints
+ * @param {Object} defaultCapabilities
  */
 function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, defaultCapabilities={}) {
   // Check if the caller sent JSONWP caps, W3C caps, or both
-  const hasW3CCaps = _.isObject(w3cCapabilities);
-  const hasJSONWPCaps = _.isObject(jsonwpCaps);
+  const hasW3CCaps = _.isPlainObject(w3cCapabilities);
+  const hasJSONWPCaps = _.isPlainObject(jsonwpCaps);
 
   // Make copies of the capabilities that include the default capabilities
   if (hasW3CCaps) {
@@ -70,7 +70,8 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
 
   // Get W3C caps
   if (hasW3CCaps) {
-    // Call the process capabilities algorithm to find matching caps on the W3C (https://github.com/jlipps/simple-wd-spec#processing-capabilities)
+    // Call the process capabilities algorithm to find matching caps on the W3C
+    // (see: https://github.com/jlipps/simple-wd-spec#processing-capabilities)
     let matchingW3CCaps = processCapabilities(w3cCapabilities, constraints, true);
 
     if (hasJSONWPCaps) {
@@ -80,7 +81,8 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
       // If JSONWP has keys that W3C doesn't have, log a warning message
       let differingKeys = _.differenceWith(jsonwpKeys, matchingW3CCapsKeys);
       if (differingKeys.length > 0) {
-        logger.warn(`The following capabilities were provided in the JSONWP desired capabilities but not the W3C capabilities: ${JSON.stringify(differingKeys)}`);
+        logger.warn(`The following capabilities were provided in the JSONWP desired capabilities but
+          not the W3C capabilities: ${JSON.stringify(differingKeys)}`);
       }
     }
 
@@ -93,23 +95,24 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
     };
   }
 
-  let newJsonwpCaps, newW3CCapabilities;
+  let processedJsonwpCaps = null;
+  let processedW3CCapabilities = null;
 
   // Create new JSONWP desired capabilities and W3C 'capabilities' objects that have the reconciled attributes
   if (hasJSONWPCaps) {
-    newJsonwpCaps = {...desiredCaps};
+    processedJsonwpCaps = {...desiredCaps};
   }
 
   // Translate the matched W3C caps back into W3C capabilities object so that it
   // can be proxied to the inner driver
   if (hasW3CCaps) {
-    newW3CCapabilities = {
+    processedW3CCapabilities = {
       alwaysMatch: {...insertAppiumPrefixes(desiredCaps)}, // Insert 'appium:' prefix to non-prefixed caps so that the Inner Driver doesn't complain about bad W3C prefixes
       firstMatch: [{}],
     };
   }
 
-  return {desiredCaps, newJsonwpCaps, newW3CCapabilities};
+  return {desiredCaps, processedJsonwpCaps, processedW3CCapabilities};
 }
 
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -80,7 +80,7 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
 
       // If JSONWP has keys that W3C doesn't have, log a warning message
       let differingKeys = _.differenceWith(jsonwpKeys, matchingW3CCapsKeys);
-      if (differingKeys.length > 0) {
+      if (!_.isEmpty(differingKeys)) {
         logger.warn(`The following capabilities were provided in the JSONWP desired capabilities but
           not the W3C capabilities: ${JSON.stringify(differingKeys)}`);
       }
@@ -118,7 +118,7 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
 
 /**
  * Takes a capabilities objects and prefixes capabilities with `appium:`
- * @param {*} caps {Object} Desired capabilities object
+ * @param {Object} caps Desired capabilities object
  */
 function insertAppiumPrefixes (caps) {
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "appium-android-driver": "1.x",
-    "appium-base-driver": "2.x",
+    "appium-base-driver": "^2.20.0",
     "appium-espresso-driver": "^1.0.0-beta.3",
     "appium-fake-driver": "^0.3.0",
     "appium-ios-driver": "1.x",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "appium-android-driver": "1.x",
     "appium-base-driver": "2.x",
     "appium-espresso-driver": "^1.0.0-beta.3",
-    "appium-fake-driver": "^0.2.x",
+    "appium-fake-driver": "^0.3.0",
     "appium-ios-driver": "1.x",
     "appium-mac-driver": "1.x",
     "appium-selendroid-driver": "1.x",

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -153,7 +153,7 @@ describe('FakeDriver - via HTTP', () => {
     });
 
     it('should reject bad W3C capabilities with a BadParametersError (400)', async () => {
-      const caps = {
+      const w3cCaps = {
         "capabilities": {
           "alwaysMatch": {
             ...caps,
@@ -161,9 +161,24 @@ describe('FakeDriver - via HTTP', () => {
           }
         },
       };
-      const {message, statusCode} = await request.post({url: baseUrl, json: caps}).should.eventually.be.rejected;
+      const {message, statusCode} = await request.post({url: baseUrl, json: w3cCaps}).should.eventually.be.rejected;
       message.should.match(/BadAutomationName not part of/);
       statusCode.should.equal(400);
+    });
+
+    it('should accept capabilities that are provided in the firstMatch array', async () => {
+      const w3cCaps = {
+        "capabilities": {
+          "alwaysMatch": {},
+          "firstMatch": [{}, {
+            ...caps
+          }],
+        },
+      };
+      const {value, sessionId, status} = await request.post({url: baseUrl, json: w3cCaps});
+      should.not.exist(status);
+      should.not.exist(sessionId);
+      value.capabilities.should.deep.equal(caps);
     });
   });
 });

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -17,9 +17,11 @@ const caps = {platformName: "Fake", deviceName: "Fake", app: TEST_FAKE_APP};
 
 describe('FakeDriver - via HTTP', () => {
   let server = null;
+  let baseUrl;
   before(async () => {
     if (shouldStartServer) {
       let args = {port: TEST_PORT, host: TEST_HOST};
+      baseUrl = `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`;
       server = await appiumServer(args);
     }
   });
@@ -77,7 +79,7 @@ describe('FakeDriver - via HTTP', () => {
       await driver.source().should.eventually.be.rejectedWith(/terminated/);
     });
 
-    it('should accept W3C capabilities', async () => {
+    it('should accept valid W3C capabilities and start a W3C session', async () => {
       // Try with valid capabilities and check that it returns a session ID
       const w3cCaps = {
         capabilities: {
@@ -86,19 +88,33 @@ describe('FakeDriver - via HTTP', () => {
         }
       };
 
-      const { status, value, sessionId } = await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, json: w3cCaps});
-      status.should.equal(0);
-      sessionId.should.be.a.string;
+      // Create the session
+      const {status, value, sessionId} = await request.post({url: baseUrl, json: w3cCaps});
+      should.not.exist(status); // Test that it's a W3C session by checking that 'status' is not in the response
+      should.not.exist(sessionId);
+      value.sessionId.should.be.a.string;
       value.should.exist;
+      value.capabilities.should.deep.equal({
+        platformName: 'Fake',
+        deviceName: 'Fake',
+        app: TEST_FAKE_APP,
+      });
 
       // Now use that sessionId to call /screenshot
-      const { status:screenshotStatus, value:screenshotValue } = await request({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}/screenshot`, json: true});
+      const {status:screenshotStatus, value:screenshotValue} = await request({url: `${baseUrl}/${value.sessionId}/screenshot`, json: true});
+      should.not.exist(screenshotStatus);
       screenshotValue.should.equal('hahahanotreallyascreenshot');
-      screenshotStatus.should.equal(0);
-      // Now use that sessionID to call an arbitrary W3C-only endpoint that isn't implemented to see if it throws correct error
-      await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}/execute/async`, json: {script: '', args: ['a']}}).should.eventually.be.rejectedWith(/501/);
 
-      // Now try with invalid capabilities and check that it returns 500 status
+      // Now use that sessionID to call an arbitrary W3C-only endpoint that isn't implemented to see if it responds with correct error
+      const {statusCode, message} = await request.post({url: `${baseUrl}/${value.sessionId}/execute/async`, json: {script: '', args: ['a']}}).should.eventually.be.rejected;
+      statusCode.should.equal(404);
+      message.should.match(/Method has not yet been implemented/);
+
+      // End session
+      await request.delete({url: `${baseUrl}/${value.sessionId}`}).should.eventually.be.resolved;
+    });
+
+    it('should reject invalid W3C capabilities and respond with a 400 Bad Parameters error', async () => {
       const badW3Ccaps = {
         capabilities: {
           alwaysMatch: {},
@@ -106,28 +122,48 @@ describe('FakeDriver - via HTTP', () => {
         }
       };
 
-      try {
-        await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, json: badW3Ccaps});
-      } catch (e) {
-        e.statusCode.should.equal(500);
-      }
+      const {statusCode, message} = await request.post({url: baseUrl, json: badW3Ccaps}).should.eventually.be.rejected;
+      statusCode.should.equal(400);
+      message.should.match(/can't be blank/);
     });
 
-    it('should accept a combo of W3C and JSONWP capabilities', async () => {
+    it('should accept a combo of W3C and JSONWP capabilities but default to W3C', async () => {
       const combinedCaps = {
-        "desiredCapabilities": caps,
+        "desiredCapabilities": {
+          ...caps,
+          mjsonwpParam: 'mjsonwpParam',
+        },
         "capabilities": {
-          "alwaysMatch": {},
+          "alwaysMatch": {...caps},
           "firstMatch": [{
-            "platformName": "Fake",
-          }]
+            w3cParam: 'w3cParam',
+          }],
         }
       };
 
-      const { status, value, sessionId } = await request.post({url: `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, json: combinedCaps});
-      status.should.equal(0);
-      value.platformName.should.equal('Fake');
-      sessionId.should.exist;
+      const {status, value, sessionId} = await request.post({url: baseUrl, json: combinedCaps});
+      should.not.exist(status); // If it's a W3C session, should not respond with 'status'
+      should.not.exist(sessionId);
+      value.sessionId.should.exist;
+      value.capabilities.should.deep.equal({
+        ...caps,
+        w3cParam: 'w3cParam',
+        mjsonwpParam: 'mjsonwpParam', // Note: For now we're accepting a mix of the two to alleviate client issues. This ought to not be supported in the future though.
+      });
+    });
+
+    it('should reject bad W3C capabilities with a BadParametersError (400)', async () => {
+      const caps = {
+        "capabilities": {
+          "alwaysMatch": {
+            ...caps,
+            "automationName": "BadAutomationName",
+          }
+        },
+      };
+      const {message, statusCode} = await request.post({url: baseUrl, json: caps}).should.eventually.be.rejected;
+      message.should.match(/BadAutomationName not part of/);
+      statusCode.should.equal(400);
     });
   });
 });

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -17,11 +17,10 @@ const caps = {platformName: "Fake", deviceName: "Fake", app: TEST_FAKE_APP};
 
 describe('FakeDriver - via HTTP', () => {
   let server = null;
-  let baseUrl;
+  const baseUrl = `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`;
   before(async () => {
     if (shouldStartServer) {
       let args = {port: TEST_PORT, host: TEST_HOST};
-      baseUrl = `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`;
       server = await appiumServer(args);
     }
   });

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -50,7 +50,7 @@ describe('AppiumDriver', () => {
 
       it('should call inner driver\'s createSession with desired capabilities', async () => {
         mockFakeDriver.expects("createSession")
-          .once().withExactArgs(BASE_CAPS, undefined, undefined, [])
+          .once().withExactArgs(BASE_CAPS, undefined, null, [])
           .returns([SESSION_ID, BASE_CAPS]);
         await appium.createSession(BASE_CAPS);
         mockFakeDriver.verify();
@@ -99,7 +99,7 @@ describe('AppiumDriver', () => {
         sessions.should.have.length(3);
 
         mockFakeDriver.expects("createSession")
-          .once().withExactArgs(BASE_CAPS, undefined, undefined, [])
+          .once().withExactArgs(BASE_CAPS, undefined, null, [])
           .returns([SESSION_ID, BASE_CAPS]);
         await appium.createSession(BASE_CAPS);
 
@@ -113,7 +113,7 @@ describe('AppiumDriver', () => {
       });
       it('should call "createSession" with W3C capabilities argument, if provided', async function () {
         mockFakeDriver.expects("createSession")
-          .once().withArgs(undefined, undefined, W3C_CAPS)
+          .once().withArgs(null, undefined, W3C_CAPS)
           .returns([SESSION_ID, BASE_CAPS]);
         await appium.createSession(undefined, undefined, W3C_CAPS);
         mockFakeDriver.verify();
@@ -127,7 +127,7 @@ describe('AppiumDriver', () => {
           },
         };
         mockFakeDriver.expects("createSession")
-          .once().withArgs(undefined, undefined, {
+          .once().withArgs(null, undefined, {
             alwaysMatch: {
               ...w3cCaps.alwaysMatch,
               'appium:someOtherParm': 'someOtherParm',

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,6 +1,7 @@
 import path from 'path';
 import wd from 'wd';
 import B from 'bluebird';
+import {insertAppiumPrefixes} from '../lib/utils';
 
 const TEST_HOST = 'localhost';
 const TEST_PORT = 4723;
@@ -24,4 +25,11 @@ function initSession (caps) {
   });
 }
 
-export { initSession, TEST_FAKE_APP, TEST_HOST, TEST_PORT };
+const BASE_CAPS = {platformName: 'Fake', deviceName: 'Fake', app: TEST_FAKE_APP};
+const W3C_PREFIXED_CAPS = {...insertAppiumPrefixes(BASE_CAPS)};
+const W3C_CAPS = {
+  alwaysMatch:{...W3C_PREFIXED_CAPS},
+  firstMatch: [{}],
+};
+
+export { initSession, TEST_FAKE_APP, TEST_HOST, TEST_PORT, BASE_CAPS, W3C_PREFIXED_CAPS, W3C_CAPS };

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -147,7 +147,7 @@ describe('utils', function () {
         'moz:someOtherCap': 'someOtherCap',
       });
     });
-    it('should apply prefixes to capabilities non-prefixed, non-standard capabilities; should not apply prefixes to any capabilities', function () {
+    it('should apply prefixes to non-prefixed, non-standard capabilities; should not apply prefixes to any other capabilities', function () {
       insertAppiumPrefixes({
         'appium:someCap': 'someCap',
         'moz:someOtherCap': 'someOtherCap',

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -10,22 +10,22 @@ chai.use(chaiAsPromised);
 describe('utils', function () {
   describe('parseCapsForInnerDriver()', () => {
     it('should return JSONWP caps unchanged if only JSONWP caps provided', function () {
-      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS);
+      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS);
       desiredCaps.should.deep.equal(BASE_CAPS);
-      newJsonwpCaps.should.deep.equal(BASE_CAPS);
-      should.not.exist(newW3CCapabilities);
+      processedJsonwpCaps.should.deep.equal(BASE_CAPS);
+      should.not.exist(processedW3CCapabilities);
     });
     it('should return W3C caps unchanged if only W3C caps were provided', function () {
-      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(undefined, W3C_CAPS);
+      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(undefined, W3C_CAPS);
       desiredCaps.should.deep.equal(BASE_CAPS);
-      should.not.exist(newJsonwpCaps);
-      newW3CCapabilities.should.deep.equal(W3C_CAPS);
+      should.not.exist(processedJsonwpCaps);
+      processedW3CCapabilities.should.deep.equal(W3C_CAPS);
     });
     it('should return JSONWP and W3C caps if both were provided', function () {
-      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS);
+      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS);
       desiredCaps.should.deep.equal(BASE_CAPS);
-      newJsonwpCaps.should.deep.equal(BASE_CAPS);
-      newW3CCapabilities.should.deep.equal(W3C_CAPS);
+      processedJsonwpCaps.should.deep.equal(BASE_CAPS);
+      processedW3CCapabilities.should.deep.equal(W3C_CAPS);
     });
     it('should merge the capabilities together if some are different', function () {
       let jsonwpCaps = {
@@ -39,7 +39,7 @@ describe('utils', function () {
           'appium:hello': 'world',
         }
       };
-      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, w3cCaps);
+      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, w3cCaps);
 
       let expectedCaps = {
         ...jsonwpCaps,
@@ -47,8 +47,8 @@ describe('utils', function () {
       };
 
       desiredCaps.should.deep.equal(expectedCaps);
-      newJsonwpCaps.should.deep.equal(expectedCaps);
-      newW3CCapabilities.should.deep.equal({
+      processedJsonwpCaps.should.deep.equal(expectedCaps);
+      processedW3CCapabilities.should.deep.equal({
         alwaysMatch: {...insertAppiumPrefixes(expectedCaps)},
         firstMatch: [{}],
       });
@@ -76,20 +76,20 @@ describe('utils', function () {
         ...w3cCaps.alwaysMatch,
       };
 
-      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, w3cCaps);
+      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, w3cCaps);
       desiredCaps.foo.should.equal('BAR');
       desiredCaps.should.deep.equal(expectedDesiredCaps);
-      newJsonwpCaps.should.deep.equal(expectedDesiredCaps);
-      newW3CCapabilities.should.deep.equal({
+      processedJsonwpCaps.should.deep.equal(expectedDesiredCaps);
+      processedW3CCapabilities.should.deep.equal({
         alwaysMatch: insertAppiumPrefixes(expectedDesiredCaps),
         firstMatch: [{}],
       });
     });
     it('should include default capabilities in results', function () {
-      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS, {}, {foo: 'bar'});
+      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS, {}, {foo: 'bar'});
       desiredCaps.should.deep.equal({foo: 'bar', ...BASE_CAPS});
-      newJsonwpCaps.should.deep.equal({foo: 'bar', ...BASE_CAPS});
-      newW3CCapabilities.alwaysMatch.should.deep.equal({'appium:foo': 'bar', ...insertAppiumPrefixes(BASE_CAPS)});
+      processedJsonwpCaps.should.deep.equal({foo: 'bar', ...BASE_CAPS});
+      processedW3CCapabilities.alwaysMatch.should.deep.equal({'appium:foo': 'bar', ...insertAppiumPrefixes(BASE_CAPS)});
     });
     it('should reject if W3C caps are not passing constraints', function () {
       (() => parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS, {hello: {presence: true}})).should.throw(/'hello' can't be blank/);
@@ -102,16 +102,16 @@ describe('utils', function () {
           {hello: 'world'},
         ],
       };
-      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, w3cCaps, {hello: {presence: true}});
+      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, w3cCaps, {hello: {presence: true}});
       const expectedResult = {hello: 'world', ...BASE_CAPS};
       desiredCaps.should.deep.equal(expectedResult);
-      newJsonwpCaps.should.deep.equal(expectedResult);
-      newW3CCapabilities.alwaysMatch.should.deep.equal(insertAppiumPrefixes(expectedResult));
+      processedJsonwpCaps.should.deep.equal(expectedResult);
+      processedW3CCapabilities.alwaysMatch.should.deep.equal(insertAppiumPrefixes(expectedResult));
     });
     it('should add appium prefixes to W3C caps that are not standard in W3C', function () {
       parseCapsForInnerDriver(undefined, {
         alwaysMatch: {platformName: 'Fake', propertyName: 'PROP_NAME'},
-      }).newW3CCapabilities.should.deep.equal({
+      }).processedW3CCapabilities.should.deep.equal({
         alwaysMatch: {
           platformName: 'Fake',
           'appium:propertyName': 'PROP_NAME',

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -1,0 +1,168 @@
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { parseCapsForInnerDriver, insertAppiumPrefixes } from '../lib/utils';
+import { BASE_CAPS, W3C_CAPS } from './helpers';
+
+
+const should = chai.should();
+chai.use(chaiAsPromised);
+
+describe('utils', function () {
+  describe('parseCapsForInnerDriver()', () => {
+    it('should return JSONWP caps unchanged if only JSONWP caps provided', function () {
+      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS);
+      desiredCaps.should.deep.equal(BASE_CAPS);
+      newJsonwpCaps.should.deep.equal(BASE_CAPS);
+      should.not.exist(newW3CCapabilities);
+    });
+    it('should return W3C caps unchanged if only W3C caps were provided', function () {
+      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(undefined, W3C_CAPS);
+      desiredCaps.should.deep.equal(BASE_CAPS);
+      should.not.exist(newJsonwpCaps);
+      newW3CCapabilities.should.deep.equal(W3C_CAPS);
+    });
+    it('should return JSONWP and W3C caps if both were provided', function () {
+      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS);
+      desiredCaps.should.deep.equal(BASE_CAPS);
+      newJsonwpCaps.should.deep.equal(BASE_CAPS);
+      newW3CCapabilities.should.deep.equal(W3C_CAPS);
+    });
+    it('should merge the capabilities together if some are different', function () {
+      let jsonwpCaps = {
+        ...BASE_CAPS,
+        foo: 'bar',
+      };
+      let w3cCaps = {
+        ...W3C_CAPS,
+        alwaysMatch: {
+          ...W3C_CAPS.alwaysMatch,
+          'appium:hello': 'world',
+        }
+      };
+      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, w3cCaps);
+
+      let expectedCaps = {
+        ...jsonwpCaps,
+        'hello': 'world'
+      };
+
+      desiredCaps.should.deep.equal(expectedCaps);
+      newJsonwpCaps.should.deep.equal(expectedCaps);
+      newW3CCapabilities.should.deep.equal({
+        alwaysMatch: {...insertAppiumPrefixes(expectedCaps)},
+        firstMatch: [{}],
+      });
+    });
+    it('should merge the capabilities together and give preference to W3C if some are matching', function () {
+      // Add caps to JSONWP caps
+      let jsonwpCaps = {
+        foo: 'bar',
+        ...BASE_CAPS,
+      };
+
+      // Add caps to W3C caps
+      let w3cCaps = {
+        alwaysMatch: {
+          hello: 'world',
+          foo: 'BAR',
+          ...BASE_CAPS,
+        },
+        firstMatch: [{}],
+      };
+
+      // Expected result is that w3c caps override jsonwp caps
+      let expectedDesiredCaps = {
+        ...jsonwpCaps,
+        ...w3cCaps.alwaysMatch,
+      };
+
+      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, w3cCaps);
+      desiredCaps.foo.should.equal('BAR');
+      desiredCaps.should.deep.equal(expectedDesiredCaps);
+      newJsonwpCaps.should.deep.equal(expectedDesiredCaps);
+      newW3CCapabilities.should.deep.equal({
+        alwaysMatch: insertAppiumPrefixes(expectedDesiredCaps),
+        firstMatch: [{}],
+      });
+    });
+    it('should include default capabilities in results', function () {
+      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS, {}, {foo: 'bar'});
+      desiredCaps.should.deep.equal({foo: 'bar', ...BASE_CAPS});
+      newJsonwpCaps.should.deep.equal({foo: 'bar', ...BASE_CAPS});
+      newW3CCapabilities.alwaysMatch.should.deep.equal({'appium:foo': 'bar', ...insertAppiumPrefixes(BASE_CAPS)});
+    });
+    it('should reject if W3C caps are not passing constraints', function () {
+      (() => parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS, {hello: {presence: true}})).should.throw(/'hello' can't be blank/);
+    });
+    it('should only accept W3C caps that have passing constraints', function () {
+      let w3cCaps = {
+        ...W3C_CAPS,
+        firstMatch: [
+          {foo: 'bar'},
+          {hello: 'world'},
+        ],
+      };
+      let {desiredCaps, newJsonwpCaps, newW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, w3cCaps, {hello: {presence: true}});
+      const expectedResult = {hello: 'world', ...BASE_CAPS};
+      desiredCaps.should.deep.equal(expectedResult);
+      newJsonwpCaps.should.deep.equal(expectedResult);
+      newW3CCapabilities.alwaysMatch.should.deep.equal(insertAppiumPrefixes(expectedResult));
+    });
+    it('should add appium prefixes to W3C caps that are not standard in W3C', function () {
+      parseCapsForInnerDriver(undefined, {
+        alwaysMatch: {platformName: 'Fake', propertyName: 'PROP_NAME'},
+      }).newW3CCapabilities.should.deep.equal({
+        alwaysMatch: {
+          platformName: 'Fake',
+          'appium:propertyName': 'PROP_NAME',
+        },
+        firstMatch: [{}],
+      });
+    });
+  });
+
+  describe('insertAppiumPrefixes()', function () {
+    it('should apply prefixes to non-standard capabilities', function () {
+      insertAppiumPrefixes({
+        someCap: 'someCap',
+      }).should.deep.equal({
+        'appium:someCap': 'someCap',
+      });
+    });
+    it('should not apply prefixes to standard capabilities', function () {
+      insertAppiumPrefixes({
+        browserName: 'BrowserName',
+        platformName: 'PlatformName',
+      }).should.deep.equal({
+        browserName: 'BrowserName',
+        platformName: 'PlatformName',
+      });
+    });
+    it('should not apply prefixes to capabilities that already have a prefix', function () {
+      insertAppiumPrefixes({
+        'appium:someCap': 'someCap',
+        'moz:someOtherCap': 'someOtherCap',
+      }).should.deep.equal({
+        'appium:someCap': 'someCap',
+        'moz:someOtherCap': 'someOtherCap',
+      });
+    });
+    it('should apply prefixes to capabilities non-prefixed, non-standard capabilities; should not apply prefixes to any capabilities', function () {
+      insertAppiumPrefixes({
+        'appium:someCap': 'someCap',
+        'moz:someOtherCap': 'someOtherCap',
+        browserName: 'BrowserName',
+        platformName: 'PlatformName',
+        someOtherCap: 'someOtherCap',
+        yetAnotherCap: 'yetAnotherCap',
+      }).should.deep.equal({
+        'appium:someCap': 'someCap',
+        'moz:someOtherCap': 'someOtherCap',
+        browserName: 'BrowserName',
+        platformName: 'PlatformName',
+        'appium:someOtherCap': 'someOtherCap',
+        'appium:yetAnotherCap': 'yetAnotherCap',
+      });
+    });
+  });
+});


### PR DESCRIPTION
* W3C compatibility 
    * Refactored code from createSession into new `util.js` method `parseCapsForInnerDriver()`
    * `parseCapsForInnerDriver()` takes jsonwp and w3c capabilities and translates them into objects that can be accepted by the "inner driver" that it proxies to
      * It adds defaultCapabilities to `capabilities.alwaysMatch` and jsonwp `desiredCaps`
      * It creates a new w3cCaps object that only has `alwaysMatch` which only contains the matching caps (because we're proxying through to an inner driver, there's no sense in passing along any other non-matching first match capabilities)
    * After `parseCapsForInnerDriver()` parses the JSONWP and W3C it passes the results along to the matching inner driver

* Insert Appium prefixes into W3C caps 
    * Added util method `insertAppiumPrefixes()`
    * Previously, Appium just took the W3C capabilities, processed them into a caps object and passed them into the inner driver as
    
    ```
    {
      alwaysMatch: parsedCaps,
      firstMatch: [{}],
    }
    ```
    
    * The problem with this is that all of the parsedCaps became unprefixed because `appium-base-driver` strips out the `appium:` and the InnerDriver complains about non-standard, non-prefixed caps
    * Now, it takes the parsedCaps and calls a new method called 'insertAppiumPrefixes' on the parsed caps like this:
    
    ```
    {
      alwaysMatch: {...insertAppiumPrefixes(parsedCaps)},
      firstMatch: [{}],
    }
    ```

* Add validation to W3C session creation  
    * Call to 'processCapabilities' does validation now so that it will match an object that passes Appium's validation rules (e.g.: platformName, deviceName required; automation name must be valid, etc...)
