### PR TITLE
Shrinkwrap fixes

### DIFF
--- a/check-npm-pack-files.js
+++ b/check-npm-pack-files.js
@@ -25,4 +25,4 @@ if (!_.isEmpty(missingFiles)) {
   throw new Error(`Files '${missingFiles.join(', ')}' are not included in package.json "files". Please make sure these files are included before publishing.`);
 }
 
-process.exit(1);
+process.exit(0);

--- a/check-npm-pack-files.js
+++ b/check-npm-pack-files.js
@@ -3,13 +3,7 @@ const _ = require('lodash');
 
 const res = JSON.parse(childProcess.execSync('npm pack --dry-run --json --ignore-scripts', {encoding: 'utf8'}))[0];
 
-// Get list of the files being packed
-const fileNames = [];
-for (const file of res.files) {
-  fileNames.push(file.path);
-}
-
-// Get list of files we want to test for existence
+// List of files we are testing to make sure they are included in package
 const testFiles = [
   'npm-shrinkwrap.json', // Check that npm-shrinkwrap.json is being packed
   'LICENSE', // Check that license is included
@@ -17,7 +11,7 @@ const testFiles = [
 ];
 
 // Get list of files in `testFiles` that aren't in the list of packaged fileNames
-const missingFiles = _.without(testFiles, ...fileNames);
+const missingFiles = _.without(testFiles, ..._.map(res.files, 'path'));
 
 if (!_.isEmpty(missingFiles)) {
   throw new Error(`Files [${missingFiles.join(', ')}] are not included in package.json "files". ` +

--- a/check-npm-pack-files.js
+++ b/check-npm-pack-files.js
@@ -1,0 +1,28 @@
+const childProcess = require('child_process');
+const _ = require('lodash');
+
+const res = JSON.parse(childProcess.execSync('npm pack --dry-run --json --ignore-scripts', {encoding: 'utf8'}))[0];
+
+const fileNamesMap = {};
+for (const file of res.files) {
+  fileNamesMap[file.path] = true;
+}
+
+const testFiles = [
+  'npm-shrinkwrap.json', // Check that npm-shrinkwrap.json is being packed
+  'LICENSE', // Check that license is included
+  'build/lib/appium.js', // Sanity check that build files are being included by testing just one file
+];
+
+const missingFiles = [];
+for (const testFile of testFiles) {
+  if (!fileNamesMap[testFile]) {
+    missingFiles.push(testFile);
+  }
+}
+
+if (!_.isEmpty(missingFiles)) {
+  throw new Error(`Files '${missingFiles.join(', ')}' are not included in package.json "files". Please make sure these files are included before publishing.`);
+}
+
+process.exit(1);

--- a/check-npm-pack-files.js
+++ b/check-npm-pack-files.js
@@ -3,26 +3,25 @@ const _ = require('lodash');
 
 const res = JSON.parse(childProcess.execSync('npm pack --dry-run --json --ignore-scripts', {encoding: 'utf8'}))[0];
 
-const fileNamesMap = {};
+// Get list of the files being packed
+const fileNames = [];
 for (const file of res.files) {
-  fileNamesMap[file.path] = true;
+  fileNames.push(file.path);
 }
 
+// Get list of files we want to test for existence
 const testFiles = [
   'npm-shrinkwrap.json', // Check that npm-shrinkwrap.json is being packed
   'LICENSE', // Check that license is included
   'build/lib/appium.js', // Sanity check that build files are being included by testing just one file
 ];
 
-const missingFiles = [];
-for (const testFile of testFiles) {
-  if (!fileNamesMap[testFile]) {
-    missingFiles.push(testFile);
-  }
-}
+// Get list of files in `testFiles` that aren't in the list of packaged fileNames
+const missingFiles = _.without(testFiles, ...fileNames);
 
 if (!_.isEmpty(missingFiles)) {
-  throw new Error(`Files '${missingFiles.join(', ')}' are not included in package.json "files". Please make sure these files are included before publishing.`);
+  throw new Error(`Files [${missingFiles.join(', ')}] are not included in package.json "files". ` +
+    `Please make sure these files are included before publishing.`);
 }
 
 process.exit(0);

--- a/docs/en/contributing-to-appium/developers-overview.md
+++ b/docs/en/contributing-to-appium/developers-overview.md
@@ -195,7 +195,7 @@ converted into the `npm-shrinkwrap.json` file.
 1. Determine whether we have a `patch` (bugfix), `minor` (feature), or `major` (breaking) release according to the principles of SemVer.
 1. Update `package.json` with the appropriate new version.
 1. Update the CHANGELOG/README with appropriate changes and submit for review as a PR, along with shrinkwrap and `package.json` changes. Wait for it to be merged, then pull it into the release branch.
-1. Run `npm run shrinkwrap-prod`. This script prunes dev dependencies (leaving only production dependencies), creates a production-only `npm-shrinkwrap.json` and then re-installs the dev dependencies by doing `npm install --no-shrinkwrap`.
+1. Run `npm run shrinkwrap:prod`. This script prunes dev dependencies (leaving only production dependencies), creates a production-only `npm-shrinkwrap.json` and then re-installs the dev dependencies by doing `npm install --no-shrinkwrap`.
 1. Create a tag of the form `v<version>` on the release branch (usually a minor branch like `1.5` or `1.4`), with: `git tag -a v<version>`, e.g., `git tag -a v1.5.0`. This is not necessary for beta versions.
 1. Push the tag to upstream: `git push --tags <remote> <branch>`
 1. Run `npm publish` (with `--tag beta` if this isn't an official release).

--- a/docs/en/contributing-to-appium/developers-overview.md
+++ b/docs/en/contributing-to-appium/developers-overview.md
@@ -195,7 +195,7 @@ converted into the `npm-shrinkwrap.json` file.
 1. Determine whether we have a `patch` (bugfix), `minor` (feature), or `major` (breaking) release according to the principles of SemVer.
 1. Update `package.json` with the appropriate new version.
 1. Update the CHANGELOG/README with appropriate changes and submit for review as a PR, along with shrinkwrap and `package.json` changes. Wait for it to be merged, then pull it into the release branch.
-1. Run `npm run shrinkwrap:prod`. This script prunes dev dependencies (leaving only production dependencies), creates a production-only `npm-shrinkwrap.json` and then re-installs the dev dependencies by doing `npm install --no-shrinkwrap`.
+1. Run `npm run shrinkwrap:prod`. This script removes `node_modules`, installs node production dependencies, creates `npm-shrinkwrap.json` (which only shrinkwrap prod dependencies) and then re-installs the dev dependencies by doing `npm install --no-shrinkwrap`.
 1. Create a tag of the form `v<version>` on the release branch (usually a minor branch like `1.5` or `1.4`), with: `git tag -a v<version>`, e.g., `git tag -a v1.5.0`. This is not necessary for beta versions.
 1. Push the tag to upstream: `git push --tags <remote> <branch>`
 1. Run `npm publish` (with `--tag beta` if this isn't an official release).

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "files": [
     "bin",
     "lib",
-    "build/lib"
+    "build/lib",
+    "npm-shrinkwrap.json"
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",
@@ -85,7 +86,7 @@
     "lint:fix": "gulp eslint --fix",
     "coverage": "gulp coveralls",
     "generate-docs": "node ./build/commands-yml/parse.js",
-    "shrinkwrap-prod": "rimraf package-lock.json && rimraf node_modules && npm install --production && npm shrinkwrap && npm install --no-shrinkwrap",
+    "shrinkwrap-prod": "rimraf package-lock.json && rimraf node_modules && npm install --production && npm shrinkwrap && node ./check-npm-pack-files && npm install --no-shrinkwrap",
     "zip": "zip -qr appium.zip .",
     "upload": "gulp github-upload",
     "zip-and-upload": "npm run zip && npm run upload"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "lint:fix": "gulp eslint --fix",
     "coverage": "gulp coveralls",
     "generate-docs": "node ./build/commands-yml/parse.js",
-    "shrinkwrap-prod": "rimraf package-lock.json && npm prune --production && npm shrinkwrap && npm install --no-shrinkwrap",
+    "shrinkwrap-prod": "rimraf package-lock.json && rimraf node_modules && npm install --production && npm shrinkwrap && npm install --no-shrinkwrap",
     "zip": "zip -qr appium.zip .",
     "upload": "gulp github-upload",
     "zip-and-upload": "npm run zip && npm run upload"

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "lint:fix": "gulp eslint --fix",
     "coverage": "gulp coveralls",
     "generate-docs": "node ./build/commands-yml/parse.js",
-    "shrinkwrap-prod": "rimraf package-lock.json && rimraf node_modules && npm install --production && npm shrinkwrap && node ./check-npm-pack-files && npm install --no-shrinkwrap",
+    "shrinkwrap:prod": "rimraf package-lock.json && rimraf node_modules && npm install --production && npm shrinkwrap && node ./check-npm-pack-files && npm install --no-shrinkwrap",
     "zip": "zip -qr appium.zip .",
     "upload": "gulp github-upload",
     "zip-and-upload": "npm run zip && npm run upload"


### PR DESCRIPTION
1. Update `shrinkwrap-prod` script to prevent stale dependencies from getting into shrinkwrap 

How it works now:

* Delete `package-lock.json` if one exists (this is defensive, because if `package-lock.json` exists and `npm shrinkwrap` is called, it just renames `package-lock.json` to `npm-shrinkwrap.json`)
* Delete `node_modules`
* Install production modules (`npm instal --production`)
* Create shrinkwrap (`npm shrinkwrap`)
* Install dev dependencies, but don't update shrinkwrap (`npm install --no-shrinkwrap`)

2. Add `npm-shrinkwrap.json` to package.json files. NPM doesn't pack it by default, surprisingly
3. Add a script that does an `npm pack` dry-run and tests that `npm-shrinkwrap.json` was included

(related to https://github.com/appium/appium/issues/11967)

