### PR TITLE
Add prepublish script to prune devDependencies from shrinkwrap

### DIFF
--- a/docs/en/contributing-to-appium/developers-overview.md
+++ b/docs/en/contributing-to-appium/developers-overview.md
@@ -195,7 +195,7 @@ converted into the `npm-shrinkwrap.json` file.
 1. Determine whether we have a `patch` (bugfix), `minor` (feature), or `major` (breaking) release according to the principles of SemVer.
 1. Update `package.json` with the appropriate new version.
 1. Update the CHANGELOG/README with appropriate changes and submit for review as a PR, along with shrinkwrap and `package.json` changes. Wait for it to be merged, then pull it into the release branch.
-1. Run `npm run shrinkwrap:prod`. This script removes `node_modules`, installs node production dependencies, creates `npm-shrinkwrap.json` (which only shrinkwrap prod dependencies) and then re-installs the dev dependencies by doing `npm install --no-shrinkwrap`.
+1. Run `npm shrinkwrap` to generate the `npm-shrinkwrap.json`
 1. Create a tag of the form `v<version>` on the release branch (usually a minor branch like `1.5` or `1.4`), with: `git tag -a v<version>`, e.g., `git tag -a v1.5.0`. This is not necessary for beta versions.
 1. Push the tag to upstream: `git push --tags <remote> <branch>`
 1. Run `npm publish` (with `--tag beta` if this isn't an official release).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,7 @@ gulp.task('fixShrinkwrap', function (done) {
               `(Original error: ${err.message})`);
     return done();
   }
-  
+
   delete shrinkwrap.dependencies.fsevents;
   const shrinkwrapString = JSON.stringify(shrinkwrap, null, '  ') + '\n';
   fs.writeFile('./npm-shrinkwrap.json', shrinkwrapString, done);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,8 +12,6 @@ const path = require('path');
 const fs = require('fs');
 const log = require('fancy-log');
 
-require('./ci/gulp');
-
 // remove 'fsevents' from shrinkwrap, since it causes errors on non-Mac hosts
 // see https://github.com/npm/npm/issues/2679
 
@@ -26,9 +24,7 @@ gulp.task('fixShrinkwrap', function (done) {
               `(Original error: ${err.message})`);
     return done();
   }
-
-// remove 'fsevents' from shrinkwrap, since it causes errors on non-Mac hosts
-// see https://github.com/npm/npm/issues/2679
+  
   delete shrinkwrap.dependencies.fsevents;
   const shrinkwrapString = JSON.stringify(shrinkwrap, null, '  ') + '\n';
   fs.writeFile('./npm-shrinkwrap.json', shrinkwrapString, done);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,9 +12,11 @@ const path = require('path');
 const fs = require('fs');
 const log = require('fancy-log');
 
+require('./ci/gulp');
 
 // remove 'fsevents' from shrinkwrap, since it causes errors on non-Mac hosts
 // see https://github.com/npm/npm/issues/2679
+
 gulp.task('fixShrinkwrap', function (done) {
   let shrinkwrap;
   try {
@@ -24,6 +26,9 @@ gulp.task('fixShrinkwrap', function (done) {
               `(Original error: ${err.message})`);
     return done();
   }
+
+// remove 'fsevents' from shrinkwrap, since it causes errors on non-Mac hosts
+// see https://github.com/npm/npm/issues/2679
   delete shrinkwrap.dependencies.fsevents;
   const shrinkwrapString = JSON.stringify(shrinkwrap, null, '  ') + '\n';
   fs.writeFile('./npm-shrinkwrap.json', shrinkwrapString, done);
@@ -42,7 +47,6 @@ boilerplate({
   test: {
     files: ['${testDir}/**/*-specs.js']
   },
-  extraPrepublishTasks: ['fixShrinkwrap'],
   preCommitTasks: ['eslint', 'once'],
 });
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "firefoxos",
     "testing"
   ],
-  "version": "1.11.0-beta.3",
+  "version": "1.11.1",
   "author": "https://github.com/appium",
   "license": "Apache-2.0",
   "repository": {
@@ -74,8 +74,11 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepare": "gulp prepublish",
-    "publish": "gulp prepublish",
+    "prepublish": "gulp prepublish",
+    "prepublishOnly": "npm run prune-shrinkwrap && gulp fixShrinkwrap",
+    "postpublish": "npm run restore-shrinkwrap",
+    "prune-shrinkwrap": "npm ci --production --ignore-scripts && npm shrinkwrap && npm install --only=dev --no-shrinkwrap",
+    "restore-shrinkwrap": "git checkout HEAD -- npm-shrinkwrap.json",
     "test": "gulp once",
     "e2e-test": "gulp e2e-test",
     "watch": "gulp watch",
@@ -87,7 +90,6 @@
     "lint:fix": "gulp eslint --fix",
     "coverage": "gulp coveralls",
     "generate-docs": "node ./build/commands-yml/parse.js",
-    "shrinkwrap:prod": "rimraf package-lock.json && rimraf node_modules && npm install --production && npm shrinkwrap && node ./check-npm-pack-files && npm install --no-shrinkwrap",
     "zip": "zip -qr appium.zip .",
     "upload": "gulp github-upload",
     "zip-and-upload": "npm run zip && npm run upload",


### PR DESCRIPTION
Currently, we use a 'production-only' npm shrinkwrap on our release branches. The problem with this is that when you try running `npm ci` (clean install) it won't work because there's an incongruency between what's in `npm-shrinkwrap.json` and what's in `package.json` (it expects the dev deps to be there). 

I'd like to be able to use `npm ci` because it installs what's in the shrinkwrap (`npm install` doesn't respect shrinkwrap) and thus we can test Appium locally using the dependencies that will be shrinkwrapped and published.

The fix for this is a `prepublishOnly` script and a `publish` (postpublish) script

This `prepublishOnly` script runs the following commands:

```
npm ci --production --ignore-scripts // Clean install production dependencies found in npm-shrinkwrap.json
npm shrinkwrap // re-create the npm-shrinkwrap.json with only prod dependencies
npm install --only=dev --no-shrinkwrap // re-install dev dependencies; don't alter shrinkwrap
```

The `publish` script runs `git checkout HEAD -- npm-shrinkwrap.json` which restores the `npm-shrinkwrap.json` to what it was before the prepublish script.

When a publish happens, it will then only ever publish an `npm-shrinkwrap.json` that has prod dependencies (which is desirable). But, we can now start committing `npm-shrinkwrap.json` on release branches to include dev _and_ prod dependencies so that we don't have the `npm ci` problems.

(NOTE: the documentation for our new release flow is forthcoming)