### PR TITLE
improve documentation

### DIFF
--- a/commands-yml/commands/device/activity/current-activity.yml
+++ b/commands-yml/commands/device/activity/current-activity.yml
@@ -8,7 +8,7 @@ example_usage:
       String activity = driver.currentActivity();
   python:
     |
-      activity = self.driver.current_activity();
+      activity = self.driver.current_activity;
   javascript_wd:
     |
       let activity = await driver.getCurrentActivity();

--- a/commands-yml/commands/device/activity/current-package.yml
+++ b/commands-yml/commands/device/activity/current-package.yml
@@ -8,7 +8,7 @@ example_usage:
       String package = driver.getCurrentPackage();
   python:
     |
-      package = self.driver.current_package();
+      package = self.driver.current_package;
   javascript_wd:
     |
       let package = await driver.getCurrentPackage();


### PR DESCRIPTION
driver.current_activity() and driver.currrent_package() should be driver.current_activity and driver.current_package because of using property feature in Python.