### PR TITLE
Use MJSONWP if dcaps have extraneous params

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -182,14 +182,14 @@ class AppiumDriver extends BaseDriver {
     let {defaultCapabilities} = this.args;
 
     // Parse the caps into a format that the InnerDriver will accept
-    let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(
+    let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(
       jsonwpCaps,
       w3cCapabilities,
       this.desiredCapConstraints, defaultCapabilities
     );
 
     // Since the processed caps may be different from the payload, update the protocol accordingly
-    this.protocol = BaseDriver.determineProtocol(processedJsonwpCaps, reqCaps, processedW3CCapabilities);
+    this.protocol = BaseDriver.determineProtocol(processedJsonwpCapabilities, reqCaps, processedW3CCapabilities);
 
     let InnerDriver = this.getDriverForCaps(desiredCaps);
     this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
@@ -224,7 +224,7 @@ class AppiumDriver extends BaseDriver {
     let innerSessionId, dCaps;
     try {
       [innerSessionId, dCaps] = await d.createSession(
-        processedJsonwpCaps,
+        processedJsonwpCapabilities,
         reqCaps,
         processedW3CCapabilities,
         [...runningDriversData, ...otherPendingDriversData]

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -187,6 +187,10 @@ class AppiumDriver extends BaseDriver {
       w3cCapabilities,
       this.desiredCapConstraints, defaultCapabilities
     );
+
+    // Since the processed caps may be different from the payload, update the protocol accordingly
+    this.protocol = BaseDriver.determineProtocol(processedJsonwpCaps, reqCaps, processedW3CCapabilities);
+
     let InnerDriver = this.getDriverForCaps(desiredCaps);
     this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,54 +64,37 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
 
   // Get MJSONWP caps
   let desiredCaps = {};
+  let processedJsonwpCaps = null;
   if (hasJSONWPCaps) {
     desiredCaps = jsonwpCaps;
+    processedJsonwpCaps = {...desiredCaps};
   }
 
   // Get W3C caps
+  let processedW3CCapabilities = null;
   if (hasW3CCaps) {
     // Call the process capabilities algorithm to find matching caps on the W3C
     // (see: https://github.com/jlipps/simple-wd-spec#processing-capabilities)
     let matchingW3CCaps = processCapabilities(w3cCapabilities, constraints, true);
+    desiredCaps = matchingW3CCaps;
 
-    if (hasJSONWPCaps) {
-      let jsonwpKeys = _.keys(desiredCaps);
-      let matchingW3CCapsKeys = _.keys(matchingW3CCaps);
-
-      // If JSONWP has keys that W3C doesn't have, log a warning message
-      let differingKeys = _.differenceWith(jsonwpKeys, matchingW3CCapsKeys);
-      if (!_.isEmpty(differingKeys)) {
-        logger.warn(`The following capabilities were provided in the JSONWP desired capabilities but
-          not the W3C capabilities: ${JSON.stringify(differingKeys)}`);
-      }
-    }
-
-    // If JSONWP caps and W3C caps were provided and there are discrepancies between them
-    // we'll be forgiving for now and just merge the two. But in the future, the clients
-    // should not be sending discrepant caps and Appium should ignore the extraneous MJSONWP caps
-    desiredCaps = {
-      ...desiredCaps, // TODO: This line should be removed once we decide to not allow discrepent caps
-      ...matchingW3CCaps,
-    };
-  }
-
-  let processedJsonwpCaps = null;
-  let processedW3CCapabilities = null;
-
-  // Create new JSONWP desired capabilities and W3C 'capabilities' objects that have the reconciled attributes
-  if (hasJSONWPCaps) {
-    processedJsonwpCaps = {...desiredCaps};
-  }
-
-  // Translate the matched W3C caps back into W3C capabilities object so that it
-  // can be proxied to the inner driver
-  if (hasW3CCaps) {
+    // Create a new w3c capabilities payload that contains only the matching caps in `alwaysMatch`
     processedW3CCapabilities = {
-      alwaysMatch: {...insertAppiumPrefixes(desiredCaps)}, // Insert 'appium:' prefix to non-prefixed caps so that the Inner Driver doesn't complain about bad W3C prefixes
+      alwaysMatch: {...insertAppiumPrefixes(desiredCaps)},
       firstMatch: [{}],
     };
-  }
 
+    // If we found extraneuous keys in JSONWP caps, fall back to JSONWP
+    if (hasJSONWPCaps) {
+      let differingKeys = _.differenceWith(_.keys(jsonwpCaps), _.keys(matchingW3CCaps));
+      if (!_.isEmpty(differingKeys)) {
+        logger.warn(`The following capabilities were provided in the JSONWP desired capabilities that are missing
+          in W3C capabilities: ${JSON.stringify(differingKeys)}. Falling back to JSONWP protocol.`);
+        desiredCaps = jsonwpCaps;
+        processedW3CCapabilities = null;
+      }
+    }
+  }
   return {desiredCaps, processedJsonwpCaps, processedW3CCapabilities};
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,10 +64,10 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
 
   // Get MJSONWP caps
   let desiredCaps = {};
-  let processedJsonwpCaps = null;
+  let processedJsonwpCapabilities = null;
   if (hasJSONWPCaps) {
     desiredCaps = jsonwpCaps;
-    processedJsonwpCaps = {...desiredCaps};
+    processedJsonwpCapabilities = {...desiredCaps};
   }
 
   // Get W3C caps
@@ -86,16 +86,16 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
 
     // If we found extraneuous keys in JSONWP caps, fall back to JSONWP
     if (hasJSONWPCaps) {
-      let differingKeys = _.differenceWith(_.keys(jsonwpCaps), _.keys(matchingW3CCaps));
+      let differingKeys = _.difference(_.keys(jsonwpCaps), _.keys(matchingW3CCaps));
       if (!_.isEmpty(differingKeys)) {
-        logger.warn(`The following capabilities were provided in the JSONWP desired capabilities that are missing
-          in W3C capabilities: ${JSON.stringify(differingKeys)}. Falling back to JSONWP protocol.`);
+        logger.warn(`The following capabilities were provided in the JSONWP desired capabilities that are missing ` +
+          `in W3C capabilities: ${JSON.stringify(differingKeys)}. Falling back to JSONWP protocol.`);
         desiredCaps = jsonwpCaps;
         processedW3CCapabilities = null;
       }
     }
   }
-  return {desiredCaps, processedJsonwpCaps, processedW3CCapabilities};
+  return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities};
 }
 
 

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -130,7 +130,6 @@ describe('FakeDriver - via HTTP', function () {
       const combinedCaps = {
         "desiredCapabilities": {
           ...caps,
-          mjsonwpParam: 'mjsonwpParam',
         },
         "capabilities": {
           "alwaysMatch": {...caps},
@@ -147,7 +146,32 @@ describe('FakeDriver - via HTTP', function () {
       value.capabilities.should.deep.equal({
         ...caps,
         w3cParam: 'w3cParam',
-        mjsonwpParam: 'mjsonwpParam', // Note: For now we're accepting a mix of the two to alleviate client issues. This ought to not be supported in the future though.
+      });
+    });
+
+    it('should accept a combo of W3C and JSONWP but use JSONWP if desiredCapabilities contains extraneous keys', async function () {
+      const combinedCaps = {
+        "desiredCapabilities": {
+          ...caps,
+          automationName: 'Fake',
+          anotherParam: 'Hello',
+        },
+        "capabilities": {
+          "alwaysMatch": {...caps},
+          "firstMatch": [{
+            w3cParam: 'w3cParam',
+          }],
+        }
+      };
+
+      const {status, sessionId, value} = await request.post({url: baseUrl, json: combinedCaps});
+      status.should.exist;
+      sessionId.should.exist;
+      should.not.exist(value.sessionId);
+      value.should.deep.equal({
+        ...caps,
+        automationName: 'Fake',
+        anotherParam: 'Hello',
       });
     });
 

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -139,6 +139,28 @@ describe('AppiumDriver', function () {
         await appium.createSession(undefined, undefined, w3cCaps);
         mockFakeDriver.verify();
       });
+      it('should call "createSession" with JSONWP capabilities if W3C has incomplete capabilities', async function () {
+        let w3cCaps = {
+          ...W3C_CAPS,
+          alwaysMatch: {
+            ...W3C_CAPS.alwaysMatch,
+            'appium:someOtherParm': 'someOtherParm',
+          },
+        };
+
+        let jsonwpCaps = {
+          ...BASE_CAPS,
+          automationName: 'Fake',
+          someOtherParam: 'someOtherParam',
+        };
+
+        mockFakeDriver.expects("createSession")
+          .once().withArgs(jsonwpCaps, undefined, null)
+          .returns([SESSION_ID, jsonwpCaps]);
+
+        await appium.createSession(jsonwpCaps, undefined, w3cCaps);
+        mockFakeDriver.verify();
+      });
     });
     describe('deleteSession', function () {
       let appium;

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -10,27 +10,27 @@ chai.use(chaiAsPromised);
 describe('utils', function () {
   describe('parseCapsForInnerDriver()', function () {
     it('should return JSONWP caps unchanged if only JSONWP caps provided', function () {
-      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS);
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS);
       desiredCaps.should.deep.equal(BASE_CAPS);
-      processedJsonwpCaps.should.deep.equal(BASE_CAPS);
+      processedJsonwpCapabilities.should.deep.equal(BASE_CAPS);
       should.not.exist(processedW3CCapabilities);
     });
     it('should return W3C caps unchanged if only W3C caps were provided', function () {
-      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(undefined, W3C_CAPS);
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(undefined, W3C_CAPS);
       desiredCaps.should.deep.equal(BASE_CAPS);
-      should.not.exist(processedJsonwpCaps);
+      should.not.exist(processedJsonwpCapabilities);
       processedW3CCapabilities.should.deep.equal(W3C_CAPS);
     });
     it('should return JSONWP and W3C caps if both were provided', function () {
-      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS);
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS);
       desiredCaps.should.deep.equal(BASE_CAPS);
-      processedJsonwpCaps.should.deep.equal(BASE_CAPS);
+      processedJsonwpCapabilities.should.deep.equal(BASE_CAPS);
       processedW3CCapabilities.should.deep.equal(W3C_CAPS);
     });
     it('should include default capabilities in results', function () {
-      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS, {}, {foo: 'bar'});
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS, {}, {foo: 'bar'});
       desiredCaps.should.deep.equal({foo: 'bar', ...BASE_CAPS});
-      processedJsonwpCaps.should.deep.equal({foo: 'bar', ...BASE_CAPS});
+      processedJsonwpCapabilities.should.deep.equal({foo: 'bar', ...BASE_CAPS});
       processedW3CCapabilities.alwaysMatch.should.deep.equal({'appium:foo': 'bar', ...insertAppiumPrefixes(BASE_CAPS)});
     });
     it('should reject if W3C caps are not passing constraints', function () {
@@ -44,10 +44,10 @@ describe('utils', function () {
           {hello: 'world'},
         ],
       };
-      let {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, w3cCaps, {hello: {presence: true}});
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, w3cCaps, {hello: {presence: true}});
       const expectedResult = {hello: 'world', ...BASE_CAPS};
       desiredCaps.should.deep.equal(expectedResult);
-      processedJsonwpCaps.should.deep.equal({...BASE_CAPS});
+      processedJsonwpCapabilities.should.deep.equal({...BASE_CAPS});
       processedW3CCapabilities.alwaysMatch.should.deep.equal(insertAppiumPrefixes(expectedResult));
     });
     it('should add appium prefixes to W3C caps that are not standard in W3C', function () {
@@ -66,13 +66,13 @@ describe('utils', function () {
         ...BASE_CAPS,
         automationName: 'Fake',
       };
-      const {desiredCaps, processedJsonwpCaps, processedW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, {
+      const {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, {
         alwaysMatch: {platformName: 'Fake', propertyName: 'PROP_NAME'},
       });
 
       should.not.exist(processedW3CCapabilities);
       desiredCaps.should.eql(jsonwpCaps);
-      processedJsonwpCaps.should.eql(jsonwpCaps);
+      processedJsonwpCapabilities.should.eql(jsonwpCaps);
     });
   });
 


### PR DESCRIPTION
* Update `parseCapsForInnerDriver` so that now if it finds extraneous keys in `jsonwpCaps`, fall back to using MJSONWP instead of W3C
* After getting processed caps, check the protocol again because if `processedW3CCapabilities` was set to null, it should be JWP
* Removed tests that tested for capabilities being merged together (those are no longer needed)
* Added tests (unit test and e2e test) that check that creation of a new session will fall back to JSONWP when there are extraneous keys
