### PR TITLE
Clean up argument for long stacktraces

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,7 @@ import { inspectObject } from './utils';
 async function preflightChecks (parser, args, throwInsteadOfExit = false) {
   try {
     checkNodeOk();
-    if (args.asyncTrace) {
+    if (args.longStacktrace) {
       require('longjohn').async_trace_limit = -1;
     }
     if (args.showConfig) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -333,8 +333,8 @@ const args = [
     nargs: 0,
   }],
 
-  [['--async-trace'], {
-    dest: 'asyncTrace',
+  [['--long-stacktrace'], {
+    dest: 'longStacktrace',
     defaultValue: false,
     required: false,
     action: 'storeTrue',
@@ -368,6 +368,27 @@ const args = [
              '| /path/to/caps.json ]',
     help: 'Set the default desired capabilities, which will be set on each ' +
           'session unless overridden by received capabilities.'
+  }],
+
+  [['--enable-heapdump'], {
+    defaultValue: false,
+    dest: 'heapdumpEnabled',
+    action: 'storeTrue',
+    required: false,
+    help: 'Enable collection of NodeJS memory heap dumps. This is useful for memory leaks lookup',
+    nargs: 0
+  }],
+
+  [['--relaxed-security'], {
+    defaultValue: false,
+    dest: 'relaxedSecurityEnabled',
+    action: 'storeTrue',
+    required: false,
+    help: 'Disable additional security checks, so it is possible to use some advanced features, provided ' +
+          'by drivers supporting this option. Only enable it if all the ' +
+          'clients are in the trusted network and it\'s not the case if a client could potentially ' +
+          'break out of the session sandbox.',
+    nargs: 0
   }],
 ];
 
@@ -730,26 +751,14 @@ const deprecatedArgs = [
     nargs: 0,
   }],
 
-  [['--enable-heapdump'], {
+  [['--async-trace'], {
+    dest: 'longStacktrace',
     defaultValue: false,
-    dest: 'heapdumpEnabled',
-    action: 'storeTrue',
     required: false,
-    help: 'Enable collection of NodeJS memory heap dumps. This is useful for memory leaks lookup',
-    nargs: 0
+    action: 'storeTrue',
+    deprecatedFor: '--long-stacktrace',
+    help: '[DEPRECATED] - Add long stack traces to log entries. Recommended for debugging only.',
   }],
-
-  [['--relaxed-security'], {
-    defaultValue: false,
-    dest: 'relaxedSecurityEnabled',
-    action: 'storeTrue',
-    required: false,
-    help: 'Disable additional security checks, so it is possible to use some advanced features, provided ' +
-          'by drivers supporting this option. Only enable it if all the ' +
-          'clients are in the trusted network and it\'s not the case if a client could potentially ' +
-          'break out of the session sandbox.',
-    nargs: 0
-  }]
 ];
 
 function updateParseArgsForDefaultCapabilities (parser) {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "dateformat": "^3.0.3",
     "find-root": "^1.1.0",
     "lodash": "=4.17.9",
+    "longjohn": "^0.2.12",
     "npmlog": "4.x",
     "request": "^2.81.0",
     "request-promise": "4.x",


### PR DESCRIPTION
## Proposed changes

We support a server argument, `--async-trace`, which makes the stack traces unlimited in length. The name [was introduced long ago](https://github.com/appium/appium/commit/f96ef4f9c8b57f3d37b963ac04cb6da30ef5a32e) and needlessly exposes internals of the functionality's implementation.

Deprecate the current argument and implement one that gives a notion of the logical effect, `--long-stacktrace`.

Further, this functionality depends on [longjohn](https://www.npmjs.com/package/longjohn) package), which we don't have as a dependency, so using the argument leads to predictable results:
```
$ appium --async-trace
[Appium] Cannot find module 'longjohn'
$
```

Further: two arguments were erroneously put in the "deprecated argument" bucket. Move them into the correct spot.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
