### PR TITLE
Collapsable widget instead of gists

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -19,9 +19,11 @@ If necessary, describe the problem you have been experiencing in more detail.
 ## Appium logs
 <details><summary>Appium Logs</summary>
 <p>
+  
   ```
   [ PASTE YOUR APPIUM LOGS HERE ]
   ```
+  
 </p>
 </details>
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,11 +16,14 @@ Briefly describe the issue you are experiencing (or the feature you want to see 
 
 If necessary, describe the problem you have been experiencing in more detail.
 
-## Link to Appium logs
-
-Create a [GIST](https://gist.github.com) which is a paste of your _full_ Appium logs, and link them here. 
-Do _NOT_ paste your full Appium logs here, as it will make this issue very long and hard to read! 
-If you are reporting a bug, _always_ include Appium logs!
+## Appium logs
+<details><summary>Appium Logs</summary>
+<p>
+  ```
+  [ PASTE YOUR APPIUM LOGS HERE ]
+  ```
+</p>
+</details>
 
 
 ## Code To Reproduce Issue [ Good To Have ]


### PR DESCRIPTION
Use collapsable widget instead of asking submitters to submit a gist. This is easier for the issue submitter without compromising readability.

The logs in the issue will look like this:

## Appium logs
<details><summary>Appium Logs</summary>
<p>
  
  ```
  [ PASTE YOUR APPIUM LOGS HERE ]
  ```
  
</p>
</details>