### PR TITLE
get rid of deprecated usage in touchaction md

### DIFF
--- a/docs/en/writing-running-appium/touch-actions.md
+++ b/docs/en/writing-running-appium/touch-actions.md
@@ -60,18 +60,6 @@ element's position, rather than absolute.
 Calling the `perform` event sends the entire sequence of events to appium,
 and the touch gesture is run on your device.
 
-Appium clients also allow one to directly execute a TouchAction through the
-driver object, rather than calling the `perform` event on the TouchAction
-object.
-
-In pseudocode, both of the following are equivalent:
-
-```center
-TouchAction().tap(el).perform()
-
-driver.perform(TouchAction().tap(el))
-```
-
 ### MultiTouch
 
 *MultiTouch* objects are collections of TouchActions.


### PR DESCRIPTION
## Proposed changes

I found in https://github.com/appium/python-client/issues/253 this part probably deprecated usage since I could not found such code in Python or other clients. All clients support `TouchAction().tap(el).perform()` format. JS has `.performXxxxYyy` style commands though.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
