### PR TITLE
address executable permission for bundletool.jar

### DIFF
--- a/docs/en/writing-running-appium/android/android-appbundle.md
+++ b/docs/en/writing-running-appium/android/android-appbundle.md
@@ -13,7 +13,7 @@ We can get distributed apk files from the `.aab` file via the CLI. Using the gen
     - The `.aab` is available over Android Studio 3.2
     - You must sign correctly when you generate `.apks` from `.aab`. This step requires data signing.
         ```bash
-        $ java -jar apks/bundletool-all-0.6.0.jar build-apks \
+        $ java -jar apks/bundletool.jar build-apks \
           --bundle apks/release/release/app.aab \ # A generated aab file
           --output apks/AppBundleSample.apks \    # An apks file you'd like to out put to
           --ks apks/sign \                        # Signing keystore
@@ -40,6 +40,10 @@ We can get distributed apk files from the `.aab` file via the CLI. Using the gen
 You can find another way to get test APKs in https://developer.android.com/guide/app-bundle/
 
 ## Tips
+### Make `bundletool.jar` executable
+
+Make sure the bundletool is executable.
+`$ chmod 655 /path/to/bundletool.jar` can make it executable, for example.
 
 ### Test with different languages
 


### PR DESCRIPTION
## Proposed changes

node `which` module can find the `bundletool.jar` if it is executable.
Thus, would like to add the permission in the doc

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
