### PR TITLE
Include shrinkwrap in files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   "files": [
     "bin",
     "lib",
-    "build/lib"
+    "build/lib",
+    "npm-shrinkwrap.json"
   ],
   "dependencies": {
     "@babel/runtime": "^7.0.0",


### PR DESCRIPTION
It appears that `npm-shrinkwrap.json` can be ignored (which I find surprising). 

When we switched to using `files` in `package.json` to whitelist files to publish, it caused `npm-shrinkwrap.json` to be ignored. This PR adds it back. Since this is in 1.9 and 1.10 I think it would be wise to patch this into the 1.9 and 1.10 branch and make a patch release for both of them.

related to https://github.com/appium/appium/issues/11967