### PR TITLE
Remove error logging from getting the build info

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -149,6 +149,7 @@ class AppiumDriver extends BaseDriver {
     // It is not recommended to access this property directly from the outside
     this.pendingDrivers = {};
 
+    // allow this to happen in the background, so no `await`
     updateBuildInfo();
   }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -40,10 +40,7 @@ async function getGitRev (useGitHubFallback = false) {
         cwd: rootDir
       });
       return stdout.trim();
-    } catch (err) {
-      logger.warn(`Cannot retrieve git revision for Appium version ${APPIUM_VER} from the local repository. ` +
-        `Original error: ${err.message}`);
-    }
+    } catch (ign) {}
   }
 
   if (!useGitHubFallback) {
@@ -64,10 +61,7 @@ async function getGitRev (useGitHubFallback = false) {
         }
       }
     }
-  } catch (err) {
-    logger.warn(`Cannot retrieve git revision for Appium version ${APPIUM_VER} from GitHub. ` +
-      `Original error: ${err.message}`);
-  }
+  } catch (ign) {}
   return null;
 }
 
@@ -78,10 +72,7 @@ async function getGitTimestamp (commitSha, useGitHubFallback = false) {
         cwd: rootDir
       });
       return stdout.trim();
-    } catch (err) {
-      logger.warn(`Cannot retrieve the timestamp for Appium git commit ${commitSha} from the local repository. ` +
-        `Original error: ${err.message}`);
-    }
+    } catch (ign) {}
   }
 
   if (!useGitHubFallback) {
@@ -103,10 +94,7 @@ async function getGitTimestamp (commitSha, useGitHubFallback = false) {
         return resBodyObj.commit.author.date;
       }
     }
-  } catch (err) {
-    logger.warn(`Cannot retrieve the timestamp for Appium git commit ${commitSha} from GitHub. ` +
-      `Original error: ${err.message}`);
-  }
+  } catch (ign) {}
   return null;
 }
 


### PR DESCRIPTION
## Proposed changes

The error messages from trying to get the git sha and timestamp from GitHub, which happens on every startup for released versions of Appium, get strewn into the server logs. The error happens all the time in certain situations, and is unnecessary.

I don't under stand why we do the Github stuff at all, but this at least makes it a little less annoying.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
