### PR TITLE
Move maps into constants

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -15,7 +15,7 @@ import { EspressoDriver } from 'appium-espresso-driver';
 import { TizenDriver } from 'appium-tizen-driver';
 import B from 'bluebird';
 import AsyncLock from 'async-lock';
-import { inspectObject, parseCapsForInnerDriver } from './utils';
+import { inspectObject, parseCapsForInnerDriver, getPackageVersion } from './utils';
 import semver from 'semver';
 
 
@@ -31,60 +31,55 @@ const AUTOMATION_NAMES = {
 const DRIVER_MAP = {
   SelendroidDriver: {
     driverClass: SelendroidDriver,
-    moduleName: 'appium-selendroid-driver',
     automationName: AUTOMATION_NAMES.SELENDROID,
+    version: getPackageVersion('appium-selendroid-driver'),
   },
   AndroidUiautomator2Driver: {
     driverClass: AndroidUiautomator2Driver,
-    moduleName: 'appium-uiautomator2-driver',
     automationName: AUTOMATION_NAMES.UIAUTOMATOR2,
+    version: getPackageVersion('appium-uiautomator2-driver'),
   },
   XCUITestDriver: {
     driverClass: XCUITestDriver,
-    moduleName: 'appium-xcuitest-driver',
     automationName: AUTOMATION_NAMES.XCUITEST,
+    version: getPackageVersion('appium-xcuitest-driver'),
   },
   YouiEngineDriver: {
     driverClass: YouiEngineDriver,
-    moduleName: 'appium-youiengine-driver',
     automationName: AUTOMATION_NAMES.YOUIENGINE,
+    version: getPackageVersion('appium-youiengine-driver'),
   },
   FakeDriver: {
     driverClass: FakeDriver,
-    moduleName: 'appium-fake-driver',
+    version: getPackageVersion('appium-fake-driver'),
   },
   AndroidDriver: {
     driverClass: AndroidDriver,
-    moduleName: 'appium-android-driver',
+    version: getPackageVersion('appium-android-driver'),
   },
   IosDriver: {
     driverClass: IosDriver,
-    moduleName: 'appium-ios-driver',
+    version: getPackageVersion('appium-ios-driver'),
   },
   WindowsDriver: {
     driverClass: WindowsDriver,
-    moduleName: 'appium-windows-driver',
+    version: getPackageVersion('appium-windows-driver'),
   },
   MacDriver: {
     driverClass: MacDriver,
-    moduleName: 'appium-mac-driver',
+    version: getPackageVersion('appium-mac-driver'),
   },
   EspressoDriver: {
     driverClass: EspressoDriver,
-    moduleName: 'appium-espresso-driver',
     automationName: AUTOMATION_NAMES.ESPRESSO,
+    version: getPackageVersion('appium-espresso-driver'),
   },
   TizenDriver: {
     driverClass: TizenDriver,
-    moduleName: 'appium-tizen-driver',
     automationName: AUTOMATION_NAMES.TIZEN,
+    version: getPackageVersion('appium-tizen-driver'),
   },
 };
-// load the version for each driver
-for (const driverProps of _.values(DRIVER_MAP)) {
-  const moduleInfo = require(`${driverProps.moduleName}/package.json`);
-  driverProps.version = moduleInfo.version;
-}
 
 const PLATFORMS_MAP = {
   fake: () => FakeDriver,

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -18,6 +18,104 @@ import AsyncLock from 'async-lock';
 import { inspectObject, parseCapsForInnerDriver } from './utils';
 import semver from 'semver';
 
+
+const AUTOMATION_NAMES = {
+  APPIUM: 'Appium',
+  SELENDROID: 'Selendroid',
+  UIAUTOMATOR2: 'UiAutomator2',
+  XCUITEST: 'XCUITest',
+  YOUIENGINE: 'YouiEngine',
+  ESPRESSO: 'Espresso',
+  FAKE: 'Fake',
+};
+const DRIVER_MAP = {
+  SelendroidDriver: {
+    driverClass: SelendroidDriver,
+    moduleName: 'appium-selendroid-driver',
+    automationName: AUTOMATION_NAMES.SELENDROID,
+  },
+  AndroidUiautomator2Driver: {
+    driverClass: AndroidUiautomator2Driver,
+    moduleName: 'appium-uiautomator2-driver',
+    automationName: AUTOMATION_NAMES.UIAUTOMATOR2,
+  },
+  XCUITestDriver: {
+    driverClass: XCUITestDriver,
+    moduleName: 'appium-xcuitest-driver',
+    automationName: AUTOMATION_NAMES.XCUITEST,
+  },
+  YouiEngineDriver: {
+    driverClass: YouiEngineDriver,
+    moduleName: 'appium-youiengine-driver',
+    automationName: AUTOMATION_NAMES.YOUIENGINE,
+  },
+  FakeDriver: {
+    driverClass: FakeDriver,
+    moduleName: 'appium-fake-driver',
+  },
+  AndroidDriver: {
+    driverClass: AndroidDriver,
+    moduleName: 'appium-android-driver',
+  },
+  IosDriver: {
+    driverClass: IosDriver,
+    moduleName: 'appium-ios-driver',
+  },
+  WindowsDriver: {
+    driverClass: WindowsDriver,
+    moduleName: 'appium-windows-driver',
+  },
+  MacDriver: {
+    driverClass: MacDriver,
+    moduleName: 'appium-mac-driver',
+  },
+  EspressoDriver: {
+    driverClass: EspressoDriver,
+    moduleName: 'appium-espresso-driver',
+    automationName: AUTOMATION_NAMES.ESPRESSO,
+  },
+  TizenDriver: {
+    driverClass: TizenDriver,
+    moduleName: 'appium-tizen-driver',
+    automationName: AUTOMATION_NAMES.TIZEN,
+  },
+};
+// load the version for each driver
+for (const driverProps of _.values(DRIVER_MAP)) {
+  const moduleInfo = require(`${driverProps.moduleName}/package.json`);
+  driverProps.version = moduleInfo.version;
+}
+
+const PLATFORMS_MAP = {
+  fake: () => FakeDriver,
+  android: (caps) => {
+    const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
+    if (platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
+      log.warn("Consider setting 'automationName' capability to " +
+        `'${AUTOMATION_NAMES.UIAUTOMATOR2}' ` +
+        "on Android >= 6, since UIAutomator framework " +
+        "is not maintained anymore by the OS vendor.");
+    }
+
+    return AndroidDriver;
+  },
+  ios: (caps) => {
+    const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
+    if (platformVersion && semver.satisfies(platformVersion, '>=10.0.0')) {
+      log.info("Requested iOS support with version >= 10, " +
+        `using '${AUTOMATION_NAMES.XCUITEST}' ` +
+        "driver instead of UIAutomation-based driver, since the " +
+        "latter is unsupported on iOS 10 and up.");
+      return XCUITestDriver;
+    }
+
+    return IosDriver;
+  },
+  windows: () => WindowsDriver,
+  mac: () => MacDriver,
+  tizen: () => TizenDriver,
+};
+
 const sessionsListGuard = new AsyncLock();
 const pendingDriversGuard = new AsyncLock();
 
@@ -39,9 +137,6 @@ class AppiumDriver extends BaseDriver {
     // it might be changed by other async calls at any time
     // It is not recommended to access this property directly from the outside
     this.pendingDrivers = {};
-
-    this._driversMapping = null;
-    this._platformsMapping = null;
   }
 
   /**
@@ -60,125 +155,23 @@ class AppiumDriver extends BaseDriver {
     return this.sessions[sessionId];
   }
 
-  get driversMapping () {
-    if (this._driversMapping) {
-      return this._driversMapping;
-    }
-
-    this._driversMapping = {
-      SelendroidDriver: {
-        driverClass: SelendroidDriver,
-        moduleName: 'appium-selendroid-driver',
-        automationName: this.validAutomations.SELENDROID,
-      },
-      AndroidUiautomator2Driver: {
-        driverClass: AndroidUiautomator2Driver,
-        moduleName: 'appium-uiautomator2-driver',
-        automationName: this.validAutomations.UIAUTOMATOR2,
-      },
-      XCUITestDriver: {
-        driverClass: XCUITestDriver,
-        moduleName: 'appium-xcuitest-driver',
-        automationName: this.validAutomations.XCUITEST,
-      },
-      YouiEngineDriver: {
-        driverClass: YouiEngineDriver,
-        moduleName: 'appium-youiengine-driver',
-        automationName: this.validAutomations.YouiEngineDriver,
-      },
-      FakeDriver: {
-        driverClass: FakeDriver,
-        moduleName: 'appium-fake-driver',
-      },
-      AndroidDriver: {
-        driverClass: AndroidDriver,
-        moduleName: 'appium-android-driver',
-      },
-      IosDriver: {
-        driverClass: IosDriver,
-        moduleName: 'appium-ios-driver',
-      },
-      WindowsDriver: {
-        driverClass: WindowsDriver,
-        moduleName: 'appium-windows-driver',
-      },
-      MacDriver: {
-        driverClass: MacDriver,
-        moduleName: 'appium-mac-driver',
-      },
-      EspressoDriver: {
-        driverClass: EspressoDriver,
-        moduleName: 'appium-espresso-driver',
-        automationName: this.validAutomations.ESPRESSO,
-      },
-      TizenDriver: {
-        driverClass: TizenDriver,
-        moduleName: 'appium-tizen-driver',
-        automationName: this.validAutomations.TIZEN,
-      },
-    };
-    for (const driverProps of _.values(this._driversMapping)) {
-      driverProps.moduleInfo = require(`${driverProps.moduleName}/package.json`);
-    }
-
-    return this._driversMapping;
-  }
-
-  get platformsMapping () {
-    if (this._platformsMapping) {
-      return this._platformsMapping;
-    }
-
-    this._platformsMapping = {
-      fake: () => FakeDriver,
-      android: (caps) => {
-        const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
-        if (platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
-          log.warn("Consider setting 'automationName' capability to " +
-            `'${this.validAutomations.UIAUTOMATOR2.toLowerCase()}' ` +
-            "on Android >= 6, since UIAutomator framework " +
-            "is not maintained anymore by the OS vendor.");
-        }
-
-        return AndroidDriver;
-      },
-      ios: (caps) => {
-        const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
-        if (platformVersion && semver.satisfies(platformVersion, '>=10.0.0')) {
-          log.info("Requested iOS support with version >= 10, " +
-            `using '${this.validAutomations.XCUITEST.toLowerCase()}' ` +
-            "driver instead of UIAutomation-based driver, since the " +
-            "latter is unsupported on iOS 10 and up.");
-          return XCUITestDriver;
-        }
-
-        return IosDriver;
-      },
-      windows: () => WindowsDriver,
-      mac: () => MacDriver,
-      tizen: () => TizenDriver,
-    };
-
-    return this._platformsMapping;
-  }
-
-  async getDriverForCaps (caps) {
+  getDriverForCaps (caps) {
     if (!_.isString(caps.platformName)) {
       throw new Error("You must include a platformName capability");
     }
 
     // we don't necessarily have an `automationName` capability,
     if (_.isString(caps.automationName)) {
-      for (const {automationName, driverClass} of _.values(this.driversMapping)) {
+      for (const {automationName, driverClass} of _.values(DRIVER_MAP)) {
         if (_.toLower(automationName) === caps.automationName.toLowerCase()) {
           return driverClass;
         }
       }
     }
 
-    const driverSelector = this.platformsMapping[caps.platformName.toLowerCase()];
+    const driverSelector = PLATFORMS_MAP[caps.platformName.toLowerCase()];
     if (driverSelector) {
-      return await driverSelector(caps);
+      return driverSelector(caps);
     }
 
     const msg = _.isString(caps.automationName)
@@ -188,10 +181,10 @@ class AppiumDriver extends BaseDriver {
     throw new Error(`${msg} Please check your desired capabilities.`);
   }
 
-  async getDriverVersion (driver) {
-    const {moduleInfo} = this.driversMapping[driver.name] || {};
-    if (moduleInfo && moduleInfo.version) {
-      return moduleInfo.version;
+  getDriverVersion (driver) {
+    const {version} = DRIVER_MAP[driver.name] || {};
+    if (version) {
+      return version;
     }
     log.warn(`Unable to get version of driver '${driver.name}'`);
   }
@@ -214,8 +207,8 @@ class AppiumDriver extends BaseDriver {
         });
   }
 
-  async printNewSessionAnnouncement (driver, caps) {
-    const driverVersion = await this.getDriverVersion(driver);
+  printNewSessionAnnouncement (driver, caps) {
+    const driverVersion = this.getDriverVersion(driver);
     const introString = driverVersion
       ? `Creating new ${driver.name} (v${driverVersion}) session`
       : `Creating new ${driver.name} session`;
@@ -232,7 +225,7 @@ class AppiumDriver extends BaseDriver {
    * @return {Array} Unique session ID and capabilities
    */
   async createSession (jsonwpCaps, reqCaps, w3cCapabilities) {
-    let {defaultCapabilities} = this.args;
+    const {defaultCapabilities} = this.args;
     let protocol;
     let innerSessionId, dCaps;
 
@@ -253,8 +246,8 @@ class AppiumDriver extends BaseDriver {
         throw error;
       }
 
-      let InnerDriver = await this.getDriverForCaps(desiredCaps);
-      await this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
+      const InnerDriver = this.getDriverForCaps(desiredCaps);
+      this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
 
       if (this.args.sessionOverride) {
         const sessionIdsToDelete = await sessionsListGuard.acquire(AppiumDriver.name, () => _.keys(this.sessions));
@@ -267,9 +260,9 @@ class AppiumDriver extends BaseDriver {
       }
 
       let runningDriversData, otherPendingDriversData;
-      let d = new InnerDriver(this.args);
+      const d = new InnerDriver(this.args);
       if (this.args.relaxedSecurityEnabled) {
-        log.info(`Applying relaxed security to ${InnerDriver.name} as per server command line argument`);
+        log.info(`Applying relaxed security to '${InnerDriver.name}' as per server command line argument`);
         d.relaxedSecurityEnabled = true;
       }
       // This assignment is required for correct web sockets functionality inside the driver

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -228,6 +228,12 @@ function removeW3CPrefixes (caps) {
   return fixedCaps;
 }
 
+function getPackageVersion (pkgName) {
+  const pkgInfo = require(`${pkgName}/package.json`) || {};
+  return pkgInfo.version;
+}
+
 const rootDir = findRoot(__dirname);
 
-export { inspectObject, parseCapsForInnerDriver, insertAppiumPrefixes, rootDir };
+export { inspectObject, parseCapsForInnerDriver, insertAppiumPrefixes, rootDir,
+         getPackageVersion };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -189,7 +189,6 @@ function fixW3cCapabilities (w3cCaps, jsonwpCaps) {
  * @param {Object} caps Desired capabilities object
  */
 function insertAppiumPrefixes (caps) {
-
   // Standard, non-prefixed capabilities (see https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities)
   const STANDARD_CAPS = [
     'browserName',

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -275,11 +275,11 @@ describe('AppiumDriver', function () {
     describe('getDriverForCaps', function () {
       it('should not blow up if user does not provide platformName', async function () {
         let appium = new AppiumDriver({});
-        await appium.getDriverForCaps({}).should.eventually.be.rejectedWith(/platformName/);
+        (() => { appium.getDriverForCaps({}); }).should.throw(/platformName/);
       });
       it('should get XCUITestDriver driver for automationName of XCUITest', async function () {
         let appium = new AppiumDriver({});
-        let driver = await appium.getDriverForCaps({
+        let driver = appium.getDriverForCaps({
           platformName: 'iOS',
           automationName: 'XCUITest'
         });
@@ -292,28 +292,28 @@ describe('AppiumDriver', function () {
           platformName: 'iOS',
           platformVersion: '8.0',
         };
-        let driver = await appium.getDriverForCaps(caps);
+        let driver = appium.getDriverForCaps(caps);
         driver.should.be.an.instanceof(Function);
         driver.should.equal(IosDriver);
 
         caps.platformVersion = '8.1';
-        driver = await appium.getDriverForCaps(caps);
+        driver = appium.getDriverForCaps(caps);
         driver.should.equal(IosDriver);
 
         caps.platformVersion = '9.4';
-        driver = await appium.getDriverForCaps(caps);
+        driver = appium.getDriverForCaps(caps);
         driver.should.equal(IosDriver);
 
         caps.platformVersion = '';
-        driver = await appium.getDriverForCaps(caps);
+        driver = appium.getDriverForCaps(caps);
         driver.should.equal(IosDriver);
 
         caps.platformVersion = 'foo';
-        driver = await appium.getDriverForCaps(caps);
+        driver = appium.getDriverForCaps(caps);
         driver.should.equal(IosDriver);
 
         delete caps.platformVersion;
-        driver = await appium.getDriverForCaps(caps);
+        driver = appium.getDriverForCaps(caps);
         driver.should.equal(IosDriver);
       });
       it('should get xcuitestdriver for ios >= 10', async function () {
@@ -322,20 +322,20 @@ describe('AppiumDriver', function () {
           platformName: 'iOS',
           platformVersion: '10',
         };
-        let driver = await appium.getDriverForCaps(caps);
+        let driver = appium.getDriverForCaps(caps);
         driver.should.be.an.instanceof(Function);
         driver.should.equal(XCUITestDriver);
 
         caps.platformVersion = '10.0';
-        driver = await appium.getDriverForCaps(caps);
+        driver = appium.getDriverForCaps(caps);
         driver.should.equal(XCUITestDriver);
 
         caps.platformVersion = '10.1';
-        driver = await appium.getDriverForCaps(caps);
+        driver = appium.getDriverForCaps(caps);
         driver.should.equal(XCUITestDriver);
 
         caps.platformVersion = '12.14';
-        driver = await appium.getDriverForCaps(caps);
+        driver = appium.getDriverForCaps(caps);
         driver.should.equal(XCUITestDriver);
       });
     });


### PR DESCRIPTION
## Proposed changes

Moce all driver-related specifications to constants. There should be no need to muck about in the code, just add to the mapping.

This also moves the list of valid automation names out of `appium-base-driver`, where it has no place. It seemed to be there so that the caps could be validated, but the individual drivers should never get an invalid automation name capability, since AppiumDriver ought to weed those out and throw an error before ever getting the particular driver.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

