### PR TITLE
Removed hyphen mentioned in phone number field in gsm-call.yml file

### DIFF
--- a/commands-yml/commands/device/network/gsm-call.yml
+++ b/commands-yml/commands/device/network/gsm-call.yml
@@ -8,7 +8,7 @@ example_usage:
       await driver.gsmCall('555-123-4567', 'Phone');
   ruby:
     |
-      @driver.gsm_call(phone_number: '555-123-4567', action: :call)
+      @driver.gsm_call(phone_number: '5551234567', action: :call)
   php:
     |
       // TODO


### PR DESCRIPTION
Updated gsm-call.yml doc: Removed hyphen mention in phone number field. 

## Proposed changes
Gsm call works only with valid numbers without hyphen. So, Removed hyphen mention in phone number field in the doc.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] No code change on functionality. Minor doc file change.
## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
