### PR TITLE
Dynamically figure out line numbers to routes file when necessary

### DIFF
--- a/commands-yml/commands/device/activity/current-activity.yml
+++ b/commands-yml/commands/device/activity/current-activity.yml
@@ -58,7 +58,7 @@ client_support:
 
 # Information about the HTTP endpoints
 endpoint:
-  url: /wd/hub/session/:session_id/device/current_activity
+  url: /wd/hub/session/:session_id/appium/device/current_activity
   method: GET
   url_parameters:
     - name: session_id

--- a/commands-yml/commands/device/activity/current-package.yml
+++ b/commands-yml/commands/device/activity/current-package.yml
@@ -1,7 +1,7 @@
 ---
 name: Get Current Package
 short_description: Get the name of the current Android package
-    
+
 example_usage:
   java:
     |
@@ -50,11 +50,11 @@ client_support:
   csharp: true
   javascript_wd: true
   javascript_wdio: false
-  
+
 
 # Information about the HTTP endpoints
 endpoint:
-  url: /wd/hub/session/:session_id/device/current_package
+  url: /wd/hub/session/:session_id/appium/device/current_package
   method: GET
   url_parameters:
     - name: session_id
@@ -64,5 +64,5 @@ endpoint:
       description: Name of the current [package](https://developer.android.com/reference/java/lang/Package.html)
 
 # Links to specifications. Should link to at least one specification
-specifications: 
+specifications:
   jsonwp: https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L369

--- a/commands-yml/commands/device/activity/start-activity.yml
+++ b/commands-yml/commands/device/activity/start-activity.yml
@@ -62,7 +62,7 @@ client_support:
 
 # Information about the HTTP endpoints
 endpoint:
-  url: /wd/hub/session/:session_id/device/start_activity
+  url: /wd/hub/session/:session_id/appium/device/start_activity
   method: POST
   url_parameters:
     - name: session_id

--- a/commands-yml/commands/device/app/install-app.yml
+++ b/commands-yml/commands/device/app/install-app.yml
@@ -62,7 +62,7 @@ client_support:
 
 # Information about the HTTP endpoints
 endpoint:
-  url: /wd/hub/session/:session_id/device/install_app
+  url: /wd/hub/session/:session_id/appium/device/install_app
   method: POST
   url_parameters:
     - name: session_id

--- a/commands-yml/commands/device/app/is-app-installed.yml
+++ b/commands-yml/commands/device/app/is-app-installed.yml
@@ -62,7 +62,7 @@ client_support:
 
 # Information about the HTTP endpoints
 endpoint:
-  url: /wd/hub/session/:session_id/device/app_installed
+  url: /wd/hub/session/:session_id/appium/device/app_installed
   method: POST
   url_parameters:
     - name: session_id

--- a/commands-yml/commands/device/app/remove-app.yml
+++ b/commands-yml/commands/device/app/remove-app.yml
@@ -63,7 +63,7 @@ client_support:
 
 # Information about the HTTP endpoints
 endpoint:
-  url: /wd/hub/session/:session_id/device/remove_app
+  url: /wd/hub/session/:session_id/appium/device/remove_app
   method: POST
   url_parameters:
     - name: session_id

--- a/commands-yml/commands/device/files/pull-folder.yml
+++ b/commands-yml/commands/device/files/pull-folder.yml
@@ -58,7 +58,7 @@ client_support:
 
 # Information about the HTTP endpoints
 endpoint:
-  url: /wd/hub/session/:session_id/device/pull_folder
+  url: /wd/hub/session/:session_id/appium/device/pull_folder
   method: POST
   url_parameters:
     - name: session_id

--- a/commands-yml/commands/device/interactions/rotate.yml
+++ b/commands-yml/commands/device/interactions/rotate.yml
@@ -1,7 +1,7 @@
 ---
 name: Rotate
 short_description: Rotate the device in three dimensions
-    
+
 example_usage:
   java:
     |
@@ -46,11 +46,11 @@ client_support:
   csharp: true
   javascript_wd: true
   javascript_wdio: true
-  
+
 
 # Information about the HTTP endpoints
 endpoint:
-  url: /wd/hub/session/:session_id/device/rotate
+  url: /wd/hub/session/:session_id/appium/device/rotate
   method: 'POST'
   url_parameters:
     - name: session_id
@@ -76,5 +76,5 @@ endpoint:
       description: The length of hold time for the specified gesture, in seconds.
 
 # Links to specifications. Should link to at least one specification
-specifications: 
+specifications:
   jsonwp: https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L361

--- a/commands-yml/commands/device/keys/is-keyboard-shown.yml
+++ b/commands-yml/commands/device/keys/is-keyboard-shown.yml
@@ -49,4 +49,4 @@ endpoint:
 
 # Links to specifications. Should link to at least one specification
 specifications:
-  jsonwp: https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L384
+  jsonwp: routes.js

--- a/commands-yml/parse.js
+++ b/commands-yml/parse.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import path from 'path';
 import yaml from 'yaml-js';
 import { fs, mkdirp } from 'appium-support';
@@ -9,6 +8,8 @@ import _ from 'lodash';
 import { asyncify } from 'asyncbox';
 import validator from './validator';
 import url from 'url';
+import log from 'fancy-log';
+import { exec } from 'teen_process';
 
 
 // What range of platforms do the driver's support
@@ -74,7 +75,7 @@ Handlebars.registerHelper('versions', (object, name, driverName) => {
 Handlebars.registerHelper('hyphenate', (str) =>  str.replace('_', '-'));
 Handlebars.registerHelper('uppercase', (str) => str.toUpperCase());
 
-Handlebars.registerHelper('capitalize', (driverName) => {
+Handlebars.registerHelper('capitalize', function (driverName) {
   switch (driverName.toLowerCase()) {
     case 'xcuitest':
       return 'XCUITest';
@@ -102,13 +103,55 @@ Handlebars.registerHelper('base_url', function (fullUrl) {
   return baseUrl.hostname;
 });
 
+async function registerSpecUrlHelper () {
+  const npmRoot = (await exec('npm', ['root'])).stdout.trim();
+  const routesFile = await fs.readFile(path.resolve(npmRoot, 'appium-base-driver', 'lib', 'protocol', 'routes.js'), 'utf8');
+  const routesFileLines = routesFile.split('\n');
+
+  Handlebars.registerHelper('spec_url', function (specUrl, endpoint) {
+    // return the url if it is not a link to our routes doc
+    if (!specUrl.includes('routes.js')) {
+      return specUrl;
+    }
+    // make sure it is a full url
+    if (specUrl.startsWith('routes.js')) {
+      specUrl = `https://github.com/appium/appium-base-driver/blob/master/lib/protocol/${specUrl}`;
+    }
+
+    // strip off any line numbers
+    specUrl = specUrl.split('#L')[0];
+
+    // the endpoint here is often `session_id` and we need `sessionId`
+    endpoint = endpoint.replace('session_id', 'sessionId');
+    // and `element_id` and we need `elementId`
+    endpoint = endpoint.replace('element_id', 'elementId');
+
+    // find the line number for this endpoint
+    let index;
+    for (const i in routesFileLines) {
+      if (routesFileLines[i].includes(endpoint)) {
+        // line numbers are 1-indexed
+        index = parseInt(i, 10) + 1;
+        break;
+      }
+    }
+    if (_.isUndefined(index)) {
+      throw new Error(`Unable to find entry in 'appium-base-driver#routes' for endpoint '${endpoint}'`);
+    }
+
+    return `${specUrl}#L${index}`;
+  });
+}
+
 async function generateCommands () {
+  await registerSpecUrlHelper();
+
   const commands = path.resolve(__dirname, 'commands/**/*.yml');
-  console.log('Traversing YML files', commands);
+  log('Traversing YML files', commands);
   await fs.rimraf(path.resolve(__dirname, '..', 'docs', 'en', 'commands'));
   let fileCount = 0;
   for (let filename of await fs.glob(commands)) {
-    console.log('Rendering file:', filename, path.relative(__dirname, filename), path.extname(filename));
+    log(`Rendering file: ${filename} ${path.relative(__dirname, filename)}`);
 
     // Translate the YML specs to JSON
     const inputYML = await fs.readFile(filename, 'utf8');
@@ -126,18 +169,18 @@ async function generateCommands () {
     // Write the markdown to its right place
     const markdownPath = replaceExt(path.relative(__dirname, filename), '.md');
     const outfile = path.resolve(__dirname, '..', 'docs', 'en', markdownPath);
-    console.log('Writing file to:', outfile);
+    log(`    Writing to: ${outfile}`);
     await mkdirp(path.dirname(outfile));
     await fs.writeFile(outfile, markdown, 'utf8');
 
     fileCount++;
   }
-  console.log(`Done writing ${fileCount} command documents`);
+  log(`Done writing ${fileCount} command documents`);
 }
 
 async function generateCommandIndex () {
   const apiIndex = path.resolve(__dirname, '..', 'docs', 'en', 'about-appium', 'api.md');
-  console.log(`Creating API index '${apiIndex}'`);
+  log(`Creating API index '${apiIndex}'`);
 
   function getTree (element, path) {
     let node = {
@@ -164,10 +207,10 @@ async function generateCommandIndex () {
     commands.push(getTree(el, '/docs/en/commands'));
   }
 
-  const template = Handlebars.compile(await fs.readFile(path.resolve(__dirname, 'api-template.md'), 'utf8'), {noEscape: true, strict: true});
-  const markdown = template({commands});
-  await fs.writeFile(apiIndex, markdown, 'utf8');
-  console.log(`Done writing API index`);
+  const commandTemplate = Handlebars.compile(await fs.readFile(path.resolve(__dirname, 'api-template.md'), 'utf8'), {noEscape: true, strict: true});
+  const commandMarkdown = commandTemplate({commands});
+  await fs.writeFile(apiIndex, commandMarkdown, 'utf8');
+  log(`Done writing API index`);
 }
 
 async function main () {

--- a/commands-yml/template.md
+++ b/commands-yml/template.md
@@ -163,10 +163,10 @@ null
 ## See Also
 
 {{#if specifications.w3c}}
-* [W3C Specification]({{specifications.w3c}})
+* [W3C Specification]({{spec_url specifications.w3c endpoint.url}})
 {{/if}}
 {{#if specifications.jsonwp}}
-* [JSONWP Specification]({{specifications.jsonwp}})
+* [JSONWP Specification]({{spec_url specifications.jsonwp endpoint.url}})
 {{/if}}
 {{#each links}}
 * [{{this.name}}]({{this.url}})

--- a/docs/en/commands/device/activity/current-activity.md
+++ b/docs/en/commands/device/activity/current-activity.md
@@ -78,7 +78,7 @@ $activity = $driver->currentActivity();
 
 ### Endpoint
 
-`GET /wd/hub/session/:session_id/device/current_activity`
+`GET /wd/hub/session/:session_id/appium/device/current_activity`
 
 ### URL Parameters
 
@@ -96,4 +96,4 @@ Name of the current [activity](https://developer.android.com/reference/android/a
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L366)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L395)

--- a/docs/en/commands/device/activity/current-package.md
+++ b/docs/en/commands/device/activity/current-package.md
@@ -75,7 +75,7 @@ let package = await driver.getCurrentPackage();
 
 ### Endpoint
 
-`GET /wd/hub/session/:session_id/device/current_package`
+`GET /wd/hub/session/:session_id/appium/device/current_package`
 
 ### URL Parameters
 
@@ -93,4 +93,4 @@ Name of the current [package](https://developer.android.com/reference/java/lang/
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L369)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L398)

--- a/docs/en/commands/device/activity/start-activity.md
+++ b/docs/en/commands/device/activity/start-activity.md
@@ -82,7 +82,7 @@ $driver->startActivity(array('appPackage' => 'com.example',
 
 ### Endpoint
 
-`POST /wd/hub/session/:session_id/device/start_activity`
+`POST /wd/hub/session/:session_id/appium/device/start_activity`
 
 ### URL Parameters
 
@@ -109,4 +109,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L411)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L484)

--- a/docs/en/commands/device/app/background-app.md
+++ b/docs/en/commands/device/app/background-app.md
@@ -114,4 +114,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L439)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L512)

--- a/docs/en/commands/device/app/close-app.md
+++ b/docs/en/commands/device/app/close-app.md
@@ -96,4 +96,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L433)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L506)

--- a/docs/en/commands/device/app/end-test-coverage.md
+++ b/docs/en/commands/device/app/end-test-coverage.md
@@ -96,4 +96,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L442)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L515)

--- a/docs/en/commands/device/app/get-app-strings.md
+++ b/docs/en/commands/device/app/get-app-strings.md
@@ -99,4 +99,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L445)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L518)

--- a/docs/en/commands/device/app/install-app.md
+++ b/docs/en/commands/device/app/install-app.md
@@ -82,7 +82,7 @@ iOS tests with XCUITest can also use the `mobile: installApp` method. See detail
 
 ### Endpoint
 
-`POST /wd/hub/session/:session_id/device/install_app`
+`POST /wd/hub/session/:session_id/appium/device/install_app`
 
 ### URL Parameters
 
@@ -102,4 +102,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L372)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L402)

--- a/docs/en/commands/device/app/is-app-installed.md
+++ b/docs/en/commands/device/app/is-app-installed.md
@@ -82,7 +82,7 @@ iOS tests with XCUITest can also use the `mobile: isAppInstalled` method. See de
 
 ### Endpoint
 
-`POST /wd/hub/session/:session_id/device/app_installed`
+`POST /wd/hub/session/:session_id/appium/device/app_installed`
 
 ### URL Parameters
 
@@ -102,4 +102,4 @@ Return true if installed, false if not (`boolean`)
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L378)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L434)

--- a/docs/en/commands/device/app/launch-app.md
+++ b/docs/en/commands/device/app/launch-app.md
@@ -100,4 +100,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L430)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L503)

--- a/docs/en/commands/device/app/remove-app.md
+++ b/docs/en/commands/device/app/remove-app.md
@@ -82,7 +82,7 @@ iOS tests with XCUITest can also use the `mobile: removeApp` method. See detaile
 
 ### Endpoint
 
-`POST /wd/hub/session/:session_id/device/remove_app`
+`POST /wd/hub/session/:session_id/appium/device/remove_app`
 
 ### URL Parameters
 
@@ -103,4 +103,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L375)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L418)

--- a/docs/en/commands/device/app/reset-app.md
+++ b/docs/en/commands/device/app/reset-app.md
@@ -96,4 +96,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L436)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L509)

--- a/docs/en/commands/device/files/pull-file.md
+++ b/docs/en/commands/device/files/pull-file.md
@@ -98,4 +98,4 @@ Contents of file in base64 (`string`)
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L390)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L463)

--- a/docs/en/commands/device/files/pull-folder.md
+++ b/docs/en/commands/device/files/pull-folder.md
@@ -78,7 +78,7 @@ $folderBase64 = $driver->pullFolder($path);
 
 ### Endpoint
 
-`POST /wd/hub/session/:session_id/device/pull_folder`
+`POST /wd/hub/session/:session_id/appium/device/pull_folder`
 
 ### URL Parameters
 
@@ -98,4 +98,4 @@ A string of Base64 encoded data, representing a zip archive of the contents of t
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L393)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L466)

--- a/docs/en/commands/device/files/push-file.md
+++ b/docs/en/commands/device/files/push-file.md
@@ -100,4 +100,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L387)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L460)

--- a/docs/en/commands/device/interactions/is-locked.md
+++ b/docs/en/commands/device/interactions/is-locked.md
@@ -94,4 +94,4 @@ True if the device is locked, false if not (`boolean`)
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L313)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L342)

--- a/docs/en/commands/device/interactions/lock.md
+++ b/docs/en/commands/device/interactions/lock.md
@@ -99,4 +99,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L307)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L336)

--- a/docs/en/commands/device/interactions/rotate.md
+++ b/docs/en/commands/device/interactions/rotate.md
@@ -74,7 +74,7 @@ driver.rotateDevice({x: 114, y: 198, duration: 5, radius: 3, rotation: 220, touc
 
 ### Endpoint
 
-`POST /wd/hub/session/:session_id/device/rotate`
+`POST /wd/hub/session/:session_id/appium/device/rotate`
 
 ### URL Parameters
 
@@ -99,4 +99,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L361)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L390)

--- a/docs/en/commands/device/interactions/shake.md
+++ b/docs/en/commands/device/interactions/shake.md
@@ -96,4 +96,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L301)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L330)

--- a/docs/en/commands/device/interactions/unlock.md
+++ b/docs/en/commands/device/interactions/unlock.md
@@ -100,4 +100,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L310)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L339)

--- a/docs/en/commands/device/keys/hide-keyboard.md
+++ b/docs/en/commands/device/keys/hide-keyboard.md
@@ -104,4 +104,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L381)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L454)

--- a/docs/en/commands/device/keys/is-keyboard-shown.md
+++ b/docs/en/commands/device/keys/is-keyboard-shown.md
@@ -85,4 +85,4 @@ True if the keyboard is shown. (`boolean`)
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L384)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L457)

--- a/docs/en/commands/device/keys/long-press-keycode.md
+++ b/docs/en/commands/device/keys/long-press-keycode.md
@@ -98,4 +98,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L331)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L360)

--- a/docs/en/commands/device/keys/press-keycode.md
+++ b/docs/en/commands/device/keys/press-keycode.md
@@ -98,4 +98,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L328)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L357)

--- a/docs/en/commands/device/network/gsm-call.md
+++ b/docs/en/commands/device/network/gsm-call.md
@@ -92,4 +92,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L340)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L369)

--- a/docs/en/commands/device/network/gsm-signal.md
+++ b/docs/en/commands/device/network/gsm-signal.md
@@ -91,4 +91,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L343)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L372)

--- a/docs/en/commands/device/network/gsm-voice.md
+++ b/docs/en/commands/device/network/gsm-voice.md
@@ -91,4 +91,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L346)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L375)

--- a/docs/en/commands/device/network/send-sms.md
+++ b/docs/en/commands/device/network/send-sms.md
@@ -92,4 +92,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L337)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L366)

--- a/docs/en/commands/device/network/toggle-airplane-mode.md
+++ b/docs/en/commands/device/network/toggle-airplane-mode.md
@@ -92,4 +92,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L396)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L469)

--- a/docs/en/commands/device/network/toggle-data.md
+++ b/docs/en/commands/device/network/toggle-data.md
@@ -92,4 +92,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L399)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L472)

--- a/docs/en/commands/device/network/toggle-location-services.md
+++ b/docs/en/commands/device/network/toggle-location-services.md
@@ -96,4 +96,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L405)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L478)

--- a/docs/en/commands/device/network/toggle-wifi.md
+++ b/docs/en/commands/device/network/toggle-wifi.md
@@ -92,4 +92,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L402)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L475)

--- a/docs/en/commands/device/performance-data/get-performance-data.md
+++ b/docs/en/commands/device/performance-data/get-performance-data.md
@@ -93,4 +93,4 @@ The information type of the system state which is supported to read as like cpu,
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L325)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L354)

--- a/docs/en/commands/device/performance-data/performance-data-types.md
+++ b/docs/en/commands/device/performance-data/performance-data-types.md
@@ -89,4 +89,4 @@ The available performance data types (cpuinfo|batteryinfo|networkinfo|memoryinfo
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L322)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L351)

--- a/docs/en/commands/device/simulator/toggle-touch-id-enrollment.md
+++ b/docs/en/commands/device/simulator/toggle-touch-id-enrollment.md
@@ -105,4 +105,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L427)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L500)

--- a/docs/en/commands/device/simulator/touch-id.md
+++ b/docs/en/commands/device/simulator/touch-id.md
@@ -113,5 +113,5 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L424)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L497)
 * [Appium Docs](https://github.com/appium/appium-xcuitest-driver/blob/master/docs/touch-id.md)

--- a/docs/en/commands/device/system/open-notifications.md
+++ b/docs/en/commands/device/system/open-notifications.md
@@ -96,4 +96,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L408)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L481)

--- a/docs/en/commands/device/system/system-bars.md
+++ b/docs/en/commands/device/system/system-bars.md
@@ -89,4 +89,4 @@ Information about visibility and bounds of status and navigation bar (`array<obj
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L418)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L491)

--- a/docs/en/commands/device/system/system-time.md
+++ b/docs/en/commands/device/system/system-time.md
@@ -96,4 +96,4 @@ Time on the device (`string`)
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L304)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L333)

--- a/docs/en/commands/element/attributes/page-index.md
+++ b/docs/en/commands/element/attributes/page-index.md
@@ -97,4 +97,4 @@ The tag name of the element (`string`)
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L285)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L314)

--- a/docs/en/commands/element/attributes/replace-value.md
+++ b/docs/en/commands/element/attributes/replace-value.md
@@ -104,4 +104,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L451)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L524)

--- a/docs/en/commands/interactions/touch/multi-touch-perform.md
+++ b/docs/en/commands/interactions/touch/multi-touch-perform.md
@@ -137,4 +137,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L295)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L324)

--- a/docs/en/commands/interactions/touch/touch-perform.md
+++ b/docs/en/commands/interactions/touch/touch-perform.md
@@ -130,4 +130,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L292)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L321)

--- a/docs/en/commands/session/settings/get-settings.md
+++ b/docs/en/commands/session/settings/get-settings.md
@@ -90,4 +90,4 @@ a JSON hash of all the currently specified settings, see [Settings API](/docs/en
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L454)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L527)

--- a/docs/en/commands/session/settings/update-settings.md
+++ b/docs/en/commands/session/settings/update-settings.md
@@ -92,4 +92,4 @@ null
 
 ## See Also
 
-* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L454)
+* [JSONWP Specification](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L527)

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-plugin-import": "2.x",
     "eslint-plugin-mocha": "4.x",
     "eslint-plugin-promise": "3.x",
+    "fancy-log": "^1.3.2",
     "gulp": "3.x",
     "handlebars": "^4.0.10",
     "mocha": "5.x",


### PR DESCRIPTION
## Proposed changes

The problem: We have links to `https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js` in our docs, linking directly to the line for the endpoint for the command. However, this breaks whenever we change something in the routes file, which is relatively often.

Rather than require one to remember to go into `appium/appium` and update the correct command yaml file, dynamically parse those files and add the correct line number at the time of publishing

Most of the work is in `commands-yml/parse.js`, as a Handlebars helper function.

Doing this work also showed a number of places where we had the wrong endpoint, so those files are fixed here.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
