### PR TITLE
Update system-time.yml

### DIFF
--- a/commands-yml/commands/device/system/system-time.yml
+++ b/commands-yml/commands/device/system/system-time.yml
@@ -8,7 +8,7 @@ example_usage:
       String time = driver.getDeviceTime();
   python:
     |
-      time = self.driver.device_time()
+      time = self.driver.device_time
   javascript_wdio:
     |
       let time = driver.getDeviceTime();


### PR DESCRIPTION
Removed "()" from device_time(python) since device_time has property decorator.
device_time() throws TypeError.

https://github.com/appium/python-client/blob/master/appium/webdriver/webdriver.py