### PR TITLE
Fix nightly bundle

### DIFF
--- a/ci-jobs/templates/bundle-template.yml
+++ b/ci-jobs/templates/bundle-template.yml
@@ -29,14 +29,14 @@ jobs:
       displayName: Create the bundle zip
     - script: npm install 
       displayName: Reinstall dev dependencies
-    - script: npm run upload
-      env:
-        GITHUB_TOKEN: $(GITHUB_TOKEN)
-      displayName: Upload to appium/appium-build-store Github Releases
     - task: PublishPipelineArtifact@0
       inputs:
         targetPath: appium.zip
         artifactName: ${{ parameters.name }}
+    - script: npm run upload
+      env:
+        GITHUB_TOKEN: $(GITHUB_TOKEN)
+      displayName: Upload to appium/appium-build-store Github Releases
     - script: npx gulp sauce-storage-upload
       displayName: Upload to Sauce Storage as sauce-storage:appium.zip
       env:

--- a/ci-jobs/templates/bundle-template.yml
+++ b/ci-jobs/templates/bundle-template.yml
@@ -32,7 +32,7 @@ jobs:
     - task: PublishPipelineArtifact@0
       inputs:
         targetPath: appium.zip
-        artifactName: ${{ parameters.name }}
+        artifactName: appium
     - script: npm run upload
       env:
         GITHUB_TOKEN: $(GITHUB_TOKEN)

--- a/ci-jobs/templates/bundle-template.yml
+++ b/ci-jobs/templates/bundle-template.yml
@@ -15,7 +15,7 @@ jobs:
     - script: npm ci || npm install # "npm ci" if shrinkwrap is present
       displayName: Install NPM Dependencies
     - script: |
-        pushd node_modules/appium-xcuitest-driver/WebDriverAgent
+        pushd node_modules/appium-webdriveragent
         carthage bootstrap --no-use-binaries
         cp Cartfile.resolved Carthage
         mkdir -p ./Resources/WebDriverAgent.bundle
@@ -33,6 +33,10 @@ jobs:
       env:
         GITHUB_TOKEN: $(GITHUB_TOKEN)
       displayName: Upload to appium/appium-build-store Github Releases
+    - task: PublishPipelineArtifact@0
+      inputs:
+        targetPath: appium.zip
+        artifactName: ${{ parameters.name }}
     - script: npx gulp sauce-storage-upload
       displayName: Upload to Sauce Storage as sauce-storage:appium.zip
       env:


### PR DESCRIPTION
WebDriverAgent is in a different directory now, so fix that. Also save Appium.zip as an artifact directly in Azure (along with doing the GitHub release).