### PR TITLE
NPM script to shrinkwrap prod deps

### DIFF
--- a/docs/en/contributing-to-appium/developers-overview.md
+++ b/docs/en/contributing-to-appium/developers-overview.md
@@ -180,8 +180,7 @@ converted into the `npm-shrinkwrap.json` file.
 1. Determine whether we have a `patch` (bugfix), `minor` (feature), or `major` (breaking) release according to the principles of SemVer.
 1. Update `package.json` with the appropriate new version.
 1. Update the CHANGELOG/README with appropriate changes and submit for review as a PR, along with shrinkwrap and `package.json` changes. Wait for it to be merged, then pull it into the release branch.
-1. `rm -rf node_modules && npm install --production` to get just the production dependencies.
-1. `npm shrinkwrap` to write the new NPM shrinkwrap JSON file, and commit this file.
+1. Run `npm run prod-shrinkwrap` to install just the production dependencies and create a shrinkwrap that only locks production dependencies.
 1. Create a tag of the form `v<version>` on the release branch (usually a minor branch like `1.5` or `1.4`), with: `git tag -a v<version>`, e.g., `git tag -a v1.5.0`. This is not necessary for beta versions.
 1. Push the tag to upstream: `git push --tags <remote> <branch>`
 1. Install dev dependencies (or at least `gulp` and `appium-gulp-plugins`), and undo the changes to the NPM shrinkwrap JSON file (e.g., `git checkout -- npm-shrinkwrap.json`).

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "coverage": "gulp coveralls",
     "generate-docs": "node ./build/commands-yml/parse.js",
     "clean": "rm -rf node_modules && rm -rf package-lock.json && npm install",
-    "clean:prod": "rm -rf node_modules && rm -rf package-lock.json && npm install --production",
+    "shrinkwrap-prod": "rm -rf package-lock.json && npm prune --production && npm shrinkwrap",
     "zip": "zip -qr appium.zip .",
     "upload": "node ./build/test/scripts/bintray-upload.js",
     "zip-and-upload": "npm run zip && npm run upload",


### PR DESCRIPTION
Added a script `shrinkwrap-prod` which deletes `package-lock.json`, prunes non-production dependencies and then shrinkwraps it.