### PR TITLE
Remove duplicate Greenkeeper badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ stumped.
 
 ### License
 
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fappium%2Fappium.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fappium%2Fappium?ref=badge_large) [![Greenkeeper badge](https://badges.greenkeeper.io/appium/appium.svg)](https://greenkeeper.io/)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fappium%2Fappium.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fappium%2Fappium?ref=badge_large)


### PR DESCRIPTION
This badge appears at the beginning of the file and once again at the end, so the end badge is removed.