### PR TITLE
Fix docs PR creation condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,21 +36,17 @@ jobs:
         - git reset --hard origin/master
         - git checkout -b generate-docs-$TRAVIS_COMMIT
         - npm install
-
       script:
         # Generate the docs
         - npm run generate-docs
 
-        # If no docs were generated, don't do anything
+        # If docs were generated, make a PR to update the docs
         - |
-          if [[ -z $(git status -s) ]]; then
-            exit 0
+          if [[ -n $(git status -s) ]]; then
+            git commit -a -n -m 'Update generated docs';
+            git push origin generate-docs-$TRAVIS_COMMIT;
+            hub pull-request -b "appium:master" -h "appium:generate-docs-$TRAVIS_COMMIT" -m "Update auto-generated docs";
           fi
-        
-        # Make a PR to update the docs
-        - git commit -a -n -m 'Update generated docs [ci skip]'
-        - git push origin generate-docs-$TRAVIS_COMMIT
-        - hub pull-request -b "appium:master" -h "appium:generate-docs-$TRAVIS_COMMIT" -m "Update auto-generated docs"
 
     - stage: BinTray Bundle Build and Upload
       # only want to run this on the main master branch
@@ -78,7 +74,7 @@ jobs:
         # Remove the dev depenedencies
         - npm prune
       script: npm run zip-and-upload
-      
+
     - stage: Update Documentation
       if: tag
       os: osx


### PR DESCRIPTION
## Proposed changes

Exiting in the middle of a Travis script does not seem to actually exit. So if no documentation is updated a push still happens and things get messy. See 
* [broken Travis job](https://travis-ci.org/appium/appium/jobs/469062301#L2353-L2381)
* [branch created](https://github.com/appium/appium/tree/generate-docs-f88c9958ac8a9340499bd9a7a52f94816eb17582)
* [ensuing Travis job](https://travis-ci.org/appium/appium/builds/469066190)

The simplest solution seemed to me to be to reverse the condition and do the git stuff within the conditional block.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

