### PR TITLE
Fix displayed documentation link in toc for appium.io

### DIFF
--- a/docs/en/about-appium/api.md
+++ b/docs/en/about-appium/api.md
@@ -94,7 +94,7 @@
     <li><a href='/docs/en/commands/element/attributes/attribute.md'>Attribute</a></li>
     <li><a href='/docs/en/commands/element/attributes/selected.md'>Selected</a></li>
     <li><a href='/docs/en/commands/element/attributes/enabled.md'>Enabled</a></li>
-    <li><a href='/docs/en/commands/element/attributes/enabled.md'>Displayed</a></li>
+    <li><a href='/docs/en/commands/element/attributes/displayed.md'>Displayed</a></li>
     <li><a href='/docs/en/commands/element/attributes/location.md'>Location</a></li>
     <li><a href='/docs/en/commands/element/attributes/size.md'>Size</a></li>
     <li><a href='/docs/en/commands/element/attributes/rect.md'>Rect</a></li>

--- a/docs/en/commands/README.md
+++ b/docs/en/commands/README.md
@@ -94,7 +94,7 @@
     <li><a href='/docs/en/commands/element/attributes/attribute.md'>Attribute</a></li>
     <li><a href='/docs/en/commands/element/attributes/selected.md'>Selected</a></li>
     <li><a href='/docs/en/commands/element/attributes/enabled.md'>Enabled</a></li>
-    <li><a href='/docs/en/commands/element/attributes/enabled.md'>Displayed</a></li>
+    <li><a href='/docs/en/commands/element/attributes/displayed.md'>Displayed</a></li>
     <li><a href='/docs/en/commands/element/attributes/location.md'>Location</a></li>
     <li><a href='/docs/en/commands/element/attributes/size.md'>Size</a></li>
     <li><a href='/docs/en/commands/element/attributes/rect.md'>Rect</a></li>

--- a/docs/en/commands/element/README.md
+++ b/docs/en/commands/element/README.md
@@ -18,7 +18,7 @@
     <li><a href='/docs/en/commands/element/attributes/attribute.md'>Attribute</a></li>
     <li><a href='/docs/en/commands/element/attributes/selected.md'>Selected</a></li>
     <li><a href='/docs/en/commands/element/attributes/enabled.md'>Enabled</a></li>
-    <li><a href='/docs/en/commands/element/attributes/enabled.md'>Displayed</a></li>
+    <li><a href='/docs/en/commands/element/attributes/displayed.md'>Displayed</a></li>
     <li><a href='/docs/en/commands/element/attributes/location.md'>Location</a></li>
     <li><a href='/docs/en/commands/element/attributes/size.md'>Size</a></li>
     <li><a href='/docs/en/commands/element/attributes/rect.md'>Rect</a></li>

--- a/docs/en/commands/element/attributes/README.md
+++ b/docs/en/commands/element/attributes/README.md
@@ -12,7 +12,7 @@
     <li><a href='/docs/en/commands/element/attributes/attribute.md'>Attribute</a></li>
     <li><a href='/docs/en/commands/element/attributes/selected.md'>Selected</a></li>
     <li><a href='/docs/en/commands/element/attributes/enabled.md'>Enabled</a></li>
-    <li><a href='/docs/en/commands/element/attributes/enabled.md'>Displayed</a></li>
+    <li><a href='/docs/en/commands/element/attributes/displayed.md'>Displayed</a></li>
     <li><a href='/docs/en/commands/element/attributes/location.md'>Location</a></li>
     <li><a href='/docs/en/commands/element/attributes/size.md'>Size</a></li>
     <li><a href='/docs/en/commands/element/attributes/rect.md'>Rect</a></li>

--- a/docs/en/commands/example.md
+++ b/docs/en/commands/example.md
@@ -72,7 +72,7 @@ An indepth description of what this command does
 |Language|Support|Documentation|
 |--------|-------|-------------|
 |[Java](https://github.com/appium/java-client/releases/latest)| All | [seleniumhq.github.io](https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/WebElement.html#click--) |
-|[Python](https://github.com/appium/python-client/releases/latest)| All | [Android](https://github.com/appium/python-client) [iOS](https://github.com/appium/python-client) |
+|[Python](https://github.com/appium/python-client/releases/latest)| All | [Android](https://github.com/appium/python-client/android-command) [iOS](https://github.com/appium/python-client/ios-command) |
 |[Javascript (WebdriverIO)](http://webdriver.io/index.html)| None |  |
 |[Javascript (WD)](https://github.com/admc/wd/releases/latest)| None | [github.com](https://github.com/admc/wd/releases) |
 |[Ruby](https://github.com/appium/ruby_lib/releases/latest)| All | [github.com](https://github.com/appium/ruby_lib/releases/latest) |

--- a/docs/toc.js
+++ b/docs/toc.js
@@ -129,7 +129,7 @@ module.exports = {
           ["Attribute", "attribute.md"],
           ["Selected", "selected.md"],
           ["Enabled", "enabled.md"],
-          ["Displayed", "enabled.md"],
+          ["Displayed", "displayed.md"],
           ["Location", "location.md"],
           ["Size", "size.md"],
           ["Rect", "rect.md"],


### PR DESCRIPTION
## Proposed changes

The link in the table of contents is wrong, so going to "displayed" gets you to "enabled" on appium.io

Cc: @simongranger 

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
