### PR TITLE
Fix incorrect page source Python example

### DIFF
--- a/commands-yml/commands/session/source.yml
+++ b/commands-yml/commands/session/source.yml
@@ -17,7 +17,7 @@ example_usage:
       String pageSource = driver.getPageSource();
   python:
     |
-      source = self.driver.page_source()
+      source = self.driver.page_source
   javascript_wd:
     |
       let pageSource = await driver.source();


### PR DESCRIPTION
## Proposed changes

In the Python implementation of page source, `self.driver_page_source` is an object; not a method. Therefore, the `()` do not belong. When the `()` is included, the following error occurs:
`TypeError: 'unicode' object is not callable.`

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

N/A
