### PR TITLE
Add vmaxim to the list of Appium committers

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -77,6 +77,7 @@ The current committers are (in addition to the TC members above):
 * [@triager](https://github.com/triager)
 * [@ddkjin](https://github.com/ddkjin)
 * [@stuartbrussell-intuit](https://github.com/stuartbrussell-intuit)
+* [@vmaxim](https://github.com/vmaxim)
 
 ### Contributors
 


### PR DESCRIPTION
## Proposed changes

@vmaxim Is doing a great job by maintaining Android codebase for Appium. Lets include him to the list of Appium committers.
