### PR TITLE
Update Execute Mobile Command docs

### DIFF
--- a/commands-yml/commands/mobile-command.yml
+++ b/commands-yml/commands/mobile-command.yml
@@ -46,7 +46,7 @@
       | mobile:installCertificate | refer to [IOS Pasteboard Guide](/docs/en/writing-running-appium/ios/ios-xctest-install-certificate.md)  | | |
       | mobile:getContexts | Retrieve available contexts, along with the url and title associated with each webview (see [get contexts](/docs/en/commands/context/get-contexts.md)) | | |
       | mobile:batteryInfo | Reads the battery information from the device under test | <none> | <none> |
-      | mobile:pressButton | Press a physical button. The supported button name is is _home_. _volumeup_ and _volumedown_ are available for real devices | `{name}` | `{name: "home"}` |
+      | mobile:pressButton | Press a physical button. The supported buttons are: _home_, _volumeup_ and _volumedown_. | `{name}` | `{name: "home"}` |
       | mobile:enrollBiometric | Enroll (or unenroll) an iOS Simulator to use [biometrics](https://developer.apple.com/design/human-interface-guidelines/ios/user-interaction/authentication/#face-id-and-touch-id) | `{isEnabled}` | `{isEnabled: true}` |
       | mobile:sendBiometricMatch | Send a matching or non-matching biometric input to an iOS Simulator. 'type' must be `touchId` or `faceId`. Match is a boolean indicating if it's a matching or non-matching input | `{type, match}` | `{type: "touchId", match: true}` |
       | mobile:isBiometricEnrolled | Check if an iOS Simulator is enrolled or not. Returns `true` if enrolled, `false` if not enrolled. |||

--- a/commands-yml/commands/mobile-command.yml
+++ b/commands-yml/commands/mobile-command.yml
@@ -46,7 +46,7 @@
       | mobile:installCertificate | refer to [IOS Pasteboard Guide](/docs/en/writing-running-appium/ios/ios-xctest-install-certificate.md)  | | |
       | mobile:getContexts | Retrieve available contexts, along with the url and title associated with each webview (see [get contexts](/docs/en/commands/context/get-contexts.md)) | | |
       | mobile:batteryInfo | Reads the battery information from the device under test | <none> | <none> |
-      | mobile:pressButton | Press a physical button. The supported buttons are: _home_, _volumeup_ and _volumedown_. | `{name}` | `{name: "home"}` |
+      | mobile:pressButton | Press a physical button. The available button options are: _home_, _volumeup_ and _volumedown_. Real devices support all three buttons whereas simulator only supports _home_. | `{name}` | `{name: "home"}` |
       | mobile:enrollBiometric | Enroll (or unenroll) an iOS Simulator to use [biometrics](https://developer.apple.com/design/human-interface-guidelines/ios/user-interaction/authentication/#face-id-and-touch-id) | `{isEnabled}` | `{isEnabled: true}` |
       | mobile:sendBiometricMatch | Send a matching or non-matching biometric input to an iOS Simulator. 'type' must be `touchId` or `faceId`. Match is a boolean indicating if it's a matching or non-matching input | `{type, match}` | `{type: "touchId", match: true}` |
       | mobile:isBiometricEnrolled | Check if an iOS Simulator is enrolled or not. Returns `true` if enrolled, `false` if not enrolled. |||


### PR DESCRIPTION
mobile:pressButton on iOS real device supports values: home, volumeup and volumedown