### PR TITLE
updated python code for example usage

### DIFF
--- a/commands-yml/commands/web/window/title.yml
+++ b/commands-yml/commands/web/window/title.yml
@@ -8,7 +8,7 @@ example_usage:
       String title = driver.getTitle();
   python:
     |
-      title = self.driver.title()
+      title = self.driver.title
   javascript_wd:
     |
       let title = await driver.title();


### PR DESCRIPTION
 python code to get title in example usage is incorrect, it was throwing error as "TypeError: 'str' object is not callable"

## Proposed changes

This is fix the documentation of get title api for Python

## Types of changes

What types of changes does your code introduce to Appium?
Non-breaking change, which fix documentation
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules


