### PR TITLE
Specify minimum and maximum Node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/appium/appium/issues"
   },
   "engines": {
-    "node": ">=8",
+    "node": ">=10 <=12",
     "npm": ">=6"
   },
   "main": "./build/lib/main.js",


### PR DESCRIPTION
The "engines" variable in package.json should specify the minimum and the maximum NodeJS version that Appium supports. This will allow cloud providers to check what the maximum supported version is and bundle that as the binary when doing Appium releases.

Note that the engines variable doesn't actually stop users from using Appium for out-of-range Node versions.
