### PR TITLE
Make sure xcuitest driver is built when bundling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ jobs:
         - CXX=g++
       before_install:
         - gcc --version
+        - brew upgrade carthage
       install:
         # Install prod dependencies
         - npm install
@@ -67,6 +68,14 @@ jobs:
         # Install only the dev dependencies that we need
         - npm install --only=dev gulp
         - npm install --only=dev appium-gulp-plugins
+
+        # get appium-xcuitest-driver fully built
+        - pushd node_modules/appium-xcuitest-driver/WebDriverAgent
+        # do not use build script because Travis _will_ have rate limits
+        - carthage bootstrap --no-use-binaries
+        - cp Cartfile.resolved Carthage
+        - mkdir -p ./Resources/WebDriverAgent.bundle
+        - popd
       before_script:
         # Build the assets
         - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,18 @@ jobs:
       script: npm run test && npm run e2e-test
       node_js: "8"
     - stage:
+      name: test documentation generation
+      os: osx
+      before_script:
+        - npm install
+      script:
+        - npm run generate-docs
+
+    - stage: Auto-generate documentation
       os: osx
       if: branch = master AND type != pull_request AND !tag
       env:
-        # this is just to indicate in the Travis job list that this is generating docs
-        - GENERATE_DOCS=true GITHUB_TOKEN=$TRIAGER_BOT_TOKEN
+        - GITHUB_TOKEN=$TRIAGER_BOT_TOKEN
       before_script:
         - brew install hub
         - hub --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       node_js: "8"
     - stage:
       name: test documentation generation
-      os: osx
+      os: linux
       before_script:
         - npm install
       script:

--- a/test/scripts/bintray-upload.js
+++ b/test/scripts/bintray-upload.js
@@ -66,10 +66,10 @@ const log = logger.getLogger('Bintray');
       }
     });
   } catch (e) {
-    if (e.statusCode !== 409) {
+    if (e.statusCode === 409) {
       // Doesn't fail on 409 because sometimes 409 means that the asset was already published
       // and if that's the case, we don't want it to fail
-      log.error(`Didn't publish upload. Upload is already available. Reason:`, e.message);
+      log.error(`Did not publish upload. Upload is already available. Reason: ${e.message}`);
     } else {
       log.error(`Failed to publish 'appium.zip' to ${BUILD_NAME}. Reason: ${JSON.stringify(e)}`);
       process.exit(-1);


### PR DESCRIPTION
## Proposed changes

When our cron job in `appium-xcuitest-driver` runs on Sauce Labs, Appium is on a read-only drive so getting the dependencies fails:
```
2018-12-18 17:24:34:553 - [debug] [XCUITest] Carthage found: '/usr/local/bin/carthage'
2018-12-18 17:24:34:554 - [debug] [XCUITest] Running WebDriverAgent bootstrap script to install dependencies
2018-12-18 17:24:34:570 - [debug] [BaseDriver] Event 'wdaStartFailed' logged at 1545153874570 (09:24:34 GMT-0800 (PST))
2018-12-18 17:24:34:570 - [debug] [XCUITest] Unable to launch WebDriverAgent because of xcodebuild failure: "spawn EACCES".
2018-12-18 17:24:34:571 - [XCUITest] Quitting and uninstalling WebDriverAgent, then retrying
```

So while bundling, run the install script (bypassing the actual script, because on Travis the call can get rate-limited, but is fine if the dependencies are built rather than downloaded as binaries).

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
