### PR TITLE
Re-enable package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 # Do not disable package-lock. Disabling package-lock also disables npm-shrinkwrap
-# package-lock=false
+package-lock=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
-package-lock=false
+# Do not disable package-lock. Disabling package-lock also disables npm-shrinkwrap
+# package-lock=false


### PR DESCRIPTION
## Proposed changes

It turns out that disabling package-lock.json _also_ disables npm-shrinkwrap.json, which means that users who have been installing Appium using npm >= 5 have been getting a non-shrinkwrapped version of Appium.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
