### PR TITLE
Try to automatically fix W3C capabilities by using existing JSONWP caps

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,8 @@ import logger from './logger';
 import { processCapabilities, BaseDriver } from 'appium-base-driver';
 import findRoot from 'find-root';
 
+const W3C_APPIUM_PREFIX = 'appium';
+
 function inspectObject (args) {
   function getValueArray (obj, indent = '  ') {
     if (!_.isObject(obj)) {
@@ -34,17 +36,30 @@ function inspectObject (args) {
 /**
  * Takes the caps that were provided in the request and translates them
  * into caps that can be used by the inner drivers.
- * @param {Object} jsonwpCaps
+ *
+ * @param {Object} jsonwpCapabilities
  * @param {Object} w3cCapabilities
  * @param {Object} constraints
  * @param {Object} defaultCapabilities
  */
-function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, defaultCapabilities={}) {
+function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constraints={}, defaultCapabilities={}) {
   // Check if the caller sent JSONWP caps, W3C caps, or both
-  const hasW3CCaps = _.isPlainObject(w3cCapabilities);
-  const hasJSONWPCaps = _.isPlainObject(jsonwpCaps);
-
-  let protocol;
+  const hasW3CCaps = _.isPlainObject(w3cCapabilities)
+    && (_.has(w3cCapabilities, 'firstMatch') || _.has(w3cCapabilities, 'alwaysMatch'));
+  const hasJSONWPCaps = _.isPlainObject(jsonwpCapabilities);
+  let protocol = null;
+  let desiredCaps = {};
+  let processedW3CCapabilities = null;
+  let processedJsonwpCapabilities = null;
+  if (!hasJSONWPCaps && !hasW3CCaps) {
+    return {
+      desiredCaps,
+      processedJsonwpCapabilities,
+      processedW3CCapabilities,
+      protocol,
+      error: new Error('Either JSONWP or W3C capabilities should be provided'),
+    };
+  }
 
   const {W3C, MJSONWP} = BaseDriver.DRIVER_PROTOCOL;
 
@@ -60,41 +75,64 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
   }
 
   if (hasJSONWPCaps) {
-    jsonwpCaps = {
+    jsonwpCapabilities = {
       ...defaultCapabilities,
-      ...jsonwpCaps,
+      ...jsonwpCapabilities,
     };
   }
 
   // Get MJSONWP caps
-  let desiredCaps = {};
-  let processedJsonwpCapabilities = null;
   if (hasJSONWPCaps) {
     protocol = MJSONWP;
-    desiredCaps = jsonwpCaps;
-    processedJsonwpCapabilities = {...desiredCaps};
+    desiredCaps = jsonwpCapabilities;
+    processedJsonwpCapabilities = removeW3CPrefixes({...desiredCaps});
   }
 
   // Get W3C caps
-  let processedW3CCapabilities = null;
-  let error;
   if (hasW3CCaps) {
     protocol = W3C;
     // Call the process capabilities algorithm to find matching caps on the W3C
     // (see: https://github.com/jlipps/simple-wd-spec#processing-capabilities)
+    let isFixingNeededForW3cCaps = false;
     try {
       desiredCaps = processCapabilities(w3cCapabilities, constraints, true);
-    } catch (err) {
-      if (jsonwpCaps) {
-        logger.warn(`Could not parse W3C capabilities: ${err.message}. Falling back to JSONWP protocol.`);
+    } catch (error) {
+      if (!hasJSONWPCaps) {
         return {
-          desiredCaps: removeW3CPrefixes(desiredCaps),
-          processedJsonwpCapabilities: removeW3CPrefixes(processedJsonwpCapabilities),
+          desiredCaps,
+          processedJsonwpCapabilities,
+          processedW3CCapabilities,
+          protocol,
+          error,
+        };
+      }
+      logger.info(`Could not parse W3C capabilities: ${error.message}`);
+      isFixingNeededForW3cCaps = true;
+    }
+
+    if (hasJSONWPCaps && !isFixingNeededForW3cCaps) {
+      const differingKeys = _.difference(_.keys(processedJsonwpCapabilities), _.keys(removeW3CPrefixes(desiredCaps)));
+      if (!_.isEmpty(differingKeys)) {
+        logger.info(`The following capabilities were provided in the JSONWP desired capabilities that are missing ` +
+          `in W3C capabilities: ${JSON.stringify(differingKeys)}`);
+        isFixingNeededForW3cCaps = true;
+      }
+    }
+
+    if (isFixingNeededForW3cCaps && hasJSONWPCaps) {
+      logger.info('Trying to fix W3C capabilities by merging them with JSONWP caps');
+      w3cCapabilities = fixW3cCapabilities(w3cCapabilities, jsonwpCapabilities);
+      try {
+        desiredCaps = processCapabilities(w3cCapabilities, constraints, true);
+      } catch (error) {
+        logger.warn(`Could not parse fixed W3C capabilities: ${error.message}. Falling back to JSONWP protocol`);
+        return {
+          desiredCaps: processedJsonwpCapabilities,
+          processedJsonwpCapabilities,
           processedW3CCapabilities: null,
           protocol: MJSONWP,
         };
       }
-      error = err;
     }
 
     // Create a new w3c capabilities payload that contains only the matching caps in `alwaysMatch`
@@ -102,23 +140,48 @@ function parseCapsForInnerDriver (jsonwpCaps, w3cCapabilities, constraints={}, d
       alwaysMatch: {...insertAppiumPrefixes(desiredCaps)},
       firstMatch: [{}],
     };
-
-    // If we found extraneuous keys in JSONWP caps, fall back to JSONWP
-    if (hasJSONWPCaps) {
-      let differingKeys = _.difference(_.keys(jsonwpCaps), _.keys(desiredCaps));
-      if (!_.isEmpty(differingKeys)) {
-        logger.warn(`The following capabilities were provided in the JSONWP desired capabilities that are missing ` +
-          `in W3C capabilities: ${JSON.stringify(differingKeys)}. Falling back to JSONWP protocol.`);
-        protocol = MJSONWP;
-        desiredCaps = jsonwpCaps;
-        return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities: null, protocol};
-      }
-    }
   }
 
-  return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, protocol, error};
+  return {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, protocol};
 }
 
+/**
+ * This helper method tries to fix corrupted W3C capabilities by
+ * merging them to existing JSONWP capabilities.
+ *
+ * @param {Objetc} w3cCaps W3C capabilities
+ * @param {Object} jsonwpCaps JSONWP capabilities
+ * @returns {Object} Fixed W3C capabilities
+ */
+function fixW3cCapabilities (w3cCaps, jsonwpCaps) {
+  const result = {
+    firstMatch: w3cCaps.firstMatch,
+    alwaysMatch: w3cCaps.alwaysMatch,
+  };
+  const keysToInsert = _.keys(jsonwpCaps);
+  const removeMatchingKeys = (match) => {
+    _.pull(keysToInsert, match);
+    const colonIndex = match.indexOf(':');
+    if (colonIndex >= 0 && match.length > colonIndex) {
+      _.pull(keysToInsert, match.substring(colonIndex + 1));
+    }
+    if (keysToInsert.includes(`${W3C_APPIUM_PREFIX}:${match}`)) {
+      _.pull(keysToInsert, `${W3C_APPIUM_PREFIX}:${match}`);
+    }
+  };
+  for (const firstMatchEntry of result.firstMatch) {
+    for (const pair of _.toPairs(firstMatchEntry)) {
+      removeMatchingKeys(pair[0]);
+    }
+  }
+  for (const pair of result.alwaysMatch) {
+    removeMatchingKeys(pair[0]);
+  }
+  for (const key of keysToInsert) {
+    result.alwaysMatch[key] = jsonwpCaps[key];
+  }
+  return result;
+}
 
 /**
  * Takes a capabilities objects and prefixes capabilities with `appium:`
@@ -144,7 +207,7 @@ function insertAppiumPrefixes (caps) {
     if (STANDARD_CAPS.includes(name) || name.includes(':')) {
       prefixedCaps[name] = value;
     } else {
-      prefixedCaps[`appium:${name}`] = value;
+      prefixedCaps[`${W3C_APPIUM_PREFIX}:${name}`] = value;
     }
   }
   return prefixedCaps;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,12 +45,13 @@ function inspectObject (args) {
 function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constraints={}, defaultCapabilities={}) {
   // Check if the caller sent JSONWP caps, W3C caps, or both
   const hasW3CCaps = _.isPlainObject(w3cCapabilities)
-    && (_.has(w3cCapabilities, 'firstMatch') || _.has(w3cCapabilities, 'alwaysMatch'));
+    && _.has(w3cCapabilities, 'firstMatch') && _.has(w3cCapabilities, 'alwaysMatch');
   const hasJSONWPCaps = _.isPlainObject(jsonwpCapabilities);
   let protocol = null;
   let desiredCaps = {};
   let processedW3CCapabilities = null;
   let processedJsonwpCapabilities = null;
+  
   if (!hasJSONWPCaps && !hasW3CCaps) {
     return {
       desiredCaps,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -149,14 +149,14 @@ function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constrain
  * This helper method tries to fix corrupted W3C capabilities by
  * merging them to existing JSONWP capabilities.
  *
- * @param {Objetc} w3cCaps W3C capabilities
+ * @param {Object} w3cCaps W3C capabilities
  * @param {Object} jsonwpCaps JSONWP capabilities
  * @returns {Object} Fixed W3C capabilities
  */
 function fixW3cCapabilities (w3cCaps, jsonwpCaps) {
   const result = {
-    firstMatch: w3cCaps.firstMatch,
-    alwaysMatch: w3cCaps.alwaysMatch,
+    firstMatch: w3cCaps.firstMatch || [],
+    alwaysMatch: w3cCaps.alwaysMatch || {},
   };
   const keysToInsert = _.keys(jsonwpCaps);
   const removeMatchingKeys = (match) => {
@@ -169,14 +169,17 @@ function fixW3cCapabilities (w3cCaps, jsonwpCaps) {
       _.pull(keysToInsert, `${W3C_APPIUM_PREFIX}:${match}`);
     }
   };
+
   for (const firstMatchEntry of result.firstMatch) {
     for (const pair of _.toPairs(firstMatchEntry)) {
       removeMatchingKeys(pair[0]);
     }
   }
-  for (const pair of result.alwaysMatch) {
+
+  for (const pair of _.toPairs(result.alwaysMatch)) {
     removeMatchingKeys(pair[0]);
   }
+
   for (const key of keysToInsert) {
     result.alwaysMatch[key] = jsonwpCaps[key];
   }

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -160,7 +160,7 @@ describe('FakeDriver - via HTTP', function () {
       await request.delete({ url: `${baseUrl}/${value.sessionId}` });
     });
 
-    it('should accept a combo of W3C and JSONWP but use JSONWP if desiredCapabilities contains extraneous keys', async function () {
+    it('should accept a combo of W3C and JSONWP and if JSONWP has extraneous keys, they should be merged into W3C capabilities', async function () {
       const combinedCaps = {
         "desiredCapabilities": {
           ...caps,
@@ -176,17 +176,18 @@ describe('FakeDriver - via HTTP', function () {
       };
 
       const {sessionId, status, value} = await request.post({url: baseUrl, json: combinedCaps});
-      status.should.exist;
-      sessionId.should.exist;
-      should.not.exist(value.sessionId);
-      value.should.deep.equal({
+      should.not.exist(sessionId);
+      should.not.exist(status);
+      value.sessionId.should.exist;
+      value.capabilities.should.deep.equal({
         ...caps,
         automationName: 'Fake',
         anotherParam: 'Hello',
+        w3cParam: 'w3cParam',
       });
 
       // End session
-      await request.delete({ url: `${baseUrl}/${sessionId}` });
+      await request.delete({ url: `${baseUrl}/${value.sessionId}` });
     });
 
     it('should reject bad W3C capabilities with a BadParametersError (400)', async function () {

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -147,8 +147,17 @@ describe('AppiumDriver', function () {
           someOtherParam: 'someOtherParam',
         };
 
+        let expectedW3cCaps = {
+          ...w3cCaps,
+          alwaysMatch: {
+            ...w3cCaps.alwaysMatch,
+            'appium:automationName': 'Fake',
+            'appium:someOtherParam': 'someOtherParam',
+          },
+        };
+
         mockFakeDriver.expects("createSession")
-          .once().withArgs(jsonwpCaps, undefined, null)
+          .once().withArgs(jsonwpCaps, undefined, expectedW3cCaps)
           .returns([SESSION_ID, jsonwpCaps]);
 
         await appium.createSession(jsonwpCaps, undefined, w3cCaps);


### PR DESCRIPTION
## Proposed changes

Now the capability parsing algorithm tries to use W3C session by default instead of JSONWP. This is done by analysing and merging existing W3C caps (in case at least one of firstMatch or alwaysMatch attributes is present in the initial input) with JSONWP caps. It helps to address poor implementation issues on the client side. See https://github.com/appium/appium/issues/10949 for more details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)