### PR TITLE
Add automationName and platformName desired cap constraints

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -111,12 +111,27 @@ const PLATFORMS_MAP = {
   tizen: () => TizenDriver,
 };
 
+const desiredCapabilityConstraints = {
+  automationName: {
+    presence: false,
+    isString: true,
+    inclusionCaseInsensitive: _.values(AUTOMATION_NAMES),
+  },
+  platformName: {
+    presence: true,
+    isString: true,
+    inclusionCaseInsensitive: _.keys(PLATFORMS_MAP),
+  },
+};
+
 const sessionsListGuard = new AsyncLock();
 const pendingDriversGuard = new AsyncLock();
 
 class AppiumDriver extends BaseDriver {
   constructor (args) {
     super();
+
+    this.desiredCapConstraints = desiredCapabilityConstraints;
 
     // the main Appium Driver has no new command timeout
     this.newCommandTimeoutMs = 0;


### PR DESCRIPTION
## Proposed changes

With recent changes to `appium-base-driver` the `automationName` cap is no longer validated, since the base driver should not know about it.

So add desired capability validation to the umbrella driver, with just `automationName` and `platformName`.

With `platformName` validated here, there will be no need to validate it on the base driver, which anyway has no reason to know what sorts of platforms are supported. This will also mean that to add a new platform the only thing that will need changing is this umbrella driver.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
