### PR TITLE
build(lodash): force resolution to 4.17.11 minimum

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "continuation-local-storage": "3.x",
     "dateformat": "^3.0.3",
     "find-root": "^1.1.0",
-    "lodash": "^4.17.9",
+    "lodash": "^4.17.11",
     "longjohn": "^0.2.12",
     "npmlog": "4.x",
     "request": "^2.81.0",


### PR DESCRIPTION
## Proposed changes

There is currently an issue in the resolution of the `lodash` library for packages depending of this package. Any version of `lodash` before the `4.17.11` cause a _moderate_ warning from NPM Audit.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The change made, forces the `lodash` resolution to the `4.17.11` version to prevent
dependency warnings due to prototype pollution from lower `lodash`
versions.
