### PR TITLE
add how to get the matched image data by find by image as debugging

### DIFF
--- a/docs/en/advanced-concepts/image-elements.md
+++ b/docs/en/advanced-concepts/image-elements.md
@@ -46,7 +46,7 @@ Note that each language-specific Appium client may make these settings available
 
 ### Debug
 
-`getMatchedImageResult` might help for debugging if Appium find provided image expectedly. `visual` attribute retuns base64 data if `getMatchedImageResult` is `true`.
+`getMatchedImageResult` might help for debugging if Appium found the provided image expectedly. `visual` attribute returns base64 data if `getMatchedImageResult` is `true`.
 
 ```ruby
 # Ruby core

--- a/docs/en/advanced-concepts/image-elements.md
+++ b/docs/en/advanced-concepts/image-elements.md
@@ -40,15 +40,13 @@ To access these settings, you should use the Appium [Settings API](/docs/en/adva
 |checkForImageElementStaleness|It can happen that, in between the time you have matched an image element and the time you choose to tap on it, the element is no longer present. The only way for Appium to determine this is to attempt to re-match the template immediately before tapping. If that re-match fails, you will get a `StaleElementException`, as you would expect. Turn this to `false` to skip the check, potentially speeding things up, but potentially running into stale element issues without the benefit of an exception to let you know you did.|`true` or `false`|`true`|
 |autoUpdateImageElementPosition|It can happen that a matched image changes position in between the time it is found and the time you tap on it. As with the previous setting, Appium can automatically adjust its position if it determines in a re-match that the position changed.|`true` or `false`|`false`|
 |imageElementTapStrategy|In order to tap on a found image element, Appium has to use one of its touch action strategies. The available strategies are the W3C Actions API, or the older MJSONWP TouchActions API. Stick to the default unless the driver you are using does not support the W3C Actions API for some reason.|`"w3cActions"` or `"touchActions"`|`"w3cActions"`|
-|getMatchedImageResult| Appium does not store matched image result. Although, storing the result in memory might help for debugging whether which area is matched by find by image. Appium retuns the image against [attribute](http://appium.io/docs/en/commands/element/attributes/attribute/) API as `visual`. | `true` or `false` | `false` |
-
+|getMatchedImageResult| Appium does not store the matched image result. Although, storing the result in memory might help for debugging whether which area is matched by find by image. Appium returns the image against [attribute](http://appium.io/docs/en/commands/element/attributes/attribute/) API as `visual`. | `true` or `false` | `false` |
 
 Note that each language-specific Appium client may make these settings available via special constants which could differ slightly from the exact setting names mentioned above.
 
 ## Debug
 
-`getMatchedImageResult` might help to debug if provided image could find expectedly.
-`visual` attribute retuns it if `getMatchedImageResult` is `true`.
+`getMatchedImageResult` might help for debugging if Appium find provided image expectedly. `visual` attribute retuns base64 data if `getMatchedImageResult` is `true`.
 
 ```ruby
 # Ruby core

--- a/docs/en/advanced-concepts/image-elements.md
+++ b/docs/en/advanced-concepts/image-elements.md
@@ -44,7 +44,7 @@ To access these settings, you should use the Appium [Settings API](/docs/en/adva
 
 Note that each language-specific Appium client may make these settings available via special constants which could differ slightly from the exact setting names mentioned above.
 
-## Debug
+### Debug
 
 `getMatchedImageResult` might help for debugging if Appium find provided image expectedly. `visual` attribute retuns base64 data if `getMatchedImageResult` is `true`.
 

--- a/docs/en/advanced-concepts/image-elements.md
+++ b/docs/en/advanced-concepts/image-elements.md
@@ -18,6 +18,7 @@ If the image match is successful, Appium will cache information about the match 
 * `getLocation`
 * `getLocationInView`
 * `getElementRect`
+* `getAttribute` (only `visual` attribute)
 
 These actions are supported on "Image Elements" because they are the actions which involve only use of screen position for their functioning. Other actions (like `sendKeys`, for example) are not supported, because all Appium can know based on your template image is whether or not there is a screen region which visually matches it--Appium has no way of turning that information into a driver-specific UI element object, which would be necessary for the use of other actions.
 
@@ -39,5 +40,28 @@ To access these settings, you should use the Appium [Settings API](/docs/en/adva
 |checkForImageElementStaleness|It can happen that, in between the time you have matched an image element and the time you choose to tap on it, the element is no longer present. The only way for Appium to determine this is to attempt to re-match the template immediately before tapping. If that re-match fails, you will get a `StaleElementException`, as you would expect. Turn this to `false` to skip the check, potentially speeding things up, but potentially running into stale element issues without the benefit of an exception to let you know you did.|`true` or `false`|`true`|
 |autoUpdateImageElementPosition|It can happen that a matched image changes position in between the time it is found and the time you tap on it. As with the previous setting, Appium can automatically adjust its position if it determines in a re-match that the position changed.|`true` or `false`|`false`|
 |imageElementTapStrategy|In order to tap on a found image element, Appium has to use one of its touch action strategies. The available strategies are the W3C Actions API, or the older MJSONWP TouchActions API. Stick to the default unless the driver you are using does not support the W3C Actions API for some reason.|`"w3cActions"` or `"touchActions"`|`"w3cActions"`|
+|getMatchedImageResult| Appium does not store matched image result. Although, storing the result in memory might help for debugging whether which area is matched by find by image. Appium retuns the image against [attribute](http://appium.io/docs/en/commands/element/attributes/attribute/) API as `visual`. | `true` or `false` | `false` |
+
 
 Note that each language-specific Appium client may make these settings available via special constants which could differ slightly from the exact setting names mentioned above.
+
+## Debug
+
+`getMatchedImageResult` might help to debug if provided image could find expectedly.
+`visual` attribute retuns it if `getMatchedImageResult` is `true`.
+
+```ruby
+# Ruby core
+@driver.update_settings({ getMatchedImageResult: false })
+el = @driver.find_element_by_image 'path/to/img.ong'
+img_el.visual # returns base64 encoded string
+```
+
+```python
+# Python
+self.driver.update_settings({"getMatchedImageResult": True}))
+el = self.driver.find_element_by_image('path/to/img.ong')
+el.get_attribute('visual') # returns base64 encoded string
+```
+
+reference: https://github.com/appium/appium-base-driver/pull/327


### PR DESCRIPTION
## Proposed changes

for https://github.com/appium/appium-base-driver/pull/327
I've added `getMatchedImageResult` for debugging.
In this PR, I mentioned about the setting and how to use it.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
