### PR TITLE
Use uia2 backend by default if platform version is greater or equal to 6

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -90,15 +90,11 @@ class AppiumDriver extends BaseDriver {
 
     if (caps.platformName.toLowerCase() === 'android') {
       const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
-      if ((!_.isString(caps.automationName) || caps.automationName.toLowerCase() !== 'uiautomator')
-          && platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
-        log.info("Requested Android support with version >= 6, " +
-                 `using ${this.validAutomations.UIAUTOMATOR2.toLowerCase()} ` +
-                 "driver instead of UIAutomation-based driver, since the " +
-                 "latter is considered as obsolete on Android 6 and up. " +
-                 "Assign 'automationName' capability to 'uiautomator' " +
-                 "if this is an undesired behavior.");
-        return AndroidUiautomator2Driver;
+      if (platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
+        log.warn("Consider setting 'automationName' capability to " +
+                 `${this.validAutomations.UIAUTOMATOR2.toLowerCase()} ` +
+                 "on Android >= 6, since UIAutomation1 framework " +
+                 "is neither supported nor maintaied by the OS vendor.");
       }
 
       return AndroidDriver;

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -92,9 +92,12 @@ class AppiumDriver extends BaseDriver {
       const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
       if ((!_.isString(caps.automationName) || caps.automationName.toLowerCase() !== 'uiautomator')
           && platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
-        log.info(`Requested Android support with version >= 6, using ${this.validAutomations.UIAUTOMATOR2.toLowerCase()} ` +
-                  "driver instead of UIAutomation-based driver, since the " +
-                  "latter is considered as obsolete on Android 6 and up.");
+        log.info("Requested Android support with version >= 6, " +
+                 `using ${this.validAutomations.UIAUTOMATOR2.toLowerCase()} ` +
+                 "driver instead of UIAutomation-based driver, since the " +
+                 "latter is considered as obsolete on Android 6 and up. " +
+                 "Assign 'automationName' capability to 'uiautomator' " +
+                 "if this is an undesired behavior.");
         return AndroidUiautomator2Driver;
       }
 
@@ -104,9 +107,10 @@ class AppiumDriver extends BaseDriver {
     if (caps.platformName.toLowerCase() === 'ios') {
       const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
       if (platformVersion && semver.satisfies(platformVersion, '>=10.0.0')) {
-        log.info(`Requested iOS support with version >= 10, using ${this.validAutomations.XCUITEST.toLowerCase()} ` +
-                  "driver instead of UIAutomation-based driver, since the " +
-                  "latter is unsupported on iOS 10 and up.");
+        log.info("Requested iOS support with version >= 10, " +
+                 `using ${this.validAutomations.XCUITEST.toLowerCase()} ` +
+                 "driver instead of UIAutomation-based driver, since the " +
+                 "latter is unsupported on iOS 10 and up.");
         return XCUITestDriver;
       }
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -94,7 +94,7 @@ class AppiumDriver extends BaseDriver {
         log.warn("Consider setting 'automationName' capability to " +
                  `${this.validAutomations.UIAUTOMATOR2.toLowerCase()} ` +
                  "on Android >= 6, since UIAutomation1 framework " +
-                 "is neither supported nor maintaied by the OS vendor.");
+                 "is not maintained anymore by the OS vendor.");
       }
 
       return AndroidDriver;

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -92,8 +92,8 @@ class AppiumDriver extends BaseDriver {
       const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
       if (platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
         log.warn("Consider setting 'automationName' capability to " +
-                 `${this.validAutomations.UIAUTOMATOR2.toLowerCase()} ` +
-                 "on Android >= 6, since UIAutomation1 framework " +
+                 `'${this.validAutomations.UIAUTOMATOR2.toLowerCase()}' ` +
+                 "on Android >= 6, since UIAutomator framework " +
                  "is not maintained anymore by the OS vendor.");
       }
 
@@ -104,7 +104,7 @@ class AppiumDriver extends BaseDriver {
       const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
       if (platformVersion && semver.satisfies(platformVersion, '>=10.0.0')) {
         log.info("Requested iOS support with version >= 10, " +
-                 `using ${this.validAutomations.XCUITEST.toLowerCase()} ` +
+                 `using '${this.validAutomations.XCUITEST.toLowerCase()}' ` +
                  "driver instead of UIAutomation-based driver, since the " +
                  "latter is unsupported on iOS 10 and up.");
         return XCUITestDriver;

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -16,6 +16,7 @@ import { EspressoDriver } from 'appium-espresso-driver';
 import B from 'bluebird';
 import AsyncLock from 'async-lock';
 import { inspectObject, parseCapsForInnerDriver } from './utils';
+import semver from 'semver';
 
 const sessionsListGuard = new AsyncLock();
 const pendingDriversGuard = new AsyncLock();
@@ -88,18 +89,22 @@ class AppiumDriver extends BaseDriver {
     }
 
     if (caps.platformName.toLowerCase() === 'android') {
+      if (semver.valid(caps.platformVersion) && semver.satisfies(caps.platformVersion, '>=6')) {
+        log.info(`Requested Android support with version >= 6, using ${this.validAutomations.UIAUTOMATOR2.toLowerCase()} ` +
+                  "driver instead of UIAutomation-based driver, since the " +
+                  "latter is considered as obsolete on Android 6 and up.");
+        return AndroidUiautomator2Driver;
+      }
+
       return AndroidDriver;
     }
 
     if (caps.platformName.toLowerCase() === 'ios') {
-      if (caps.platformVersion) {
-        let majorVer = caps.platformVersion.toString().split(".")[0];
-        if (parseInt(majorVer, 10) >= 10) {
-          log.info("Requested iOS support with version >= 10, using XCUITest " +
-                   "driver instead of UIAutomation-based driver, since the " +
-                   "latter is unsupported on iOS 10 and up.");
-          return XCUITestDriver;
-        }
+      if (semver.valid(caps.platformVersion) && semver.satisfies(caps.platformVersion, '>=10')) {
+        log.info(`Requested iOS support with version >= 10, using ${this.validAutomations.XCUITEST.toLowerCase()} ` +
+                  "driver instead of UIAutomation-based driver, since the " +
+                  "latter is unsupported on iOS 10 and up.");
+        return XCUITestDriver;
       }
 
       return IosDriver;

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -89,8 +89,9 @@ class AppiumDriver extends BaseDriver {
     }
 
     if (caps.platformName.toLowerCase() === 'android') {
+      const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
       if ((!_.isString(caps.automationName) || caps.automationName.toLowerCase() !== 'uiautomator')
-          && semver.valid(caps.platformVersion) && semver.satisfies(caps.platformVersion, '>=6')) {
+          && platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
         log.info(`Requested Android support with version >= 6, using ${this.validAutomations.UIAUTOMATOR2.toLowerCase()} ` +
                   "driver instead of UIAutomation-based driver, since the " +
                   "latter is considered as obsolete on Android 6 and up.");
@@ -101,7 +102,8 @@ class AppiumDriver extends BaseDriver {
     }
 
     if (caps.platformName.toLowerCase() === 'ios') {
-      if (semver.valid(caps.platformVersion) && semver.satisfies(caps.platformVersion, '>=10')) {
+      const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
+      if (platformVersion && semver.satisfies(platformVersion, '>=10.0.0')) {
         log.info(`Requested iOS support with version >= 10, using ${this.validAutomations.XCUITEST.toLowerCase()} ` +
                   "driver instead of UIAutomation-based driver, since the " +
                   "latter is unsupported on iOS 10 and up.");

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -89,7 +89,8 @@ class AppiumDriver extends BaseDriver {
     }
 
     if (caps.platformName.toLowerCase() === 'android') {
-      if (semver.valid(caps.platformVersion) && semver.satisfies(caps.platformVersion, '>=6')) {
+      if ((!_.isString(caps.automationName) || caps.automationName.toLowerCase() !== 'uiautomator')
+          && semver.valid(caps.platformVersion) && semver.satisfies(caps.platformVersion, '>=6')) {
         log.info(`Requested Android support with version >= 6, using ${this.validAutomations.UIAUTOMATOR2.toLowerCase()} ` +
                   "driver instead of UIAutomation-based driver, since the " +
                   "latter is considered as obsolete on Android 6 and up.");

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "npmlog": "2.x",
     "request": "^2.81.0",
     "request-promise": "1.x",
+    "semver": "^5.5.0",
     "source-map-support": "0.x",
     "teen_process": "1.x",
     "winston": "2.x"

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -8,8 +8,6 @@ import sinon from 'sinon';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { XCUITestDriver } from 'appium-xcuitest-driver';
-import { AndroidDriver } from 'appium-android-driver';
-import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { IosDriver } from 'appium-ios-driver';
 import { sleep } from 'asyncbox';
 import { insertAppiumPrefixes } from '../lib/utils';

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -338,53 +338,6 @@ describe('AppiumDriver', function () {
         driver = appium.getDriverForCaps(caps);
         driver.should.equal(XCUITestDriver);
       });
-      it('should get uiatomator2 for android >= 6', function () {
-        let appium = new AppiumDriver({});
-        let caps = {
-          platformName: 'Android',
-          platformVersion: '6',
-        };
-        let driver = appium.getDriverForCaps(caps);
-        driver.should.be.an.instanceof(Function);
-        driver.should.equal(AndroidUiautomator2Driver);
-
-        caps.platformVersion = '6.0.1';
-        driver = appium.getDriverForCaps(caps);
-        driver.should.equal(AndroidUiautomator2Driver);
-
-        caps.platformVersion = '8.1';
-        driver = appium.getDriverForCaps(caps);
-        driver.should.equal(AndroidUiautomator2Driver);
-      });
-      it('should get uiatomator for android < 6 or if platformVersion cannot be parsed', function () {
-        let appium = new AppiumDriver({});
-        let caps = {
-          platformName: 'Android',
-          platformVersion: '5.0',
-        };
-        let driver = appium.getDriverForCaps(caps);
-        driver.should.be.an.instanceof(Function);
-        driver.should.equal(AndroidDriver);
-
-        caps.platformVersion = undefined;
-        driver = appium.getDriverForCaps(caps);
-        driver.should.equal(AndroidDriver);
-
-        caps.platformVersion = 'abc';
-        driver = appium.getDriverForCaps(caps);
-        driver.should.equal(AndroidDriver);
-      });
-      it('should get uiatomator for android >= 6 if set forcefully', function () {
-        let appium = new AppiumDriver({});
-        let caps = {
-          platformName: 'Android',
-          platformVersion: '7.2',
-          automationName: 'uiautomator',
-        };
-        let driver = appium.getDriverForCaps(caps);
-        driver.should.be.an.instanceof(Function);
-        driver.should.equal(AndroidDriver);
-      });
     });
   });
 });

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -8,6 +8,8 @@ import sinon from 'sinon';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { XCUITestDriver } from 'appium-xcuitest-driver';
+import { AndroidDriver } from 'appium-android-driver';
+import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { IosDriver } from 'appium-ios-driver';
 import { sleep } from 'asyncbox';
 import { insertAppiumPrefixes } from '../lib/utils';
@@ -335,6 +337,53 @@ describe('AppiumDriver', function () {
         caps.platformVersion = '12.14';
         driver = appium.getDriverForCaps(caps);
         driver.should.equal(XCUITestDriver);
+      });
+      it('should get uiatomator2 for android >= 6', function () {
+        let appium = new AppiumDriver({});
+        let caps = {
+          platformName: 'Android',
+          platformVersion: '6',
+        };
+        let driver = appium.getDriverForCaps(caps);
+        driver.should.be.an.instanceof(Function);
+        driver.should.equal(AndroidUiautomator2Driver);
+
+        caps.platformVersion = '6.0.1';
+        driver = appium.getDriverForCaps(caps);
+        driver.should.equal(AndroidUiautomator2Driver);
+
+        caps.platformVersion = '8.1';
+        driver = appium.getDriverForCaps(caps);
+        driver.should.equal(AndroidUiautomator2Driver);
+      });
+      it('should get uiatomator for android < 6 or if platformVersion cannot be parsed', function () {
+        let appium = new AppiumDriver({});
+        let caps = {
+          platformName: 'Android',
+          platformVersion: '5.0',
+        };
+        let driver = appium.getDriverForCaps(caps);
+        driver.should.be.an.instanceof(Function);
+        driver.should.equal(AndroidDriver);
+
+        caps.platformVersion = undefined;
+        driver = appium.getDriverForCaps(caps);
+        driver.should.equal(AndroidDriver);
+
+        caps.platformVersion = 'abc';
+        driver = appium.getDriverForCaps(caps);
+        driver.should.equal(AndroidDriver);
+      });
+      it('should get uiatomator for android >= 6 if set forcefully', function () {
+        let appium = new AppiumDriver({});
+        let caps = {
+          platformName: 'Android',
+          platformVersion: '7.2',
+          automationName: 'uiautomator',
+        };
+        let driver = appium.getDriverForCaps(caps);
+        driver.should.be.an.instanceof(Function);
+        driver.should.equal(AndroidDriver);
       });
     });
   });


### PR DESCRIPTION
## Proposed changes

Use uia2 backend by default if platform version is greater or equal to 6

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

We had to do this a while ago. UIObject is considered as obsolete and is not supported anymore by Google since Android 6 (or even 5).