### PR TITLE
Set UiAutomator2 as default Android driver

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -85,19 +85,17 @@ const DRIVER_MAP = {
 
 const PLATFORMS_MAP = {
   [PLATFORMS.FAKE]: () => AUTOMATION_NAMES.FAKE,
-  [PLATFORMS.ANDROID]: (caps) => {
-    const platformVersion = semver.valid(semver.coerce(caps.platformVersion));
-
+  [PLATFORMS.ANDROID]: () => {
     // Warn users that default automation is going to change to UiAutomator2 for 1.14
     // and will become required on Appium 2.0
     const logDividerLength = 70; // Fit in command line
 
     const automationWarning = [
       `The 'automationName' capability was not provided in the desired capabilities for this Android session`,
-      `Setting 'automationName=UiAutomator1' by default and using the UiAutomator1 Driver`,
-      `The next minor version of Appium (1.14.x) will set 'automationName=UiAutomator2' by default and use the UiAutomator2 Driver`,
+      `Setting 'automationName=UiAutomator2' by default and using the UiAutomator2 Driver`,
       `The next major version of Appium (2.x) will **require** the 'automationName' capability to be set for all sessions on all platforms`,
-      `If you are happy with 'UiAutomator1' and do not wish to upgrade Android drivers, please add 'automationName=UiAutomator1' to your desired capabilities`,
+      `In previous versions (Appium <= 1.13.x), the default was 'automationName=UiAutomator1'`,
+      `If you wish to use that automation instead of UiAutomator2, please add 'automationName=UiAutomator1' to your desired capabilities`,
       `For more information about drivers, please visit http://appium.io/docs/en/about-appium/intro/ and explore the 'Drivers' menu`
     ];
 
@@ -111,14 +109,8 @@ const PLATFORMS_MAP = {
 
     // Recommend users to upgrade to UiAutomator2 if they're using Android >= 6
     log.warn(automationWarningString);
-    log.info(`Setting automation to '${AUTOMATION_NAMES.UIAUTOMATOR1}'. `);
-    if (platformVersion && semver.satisfies(platformVersion, '>=6.0.0')) {
-      log.warn(`Consider setting 'automationName' capability to '${AUTOMATION_NAMES.UIAUTOMATOR2}' ` +
-        'on Android >= 6, since UIAutomator1 framework ' +
-        'is not maintained anymore by the OS vendor.');
-    }
 
-    return AUTOMATION_NAMES.UIAUTOMATOR1;
+    return AUTOMATION_NAMES.UIAUTOMATOR2;
   },
   [PLATFORMS.IOS]: (caps) => {
     const platformVersion = semver.valid(semver.coerce(caps.platformVersion));

--- a/test/driver-specs.js
+++ b/test/driver-specs.js
@@ -9,7 +9,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { XCUITestDriver } from 'appium-xcuitest-driver';
 import { IosDriver } from 'appium-ios-driver';
-import { AndroidDriver } from 'appium-android-driver';
+import { AndroidUiautomator2Driver } from 'appium-uiautomator2-driver';
 import { sleep } from 'asyncbox';
 import { insertAppiumPrefixes } from '../lib/utils';
 
@@ -290,7 +290,7 @@ describe('AppiumDriver', function () {
           automationName: 'Appium'
         });
         driver.should.be.an.instanceof(Function);
-        driver.should.equal(AndroidDriver);
+        driver.should.equal(AndroidUiautomator2Driver);
       });
       it('should get XCUITestDriver driver for automationName of XCUITest', function () {
         const appium = new AppiumDriver({});


### PR DESCRIPTION
Make UiAutomator2 the default and issue a warning to users that it's UiAutomator2 now and _not_ UiAutomator1.