### PR TITLE
Remove the obsolete --enable-heapdump command line arg

### DIFF
--- a/docs/cn/writing-running-appium/server-args.md
+++ b/docs/cn/writing-running-appium/server-args.md
@@ -90,7 +90,6 @@ Appium v1.5里某些服务器参数已被弃用，取而代之使用的-default-
 | `--native-instruments-lib`      | false                            | [弃用] - (仅iOS) iOS 内建了一个怪异的不可能避免的延迟，我们在Appium里修复了它，如果你想用原来的，你可以使用这个参数 |                                          |
 | `--keep-keychains`              | false                            | [弃用] - (仅iOS) 当Appium启动或者关闭的时候，是否保留keychains(Library/Keychains) |                                          |
 | `--localizable-strings-dir`     | en.lproj                         | [弃用] - (仅iOS)定位.strings所在目录的相对路径         | `--localizable-strings-dir en.lproj`     |
-| `--show-ios-log`                | false                            | [弃用] - (仅iOS) 如果设置了，iOS系统日志会输出到终端        |                                          |
-|`--enable-heapdump`|false|激活 NodeJS 内存 dumps 收集功能。这个功能对找到内存泄露非常有用。用 'kill -SIGUSR2 &lt;PID&gt;' 命令来创建 node 进程的内存堆栈dump，只有在 *nix 系统有效。dump 文件会被创建在 appium 运行的目录，文件使用 *.heapsnapshot 做后缀。如果后续想要深入研究，这个快照可以被加载到 Chrome Inspector 里去。参加 [Rising Stack article](https://blog.risingstack.com/finding-a-memory-leak-in-node-js/) for more details.||
+| `--show-ios-log`                | false                            | [弃用] - (仅iOS) 如果设置了，iOS系统日志会输出到终端        |
 
 本文由 [testly](https://github.com/testly) 翻译，由 [lihuazhang](https://github.com/lihuazhang) 校验。

--- a/docs/en/advanced-concepts/memory-collection.md
+++ b/docs/en/advanced-concepts/memory-collection.md
@@ -1,51 +1,27 @@
 ## Memory Collection
 
-It is possible to collect the dumps of Appium's memory usage to be analyzed for
-problems. This is _extrememly_ useful for finding memory leaks.
+Since Node v. 12 it is possible to collect the dumps of Appium's memory usage to be analyzed for problems.
+This is _extremely_ useful for finding memory leaks.
 
-
-### Enabling
-
-The feature is enabled by starting Appium with the `--enable-heapdump`
-[server argument](../writing-running-appium/server-args.md)
-```
-appium --enable-heapdump
-```
 
 ### Creating a dump file
 
-To create a dump file at any given time, execute the command
+To create a dump file at any given time, add the following command line parameter to `node` process, which executes the appium.js script:
+
 ```
-kill -SIGUSR2 &lt;PID&gt;
+--heapsnapshot-signal=&lt;signal&gt;
 ```
 
-Dump files are created in the same folder as the main Appium script was executed.
-They will have the `.heapsnapshot` extension, and can be loaded into the Chrome
-Inspector for further investigation.
+where `signal` can be one of available custom signals, for example `SIGUSR2`. Then you will be able to
+
+```
+kill -SIGUSR2 &lt;nodePID&gt;
+```
+
+Dump files are created in the same folder where the main Appium script has been executed.
+They have the `.heapsnapshot` extension, and can be loaded into the Chrome Inspector for further investigation.
+
 
 ### Dump file analysis
 
 Read the [Rising Stack article](https://blog.risingstack.com/finding-a-memory-leak-in-node-js/) for more details.
-
-### Installation
-
-For this feature to work, the [heapdump](https://www.npmjs.com/package/heapdump)
-package must be installed and available to the Appium. This can be done either by
-installing `heapdump` in the Appium directory
-```
-cd <location of appium installation>
-npm install heapdump
-```
-Alternatively, since `heapdump` is built on install, it may be helpful to install
-it once and then link it to the Appium installation
-```
-npm install -g heapdump
-cd <location of appium installation>
-npm link heapdump
-```
-
-**Note:** The installation of `heapdump` requires Python 2. If you do not have
-Python installed, make sure you install Python 2, not 3. If you have Python 3
-installed, install Python 2 (see [stack overflow](https://stackoverflow.com/a/2547577)
-for information on having multiple Python versions installed on the same
-machine).

--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -92,5 +92,4 @@ All flags are optional, but some are required in conjunction with certain others
 |`--keep-keychains`|false|[DEPRECATED] - (iOS-only) Whether to keep keychains (Library/Keychains) when reset app between sessions||
 |`--localizable-strings-dir`|en.lproj|[DEPRECATED] - (IOS-only) the relative path of the dir where Localizable.strings file resides |`--localizable-strings-dir en.lproj`|
 |`--show-ios-log`|false|[DEPRECATED] - (IOS-only) if set, the iOS system log will be written to the console||
-|`--enable-heapdump`|false|Enables NodeJS memory dumps collection feature. This feature is extremely useful for finding memory leaks. See [memory collection docs](../advanced-concepts/memory-collection.md) for more information.||
 |`--relaxed-security`|false|Disable additional security checks, so it is possible to use some advanced features, provided by drivers supporting this option. Only enable it if all the clients are in the trusted network and it is not the case if a client could potentially break out of the session sandbox.||

--- a/lib/main.js
+++ b/lib/main.js
@@ -90,19 +90,6 @@ function logServerPort (address, port) {
   logger.info(logMessage);
 }
 
-function initHeapdump (args) {
-  if (args.heapdumpEnabled) {
-    try {
-      require('heapdump');
-    } catch (err) {
-      logger.error(`Memory dump enabled through the '--enable-heapdump' server argument\n` +
-                   `but 'heapdump' not installed.\n` +
-                   `See https://github.com/appium/appium/tree/master/docs/en/advanced-concepts/memory-collection.md ` +
-                   `for more information.`);
-    }
-  }
-}
-
 async function main (args = null) {
   let parser = getParser();
   let throwInsteadOfExit = false;
@@ -123,7 +110,6 @@ async function main (args = null) {
     // otherwise parse from CLI
     args = parser.parseArgs();
   }
-  initHeapdump(args);
   await logsinkInit(args);
   await preflightChecks(parser, args, throwInsteadOfExit);
   await logStartupInfo(parser, args);

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -381,15 +381,6 @@ const args = [
           'session unless overridden by received capabilities.'
   }],
 
-  [['--enable-heapdump'], {
-    defaultValue: false,
-    dest: 'heapdumpEnabled',
-    action: 'storeTrue',
-    required: false,
-    help: 'Enable collection of NodeJS memory heap dumps. This is useful for memory leaks lookup',
-    nargs: 0
-  }],
-
   [['--relaxed-security'], {
     defaultValue: false,
     dest: 'relaxedSecurityEnabled',


### PR DESCRIPTION
## Proposed changes

Node12 introduced the built-in heap dumping feature, so it is time to get rid of the custom `heapdump` module usage (especially taking into account it's native and does not always compile properly for newer Node releases)


## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

