### PR TITLE
add W3C link in touch actions doc

### DIFF
--- a/docs/en/writing-running-appium/touch-actions.md
+++ b/docs/en/writing-running-appium/touch-actions.md
@@ -15,9 +15,9 @@ of using this API.
 
 **Note for W3C actions**
 
-[W3C actions](https://www.w3.org/TR/webdriver1/#actions) is also parcially available in some drivers such as XCUITest, UIA2 and Espresso.
-We've implemented W3C actions as possible, but OSs has limitations to behave full W3C compatible actions.
-e.g. WDA cannot handle zero wait [PR](https://github.com/appium/appium-xcuitest-driver/pull/753). Additional actions in [espresso](https://github.com/appium/appium-espresso-driver/issues/272).
+[W3C actions](https://www.w3.org/TR/webdriver1/#actions) is also available in some drivers such as XCUITest, UIA2, Espresso and Windows.
+W3C actions are implemented to the best of the limitations of the operating systems' test frameworks.
+e.g. WDA cannot handle zero wait [PR](https://github.com/appium/appium-xcuitest-driver/pull/753).
 
 [API doc](http://appium.io/docs/en/commands/interactions/actions/) and API docs of each client help to understand how to call them.
 

--- a/docs/en/writing-running-appium/touch-actions.md
+++ b/docs/en/writing-running-appium/touch-actions.md
@@ -13,6 +13,10 @@ These APIs allow you to build up arbitrary gestures with multiple actuators.
 Please see the Appium client docs for your language in order to find examples
 of using this API.
 
+**Note for W3C actions**
+
+[W3C actions](https://www.w3.org/TR/webdriver1/#actions) is also available in some drivers such as XCUITest, UIA2 and Espresso. [API doc](http://appium.io/docs/en/commands/interactions/actions/) and API docs of each binding help to understand how to call them.
+
 ### An Overview of the TouchAction / MultiAction API
 
 ### TouchAction

--- a/docs/en/writing-running-appium/touch-actions.md
+++ b/docs/en/writing-running-appium/touch-actions.md
@@ -15,7 +15,11 @@ of using this API.
 
 **Note for W3C actions**
 
-[W3C actions](https://www.w3.org/TR/webdriver1/#actions) is also available in some drivers such as XCUITest, UIA2 and Espresso. [API doc](http://appium.io/docs/en/commands/interactions/actions/) and API docs of each binding help to understand how to call them.
+[W3C actions](https://www.w3.org/TR/webdriver1/#actions) is also parcially available in some drivers such as XCUITest, UIA2 and Espresso.
+We've implemented W3C actions as possible, but OSs has limitations to behave full W3C compatible actions.
+e.g. WDA cannot handle zero wait [PR](https://github.com/appium/appium-xcuitest-driver/pull/753). Additional actions in [espresso](https://github.com/appium/appium-espresso-driver/issues/272).
+
+[API doc](http://appium.io/docs/en/commands/interactions/actions/) and API docs of each client help to understand how to call them.
 
 ### An Overview of the TouchAction / MultiAction API
 
@@ -183,8 +187,8 @@ $driver->executeScript("mobile: scroll", $params);
 
 **Swiping**
 
-This is an XCUITest driver specific method that is similar to scrolling (for reference, see 
-https://developer.apple.com/reference/xctest/xcuielement). 
+This is an XCUITest driver specific method that is similar to scrolling (for reference, see
+https://developer.apple.com/reference/xctest/xcuielement).
 
 This method has the same API as [Scrolling](#scrolling), just replace "mobile: scroll"
 with "mobile: swipe"


### PR DESCRIPTION
## Proposed changes

It's good to set a link to W3C actions in touch actions doc. It helps users to notice the command.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
