### PR TITLE
Fix color stripping from console logger

### DIFF
--- a/lib/logsink.js
+++ b/lib/logsink.js
@@ -79,7 +79,7 @@ function createConsoleTransport (args, logLvl) {
         return info;
       })(),
       timestampFormat,
-      colorizeFormat,
+      args.logNoColors ? stripColorFormat : colorizeFormat,
       format.printf(function (info) {
         return `${args.logTimestamp ? `${info.timestamp} - ` : ''}${info.message}`;
       })


### PR DESCRIPTION
## Proposed changes

Console logging with no colors is a bit off. See #11848.

Winston's `colorize` format is supposed to take care of this, but does not for our Express logging since that coloring is [done manually elsewhere](https://github.com/appium/appium-base-driver/blob/master/lib/express/express-logging.js).

So, when `--log-no-colors` is used, strip the colors ourselves within the logging layer.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

