### PR TITLE
Lazy load drivers upon request

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -1,22 +1,12 @@
 import _ from 'lodash';
 import log from './logger';
-import { getBuildInfo, updateBuildInfo } from './config';
+import { getBuildInfo, updateBuildInfo, APPIUM_VER } from './config';
 import { BaseDriver, errors, isSessionCommand } from 'appium-base-driver';
-import { FakeDriver } from 'appium-fake-driver';
-import { AndroidDriver } from 'appium-android-driver';
-import { IosDriver } from 'appium-ios-driver';
-import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
-import { SelendroidDriver } from 'appium-selendroid-driver';
-import { XCUITestDriver } from 'appium-xcuitest-driver';
-import { YouiEngineDriver } from 'appium-youiengine-driver';
-import { WindowsDriver } from 'appium-windows-driver';
-import { MacDriver } from 'appium-mac-driver';
-import { EspressoDriver } from 'appium-espresso-driver';
-import { TizenDriver } from 'appium-tizen-driver';
 import B from 'bluebird';
 import AsyncLock from 'async-lock';
 import { inspectObject, parseCapsForInnerDriver, getPackageVersion } from './utils';
 import semver from 'semver';
+
 
 const PLATFORMS = {
   FAKE: 'fake',
@@ -38,64 +28,58 @@ const AUTOMATION_NAMES = {
   TIZEN: 'Tizen',
   FAKE: 'Fake',
   INSTRUMENTS: 'Instruments',
+  WINDOWS: 'Windows',
+  MAC: 'Mac',
 };
 const DRIVER_MAP = {
-  SelendroidDriver: {
-    driverClass: SelendroidDriver,
-    automationName: AUTOMATION_NAMES.SELENDROID,
-    version: getPackageVersion('appium-selendroid-driver'),
+  [AUTOMATION_NAMES.SELENDROID]: {
+    driverClassName: 'SelendroidDriver',
+    driverPackage: 'appium-selendroid-driver',
   },
-  AndroidUiautomator2Driver: {
-    driverClass: AndroidUiautomator2Driver,
-    automationName: AUTOMATION_NAMES.UIAUTOMATOR2,
-    version: getPackageVersion('appium-uiautomator2-driver'),
+  [AUTOMATION_NAMES.UIAUTOMATOR2]: {
+    driverClassName: 'AndroidUiautomator2Driver',
+    driverPackage: 'appium-uiautomator2-driver',
   },
-  XCUITestDriver: {
-    driverClass: XCUITestDriver,
-    automationName: AUTOMATION_NAMES.XCUITEST,
-    version: getPackageVersion('appium-xcuitest-driver'),
+  [AUTOMATION_NAMES.XCUITEST]: {
+    driverClassName: 'XCUITestDriver',
+    driverPackage: 'appium-xcuitest-driver',
   },
-  YouiEngineDriver: {
-    driverClass: YouiEngineDriver,
-    automationName: AUTOMATION_NAMES.YOUIENGINE,
-    version: getPackageVersion('appium-youiengine-driver'),
+  [AUTOMATION_NAMES.YOUIENGINE]: {
+    driverClassName: 'YouiEngineDriver',
+    driverPackage: 'appium-youiengine-driver',
   },
-  FakeDriver: {
-    driverClass: FakeDriver,
-    version: getPackageVersion('appium-fake-driver'),
+  [AUTOMATION_NAMES.FAKE]: {
+    driverClassName: 'FakeDriver',
+    driverPackage: 'appium-fake-driver',
   },
-  AndroidDriver: {
-    driverClass: AndroidDriver,
-    automationName: AUTOMATION_NAMES.UIAUTOMATOR1,
-    version: getPackageVersion('appium-android-driver'),
+  [AUTOMATION_NAMES.UIAUTOMATOR1]: {
+    driverClassName: 'AndroidDriver',
+    driverPackage: 'appium-android-driver',
   },
-  IosDriver: {
-    driverClass: IosDriver,
-    automationName: AUTOMATION_NAMES.INSTRUMENTS,
-    version: getPackageVersion('appium-ios-driver'),
+  [AUTOMATION_NAMES.INSTRUMENTS]: {
+    driverClassName: 'IosDriver',
+    driverPackage: 'appium-ios-driver',
   },
-  WindowsDriver: {
-    driverClass: WindowsDriver,
-    version: getPackageVersion('appium-windows-driver'),
+  [AUTOMATION_NAMES.WINDOWS]: {
+    driverClassName: 'WindowsDriver',
+    driverPackage: 'appium-windows-driver',
   },
-  MacDriver: {
-    driverClass: MacDriver,
-    version: getPackageVersion('appium-mac-driver'),
+  [AUTOMATION_NAMES.MAC]: {
+    driverClassName: 'MacDriver',
+    driverPackage: 'appium-mac-driver',
   },
-  EspressoDriver: {
-    driverClass: EspressoDriver,
-    automationName: AUTOMATION_NAMES.ESPRESSO,
-    version: getPackageVersion('appium-espresso-driver'),
+  [AUTOMATION_NAMES.ESPRESSO]: {
+    driverClassName: 'EspressoDriver',
+    driverPackage: 'appium-espresso-driver',
   },
-  TizenDriver: {
-    driverClass: TizenDriver,
-    automationName: AUTOMATION_NAMES.TIZEN,
-    version: getPackageVersion('appium-tizen-driver'),
+  [AUTOMATION_NAMES.TIZEN]: {
+    driverClassName: 'TizenDriver',
+    driverPackage: 'appium-package-driver',
   },
 };
 
 const PLATFORMS_MAP = {
-  [PLATFORMS.FAKE]: () => FakeDriver,
+  [PLATFORMS.FAKE]: () => AUTOMATION_NAMES.FAKE,
   [PLATFORMS.ANDROID]: (caps) => {
     const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
     log.warn(`DeprecationWarning: 'automationName' capability was not provided. ` +
@@ -107,7 +91,7 @@ const PLATFORMS_MAP = {
         'is not maintained anymore by the OS vendor.');
     }
 
-    return AndroidDriver;
+    return AUTOMATION_NAMES.UIAUTOMATOR1;
   },
   [PLATFORMS.IOS]: (caps) => {
     const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
@@ -118,14 +102,14 @@ const PLATFORMS_MAP = {
         `using '${AUTOMATION_NAMES.XCUITEST}' ` +
         'driver instead of UIAutomation-based driver, since the ' +
         'latter is unsupported on iOS 10 and up.');
-      return XCUITestDriver;
+      return AUTOMATION_NAMES.XCUITEST;
     }
 
-    return IosDriver;
+    return AUTOMATION_NAMES.INSTRUMENTS;
   },
-  [PLATFORMS.WINDOWS]: () => WindowsDriver,
-  [PLATFORMS.MAC]: () => MacDriver,
-  [PLATFORMS.TIZEN]: () => TizenDriver,
+  [PLATFORMS.WINDOWS]: () => AUTOMATION_NAMES.WINDOWS,
+  [PLATFORMS.MAC]: () => AUTOMATION_NAMES.MAC,
+  [PLATFORMS.TIZEN]: () => AUTOMATION_NAMES.TIZEN,
 };
 
 const desiredCapabilityConstraints = {
@@ -185,25 +169,32 @@ class AppiumDriver extends BaseDriver {
     return this.sessions[sessionId];
   }
 
-  getDriverForCaps (caps) {
+  getDriverAndVersionForCaps (caps) {
     if (!_.isString(caps.platformName)) {
       throw new Error('You must include a platformName capability');
     }
 
     const platformName = caps.platformName.toLowerCase();
 
-    // we don't necessarily have an `automationName` capability,
-    if (_.isString(caps.automationName)) {
-      for (const {automationName, driverClass} of _.values(DRIVER_MAP)) {
-        if (_.toLower(automationName) === caps.automationName.toLowerCase()) {
-          return driverClass;
-        }
+    // we don't necessarily have an `automationName` capability
+    let automationNameCap = caps.automationName;
+    if (!_.isString(automationNameCap)) {
+      const driverSelector = PLATFORMS_MAP[platformName];
+      if (driverSelector) {
+        automationNameCap = driverSelector(caps);
       }
     }
 
-    const driverSelector = PLATFORMS_MAP[platformName];
-    if (driverSelector) {
-      return driverSelector(caps);
+    try {
+      const {driverPackage, driverClassName} = DRIVER_MAP[automationNameCap];
+      const driver = require(driverPackage)[driverClassName];
+      return {
+        driver,
+        version: this.getDriverVersion(driver.name, driverPackage),
+      };
+    } catch (ign) {
+      // error will be reported below, and here would come out as an unclear
+      // problem with destructuring undefined
     }
 
     const msg = _.isString(caps.automationName)
@@ -213,12 +204,12 @@ class AppiumDriver extends BaseDriver {
     throw new Error(`${msg} Please check your desired capabilities.`);
   }
 
-  getDriverVersion (driver) {
-    const {version} = DRIVER_MAP[driver.name] || {};
+  getDriverVersion (driverName, driverPackage) {
+    const version = getPackageVersion(driverPackage);
     if (version) {
       return version;
     }
-    log.warn(`Unable to get version of driver '${driver.name}'`);
+    log.warn(`Unable to get version of driver '${driverName}'`);
   }
 
   async getStatus () { // eslint-disable-line require-await
@@ -230,16 +221,15 @@ class AppiumDriver extends BaseDriver {
   async getSessions () {
     const sessions = await sessionsListGuard.acquire(AppiumDriver.name, () => this.sessions);
     return _.toPairs(sessions)
-        .map(([id, driver]) => {
-          return {id, capabilities: driver.caps};
-        });
+      .map(([id, driver]) => {
+        return {id, capabilities: driver.caps};
+      });
   }
 
-  printNewSessionAnnouncement (driver, caps) {
-    const driverVersion = this.getDriverVersion(driver);
+  printNewSessionAnnouncement (caps, driverName, driverVersion) {
     const introString = driverVersion
-      ? `Creating new ${driver.name} (v${driverVersion}) session`
-      : `Creating new ${driver.name} session`;
+      ? `Appium v${APPIUM_VER} creating new ${driverName} (v${driverVersion}) session`
+      : `Appium v${APPIUM_VER} creating new ${driverName} session`;
     log.info(introString);
     log.info('Capabilities:');
     inspectObject(caps);
@@ -266,7 +256,7 @@ class AppiumDriver extends BaseDriver {
         defaultCapabilities
       );
 
-      let {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, error} = parsedCaps;
+      const {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities, error} = parsedCaps;
       protocol = parsedCaps.protocol;
 
       // If the parsing of the caps produced an error, throw it in here
@@ -274,8 +264,8 @@ class AppiumDriver extends BaseDriver {
         throw error;
       }
 
-      const InnerDriver = this.getDriverForCaps(desiredCaps);
-      this.printNewSessionAnnouncement(InnerDriver, desiredCaps);
+      const {driver: InnerDriver, version: driverVersion} = this.getDriverAndVersionForCaps(desiredCaps);
+      this.printNewSessionAnnouncement(desiredCaps, InnerDriver.name, driverVersion);
 
       if (this.args.sessionOverride) {
         const sessionIdsToDelete = await sessionsListGuard.acquire(AppiumDriver.name, () => _.keys(this.sessions));

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -32,47 +32,47 @@ const AUTOMATION_NAMES = {
   MAC: 'Mac',
 };
 const DRIVER_MAP = {
-  [AUTOMATION_NAMES.SELENDROID]: {
+  [AUTOMATION_NAMES.SELENDROID.toLowerCase()]: {
     driverClassName: 'SelendroidDriver',
     driverPackage: 'appium-selendroid-driver',
   },
-  [AUTOMATION_NAMES.UIAUTOMATOR2]: {
+  [AUTOMATION_NAMES.UIAUTOMATOR2.toLowerCase()]: {
     driverClassName: 'AndroidUiautomator2Driver',
     driverPackage: 'appium-uiautomator2-driver',
   },
-  [AUTOMATION_NAMES.XCUITEST]: {
+  [AUTOMATION_NAMES.XCUITEST.toLowerCase()]: {
     driverClassName: 'XCUITestDriver',
     driverPackage: 'appium-xcuitest-driver',
   },
-  [AUTOMATION_NAMES.YOUIENGINE]: {
+  [AUTOMATION_NAMES.YOUIENGINE.toLowerCase()]: {
     driverClassName: 'YouiEngineDriver',
     driverPackage: 'appium-youiengine-driver',
   },
-  [AUTOMATION_NAMES.FAKE]: {
+  [AUTOMATION_NAMES.FAKE.toLowerCase()]: {
     driverClassName: 'FakeDriver',
     driverPackage: 'appium-fake-driver',
   },
-  [AUTOMATION_NAMES.UIAUTOMATOR1]: {
+  [AUTOMATION_NAMES.UIAUTOMATOR1.toLowerCase()]: {
     driverClassName: 'AndroidDriver',
     driverPackage: 'appium-android-driver',
   },
-  [AUTOMATION_NAMES.INSTRUMENTS]: {
+  [AUTOMATION_NAMES.INSTRUMENTS.toLowerCase()]: {
     driverClassName: 'IosDriver',
     driverPackage: 'appium-ios-driver',
   },
-  [AUTOMATION_NAMES.WINDOWS]: {
+  [AUTOMATION_NAMES.WINDOWS.toLowerCase()]: {
     driverClassName: 'WindowsDriver',
     driverPackage: 'appium-windows-driver',
   },
-  [AUTOMATION_NAMES.MAC]: {
+  [AUTOMATION_NAMES.MAC.toLowerCase()]: {
     driverClassName: 'MacDriver',
     driverPackage: 'appium-mac-driver',
   },
-  [AUTOMATION_NAMES.ESPRESSO]: {
+  [AUTOMATION_NAMES.ESPRESSO.toLowerCase()]: {
     driverClassName: 'EspressoDriver',
     driverPackage: 'appium-espresso-driver',
   },
-  [AUTOMATION_NAMES.TIZEN]: {
+  [AUTOMATION_NAMES.TIZEN.toLowerCase()]: {
     driverClassName: 'TizenDriver',
     driverPackage: 'appium-package-driver',
   },
@@ -184,6 +184,7 @@ class AppiumDriver extends BaseDriver {
         automationNameCap = driverSelector(caps);
       }
     }
+    automationNameCap = automationNameCap.toLowerCase();
 
     try {
       const {driverPackage, driverClassName} = DRIVER_MAP[automationNameCap];

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -343,6 +343,27 @@ describe('AppiumDriver', function () {
         ({driver} = appium.getDriverAndVersionForCaps(caps));
         driver.should.equal(XCUITestDriver);
       });
+      it('should be able to handle different cases in automationName', function () {
+        const appium = new AppiumDriver({});
+        const caps = {
+          platformName: 'iOS',
+          platformVersion: '10',
+          automationName: 'XcUiTeSt',
+        };
+        let {driver} = appium.getDriverAndVersionForCaps(caps);
+        driver.should.be.an.instanceof(Function);
+        driver.should.equal(XCUITestDriver);
+      });
+      it('should be able to handle different case in platformName', function () {
+        const appium = new AppiumDriver({});
+        const caps = {
+          platformName: 'IoS',
+          platformVersion: '10',
+        };
+        let {driver} = appium.getDriverAndVersionForCaps(caps);
+        driver.should.be.an.instanceof(Function);
+        driver.should.equal(XCUITestDriver);
+      });
     });
   });
 });

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -20,12 +20,15 @@ const SESSION_ID = 1;
 describe('AppiumDriver', function () {
   describe('AppiumDriver', function () {
     function getDriverAndFakeDriver () {
-      let appium = new AppiumDriver({});
-      let fakeDriver = new FakeDriver();
-      let mockFakeDriver = sinon.mock(fakeDriver);
-      appium.getDriverForCaps = function (/*args*/) {
-        return function Driver () {
-          return fakeDriver;
+      const appium = new AppiumDriver({});
+      const fakeDriver = new FakeDriver();
+      const mockFakeDriver = sinon.mock(fakeDriver);
+      appium.getDriverAndVersionForCaps = function (/*args*/) {
+        return {
+          driver: function Driver () {
+            return fakeDriver;
+          },
+          version: '1.2.3',
         };
       };
       return [appium, mockFakeDriver];
@@ -274,14 +277,14 @@ describe('AppiumDriver', function () {
         _.keys(appium.sessions).should.contain(sessionId);
       });
     });
-    describe('getDriverForCaps', function () {
+    describe('getDriverAndVersionForCaps', function () {
       it('should not blow up if user does not provide platformName', function () {
-        let appium = new AppiumDriver({});
-        (() => { appium.getDriverForCaps({}); }).should.throw(/platformName/);
+        const appium = new AppiumDriver({});
+        (() => { appium.getDriverAndVersionForCaps({}); }).should.throw(/platformName/);
       });
       it('should get XCUITestDriver driver for automationName of XCUITest', function () {
-        let appium = new AppiumDriver({});
-        let driver = appium.getDriverForCaps({
+        const appium = new AppiumDriver({});
+        const {driver} = appium.getDriverAndVersionForCaps({
           platformName: 'iOS',
           automationName: 'XCUITest'
         });
@@ -289,55 +292,55 @@ describe('AppiumDriver', function () {
         driver.should.equal(XCUITestDriver);
       });
       it('should get iosdriver for ios < 10', function () {
-        let appium = new AppiumDriver({});
-        let caps = {
+        const appium = new AppiumDriver({});
+        const caps = {
           platformName: 'iOS',
           platformVersion: '8.0',
         };
-        let driver = appium.getDriverForCaps(caps);
+        let {driver} = appium.getDriverAndVersionForCaps(caps);
         driver.should.be.an.instanceof(Function);
         driver.should.equal(IosDriver);
 
         caps.platformVersion = '8.1';
-        driver = appium.getDriverForCaps(caps);
+        ({driver} = appium.getDriverAndVersionForCaps(caps));
         driver.should.equal(IosDriver);
 
         caps.platformVersion = '9.4';
-        driver = appium.getDriverForCaps(caps);
+        ({driver} = appium.getDriverAndVersionForCaps(caps));
         driver.should.equal(IosDriver);
 
         caps.platformVersion = '';
-        driver = appium.getDriverForCaps(caps);
+        ({driver} = appium.getDriverAndVersionForCaps(caps));
         driver.should.equal(IosDriver);
 
         caps.platformVersion = 'foo';
-        driver = appium.getDriverForCaps(caps);
+        ({driver} = appium.getDriverAndVersionForCaps(caps));
         driver.should.equal(IosDriver);
 
         delete caps.platformVersion;
-        driver = appium.getDriverForCaps(caps);
+        ({driver} = appium.getDriverAndVersionForCaps(caps));
         driver.should.equal(IosDriver);
       });
       it('should get xcuitestdriver for ios >= 10', function () {
-        let appium = new AppiumDriver({});
-        let caps = {
+        const appium = new AppiumDriver({});
+        const caps = {
           platformName: 'iOS',
           platformVersion: '10',
         };
-        let driver = appium.getDriverForCaps(caps);
+        let {driver} = appium.getDriverAndVersionForCaps(caps);
         driver.should.be.an.instanceof(Function);
         driver.should.equal(XCUITestDriver);
 
         caps.platformVersion = '10.0';
-        driver = appium.getDriverForCaps(caps);
+        ({driver} = appium.getDriverAndVersionForCaps(caps));
         driver.should.equal(XCUITestDriver);
 
         caps.platformVersion = '10.1';
-        driver = appium.getDriverForCaps(caps);
+        ({driver} = appium.getDriverAndVersionForCaps(caps));
         driver.should.equal(XCUITestDriver);
 
         caps.platformVersion = '12.14';
-        driver = appium.getDriverForCaps(caps);
+        ({driver} = appium.getDriverAndVersionForCaps(caps));
         driver.should.equal(XCUITestDriver);
       });
     });


### PR DESCRIPTION
## Proposed changes

I do not have time to go in depth into #11067, and I especially think the structure of the driver definitions needs to be discussed a lot more. This is work that should be included in the [Appium 2.0](https://github.com/appium/appium/issues/7175) efforts.

However, there is a lot of value in _not_ having all the drivers imported at load time. This decreases the memory footprint, for one thing, as well as load time. It also means that we aren't loading drivers we do not control, by default.

For instance, using Node 11 (so `Buffer()` is deprecated) Appium will print a deprecation warning, because the published version of [appium-sbd](https://github.com/Samsung/appium-sdb), a dependency of [appium-tizen-driver](https://github.com/Samsung/appium-tizen-driver), which is out of our control, uses an older version of [source-map-support](https://www.npmjs.com/package/source-map-support), and Node loads it instead of the version the `AppiumDriver` includes.

Who knows where else this is happening.

**This PR**
1. Removes the static imports and moves to `require`-ing the drivers as they are requested.
1. Changes the `DRIVER_MAP` to use `automationName` as the keys, so we can just get the driver rather than cycling through to find the correct one.
1. Only gets the version of the driver when necessary.
1. Puts the Appium version into the driver version log line.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
