### PR TITLE
`prepare` supersedes `prepublish`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install",
-    "prepublish": "gulp prepublish",
+    "prepare": "gulp prepublish",
     "prepublishOnly": "npm run prune-shrinkwrap && gulp fixShrinkwrap",
     "postpublish": "npm run restore-shrinkwrap",
     "prune-shrinkwrap": "!(test -e npm-shrinkwrap.json) || (npm ci --production --ignore-scripts && npm shrinkwrap && npm install --only=dev --no-shrinkwrap)",


### PR DESCRIPTION

## Proposed changes

In `package.json`, `prepare` supersedes `prepublish`. This will also helps with install directly via git,
e.g. `npm i -g git://github.com/appium/appium`

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Ability to install directly from git help with experimentation that we are not comfortable to official publish on `npm` yet, such as https://github.com/appium/appium/pull/12945