### PR TITLE
Fix the build

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -236,7 +236,6 @@ class AppiumDriver extends BaseDriver {
     let protocol;
     let innerSessionId, dCaps;
 
-
     try {
       // Parse the caps into a format that the InnerDriver will accept
       const parsedCaps = parseCapsForInnerDriver(

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -42,22 +42,19 @@ function inspectObject (args) {
  * @param {Object} constraints
  * @param {Object} defaultCapabilities
  */
-function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constraints={}, defaultCapabilities={}) {
+function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constraints = {}, defaultCapabilities = {}) {
   // Check if the caller sent JSONWP caps, W3C caps, or both
-  const hasW3CCaps = _.isPlainObject(w3cCapabilities)
-    && _.has(w3cCapabilities, 'firstMatch') && _.has(w3cCapabilities, 'alwaysMatch');
+  const hasW3CCaps = _.isPlainObject(w3cCapabilities) &&
+    (_.has(w3cCapabilities, 'alwaysMatch') || _.has(w3cCapabilities, 'firstMatch'));
   const hasJSONWPCaps = _.isPlainObject(jsonwpCapabilities);
   let protocol = null;
   let desiredCaps = {};
   let processedW3CCapabilities = null;
   let processedJsonwpCapabilities = null;
-  
+
   if (!hasJSONWPCaps && !hasW3CCaps) {
     return {
-      desiredCaps,
-      processedJsonwpCapabilities,
-      processedW3CCapabilities,
-      protocol,
+      protocol: BaseDriver.DRIVER_PROTOCOL.W3C,
       error: new Error('Either JSONWP or W3C capabilities should be provided'),
     };
   }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "continuation-local-storage": "3.x",
     "dateformat": "^3.0.3",
     "find-root": "^1.1.0",
-    "lodash": "4.x",
+    "lodash": "=4.17.9",
     "npmlog": "4.x",
     "request": "^2.81.0",
     "request-promise": "4.x",

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -60,7 +60,10 @@ describe('utils', function () {
     });
     it('should add appium prefixes to W3C caps that are not standard in W3C', function () {
       parseCapsForInnerDriver(undefined, {
-        alwaysMatch: {platformName: 'Fake', propertyName: 'PROP_NAME'},
+        alwaysMatch: {
+          platformName: 'Fake',
+          propertyName: 'PROP_NAME',
+        },
       }).processedW3CCapabilities.should.deep.equal({
         alwaysMatch: {
           platformName: 'Fake',


### PR DESCRIPTION
## Proposed changes

Fix issues resulting from the merge of https://github.com/appium/appium/commit/eebc1d57a12d191b236ee6e8b3ace83c68d127fd, which did not even pass linting, let alone the test suite.

Other than some cosmetic things, the two main parts:
1. I see nothing in the spec which indicates that _both_ `firstMatch` and `alwaysMatch` need to be in the `capabilities` object. So change an `&&` to an `||`.
1. If neither a W3C nor a MJSONWP request comes in for session startup, we end up with an error but no protocol. This is then returned as a completed session startup and a value of `{}`. So default to returning a W3C error. Not sure if this should be MJSONWP.

This all could have been handled in the PR, if it hadn't been merged before the build finished. The problems should have come up with the pre-commit hooks, too, and never even made it into github. Alas.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
