### PR TITLE
add deviceType for tvOS support instead of adding a new platform name

### DIFF
--- a/docs/en/drivers/ios-xcuitest.md
+++ b/docs/en/drivers/ios-xcuitest.md
@@ -46,7 +46,7 @@ the value `XCUITest`. Of course, you must also include appropriate
 `platformName`, `platformVersion`, `deviceName`, and `app` capabilities, at
 a minimum.
 
-The `platformName` should be `iOS` for iPhone or iPad. tvOS devices are available if the `platformName` is `tvOS`.
+The `platformName` should be `iOS` for iPhone or iPad. `deviceType` should be `tv` for tvOS.
 
 - iOS
    ```json
@@ -62,9 +62,10 @@ The `platformName` should be `iOS` for iPhone or iPad. tvOS devices are availabl
    ```json
    {
       "automationName": "XCUITest",
-      "platformName": "tvOS",
+      "platformName": "iOS",
       "platformVersion": "12.2",
       "deviceName": "Apple TV",
+      "deviceType": "tv"
       ...
    }
    ```

--- a/docs/en/writing-running-appium/ios/ios-tvos.md
+++ b/docs/en/writing-running-appium/ios/ios-tvos.md
@@ -4,17 +4,17 @@ Appium 1.13.0+ has tvOS support via XCUITest driver.
 
 ## Setup
 
-You can run tests for tvOS by changing the `platformName` capability like it is done below.
+You can run tests for tvOS by adding devic type as  `tv` capability like it is done below.
 
 ```json
 {
     "automationName": "XCUITest",
-    "platformName": "tvOS",
+    "platformName": "iOS",
     "platformVersion": "12.2",
     "deviceName": "Apple TV",
+    "deviceType": "tv",
     ...
 }
-```
 
 ## Limitations
 Gesture commands do not work for tvOS. Some commands such as pasteboard do not work as well.

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -14,7 +14,6 @@ const PLATFORMS = {
   FAKE: 'fake',
   ANDROID: 'android',
   IOS: 'ios',
-  APPLE_TVOS: 'tvos',
   WINDOWS: 'windows',
   MAC: 'mac',
   TIZEN: 'tizen',
@@ -108,9 +107,13 @@ const PLATFORMS_MAP = {
       return AUTOMATION_NAMES.XCUITEST;
     }
 
+    if (caps.deviceType && caps.deviceType.toLowerCase() === 'tv') {
+      log.info(`tvOS requires '${AUTOMATION_NAMES.XCUITEST}'`);
+      return AUTOMATION_NAMES.XCUITEST;
+    }
+
     return AUTOMATION_NAMES.INSTRUMENTS;
   },
-  [PLATFORMS.APPLE_TVOS]: () => AUTOMATION_NAMES.XCUITEST,
   [PLATFORMS.WINDOWS]: () => AUTOMATION_NAMES.WINDOWS,
   [PLATFORMS.MAC]: () => AUTOMATION_NAMES.MAC,
   [PLATFORMS.TIZEN]: () => AUTOMATION_NAMES.TIZEN,

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -107,11 +107,6 @@ const PLATFORMS_MAP = {
       return AUTOMATION_NAMES.XCUITEST;
     }
 
-    if (caps.deviceType && caps.deviceType.toLowerCase() === 'tv') {
-      log.info(`tvOS requires '${AUTOMATION_NAMES.XCUITEST}'`);
-      return AUTOMATION_NAMES.XCUITEST;
-    }
-
     return AUTOMATION_NAMES.INSTRUMENTS;
   },
   [PLATFORMS.WINDOWS]: () => AUTOMATION_NAMES.WINDOWS,


### PR DESCRIPTION
## Proposed changes

I've introduced tvOS in https://github.com/appium/appium/pull/12401/files
after a while, I considered adding `deviceType` was better than adding new platform since the tv was kind of new device/product in iOS(Apple) platform.

If we start considering such deviceType, we probably can think device variations such as watch, tv etc even if they are Android/iOS/Windows etc platform.


Will update xcuitest-driver and bump the version in package.json in this repository

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
