### PR TITLE
docs: Describe mobile commands in execute yml

### DIFF
--- a/commands-yml/commands/web/execute.yml
+++ b/commands-yml/commands/web/execute.yml
@@ -1,6 +1,6 @@
 ---
 name: Execute Script
-short_description: Inject a snippet of JavaScript into the page for execution in the context of the currently selected frame (Web context only)
+short_description: Inject a snippet of JavaScript into the page for execution in the context of the currently selected frame (Web context). Run a native [mobile command](/docs/en/commands/mobile-command.md) (Native Context).
 
 description:
   |


### PR DESCRIPTION
Execute docs say that it's web only, which is incorrect. Update description to reflect that.
