### PR TITLE
Update of documentation of command regarding Android automation type and Appium version 

### DIFF
--- a/commands-yml/commands/mobile-command.yml
+++ b/commands-yml/commands/mobile-command.yml
@@ -59,10 +59,7 @@
       | mobile:shell | Execute [ADB shell](https://developer.android.com/studio/command-line/adb#shellcommands) commands (requires [server flag](/docs/en/writing-running-appium/server-args.md#server-flags) `--relaxed-security` to be set) | ADB shell string | `am start -n com.example.demo/com.example.test.MainActivity` |
       | mobile:startLogsBroadcast |  Starts Android logcat broadcast websocket on the same host and port where Appium is running at `/ws/session/:sessionId:/appium/logcat` endpoint | <none> | <none> |
       | mobile:stopLogsBroadcast |  Stops the logcat broadcasting websocket server started by `mobile:startLogsBroadcast` | <none> | <none> |
-      | mobile:batteryInfo | Reads the battery information from the device under test | <none> | <none> |
-      | mobile:acceptAlert | Accepts an on-screen alert | Optional button label to click on | <none> |
-      | mobile:dismissAlert | Dismisses an on-screen alert | Optional button label to click on | <none> |
-      | mobile:performEditorAction | Performs the given editor action on the focused input field. The following action names are supported: `normal, unspecified, none, go, search, send, next, done, previous`.   | {action} | {action: "previous"}|
+      | mobile:performEditorAction | Performs the given editor action on the focused input field (available from Appium v1.10.0). The following action names are supported: `normal, unspecified, none, go, search, send, next, done, previous`.   | {action} | {action: "previous"}|
 
       ### Android (UiAutomator2 only)
       | Command | Description | Argument | Argument Example |
@@ -71,6 +68,9 @@
       | mobile:viewportScreenshot | Like [screenshot](/commands/session/screenshot/) but only includes contents of viewport | <none> | <none> |
       | mobile:deepLink | Opens a deep-link URL for testing [Instant Apps](https://support.google.com/googleplay/answer/7240211?hl=en) | `{url, package}` | `{url: "https://www.site.com/", package: "com.site.SomeAndroidPackage"}` |
       | mobile:getDeviceInfo | Gets device information like manufacturer and model. Read [GetDeviceInfo](https://github.com/appium/appium-uiautomator2-server/blob/master/app/src/main/java/io/appium/uiautomator2/handler/GetDeviceInfo.java) for more details. | <none> | <none> |
+      | mobile:batteryInfo | Reads the battery information from the device under test | <none> | <none> |
+      | mobile:acceptAlert | Accepts an on-screen alert | Optional button label to click on | <none> |
+      | mobile:dismissAlert | Dismisses an on-screen alert | Optional button label to click on | <none> |
 
       ### Android (Espresso only)
       | Command | Description | Argument | Argument Example |


### PR DESCRIPTION
Moved commands that are not supported by `UiAutomator` to `UiAutomator2 only` section.
Added comment about support version of `performEditorAction` command (optional change, since it's probably should include other commands that were not investigated from my side).

## Proposed changes

It's just a small improvement of the great documentation. I've personally spent some time on trying and failing of adding `performEditorAction` into Appium version 1.9.1 and `batteryInfo` without using UiAutomator2 as automation capability. Additionally wasted contributors' time by filing the defect on this matter. 

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
