### PR TITLE
Adding new capability to specify the chromedriver url  #10651

### DIFF
--- a/docs/en/writing-running-appium/caps.md
+++ b/docs/en/writing-running-appium/caps.md
@@ -89,6 +89,7 @@ These Capabilities are available only on Android-based drivers (like
 |`keyAlias`| Alias for key |e.g., `androiddebugkey`|
 |`keyPassword`| Password for key |e.g., `foo`|
 |`chromedriverExecutable`| The absolute local path to webdriver executable (if Chromium embedder provides its own webdriver, it should be used instead of original chromedriver bundled with Appium) |`/abs/path/to/webdriver`|
+|`chromedriverExecutableUrl`|Link to the zip file of chromedriver binary|e.g.,`https://chromedriver.storage.googleapis.com/75.0.3770.90/chromedriver_mac64.zip`|
 |`chromedriverArgs`| An array of arguments to be passed to the chromedriver binary when it's run by Appium. By default no CLI args are added beyond what Appium uses internally (such as `--url-base`, `--port`, `--adb-port`, and `--log-path`. | e.g., `["--disable-gpu", "--disable-web-security"]` |
 |`chromedriverExecutableDir`| The absolute path to a directory to look for Chromedriver executables in, for automatic discovery of compatible Chromedrivers. Ignored if `chromedriverUseSystemExecutable` is `true` |`/abs/path/to/chromedriver/directory`|
 |`chromedriverChromeMappingFile` | The absolute path to a file which maps Chromedriver versions to the minimum Chrome that it supports. Ignored if `chromedriverUseSystemExecutable` is `true`|`/abs/path/to/mapping.json`|


### PR DESCRIPTION
## Proposed changes

Adding new capability to specify the chromedriver url. Currently, the client can only specify the path to `chromedriverExecutable` (which is accessible to the server). This feature will enable the clients to pass-in the URL as a capability to download the chromedriver binary. This will fix issue #10651


## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments
PR for base-driver  [https://github.com/appium/appium-base-driver/pull/330](https://github.com/appium/appium-base-driver/pull/330). This will just the export the method to download the zip file

PR for android-driver [https://github.com/appium/appium-android-driver/pull/546](https://github.com/appium/appium-android-driver/pull/546). Changes here include - download the zip file from the URL, unzip it to a temp path and use that chromedriver binary. Also, a check is added to not download the zip file again if it already exists. This will be useful when multiple sessions are created with a single server instance 

