### PR TITLE
remove (Sim/Emu-only) for lang and locale

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -42,7 +42,7 @@ These Capabilities span multiple drivers.
 |`app`|The absolute local path _or_ remote http URL to a `.ipa` file (IOS), `.app` folder (IOS Simulator) or `.apk` file (Android), or a `.zip` file containing one of these (for .app, the .app folder must be the root of the zip file). Appium will attempt to install this app binary on the appropriate device first. Note that this capability is not required for Android if you specify `appPackage` and `appActivity` capabilities (see below). Incompatible with `browserName`.|`/abs/path/to/my.apk` or `http://myapp.com/app.ipa`|
 |`browserName`|Name of mobile web browser to automate. Should be an empty string if automating an app instead.|'Safari' for iOS and 'Chrome', 'Chromium', or 'Browser' for Android|
 |`newCommandTimeout`|How long (in seconds) Appium will wait for a new command from the client before assuming the client quit and ending the session|e.g. `60`|
-|`language`| Language to set for iOS and Android. On iOS, it's available for simulator. |e.g. `fr`|
+|`language`| Language to set for iOS and Android. On iOS, it is only available for simulator. |e.g. `fr`|
 |`locale`| Locale to set for iOS and Android. On iOS, it's available for simulator. `fr_CA` format for iOS. `CA` format (country) for Android |e.g. `fr_CA`, `CA` |
 |`udid`| Unique device identifier of the connected physical device|e.g. `1ae203187fc012g`|
 |`orientation`| (Sim/Emu-only) start in a certain orientation|`LANDSCAPE` or `PORTRAIT`|

--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -43,7 +43,7 @@ These Capabilities span multiple drivers.
 |`browserName`|Name of mobile web browser to automate. Should be an empty string if automating an app instead.|'Safari' for iOS and 'Chrome', 'Chromium', or 'Browser' for Android|
 |`newCommandTimeout`|How long (in seconds) Appium will wait for a new command from the client before assuming the client quit and ending the session|e.g. `60`|
 |`language`| Language to set for iOS and Android. It is only available for simulator on iOS |e.g. `fr`|
-|`locale`| Locale to set for iOS and Android. It is available for simulator on iOS. `fr_CA` format for iOS. `CA` format (country) for Android |e.g. `fr_CA`, `CA` |
+|`locale`| Locale to set for iOS and Android. It is only available for simulator on iOS. `fr_CA` format for iOS. `CA` format (country name abbreviation) for Android |e.g. `fr_CA`, `CA` |
 |`udid`| Unique device identifier of the connected physical device|e.g. `1ae203187fc012g`|
 |`orientation`| (Sim/Emu-only) start in a certain orientation|`LANDSCAPE` or `PORTRAIT`|
 |`autoWebview`| Move directly into Webview context. Default `false`|`true`, `false`|

--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -42,7 +42,7 @@ These Capabilities span multiple drivers.
 |`app`|The absolute local path _or_ remote http URL to a `.ipa` file (IOS), `.app` folder (IOS Simulator) or `.apk` file (Android), or a `.zip` file containing one of these (for .app, the .app folder must be the root of the zip file). Appium will attempt to install this app binary on the appropriate device first. Note that this capability is not required for Android if you specify `appPackage` and `appActivity` capabilities (see below). Incompatible with `browserName`.|`/abs/path/to/my.apk` or `http://myapp.com/app.ipa`|
 |`browserName`|Name of mobile web browser to automate. Should be an empty string if automating an app instead.|'Safari' for iOS and 'Chrome', 'Chromium', or 'Browser' for Android|
 |`newCommandTimeout`|How long (in seconds) Appium will wait for a new command from the client before assuming the client quit and ending the session|e.g. `60`|
-|`language`| Language to set for iOS and Android. On iOS, it is only available for simulator. |e.g. `fr`|
+|`language`| Language to set for iOS and Android. On iOS, it is only available for simulator |e.g. `fr`|
 |`locale`| Locale to set for iOS and Android. On iOS, it's available for simulator. `fr_CA` format for iOS. `CA` format (country) for Android |e.g. `fr_CA`, `CA` |
 |`udid`| Unique device identifier of the connected physical device|e.g. `1ae203187fc012g`|
 |`orientation`| (Sim/Emu-only) start in a certain orientation|`LANDSCAPE` or `PORTRAIT`|

--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -42,8 +42,8 @@ These Capabilities span multiple drivers.
 |`app`|The absolute local path _or_ remote http URL to a `.ipa` file (IOS), `.app` folder (IOS Simulator) or `.apk` file (Android), or a `.zip` file containing one of these (for .app, the .app folder must be the root of the zip file). Appium will attempt to install this app binary on the appropriate device first. Note that this capability is not required for Android if you specify `appPackage` and `appActivity` capabilities (see below). Incompatible with `browserName`.|`/abs/path/to/my.apk` or `http://myapp.com/app.ipa`|
 |`browserName`|Name of mobile web browser to automate. Should be an empty string if automating an app instead.|'Safari' for iOS and 'Chrome', 'Chromium', or 'Browser' for Android|
 |`newCommandTimeout`|How long (in seconds) Appium will wait for a new command from the client before assuming the client quit and ending the session|e.g. `60`|
-|`language`| Language to set for iOS and Android. On iOS, it is only available for simulator |e.g. `fr`|
-|`locale`| Locale to set for iOS and Android. On iOS, it's available for simulator. `fr_CA` format for iOS. `CA` format (country) for Android |e.g. `fr_CA`, `CA` |
+|`language`| Language to set for iOS and Android. It is only available for simulator on iOS |e.g. `fr`|
+|`locale`| Locale to set for iOS and Android. It is available for simulator on iOS. `fr_CA` format for iOS. `CA` format (country) for Android |e.g. `fr_CA`, `CA` |
 |`udid`| Unique device identifier of the connected physical device|e.g. `1ae203187fc012g`|
 |`orientation`| (Sim/Emu-only) start in a certain orientation|`LANDSCAPE` or `PORTRAIT`|
 |`autoWebview`| Move directly into Webview context. Default `false`|`true`, `false`|

--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -42,8 +42,8 @@ These Capabilities span multiple drivers.
 |`app`|The absolute local path _or_ remote http URL to a `.ipa` file (IOS), `.app` folder (IOS Simulator) or `.apk` file (Android), or a `.zip` file containing one of these (for .app, the .app folder must be the root of the zip file). Appium will attempt to install this app binary on the appropriate device first. Note that this capability is not required for Android if you specify `appPackage` and `appActivity` capabilities (see below). Incompatible with `browserName`.|`/abs/path/to/my.apk` or `http://myapp.com/app.ipa`|
 |`browserName`|Name of mobile web browser to automate. Should be an empty string if automating an app instead.|'Safari' for iOS and 'Chrome', 'Chromium', or 'Browser' for Android|
 |`newCommandTimeout`|How long (in seconds) Appium will wait for a new command from the client before assuming the client quit and ending the session|e.g. `60`|
-|`language`| (Sim/Emu-only) Language to set for the simulator / emulator. On Android, available only on API levels 22 and below |e.g. `fr`|
-|`locale`| (Sim/Emu-only) Locale to set for the simulator / emulator. |e.g. `fr_CA`|
+|`language`| Language to set for iOS and Android. On iOS, it's available for simulator. |e.g. `fr`|
+|`locale`| Locale to set for iOS and Android. On iOS, it's available for simulator. `fr_CA` format for iOS. `CA` format (country) for Android |e.g. `fr_CA`, `CA` |
 |`udid`| Unique device identifier of the connected physical device|e.g. `1ae203187fc012g`|
 |`orientation`| (Sim/Emu-only) start in a certain orientation|`LANDSCAPE` or `PORTRAIT`|
 |`autoWebview`| Move directly into Webview context. Default `false`|`true`, `false`|


### PR DESCRIPTION
## Proposed changes

I noticed we can remove _Sim/Emu-only_ mark since we use io.appium.settings to handle locale for Android. Android the format for Android should be `JP` or `CA`, for example in the locale like https://github.com/KazuCocoa/AppBundleSample/blob/master/test.rb#L14-L15

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
