### PR TITLE
Remove prefixes from MJSONWP capabilities if W3C protocol cannot be enabled

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,19 +82,20 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
     protocol = W3C;
     // Call the process capabilities algorithm to find matching caps on the W3C
     // (see: https://github.com/jlipps/simple-wd-spec#processing-capabilities)
-    let matchingW3CCaps;
     try {
-      matchingW3CCaps = processCapabilities(w3cCapabilities, constraints, true);
+      desiredCaps = processCapabilities(w3cCapabilities, constraints, true);
     } catch (err) {
       if (jsonwpCaps) {
         logger.warn(`Could not parse W3C capabilities: ${err.message}. Falling back to JSONWP protocol.`);
-        protocol = MJSONWP;
-      } else {
-        error = err;
+        return {
+          desiredCaps: removeW3CPrefixes(desiredCaps),
+          processedJsonwpCapabilities: removeW3CPrefixes(processedJsonwpCapabilities),
+          processedW3CCapabilities: null,
+          protocol: MJSONWP,
+        };
       }
+      error = err;
     }
-
-    desiredCaps = matchingW3CCaps;
 
     // Create a new w3c capabilities payload that contains only the matching caps in `alwaysMatch`
     processedW3CCapabilities = {
@@ -104,7 +105,7 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
 
     // If we found extraneuous keys in JSONWP caps, fall back to JSONWP
     if (hasJSONWPCaps) {
-      let differingKeys = _.difference(_.keys(jsonwpCaps), _.keys(matchingW3CCaps));
+      let differingKeys = _.difference(_.keys(jsonwpCaps), _.keys(desiredCaps));
       if (!_.isEmpty(differingKeys)) {
         logger.warn(`The following capabilities were provided in the JSONWP desired capabilities that are missing ` +
           `in W3C capabilities: ${JSON.stringify(differingKeys)}. Falling back to JSONWP protocol.`);
@@ -147,6 +148,20 @@ function insertAppiumPrefixes (caps) {
     }
   }
   return prefixedCaps;
+}
+
+function removeW3CPrefixes (caps) {
+  if (!_.isPlainObject(caps)) {
+    return caps;
+  }
+
+  const fixedCaps = {};
+  for (let [name, value] of _.toPairs(caps)) {
+    const colonPos = name.indexOf(':');
+    const key = colonPos > 0 ? name.substring(colonPos + 1) : name;
+    fixedCaps[key] = value;
+  }
+  return fixedCaps;
 }
 
 const rootDir = findRoot(__dirname);


### PR DESCRIPTION
There might be a situation when we try to pass capabilities with W3C prefixes, but the client does not pass them properly. Although Appium did not strip `appium:` prefixes from these, so session init failed as a result. This PR tries to cut the redundant prefixes off in case of the fallback situation.

Issue log:

```
2018-06-26 09:24:07:687 - info: [HTTP] {"desiredCapabilities":{"app":"http://192.168.120.33:8080/view/Pipelines/job/Wire%20Internal%20Build/lastSuccessfulBuild/artifact/app/build/outputs/apk/wire-internal-release-latest.apk","appium:otherApps":"http://192.168.120.33:8080/job/Testing%20Gallery/lastSuccessfulBuild/artifact/build/artifact/testing_gallery-debug.apk","server:CONFIG_UUID":"b860ed70-4df9-4ef4-96d2-4c2011bd7b0d","newCommandTimeout":600,"automationName":"uiautomator2","appium:skipUnlock":true,"autoGrantPermissions":true,"appium:disableWindowAnimation":true,"platformName":"android","deviceName":"null"},"capabilities":{"desiredCapabilities":{"app":"http://192.168.120.33:8080/view/Pipelines/job/Wire%20Internal%20Build/lastSuccessfulBuild/artifact/app/build/outputs/apk/wire-internal-release-latest.apk","appium:otherApps":"http://192.168.120.33:8080/job/Testing%20Gallery/lastSuccessfulBuild/artifact/build/artifact/testing_gallery-debug.apk","server:CONFIG_UUID":"b860ed70-4df9-4ef4-96d2-4c2011bd7b0d","newCommandTimeout":6
2018-06-26 09:24:07:688 - info: [debug] [W3C] Calling AppiumDriver.createSession() with args: [{"app":"http://192.168.120.33:8080/view/Pipelines/job/Wire%20Internal%20Build/lastSuccessfulBuild/artifact/app/build/outputs/apk/wire-internal-release-latest.apk","appium:otherApps":"http://192.168.120.33:8080/job/Testing%20Gallery/lastSuccessfulBuild/artifact/build/artifact/testing_gallery-debug.apk","server:CONFIG_UUID":"b860ed70-4df9-4ef4-96d2-4c2011bd7b0d","newCommandTimeout":600,"automationName":"uiautomator2","appium:skipUnlock":true,"autoGrantPermissions":true,"appium:disableWindowAnimation":true,"platformName":"android","deviceName":"null"},null,{"desiredCapabilities":{"app":"http://192.168.120.33:8080/view/Pipelines/job/Wire%20Internal%20Build/lastSuccessfulBuild/artifact/app/build/outputs/apk/wire-internal-release-latest.apk","appium:otherApps":"http://192.168.120.33:8080/job/Testing%20Gallery/lastSuccessfulBuild/artifact/build/artifact/testing_gallery-debug.apk","server:CONFIG_UUID":"b860ed70-4df9-4ef4-96d2-4c2011bd7b0d","newCommandTimeout":600,"automationName":"uiautomator2","appium:skipUnlock...
2018-06-26 09:24:07:689 - info: [debug] [BaseDriver] Event 'newSessionRequested' logged at 1530005047689 (02:24:07 GMT-0700 (PDT))
2018-06-26 09:24:07:703 - warn: [Appium] Could not parse W3C capabilities: 'deviceName' can't be blank. Falling back to JSONWP protocol.
2018-06-26 09:24:07:704 - warn: [Appium] The following capabilities were provided in the JSONWP desired capabilities that are missing in W3C capabilities: ["app","appium:otherApps","server:CONFIG_UUID","newCommandTimeout","automationName","appium:skipUnlock","autoGrantPermissions","appium:disableWindowAnimation","platformName","deviceName"]. Falling back to JSONWP protocol.
2018-06-26 09:24:07:705 - info: [Appium] Creating new AndroidUiautomator2Driver (v1.12.0) session
2018-06-26 09:24:07:706 - info: [Appium] Capabilities:
2018-06-26 09:24:07:706 - info: [Appium]   app: http://192.168.120.33:8080/view/Pipelines/job/Wire%20Internal%20Build/lastSuccessfulBuild/artifact/app/build/outputs/apk/wire-internal-release-latest.apk
2018-06-26 09:24:07:707 - info: [Appium]   appium:otherApps: http://192.168.120.33:8080/job/Testing%20Gallery/lastSuccessfulBuild/artifact/build/artifact/testing_gallery-debug.apk
2018-06-26 09:24:07:707 - info: [Appium]   server:CONFIG_UUID: b860ed70-4df9-4ef4-96d2-4c2011bd7b0d
2018-06-26 09:24:07:707 - info: [Appium]   newCommandTimeout: 600
2018-06-26 09:24:07:707 - info: [Appium]   automationName: uiautomator2
2018-06-26 09:24:07:708 - info: [Appium]   appium:skipUnlock: true
2018-06-26 09:24:07:708 - info: [Appium]   autoGrantPermissions: true
2018-06-26 09:24:07:708 - info: [Appium]   appium:disableWindowAnimation: true
2018-06-26 09:24:07:708 - info: [Appium]   platformName: android
2018-06-26 09:24:07:709 - info: [Appium]   deviceName: null
2018-06-26 09:24:07:713 - info: [Appium] Applying relaxed security to AndroidUiautomator2Driver as per server command line argument
2018-06-26 09:24:07:716 - info: [debug] [BaseDriver] Creating session with MJSONWP desired capabilities: {"app":"http://192.168.120....
2018-06-26 09:24:07:720 - warn: [BaseDriver] The following capabilities were provided, but are not recognized by appium: appium:otherApps, server:CONFIG_UUID, appium:skipUnlock, appium:disableWindowAnimation.
2
```