### PR TITLE
Update parallel-tests.md with warning about Jenkins ProcessTreeKiller

### DIFF
--- a/docs/en/advanced-concepts/parallel-tests.md
+++ b/docs/en/advanced-concepts/parallel-tests.md
@@ -35,3 +35,10 @@ Refer: https://github.com/appium/appium/issues/9209
 - `udid` the device id
 - `wdaLocalPort` unique wdaPort, as WDA defaults to 8100
 - `webkitDebugProxyPort` unique webKitProxy, as IWDP defaults to 27753
+
+### Troubleshooting
+
+When running on Jenkins, watch out for the [ProcessTreeKiller](https://wiki.jenkins.io/display/JENKINS/ProcessTreeKiller) when running multiple parallel test jobs on the same machine. If you are spawning simulators in one test job, Jenkins might kill all your simulators when the first test ends - causing errors in the remaining test jobs!
+
+Use `BUILD_ID=dontKillMe` to prevent this from happening.
+


### PR DESCRIPTION
## Proposed changes

Add a warning about Jenkins ProcessTreeKiller. I banged my head on this for a few days so I thought a few lines might help people in the future. 

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The issue happens because jenkins indiscriminately kills all simulator processes when one test run ends, so if you have separate jenkins jobs running on your machine then the first test that ends will also cause all your simulators to die as well.
