### PR TITLE
give arg to super in AppiumDriver

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -158,7 +158,7 @@ const pendingDriversGuard = new AsyncLock();
 
 class AppiumDriver extends BaseDriver {
   constructor (args) {
-    super();
+    super(args);
 
     this.desiredCapConstraints = desiredCapabilityConstraints;
 


### PR DESCRIPTION
## Proposed changes

Fix missing initial arg to BaseDriver in AppiumDriver.

This change fixes an issue which happens before calling createSession by clients after launching the Appium server.

We can get below outputs after launching Appium. In this sequence, `AppiumDriver` is called before `Appium REST http interface listener started on 0.0.0.0:4723` message.

```
[Appium] Welcome to Appium v1.13.0-beta.3 (REV 1a20aab8754d3187c3de36a7b6eb8bafbf4a93ce)
[Appium] Non-default server args:
[Appium]   tmpDir: /Users/kazu/GitHub/appium/tmp
[Appium] Appium REST http interface listener started on 0.0.0.0:4723
```

But `AppiumDriver` does not give `arg` to the `super`, `BaseDriver`.
Then, the `super` cannot handle `ops` field [in the driver](https://github.com/appium/appium-base-driver/blob/master/lib/basedriver/driver.js#L29-L82) correctly.

For example, when I set `tmpDir` as a server argument, it does not work then.
`this.opts.tmpDir` in `super`(`BaseDriver`) should not be `undefined`.

```
[Appium] Welcome to Appium v1.13.0-beta.3 (REV 1a20aab8754d3187c3de36a7b6eb8bafbf4a93ce)
[Appium] Non-default server args:
[Appium]   tmpDir: /Users/kazu/GitHub/appium/tmp
[BaseDriver] =======this.opts.tmpDir in constructor: undefined
[Appium] Appium REST http interface listener started on 0.0.0.0:4723
```

After this fix, the output will be like below.

```
[Appium] Welcome to Appium v1.13.0-beta.3 (REV 1a20aab8754d3187c3de36a7b6eb8bafbf4a93ce)
[Appium] Non-default server args:
[Appium]   tmpDir: /Users/kazu/GitHub/appium/tmp
[BaseDriver] =======this.opts.tmpDir in constructor: /Users/kazu/GitHub/appium/tmp
[Appium] Appium REST http interface listener started on 0.0.0.0:4723
```

Other drivers give their options to the BaseDriver correctly. Thus, they do not have this issue.
So, this issue should not impact us, for now.

---

I found this behaviour in https://github.com/appium/appium/issues/12527 

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

I've run uiautomator2 driver on my local and ensured it worked as well as before applying this PR.