### PR TITLE
docs: espresso driver does not support reset [skip ci]

### DIFF
--- a/commands-yml/commands/device/app/reset-app.yml
+++ b/commands-yml/commands/device/app/reset-app.yml
@@ -43,7 +43,7 @@ driver_support:
     xcuitest: true
     uiautomation: true
   android:
-    espresso: true
+    espresso: false
     uiautomator2: true
     uiautomator: true
   mac:


### PR DESCRIPTION
## Proposed changes

https://github.com/appium/appium-espresso-driver/pull/491 started to raise an error for reset as same as launchApp and closeApp on espresso driver

It is equal to delete and create a new session in espresso driver case

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
