### PR TITLE
Include .wait in javascript wd docs

### DIFF
--- a/commands-yml/commands/interactions/touch/move.yml
+++ b/commands-yml/commands/interactions/touch/move.yml
@@ -23,6 +23,7 @@ example_usage:
     |
       let action = new wd.TouchAction(driver);
       action.press({x: 10, y: 10})
+            .wait(1000)
             .moveTo({x: 50, y: 50})
             .release();
       await action.perform();


### PR DESCRIPTION
## Proposed changes
Without .wait() touch action doesn't press and move. I think it's mainly because it needs time to press move is too sudden for ios to capture. Anyways, I'm unsure of the reason but adding .wait to the documentation will be helpful. I personally spent couple hours trying to figure this out. 

Hope this helps others 😄 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

