### PR TITLE
Add deprecation warning for Android

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -9,6 +9,7 @@ import {
   pullSettings } from './utils';
 import semver from 'semver';
 import wrap from 'word-wrap';
+import { EOL } from 'os';
 
 
 const PLATFORMS = {
@@ -100,11 +101,11 @@ const PLATFORMS_MAP = {
       `For more information about drivers, please visit http://appium.io/docs/en/about-appium/intro/ and explore the 'Drivers' menu`
     ];
 
-    let divider = `\n${_.repeat('=', logDividerLength)}\n`;
+    let divider = `${EOL}${_.repeat('=', logDividerLength)}${EOL}`;
     let automationWarningString = divider;
-    automationWarningString += `  DEPRECATION WARNING:\n`;
+    automationWarningString += `  DEPRECATION WARNING:` + EOL;
     for (let log of automationWarning) {
-      automationWarningString += '\n' + wrap(log, {width: logDividerLength - 2}) + '\n';
+      automationWarningString += EOL + wrap(log, {width: logDividerLength - 2}) + EOL;
     }
     automationWarningString += divider;
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -85,8 +85,32 @@ const PLATFORMS_MAP = {
   [PLATFORMS.FAKE]: () => AUTOMATION_NAMES.FAKE,
   [PLATFORMS.ANDROID]: (caps) => {
     const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
-    log.warn(`DeprecationWarning: 'automationName' capability was not provided. ` +
-      `Future versions of Appium will require 'automationName' capability to be set for Android sessions.`);
+
+    // Warn users that automationName is going to change to UiAutomator2 for 1.14
+    // and will become required on Appium 2.0
+    const logDividerLength = 100;
+    const automationWarning = `\n\n
+${'='.repeat(logDividerLength)}
+IMPORTANT DEPRECATION WARNING: 
+'automationName' was not provided in the desired capabilities for this Android session.
+
+Setting 'automationName=UiAutomator1' by default and using the UiAutomator1 Driver
+
+The next minor version of Appium (1.14.x) will set 'automationName=UiAutomator2' by default
+and use the UiAutomator2 Driver
+
+The next major version of Appium (2.x) will **require** the 'automationName' capability
+to be set for all sessions on all platforms
+
+If you're happy with 'UiAutomator1' and don't wish to upgrade Android drivers, please add 
+'automationName=UiAutomator1' to your desired capabilities.
+
+For more information about drivers, please visit http://appium.io/docs/en/about-appium/intro/
+and explore the 'Drivers' menu
+
+${'='.repeat(logDividerLength)}\n\n`;
+
+    log.warn(automationWarning);
     log.info(`Setting automation to '${AUTOMATION_NAMES.UIAUTOMATOR1}'. `);
     if (platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
       log.warn(`Consider setting 'automationName' capability to '${AUTOMATION_NAMES.UIAUTOMATOR2}' ` +

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -96,7 +96,7 @@ const PLATFORMS_MAP = {
       `Setting 'automationName=UiAutomator1' by default and using the UiAutomator1 Driver`,
       `The next minor version of Appium (1.14.x) will set 'automationName=UiAutomator2' by default and use the UiAutomator2 Driver`,
       `The next major version of Appium (2.x) will **require** the 'automationName' capability to be set for all sessions on all platforms`,
-      `If you're happy with 'UiAutomator1' and do not wish to upgrade Android drivers, please add 'automationName=UiAutomator1' to your desired capabilities`,
+      `If you are happy with 'UiAutomator1' and do not wish to upgrade Android drivers, please add 'automationName=UiAutomator1' to your desired capabilities`,
       `For more information about drivers, please visit http://appium.io/docs/en/about-appium/intro/ and explore the 'Drivers' menu`
     ];
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -8,6 +8,7 @@ import {
   inspectObject, parseCapsForInnerDriver, getPackageVersion,
   pullSettings } from './utils';
 import semver from 'semver';
+import wrap from 'word-wrap';
 
 
 const PLATFORMS = {
@@ -86,31 +87,29 @@ const PLATFORMS_MAP = {
   [PLATFORMS.ANDROID]: (caps) => {
     const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
 
-    // Warn users that automationName is going to change to UiAutomator2 for 1.14
+    // Warn users that default automation is going to change to UiAutomator2 for 1.14
     // and will become required on Appium 2.0
-    const logDividerLength = 100;
-    const automationWarning = `\n\n
-${'='.repeat(logDividerLength)}
-IMPORTANT DEPRECATION WARNING: 
-'automationName' was not provided in the desired capabilities for this Android session.
+    const logDividerLength = 70; // Fit in command line
 
-Setting 'automationName=UiAutomator1' by default and using the UiAutomator1 Driver
+    const automationWarning = [
+      `The 'automationName' capability was not provided in the desired capabilities for this Android session`,
+      `Setting 'automationName=UiAutomator1' by default and using the UiAutomator1 Driver`,
+      `The next minor version of Appium (1.14.x) will set 'automationName=UiAutomator2' by default and use the UiAutomator2 Driver`,
+      `The next major version of Appium (2.x) will **require** the 'automationName' capability to be set for all sessions on all platforms`,
+      `If you're happy with 'UiAutomator1' and do not wish to upgrade Android drivers, please add 'automationName=UiAutomator1' to your desired capabilities`,
+      `For more information about drivers, please visit http://appium.io/docs/en/about-appium/intro/ and explore the 'Drivers' menu`
+    ];
 
-The next minor version of Appium (1.14.x) will set 'automationName=UiAutomator2' by default
-and use the UiAutomator2 Driver
+    let divider = `\n${_.repeat('=', logDividerLength)}\n`;
+    let automationWarningString = divider;
+    automationWarningString += `  DEPRECATION WARNING:\n`;
+    for (let log of automationWarning) {
+      automationWarningString += '\n' + wrap(log, {width: logDividerLength - 2}) + '\n';
+    }
+    automationWarningString += divider;
 
-The next major version of Appium (2.x) will **require** the 'automationName' capability
-to be set for all sessions on all platforms
-
-If you're happy with 'UiAutomator1' and don't wish to upgrade Android drivers, please add 
-'automationName=UiAutomator1' to your desired capabilities.
-
-For more information about drivers, please visit http://appium.io/docs/en/about-appium/intro/
-and explore the 'Drivers' menu
-
-${'='.repeat(logDividerLength)}\n\n`;
-
-    log.warn(automationWarning);
+    // Recommend users to upgrade to UiAutomator2 if they're using Android >= 6
+    log.warn(automationWarningString);
     log.info(`Setting automation to '${AUTOMATION_NAMES.UIAUTOMATOR1}'. `);
     if (platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
       log.warn(`Consider setting 'automationName' capability to '${AUTOMATION_NAMES.UIAUTOMATOR2}' ` +

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "semver": "^6.0.0",
     "source-map-support": "0.x",
     "teen_process": "1.x",
-    "winston": "3.x"
+    "winston": "3.x",
+    "word-wrap": "^1.2.3"
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",


### PR DESCRIPTION
Warn users that next minor version of Appium will set the default Android automation from UiAutomator1 to UiAutomator2

Here's how it looks in the logs:

```
[Appium] Welcome to Appium v1.13.0-beta.2 (REV 438d6c3b38e785edc701354cf660aa9f76baceaf)
[Appium] Non-default server args:
[Appium]   port: 4747
[Appium] Appium REST http interface listener started on 0.0.0.0:4747
[HTTP] --> POST /wd/hub/session
[HTTP] {"desiredCapabilities":{"adbExecTimeout":"200000","app":"/Users/danielgraham/android-apidemos/apks/ApiDemos-debug.apk","autoGrantPermissions":false,"deviceName":"Android Emulator","forceEspressoRebuild":true,"fullReset":true,"newCommandTimeout":700000,"platformName":"Android","connectHardwareKeyboard":true}}
[debug] [MJSONWP] Calling AppiumDriver.createSession() with args: [{"adbExecTimeout":"200000","app":"/Users/danielgraham/android-apidemos/apks/ApiDemos-debug.apk","autoGrantPermissions":false,"deviceName":"Android Emulator","forceEspressoRebuild":true,"fullReset":true,"newCommandTimeout":700000,"platformName":"Android","connectHardwareKeyboard":true},null,null]
[debug] [BaseDriver] Event 'newSessionRequested' logged at 1555024028845 (16:07:08 GMT-0700 (Pacific Daylight Time))
[Appium] 
[Appium] 
[Appium] 
[Appium] ====================================================================================================
[Appium] IMPORTANT DEPRECATION WARNING: 
[Appium] 'automationName' was not provided in the desired capabilities for this Android session.
[Appium] 
[Appium] Setting 'automationName=UiAutomator1' by default and using the UiAutomator1 Driver
[Appium] 
[Appium] The next minor version of Appium (1.14.x) will set 'automationName=UiAutomator2' by default
[Appium] and use the UiAutomator2 Driver
[Appium] 
[Appium] The next major version of Appium (2.x) will **require** the 'automationName' capability
[Appium] to be set for all sessions on all platforms
[Appium] 
[Appium] If you're happy with 'UiAutomator1' and don't wish to upgrade Android drivers, please add 
[Appium] 'automationName=UiAutomator1' to your desired capabilities.
[Appium] 
[Appium] For more information about drivers, please visit http://appium.io/docs/en/about-appium/intro/
[Appium] and explore the 'Drivers' menu
[Appium] 
[Appium] ====================================================================================================
[Appium] 
[Appium] 
[Appium] Setting automation to 'UiAutomator1'. 
[Appium] Appium v1.13.0-beta.2 creating new AndroidDriver (v4.11.0) session
[Appium] Capabilities:
[Appium]   adbExecTimeout: 200000
[Appium]   app: /Users/danielgraham/android-apidemos/apks/ApiDemos-debug.apk
[Appium]   autoGrantPermissions: false
[Appium]   deviceName: Android Emulator
[Appium]   forceEspressoRebuild: true
[Appium]   fullReset: true
[Appium]   newCommandTimeout: 700000
[Appium]   platformName: Android
[Appium]   connectHardwareKeyboard: true
[debug] [BaseDriver] Creating session with MJSONWP desired capabilities: {"adbExecTimeout":"200000",...
[BaseDriver] Capability 'adbExecTimeout' changed from string ('200000') to integer (200000). This may cause unexpected behavior
[BaseDriver] The following capabilities were provided, but are not recognized by appium: forceEspressoRebuild, connectHardwareKeyboard.
[BaseDriver] Session created with session id: 64960709-ff07-4830-9556-a10c85fb7a88
[ADB] Checking whether adb is present
[ADB] Found 10 'build-tools' folders under '/Users/danielgraham/Library/Android/sdk' (newest first):
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/28.0.3
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/27.0.3
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/27.0.1
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/26.0.2
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/26.0.1
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/25.0.3
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/25.0.0
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/24.0.1
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/23.0.1
[ADB]     /Users/danielgraham/Library/Android/sdk/build-tools/23.0.0
[ADB] Using adb from /Users/danielgraham/Library/Android/sdk/platform-tools/adb
[AndroidDriver] Retrieving device list
[debug] [ADB] Trying to find a connected android device
[debug] [ADB] Getting connected devices...
[debug] [ADB] 1 device(s) connected
[AndroidDriver] Using device: emulator-5554
[debug] [ADB] Setting device id to emulator-5554
[debug] [ADB] Running '/Users/danielgraham/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell getprop ro.build.version.sdk'
[debug] [ADB] Current device property 'ro.build.version.sdk': 28
[debug] [ADB] Device API level: 28
[AndroidDriver] Consider setting 'automationName' capability to 'uiautomator2' on Android >= 6, since UIAutomator framework is not maintained anymore by the OS vendor.
[BaseDriver] Using local app '/Users/danielgraham/android-apidemos/apks/ApiDemos-debug.apk'
[debug] [AndroidDriver] Checking whether app is actually present
[AndroidDriver] Starting Android session
[debug] [ADB] Running '/Users/danielgraham/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 wait-for-device'
[debug] [ADB] Running '/Users/danielgraham/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell echo ping'
^Cs_apk-debug.apk'
[debug] [ADB] Getting IDs of all 'io.appium.settings' processes
[debug] [ADB] Running '/Users/danielgraham/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell 'pgrep --help; echo $?''
[Appium] Received SIGINT - shutting down
[debug] [ADB] Running '/Users/danielgraham/Library/Android/sdk/platform-tools/adb -P 5037 -s emulator-5554 shell pgrep -f \^io\\.appium\\.settings\$'
```