### PR TITLE
Add option to use a remote debugger proxy

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -144,8 +144,7 @@ Driver](/docs/en/drivers/ios-uiautomation.md).
 |`appName`| The display name of the application under test. Used to automate backgrounding the app in iOS 9+.|e.g., `UICatalog`|
 |`customSSLCert`|(Sim only) Add an SSL certificate to IOS Simulator. | e.g. <br/>`-----BEGIN CERTIFICATE-----MIIFWjCCBEKg...`<br/>`-----END CERTIFICATE-----`|
 |`webkitResponseTimeout`|(Real device only) Set the time, in ms, to wait for a response from WebKit in a Safari session. Defaults to `5000`|e.g., `10000`|
-|`remoteDebugProxyPort`| (Sim only, <= 11.2) If set, Appium sends and receives remote debugging messages through a proxy on this local port instead of communicating with the iOS remote debugger directly. |e.g. `12000`|
-|`remoteDebugProxySocketPath`| (Sim only >= 11.3) If set, Appium sends and receives remote debugging messages through a proxy on this unix socket instead of communicating with the iOS remote debugger directly. |e.g. `"/tmp/my.proxy.socket"`|
+|`remoteDebugProxy`| (Sim only, <= 11.2) If set, Appium sends and receives remote debugging messages through a proxy on either the local port (Sim only, <= 11.2) or a proxy on this unix socket (Sim only >= 11.3) instead of communicating with the iOS remote debugger directly. |e.g. `12000` or `"/tmp/my.proxy.socket"`|
 
 ### iOS Only, using XCUITest
 

--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -144,6 +144,8 @@ Driver](/docs/en/drivers/ios-uiautomation.md).
 |`appName`| The display name of the application under test. Used to automate backgrounding the app in iOS 9+.|e.g., `UICatalog`|
 |`customSSLCert`|(Sim only) Add an SSL certificate to IOS Simulator. | e.g. <br/>`-----BEGIN CERTIFICATE-----MIIFWjCCBEKg...`<br/>`-----END CERTIFICATE-----`|
 |`webkitResponseTimeout`|(Real device only) Set the time, in ms, to wait for a response from WebKit in a Safari session. Defaults to `5000`|e.g., `10000`|
+|`remoteDebugProxyPort`| (Sim only, <= 11.2) If set, Appium sends and receives remote debugging messages through a proxy on this local port instead of communicating with the iOS remote debugger directly. |e.g. `12000`|
+|`remoteDebugProxySocketPath`| (Sim only >= 11.3) If set, Appium sends and receives remote debugging messages through a proxy on this unix socket instead of communicating with the iOS remote debugger directly. |e.g. `"/tmp/my.proxy.socket"`|
 
 ### iOS Only, using XCUITest
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -350,6 +350,27 @@ const args = [
     help: '(IOS-only) Local port used for communication with ios-webkit-debug-proxy'
   }],
 
+  [['--remote-debug-proxy-port'], {
+    defaultValue: false,
+    dest: 'remoteDebugProxyPort',
+    required: false,
+    type: 'int',
+    example: "12000",
+    help: '(IOS-only, <= 11.2) If set, Appium sends and receives remote debugging messages' +
+          'through a proxy on this local port instead of communicating with the ' +
+          'iOS remote debugger directly.'
+  }],
+
+  [['--remote-debug-proxy-socket-path'], {
+    defaultValue: false,
+    dest: 'remoteDebugProxySocketPath',
+    required: false,
+    example: "/tmp/my.proxy.socket",
+    help: '(IOS-only >= 11.3) If set, Appium sends and receives remote debugging messages' +
+          'through a proxy on this unix socket instead of communicating with the ' +
+          'iOS remote debugger directly.'
+  }],
+
   [['--webdriveragent-port'], {
     defaultValue: 8100,
     dest: 'wdaLocalPort',

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -350,27 +350,6 @@ const args = [
     help: '(IOS-only) Local port used for communication with ios-webkit-debug-proxy'
   }],
 
-  [['--remote-debug-proxy-port'], {
-    defaultValue: false,
-    dest: 'remoteDebugProxyPort',
-    required: false,
-    type: 'int',
-    example: "12000",
-    help: '(IOS-only, <= 11.2) If set, Appium sends and receives remote debugging messages' +
-          'through a proxy on this local port instead of communicating with the ' +
-          'iOS remote debugger directly.'
-  }],
-
-  [['--remote-debug-proxy-socket-path'], {
-    defaultValue: false,
-    dest: 'remoteDebugProxySocketPath',
-    required: false,
-    example: "/tmp/my.proxy.socket",
-    help: '(IOS-only >= 11.3) If set, Appium sends and receives remote debugging messages' +
-          'through a proxy on this unix socket instead of communicating with the ' +
-          'iOS remote debugger directly.'
-  }],
-
   [['--webdriveragent-port'], {
     defaultValue: 8100,
     dest: 'wdaLocalPort',


### PR DESCRIPTION
## Proposed changes

The changes make it possible to let Appium's remote debugger connect to a proxy instead of the iOS simulator directly when running tests on iOS simulators.
This enables sending additional Web Inspector protocol messages to the simulator and also logging all Web Inspector protocol messages that are sent from Appium to the simulator and vice versa.

The actual implementation and message handling of the proxy is completely up to the developers who want to use this feature.

The pull requests for the other affected Appium packages of this feature are:
* https://github.com/appium/appium-xcuitest-driver/pull/710
* https://github.com/appium/appium-remote-debugger/pull/81

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
