### PR TITLE
Pass protocol in execute command

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -335,10 +335,17 @@ class AppiumDriver extends BaseDriver {
         // be in otherwise
         delete this.sessions[sessionId];
       });
-      await dstSession.deleteSession(sessionId, otherSessionsData);
+      return {
+        protocol: this.protocol,
+        value: await dstSession.deleteSession(sessionId, otherSessionsData),
+      };
     } catch (e) {
       log.error(`Had trouble ending session ${sessionId}: ${e.message}`);
-      throw e;
+      //throw e;
+      return {
+        protocol: this.protocol,
+        error: e,
+      };
     }
   }
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -187,81 +187,96 @@ class AppiumDriver extends BaseDriver {
    */
   async createSession (jsonwpCaps, reqCaps, w3cCapabilities) {
     let {defaultCapabilities} = this.args;
-
-    // Parse the caps into a format that the InnerDriver will accept
-    let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(
-      jsonwpCaps,
-      w3cCapabilities,
-      this.desiredCapConstraints, defaultCapabilities
-    );
-
-    // Since the processed caps may be different from the payload, update the protocol accordingly
-    this.protocol = BaseDriver.determineProtocol(processedJsonwpCapabilities, reqCaps, processedW3CCapabilities);
-
-    let InnerDriver = this.getDriverForCaps(desiredCaps);
-    this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
-
-    if (this.args.sessionOverride) {
-      const sessionIdsToDelete = await sessionsListGuard.acquire(AppiumDriver.name, () => _.keys(this.sessions));
-      if (sessionIdsToDelete.length) {
-        log.info(`Session override is on. Deleting other ${sessionIdsToDelete.length} active session${sessionIdsToDelete.length ? '' : 's'}.`);
-        try {
-          await B.map(sessionIdsToDelete, (id) => this.deleteSession(id));
-        } catch (ign) {}
-      }
-    }
-
-    let runningDriversData, otherPendingDriversData;
-    let d = new InnerDriver(this.args);
-
-    if (this.args.relaxedSecurityEnabled) {
-      log.info(`Applying relaxed security to ${InnerDriver.name} as per server command line argument`);
-      d.relaxedSecurityEnabled = true;
-    }
-
-    // Attach server instance
-    d.server = this.server;
-
-    try {
-      runningDriversData = await this.curSessionDataForDriver(InnerDriver);
-    } catch (e) {
-      throw new errors.SessionNotCreatedError(e.message);
-    }
-    await pendingDriversGuard.acquire(AppiumDriver.name, () => {
-      this.pendingDrivers[InnerDriver.name] = this.pendingDrivers[InnerDriver.name] || [];
-      otherPendingDriversData = this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData);
-      this.pendingDrivers[InnerDriver.name].push(d);
-    });
-
+    let protocol;
     let innerSessionId, dCaps;
+
+
     try {
-      [innerSessionId, dCaps] = await d.createSession(
-        processedJsonwpCapabilities,
-        reqCaps,
-        processedW3CCapabilities,
-        [...runningDriversData, ...otherPendingDriversData]
+      // Parse the caps into a format that the InnerDriver will accept
+      const parsedCaps = parseCapsForInnerDriver(
+        jsonwpCaps,
+        w3cCapabilities,
+        this.desiredCapConstraints,
+        defaultCapabilities
       );
-      await sessionsListGuard.acquire(AppiumDriver.name, () => {
-        this.sessions[innerSessionId] = d;
-      });
-    } finally {
+
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, error} = parsedCaps;
+      protocol = parsedCaps.protocol;
+
+      // If the parsing of the caps produced an error, throw it in here
+      if (error) {
+        throw error;
+      }
+
+      let InnerDriver = this.getDriverForCaps(desiredCaps);
+      this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
+
+      if (this.args.sessionOverride) {
+        const sessionIdsToDelete = await sessionsListGuard.acquire(AppiumDriver.name, () => _.keys(this.sessions));
+        if (sessionIdsToDelete.length) {
+          log.info(`Session override is on. Deleting other ${sessionIdsToDelete.length} active session${sessionIdsToDelete.length ? '' : 's'}.`);
+          try {
+            await B.map(sessionIdsToDelete, (id) => this.deleteSession(id));
+          } catch (ign) {}
+        }
+      }
+
+      let runningDriversData, otherPendingDriversData;
+      let d = new InnerDriver(this.args);
+      if (this.args.relaxedSecurityEnabled) {
+        log.info(`Applying relaxed security to ${InnerDriver.name} as per server command line argument`);
+        d.relaxedSecurityEnabled = true;
+      }
+      try {
+        runningDriversData = await this.curSessionDataForDriver(InnerDriver);
+      } catch (e) {
+        throw new errors.SessionNotCreatedError(e.message);
+      }
       await pendingDriversGuard.acquire(AppiumDriver.name, () => {
-        _.pull(this.pendingDrivers[InnerDriver.name], d);
+        this.pendingDrivers[InnerDriver.name] = this.pendingDrivers[InnerDriver.name] || [];
+        otherPendingDriversData = this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData);
+        this.pendingDrivers[InnerDriver.name].push(d);
       });
+
+      try {
+        [innerSessionId, dCaps] = await d.createSession(
+          processedJsonwpCapabilities,
+          reqCaps,
+          processedW3CCapabilities,
+          [...runningDriversData, ...otherPendingDriversData]
+        );
+        protocol = d.protocol;
+        await sessionsListGuard.acquire(AppiumDriver.name, () => {
+          this.sessions[innerSessionId] = d;
+        });
+      } finally {
+        await pendingDriversGuard.acquire(AppiumDriver.name, () => {
+          _.pull(this.pendingDrivers[InnerDriver.name], d);
+        });
+      }
+
+      // this is an async function but we don't await it because it handles
+      // an out-of-band promise which is fulfilled if the inner driver
+      // unexpectedly shuts down
+      this.attachUnexpectedShutdownHandler(d, innerSessionId);
+
+
+      log.info(`New ${InnerDriver.name} session created successfully, session ` +
+              `${innerSessionId} added to master session list`);
+
+      // set the New Command Timeout for the inner driver
+      d.startNewCommandTimeout();
+    } catch (error) {
+      return {
+        protocol,
+        error,
+      };
     }
 
-    // this is an async function but we don't await it because it handles
-    // an out-of-band promise which is fulfilled if the inner driver
-    // unexpectedly shuts down
-    this.attachUnexpectedShutdownHandler(d, innerSessionId);
-
-    log.info(`New ${InnerDriver.name} session created successfully, session ` +
-             `${innerSessionId} added to master session list`);
-
-    // set the New Command Timeout for the inner driver
-    d.startNewCommandTimeout();
-
-    return [innerSessionId, dCaps];
+    return {
+      protocol,
+      value: [innerSessionId, dCaps, protocol]
+    };
   }
 
   async attachUnexpectedShutdownHandler (driver, innerSessionId) {
@@ -333,7 +348,19 @@ class AppiumDriver extends BaseDriver {
     if (cmd === 'getStatus') {
       return await this.getStatus();
     }
-    if (isAppiumDriverCommand(cmd)) {
+
+    let res = {};
+    if (cmd === 'createSession') {
+      let value = await super.executeCommand(cmd, ...args);
+      if (_.isObject(value) && value.error) {
+        res._W3C = value.protocol === BaseDriver.DRIVER_PROTOCOL.W3C,
+        res.error = value.error;
+      } else {
+        res._W3C = value.protocol === BaseDriver.DRIVER_PROTOCOL.W3C,
+        res.value = value.value;
+      }
+      return res;
+    } else if (isAppiumDriverCommand(cmd)) {
       return await super.executeCommand(cmd, ...args);
     }
 
@@ -342,7 +369,19 @@ class AppiumDriver extends BaseDriver {
     if (!dstSession) {
       throw new Error(`The session with id '${sessionId}' does not exist`);
     }
-    return await dstSession.executeCommand(cmd, ...args);
+
+    // Return a payload that has a key indicating what the protocol is and
+    // either the value of the execution or the error
+    res = {
+      _W3C: dstSession.isW3CProtocol(),
+    };
+
+    try {
+      res.value = await dstSession.executeCommand(cmd, ...args);
+    } catch (e) {
+      res.error = e;
+    }
+    return res;
   }
 
   proxyActive (sessionId) {

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -350,17 +350,8 @@ class AppiumDriver extends BaseDriver {
     }
 
     let res = {};
-    if (cmd === 'createSession') {
-      let value = await super.executeCommand(cmd, ...args);
-      if (_.isObject(value) && value.error) {
-        res._W3C = value.protocol === BaseDriver.DRIVER_PROTOCOL.W3C,
-        res.error = value.error;
-      } else {
-        res._W3C = value.protocol === BaseDriver.DRIVER_PROTOCOL.W3C,
-        res.value = value.value;
-      }
-      return res;
-    } else if (isAppiumDriverCommand(cmd)) {
+
+    if (isAppiumDriverCommand(cmd)) {
       return await super.executeCommand(cmd, ...args);
     }
 
@@ -370,10 +361,8 @@ class AppiumDriver extends BaseDriver {
       throw new Error(`The session with id '${sessionId}' does not exist`);
     }
 
-    // Return a payload that has a key indicating what the protocol is and
-    // either the value of the execution or the error
     res = {
-      _W3C: dstSession.isW3CProtocol(),
+      protocol: dstSession.protocol
     };
 
     try {

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -349,8 +349,6 @@ class AppiumDriver extends BaseDriver {
       return await this.getStatus();
     }
 
-    let res = {};
-
     if (isAppiumDriverCommand(cmd)) {
       return await super.executeCommand(cmd, ...args);
     }
@@ -361,7 +359,7 @@ class AppiumDriver extends BaseDriver {
       throw new Error(`The session with id '${sessionId}' does not exist`);
     }
 
-    res = {
+    let res = {
       protocol: dstSession.protocol
     };
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -317,6 +317,7 @@ class AppiumDriver extends BaseDriver {
   }
 
   async deleteSession (sessionId) {
+    let protocol;
     try {
       let otherSessionsData = null;
       let dstSession = null;
@@ -329,6 +330,7 @@ class AppiumDriver extends BaseDriver {
               .filter(([key, value]) => value.constructor.name === curConstructorName && key !== sessionId)
               .map(([, value]) => value.driverData);
         dstSession = this.sessions[sessionId];
+        protocol = dstSession.protocol;
         log.info(`Removing session ${sessionId} from our master session list`);
         // regardless of whether the deleteSession completes successfully or not
         // make the session unavailable, because who knows what state it might
@@ -336,14 +338,13 @@ class AppiumDriver extends BaseDriver {
         delete this.sessions[sessionId];
       });
       return {
-        protocol: this.protocol,
+        protocol,
         value: await dstSession.deleteSession(sessionId, otherSessionsData),
       };
     } catch (e) {
       log.error(`Had trouble ending session ${sessionId}: ${e.message}`);
-      //throw e;
       return {
-        protocol: this.protocol,
+        protocol,
         error: e,
       };
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import logger from './logger';
-import { processCapabilities } from 'appium-base-driver';
+import { processCapabilities, BaseDriver } from 'appium-base-driver';
 
 
 function inspectObject (args) {
@@ -44,6 +44,10 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
   const hasW3CCaps = _.isPlainObject(w3cCapabilities);
   const hasJSONWPCaps = _.isPlainObject(jsonwpCaps);
 
+  let protocol;
+
+  const {W3C, MJSONWP} = BaseDriver.DRIVER_PROTOCOL;
+
   // Make copies of the capabilities that include the default capabilities
   if (hasW3CCaps) {
     w3cCapabilities = {
@@ -66,13 +70,16 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
   let desiredCaps = {};
   let processedJsonwpCapabilities = null;
   if (hasJSONWPCaps) {
+    protocol = MJSONWP;
     desiredCaps = jsonwpCaps;
     processedJsonwpCapabilities = {...desiredCaps};
   }
 
   // Get W3C caps
   let processedW3CCapabilities = null;
+  let error;
   if (hasW3CCaps) {
+    protocol = W3C;
     // Call the process capabilities algorithm to find matching caps on the W3C
     // (see: https://github.com/jlipps/simple-wd-spec#processing-capabilities)
     let matchingW3CCaps;
@@ -81,9 +88,9 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
     } catch (err) {
       if (jsonwpCaps) {
         logger.warn(`Could not parse W3C capabilities: ${err.message}. Falling back to JSONWP protocol.`);
-        return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities};
+        protocol = MJSONWP;
       } else {
-        throw err;
+        error = err;
       }
     }
 
@@ -101,13 +108,14 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
       if (!_.isEmpty(differingKeys)) {
         logger.warn(`The following capabilities were provided in the JSONWP desired capabilities that are missing ` +
           `in W3C capabilities: ${JSON.stringify(differingKeys)}. Falling back to JSONWP protocol.`);
+        protocol = MJSONWP;
         desiredCaps = jsonwpCaps;
         return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities: null};
       }
     }
   }
 
-  return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities};
+  return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, protocol, error};
 }
 
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -110,7 +110,7 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
           `in W3C capabilities: ${JSON.stringify(differingKeys)}. Falling back to JSONWP protocol.`);
         protocol = MJSONWP;
         desiredCaps = jsonwpCaps;
-        return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities: null};
+        return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities: null, protocol};
       }
     }
   }

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -173,7 +173,6 @@ describe('FakeDriver - via HTTP', function () {
         }
       };
 
-      //const {status, sessionId, value} = await request.post({url: baseUrl, json: combinedCaps});
       const {sessionId, status, value} = await request.post({url: baseUrl, json: combinedCaps});
       status.should.exist;
       sessionId.should.exist;

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -165,7 +165,7 @@ describe('AppiumDriver', function () {
         mockFakeDriver.restore();
       });
       it('should remove the session if it is found', async function () {
-        let [sessionId] = await appium.createSession(BASE_CAPS);
+        let [sessionId] = (await appium.createSession(BASE_CAPS)).value;
         let sessions = await appium.getSessions();
         sessions.should.have.length(1);
         await appium.deleteSession(sessionId);
@@ -173,7 +173,7 @@ describe('AppiumDriver', function () {
         sessions.should.have.length(0);
       });
       it('should call inner driver\'s deleteSession method', async function () {
-        const [sessionId] = await appium.createSession(BASE_CAPS);
+        const [sessionId] =  (await appium.createSession(BASE_CAPS)).value;
         mockFakeDriver.expects("deleteSession")
           .once().withExactArgs(sessionId, [])
           .returns();
@@ -201,8 +201,8 @@ describe('AppiumDriver', function () {
         sessions.should.be.empty;
       });
       it('should return sessions created', async function () {
-        let session1 = await appium.createSession(_.extend(_.clone(BASE_CAPS), {cap: 'value'}));
-        let session2 = await appium.createSession(_.extend(_.clone(BASE_CAPS), {cap: 'other value'}));
+        let session1 = (await appium.createSession(_.extend(_.clone(BASE_CAPS), {cap: 'value'}))).value;
+        let session2 = (await appium.createSession(_.extend(_.clone(BASE_CAPS), {cap: 'other value'}))).value;
 
         sessions = await appium.getSessions();
         sessions.should.be.an.array;
@@ -239,7 +239,7 @@ describe('AppiumDriver', function () {
       });
 
       it('should remove session if inner driver unexpectedly exits with an error', async function () {
-        let [sessionId,] = await appium.createSession(_.clone(BASE_CAPS)); // eslint-disable-line comma-spacing
+        let [sessionId,] = (await appium.createSession(_.clone(BASE_CAPS))).value; // eslint-disable-line comma-spacing
         _.keys(appium.sessions).should.contain(sessionId);
         appium.sessions[sessionId].unexpectedShutdownDeferred.reject(new Error("Oops"));
         // let event loop spin so rejection is handled
@@ -247,7 +247,7 @@ describe('AppiumDriver', function () {
         _.keys(appium.sessions).should.not.contain(sessionId);
       });
       it('should remove session if inner driver unexpectedly exits with no error', async function () {
-        let [sessionId,] = await appium.createSession(_.clone(BASE_CAPS)); // eslint-disable-line comma-spacing
+        let [sessionId,] = (await appium.createSession(_.clone(BASE_CAPS))).value; // eslint-disable-line comma-spacing
         _.keys(appium.sessions).should.contain(sessionId);
         appium.sessions[sessionId].unexpectedShutdownDeferred.resolve();
         // let event loop spin so rejection is handled
@@ -255,7 +255,7 @@ describe('AppiumDriver', function () {
         _.keys(appium.sessions).should.not.contain(sessionId);
       });
       it('should not remove session if inner driver cancels unexpected exit', async function () {
-        let [sessionId,] = await appium.createSession(_.clone(BASE_CAPS)); // eslint-disable-line comma-spacing
+        let [sessionId,] = (await appium.createSession(_.clone(BASE_CAPS))).value; // eslint-disable-line comma-spacing
         _.keys(appium.sessions).should.contain(sessionId);
         appium.sessions[sessionId].onUnexpectedShutdown.cancel();
         // let event loop spin so rejection is handled

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -11,22 +11,25 @@ chai.use(chaiAsPromised);
 describe('utils', function () {
   describe('parseCapsForInnerDriver()', function () {
     it('should return JSONWP caps unchanged if only JSONWP caps provided', function () {
-      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS);
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, protocol} = parseCapsForInnerDriver(BASE_CAPS);
       desiredCaps.should.deep.equal(BASE_CAPS);
       processedJsonwpCapabilities.should.deep.equal(BASE_CAPS);
       should.not.exist(processedW3CCapabilities);
+      protocol.should.equal('MJSONWP');
     });
     it('should return W3C caps unchanged if only W3C caps were provided', function () {
-      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(undefined, W3C_CAPS);
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, protocol} = parseCapsForInnerDriver(undefined, W3C_CAPS);
       desiredCaps.should.deep.equal(BASE_CAPS);
       should.not.exist(processedJsonwpCapabilities);
       processedW3CCapabilities.should.deep.equal(W3C_CAPS);
+      protocol.should.equal('W3C');
     });
     it('should return JSONWP and W3C caps if both were provided', function () {
-      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS);
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, protocol} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS);
       desiredCaps.should.deep.equal(BASE_CAPS);
       processedJsonwpCapabilities.should.deep.equal(BASE_CAPS);
       processedW3CCapabilities.should.deep.equal(W3C_CAPS);
+      protocol.should.equal('W3C');
     });
     it('should include default capabilities in results', function () {
       let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, W3C_CAPS, {}, {foo: 'bar'});
@@ -48,11 +51,12 @@ describe('utils', function () {
           {hello: 'world'},
         ],
       };
-      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(BASE_CAPS, w3cCaps, {hello: {presence: true}});
+      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, protocol} = parseCapsForInnerDriver(BASE_CAPS, w3cCaps, {hello: {presence: true}});
       const expectedResult = {hello: 'world', ...BASE_CAPS};
       desiredCaps.should.deep.equal(expectedResult);
       processedJsonwpCapabilities.should.deep.equal({...BASE_CAPS});
       processedW3CCapabilities.alwaysMatch.should.deep.equal(insertAppiumPrefixes(expectedResult));
+      protocol.should.equal('W3C');
     });
     it('should add appium prefixes to W3C caps that are not standard in W3C', function () {
       parseCapsForInnerDriver(undefined, {
@@ -70,13 +74,14 @@ describe('utils', function () {
         ...BASE_CAPS,
         automationName: 'Fake',
       };
-      const {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver(jsonwpCaps, {
+      const {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, protocol} = parseCapsForInnerDriver(jsonwpCaps, {
         alwaysMatch: {platformName: 'Fake', propertyName: 'PROP_NAME'},
       });
 
       should.not.exist(processedW3CCapabilities);
       desiredCaps.should.eql(jsonwpCaps);
       processedJsonwpCapabilities.should.eql(jsonwpCaps);
+      protocol.should.equal('MJSONWP');
     });
     it('should fall back to MJSONWP caps if W3C capabilities are invalid', function () {
       let w3cCapabilities = {
@@ -87,11 +92,12 @@ describe('utils', function () {
           presence: true,
         }
       };
-      const {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = parseCapsForInnerDriver({...BASE_CAPS}, w3cCapabilities, constraints);
+      const {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, protocol} = parseCapsForInnerDriver({...BASE_CAPS}, w3cCapabilities, constraints);
 
       should.not.exist(processedW3CCapabilities);
       desiredCaps.should.eql(BASE_CAPS);
       processedJsonwpCapabilities.should.eql(BASE_CAPS);
+      protocol.should.equal('MJSONWP');
     });
   });
 

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -2,6 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { parseCapsForInnerDriver, insertAppiumPrefixes } from '../lib/utils';
 import { BASE_CAPS, W3C_CAPS } from './helpers';
+import _ from 'lodash';
 
 
 const should = chai.should();
@@ -34,7 +35,10 @@ describe('utils', function () {
       processedW3CCapabilities.alwaysMatch.should.deep.equal({'appium:foo': 'bar', ...insertAppiumPrefixes(BASE_CAPS)});
     });
     it('should reject if W3C caps are not passing constraints', function () {
-      (() => parseCapsForInnerDriver(undefined, W3C_CAPS, {hello: {presence: true}})).should.throw(/'hello' can't be blank/);
+      const err = parseCapsForInnerDriver(undefined, W3C_CAPS, {hello: {presence: true}}).error;
+      err.message.should.match(/'hello' can't be blank/);
+      _.isError(err).should.be.true;
+
     });
     it('should only accept W3C caps that have passing constraints', function () {
       let w3cCaps = {


### PR DESCRIPTION
* Previous implementations of W3C assumed that there was only one session running at a time
* We should be assuming that there are _multiple_ sessions that may have different protocols
* The fix is to make it so executeCommand returns protocol and value/error (instead of just throwing the value/error)
    * This is so that base driver can read the protocol and serve the response (base driver doesn't know what the protocol of the inner drivers are)
    * Added tests to confirm that it falls back to MJSONWP if an inner driver is not ready and handles concurrent MJSONWP and W3C sessions
    * Updated unit tests to match new format

* e.g.)

  * Previously executeCommand `getScreenshot` would have returned

   ```javascript
    "somescreenshotdata...."
    ```

  * Now it returns

    ```javascript
    { protocol: "W3C | MJSONWP", value: "somescreenshotdata...." }
    ```

* The new base driver changes (https://github.com/appium/appium-base-driver/compare/dpgraham-parse-protocol-from-execute-command?expand=1) looks for this new format and sends the appropriate HTTP response