### PR TITLE
Add a possibility to parse initial values for Appium settings from capabilities

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -254,7 +254,13 @@ class AppiumDriver extends BaseDriver {
     jsonwpCaps = _.cloneDeep(jsonwpCaps);
     const jwpSettings = Object.assign({}, defaultSettings, pullSettings(jsonwpCaps));
     w3cCapabilities = _.cloneDeep(w3cCapabilities);
-    const w3cSettings = Object.assign({}, jwpSettings, pullSettings(w3cCapabilities));
+    const allW3cCaps = Object.assign({},
+      (w3cCapabilities || {}).alwaysMatch || {},
+      ((w3cCapabilities || {}).firstMatch || [])
+        .filter((x) => _.isPlainObject(x))
+        .reduce((acc, x) => Object.assign(acc, x), {})
+    );
+    const w3cSettings = Object.assign({}, jwpSettings, pullSettings(allW3cCaps));
 
     let protocol;
     let innerSessionId, dCaps;

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -248,12 +248,15 @@ class AppiumDriver extends BaseDriver {
    * @return {Array} Unique session ID and capabilities
    */
   async createSession (jsonwpCaps, reqCaps, w3cCapabilities) {
-    let {defaultCapabilities} = this.args;
-    defaultCapabilities = _.cloneDeep(defaultCapabilities);
+    const defaultCapabilities = _.cloneDeep(this.args.defaultCapabilities);
     const defaultSettings = pullSettings(defaultCapabilities);
     jsonwpCaps = _.cloneDeep(jsonwpCaps);
     const jwpSettings = Object.assign({}, defaultSettings, pullSettings(jsonwpCaps));
     w3cCapabilities = _.cloneDeep(w3cCapabilities);
+    // It is possible that the client only provides caps using JSONWP standard,
+    // although firstMatch/alwaysMatch properties are still present.
+    // In such case we assume the client understands W3C protocol and merge the given
+    // JSONWP caps to W3C caps
     const w3cSettings = Object.assign({}, jwpSettings);
     Object.assign(w3cSettings, pullSettings((w3cCapabilities || {}).alwaysMatch || {}));
     for (const firstMatchEntry of ((w3cCapabilities || {}).firstMatch || [])) {

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -4,7 +4,9 @@ import { getBuildInfo, updateBuildInfo, APPIUM_VER } from './config';
 import { BaseDriver, errors, isSessionCommand } from 'appium-base-driver';
 import B from 'bluebird';
 import AsyncLock from 'async-lock';
-import { inspectObject, parseCapsForInnerDriver, getPackageVersion } from './utils';
+import {
+  inspectObject, parseCapsForInnerDriver, getPackageVersion,
+  pullSettings } from './utils';
 import semver from 'semver';
 
 
@@ -246,10 +248,16 @@ class AppiumDriver extends BaseDriver {
    * @return {Array} Unique session ID and capabilities
    */
   async createSession (jsonwpCaps, reqCaps, w3cCapabilities) {
-    const {defaultCapabilities} = this.args;
+    let {defaultCapabilities} = this.args;
+    defaultCapabilities = _.cloneDeep(defaultCapabilities);
+    const defaultSettings = pullSettings(defaultCapabilities);
+    jsonwpCaps = _.cloneDeep(jsonwpCaps);
+    const jwpSettings = Object.assign({}, defaultSettings, pullSettings(jsonwpCaps));
+    w3cCapabilities = _.cloneDeep(w3cCapabilities);
+    const w3cSettings = Object.assign({}, jwpSettings, pullSettings(w3cCapabilities));
+
     let protocol;
     let innerSessionId, dCaps;
-
     try {
       // Parse the caps into a format that the InnerDriver will accept
       const parsedCaps = parseCapsForInnerDriver(
@@ -321,12 +329,22 @@ class AppiumDriver extends BaseDriver {
       // unexpectedly shuts down
       this.attachUnexpectedShutdownHandler(d, innerSessionId);
 
-
       log.info(`New ${InnerDriver.name} session created successfully, session ` +
               `${innerSessionId} added to master session list`);
 
       // set the New Command Timeout for the inner driver
       d.startNewCommandTimeout();
+
+      // apply initial values to Appium settings (if provided)
+      if (d.isW3CProtocol() && !_.isEmpty(w3cSettings)) {
+        log.info(`Applying the initial values to Appium settings parsed from W3C caps: ` +
+          JSON.stringify(w3cSettings));
+        await d.updateSettings(w3cSettings);
+      } else if (d.isMjsonwpProtocol() && !_.isEmpty(jwpSettings)) {
+        log.info(`Applying the initial values to Appium settings parsed from MJSONWP caps: ` +
+          JSON.stringify(jwpSettings));
+        await d.updateSettings(jwpSettings);
+      }
     } catch (error) {
       return {
         protocol,

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -254,13 +254,12 @@ class AppiumDriver extends BaseDriver {
     jsonwpCaps = _.cloneDeep(jsonwpCaps);
     const jwpSettings = Object.assign({}, defaultSettings, pullSettings(jsonwpCaps));
     w3cCapabilities = _.cloneDeep(w3cCapabilities);
-    const allW3cCaps = Object.assign({},
-      (w3cCapabilities || {}).alwaysMatch || {},
-      ((w3cCapabilities || {}).firstMatch || [])
-        .filter((x) => _.isPlainObject(x))
-        .reduce((acc, x) => Object.assign(acc, x), {})
-    );
-    const w3cSettings = Object.assign({}, jwpSettings, pullSettings(allW3cCaps));
+    const w3cSettings = Object.assign({}, jwpSettings);
+    Object.assign(w3cSettings, pullSettings((w3cCapabilities || {}).alwaysMatch || {}));
+    const firstMatchEntries = ((w3cCapabilities || {}).firstMatch || []).filter((x) => _.isPlainObject(x));
+    for (const firstMatchEntry of firstMatchEntries) {
+      Object.assign(w3cSettings, pullSettings(firstMatchEntry));
+    }
 
     let protocol;
     let innerSessionId, dCaps;

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -256,8 +256,7 @@ class AppiumDriver extends BaseDriver {
     w3cCapabilities = _.cloneDeep(w3cCapabilities);
     const w3cSettings = Object.assign({}, jwpSettings);
     Object.assign(w3cSettings, pullSettings((w3cCapabilities || {}).alwaysMatch || {}));
-    const firstMatchEntries = ((w3cCapabilities || {}).firstMatch || []).filter((x) => _.isPlainObject(x));
-    for (const firstMatchEntry of firstMatchEntries) {
+    for (const firstMatchEntry of ((w3cCapabilities || {}).firstMatch || [])) {
       Object.assign(w3cSettings, pullSettings(firstMatchEntry));
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -257,6 +257,9 @@ function getPackageVersion (pkgName) {
  * `setting[setting_name]: setting_value`
  * The capabilities argument itself gets mutated, so it does not contain parsed
  * settings anymore to avoid further parsing issues.
+ * Check
+ * https://github.com/appium/appium/blob/master/docs/en/advanced-concepts/settings.md
+ * for more details on the available settings.
  *
  * @param {?Object} caps - Capabilities dictionary. It is mutated if
  * one or more settings have been pulled from it
@@ -273,9 +276,6 @@ function pullSettings (caps) {
   for (const [key, value] of _.toPairs(caps)) {
     const match = /\bsettings\[(\S+)\]$/.exec(key);
     if (!match) {
-      if (_.isPlainObject(value)) {
-        Object.assign(result, pullSettings(value));
-      }
       continue;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -251,9 +251,43 @@ function getPackageVersion (pkgName) {
   return pkgInfo.version;
 }
 
+/**
+ * Pulls the initial values of Appium settings from the given capabilities argument.
+ * Each setting item must satisfy the following format:
+ * `setting[setting_name]: setting_value`
+ * The capabilities argument itself gets mutated, so it does not contain parsed
+ * settings anymore to avoid further parsing issues.
+ *
+ * @param {?Object} caps - Capabilities dictionary. It is mutated if
+ * one or more settings have been pulled from it
+ * @returns {Object} - An empty dictionary if the given caps contains no
+ * setting items or a dictionary containing parsed Appium setting names along with
+ * their values.
+ */
+function pullSettings (caps) {
+  if (!_.isPlainObject(caps) || _.isEmpty(caps)) {
+    return {};
+  }
+
+  const result = {};
+  for (const [key, value] of _.toPairs(caps)) {
+    const match = /\bsettings\[(\S+)\]$/.exec(key);
+    if (!match) {
+      if (_.isPlainObject(value)) {
+        Object.assign(result, pullSettings(value));
+      }
+      continue;
+    }
+
+    result[match[1]] = value;
+    delete caps[key];
+  }
+  return result;
+}
+
 const rootDir = findRoot(__dirname);
 
 export {
   inspectObject, parseCapsForInnerDriver, insertAppiumPrefixes, rootDir,
-  getPackageVersion,
+  getPackageVersion, pullSettings,
 };

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -198,25 +198,19 @@ describe('utils', function () {
         browserName: 'bar',
       });
     });
-    it('should pull settings recursively from caps', function () {
+    it('should pull settings dict if object values are present in caps', function () {
       const caps = {
-        firstMatch: {
-          platformName: 'foo',
-          browserName: 'bar',
-          'settings[settingName]': 'baz',
-          'appium:settings[settingName2]': 'baz2',
-        }
+        platformName: 'foo',
+        browserName: 'bar',
+        'settings[settingName]': {key: 'baz'},
       };
       const settings = pullSettings(caps);
       settings.should.eql({
-        settingName: 'baz',
-        settingName2: 'baz2',
+        settingName: {key: 'baz'},
       });
       caps.should.eql({
-        firstMatch: {
-          platformName: 'foo',
-          browserName: 'bar',
-        }
+        platformName: 'foo',
+        browserName: 'bar',
       });
     });
     it('should pull empty dict if no settings are present in caps', function () {

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -1,6 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { parseCapsForInnerDriver, insertAppiumPrefixes } from '../lib/utils';
+import {
+  parseCapsForInnerDriver, insertAppiumPrefixes, pullSettings } from '../lib/utils';
 import { BASE_CAPS, W3C_CAPS } from './helpers';
 import _ from 'lodash';
 
@@ -176,6 +177,67 @@ describe('utils', function () {
         'appium:someOtherCap': 'someOtherCap',
         'appium:yetAnotherCap': 'yetAnotherCap',
       });
+    });
+  });
+
+  describe('pullSettings()', function () {
+    it('should pull settings from caps', function () {
+      const caps = {
+        platformName: 'foo',
+        browserName: 'bar',
+        'settings[settingName]': 'baz',
+        'settings[settingName2]': 'baz2',
+      };
+      const settings = pullSettings(caps);
+      settings.should.eql({
+        settingName: 'baz',
+        settingName2: 'baz2',
+      });
+      caps.should.eql({
+        platformName: 'foo',
+        browserName: 'bar',
+      });
+    });
+    it('should pull settings recursively from caps', function () {
+      const caps = {
+        firstMatch: {
+          platformName: 'foo',
+          browserName: 'bar',
+          'settings[settingName]': 'baz',
+          'appium:settings[settingName2]': 'baz2',
+        }
+      };
+      const settings = pullSettings(caps);
+      settings.should.eql({
+        settingName: 'baz',
+        settingName2: 'baz2',
+      });
+      caps.should.eql({
+        firstMatch: {
+          platformName: 'foo',
+          browserName: 'bar',
+        }
+      });
+    });
+    it('should pull empty dict if no settings are present in caps', function () {
+      const caps = {
+        platformName: 'foo',
+        browserName: 'bar',
+        'setting[settingName]': 'baz',
+      };
+      const settings = pullSettings(caps);
+      settings.should.eql({});
+      caps.should.eql({
+        platformName: 'foo',
+        browserName: 'bar',
+        'setting[settingName]': 'baz',
+      });
+    });
+    it('should pull empty dict if caps are empty', function () {
+      const caps = {};
+      const settings = pullSettings(caps);
+      settings.should.eql({});
+      caps.should.eql({});
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

It is sometimes necessary to set some particular appium setting per session. This feature will allow to pass default Appium settings values in capabilities, for example

```
{
        platformName: 'foo',
        browserName: 'bar',
        'settings[settingName]': 'baz',
        'settings[settingName2]': 'baz2',
}
```

so there is no need to separately call `updateSettings` API after the session is created.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
