### PR TITLE
Allow 'appium' automationName and particular platformName

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -178,7 +178,7 @@ class AppiumDriver extends BaseDriver {
 
     // we don't necessarily have an `automationName` capability
     let automationNameCap = caps.automationName;
-    if (!_.isString(automationNameCap)) {
+    if (!_.isString(automationNameCap) || automationNameCap.toLowerCase() === 'appium') {
       const driverSelector = PLATFORMS_MAP[platformName];
       if (driverSelector) {
         automationNameCap = driverSelector(caps);

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -9,6 +9,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { XCUITestDriver } from 'appium-xcuitest-driver';
 import { IosDriver } from 'appium-ios-driver';
+import { AndroidDriver } from 'appium-android-driver';
 import { sleep } from 'asyncbox';
 import { insertAppiumPrefixes } from '../lib/utils';
 
@@ -281,6 +282,15 @@ describe('AppiumDriver', function () {
       it('should not blow up if user does not provide platformName', function () {
         const appium = new AppiumDriver({});
         (() => { appium.getDriverAndVersionForCaps({}); }).should.throw(/platformName/);
+      });
+      it('should ignore automationName Appium', function () {
+        const appium = new AppiumDriver({});
+        const {driver} = appium.getDriverAndVersionForCaps({
+          platformName: 'Android',
+          automationName: 'Appium'
+        });
+        driver.should.be.an.instanceof(Function);
+        driver.should.equal(AndroidDriver);
       });
       it('should get XCUITestDriver driver for automationName of XCUITest', function () {
         const appium = new AppiumDriver({});


### PR DESCRIPTION
## Proposed changes

If a test specifies `automationName = 'appium'` and a particular `platformName`, Appium will get confused and error (see #12408).

This PR allows the `automationName` but still goes through the mapping for `platformName`.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

