### PR TITLE
Move to minimum node 6

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -38,16 +38,16 @@ async function getAppiumConfig () {
 
 function checkNodeOk () {
   let [major, minor] = getNodeVersion();
-  if (major < 5) {
-    let msg = `Node version must be >= 5. Currently ${major}.${minor}`;
+  if (major < 6) {
+    let msg = `Node version must be >= 6. Currently ${major}.${minor}`;
     logger.errorAndThrow(msg);
   }
 }
 
 function warnNodeDeprecations () {
   let [major] = getNodeVersion();
-  if (major < 4) {
-    logger.warn("Appium support for versions of node < 4 has been " +
+  if (major < 8) {
+    logger.warn("Appium support for versions of node < 8 has been " +
                 "deprecated and will be removed in a future version. Please " +
                 "upgrade!");
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/appium/appium/issues"
   },
   "engines": {
-    "node": ">=5",
+    "node": ">=6",
     "npm": ">=3"
   },
   "main": "./build/lib/main.js",

--- a/test/config-specs.js
+++ b/test/config-specs.js
@@ -64,7 +64,7 @@ describe('Config', function () {
       process = _process;
     });
     describe('checkNodeOk', function () {
-      it('should fail if node is below 4', function () {
+      it('should fail if node is below 6', function () {
         process.version = 'v4.4.7';
         checkNodeOk.should.throw();
         process.version = 'v0.9.12';
@@ -75,10 +75,8 @@ describe('Config', function () {
         checkNodeOk.should.throw();
         process.version = 'v0.12.14';
         checkNodeOk.should.throw();
-      });
-      it('should succeed if node is 5+', function () {
         process.version = 'v5.7.0';
-        checkNodeOk.should.not.throw();
+        checkNodeOk.should.throw();
       });
       it('should succeed if node is 6+', function () {
         process.version = 'v6.3.1';
@@ -92,6 +90,10 @@ describe('Config', function () {
         process.version = 'v8.1.2';
         checkNodeOk.should.not.throw();
       });
+      it('should succeed if node is 9+', function () {
+        process.version = 'v9.1.2';
+        checkNodeOk.should.not.throw();
+      });
     });
 
     describe('warnNodeDeprecations', function () {
@@ -102,28 +104,18 @@ describe('Config', function () {
       beforeEach(function () {
         spy.reset();
       });
-      it('should log a warning if node is below 4', function () {
-        process.version = 'v0.9.12';
+      it('should log a warning if node is below 8', function () {
+        process.version = 'v7.10.1';
         warnNodeDeprecations();
         logger.warn.callCount.should.equal(1);
       });
-      it('should log a warning if node is 0.12', function () {
-        process.version = 'v0.12.0';
-        warnNodeDeprecations();
-        logger.warn.callCount.should.equal(1);
-      });
-      it('should not log a warning if node is 4+', function () {
-        process.version = 'v4.4.7';
+      it('should not log a warning if node is 8+', function () {
+        process.version = 'v8.0.0';
         warnNodeDeprecations();
         logger.warn.callCount.should.equal(0);
       });
-      it('should not log a warning if node is 5+', function () {
-        process.version = 'v5.7.0';
-        warnNodeDeprecations();
-        logger.warn.callCount.should.equal(0);
-      });
-      it('should not log a warning if node is 6+', function () {
-        process.version = 'v6.3.1';
+      it('should not log a warning if node is 9+', function () {
+        process.version = 'v9.0.0';
         warnNodeDeprecations();
         logger.warn.callCount.should.equal(0);
       });

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -150,6 +150,9 @@ describe('FakeDriver - via HTTP', function () {
         ...caps,
         w3cParam: 'w3cParam',
       });
+
+      // End session
+      await request.delete({ url: `${baseUrl}/${value.sessionId}` }).should.eventually.be.resolved;
     });
 
     it('should accept a combo of W3C and JSONWP but use JSONWP if desiredCapabilities contains extraneous keys', async function () {
@@ -176,6 +179,9 @@ describe('FakeDriver - via HTTP', function () {
         automationName: 'Fake',
         anotherParam: 'Hello',
       });
+
+      // End session
+      await request.delete({ url: `${baseUrl}/${value.sessionId}` }).should.eventually.be.resolved;
     });
 
     it('should reject bad W3C capabilities with a BadParametersError (400)', async function () {
@@ -207,6 +213,9 @@ describe('FakeDriver - via HTTP', function () {
       should.not.exist(status);
       should.not.exist(sessionId);
       value.capabilities.should.deep.equal(caps);
+
+      // End session
+      await request.delete({ url: `${baseUrl}/${value.sessionId}` }).should.eventually.be.resolved;
     });
 
     it('should fall back to MJSONWP if w3c caps are invalid', async function () {
@@ -226,6 +235,9 @@ describe('FakeDriver - via HTTP', function () {
       status.should.exist;
       sessionId.should.exist;
       value.should.deep.equal(caps);
+
+      // End session
+      await request.delete({ url: `${baseUrl}/${value.sessionId}` }).should.eventually.be.resolved;
     });
   });
 });
@@ -248,8 +260,9 @@ describe('Logsink', function () {
 
   it('should send logs to a logHandler passed in by a parent package', async function () {
     logs.length.should.be.above(1);
-    logs[0].length.should.equal(2);
-    logs[0][1].should.include("Welcome to Appium");
+    let welcomeIndex = logs[0][1].includes('versions of node') ? 1 : 0;
+    logs[welcomeIndex].length.should.equal(2);
+    logs[welcomeIndex][1].should.include("Welcome to Appium");
   });
 
 });


### PR DESCRIPTION
## Proposed changes

Appium currently supports Node 5 for historical reasons that no longer apply. So bump up the version to 6, which is what is documented anyway.

Also, bump the node deprecation warning to 8, so as to warn about older versions. We were warning about node 4, which we don't even support. Getting people onto more recent versions of node is a win.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
