### PR TITLE
Fix formatting on homebrew installation of ios-webkit-debug-proxy

### DIFF
--- a/docs/en/writing-running-appium/web/ios-webkit-debug-proxy.md
+++ b/docs/en/writing-running-appium/web/ios-webkit-debug-proxy.md
@@ -9,11 +9,11 @@ For accessing web views on real iOS device appium uses [ios_webkit_debug_proxy](
 To install the latest tagged version of the ios-webkit-debug-proxy using
 Homebrew, run the following commands in the terminal:
 
- ``` center
+ ``` shell
  # The first command is only required if you don't have brew installed.
- > ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
- > brew update
- > brew install ios-webkit-debug-proxy
+ $ ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+ $ brew update
+ $ brew install ios-webkit-debug-proxy
  ```
 
 #### Building ios-webkit-debug-proxy from source


### PR DESCRIPTION
Display of instructions for the Homebrew installation wasn't clear on the wiki page. This change clarifies how this information is presented to the reader.

## Proposed changes

The formatting of instructions for homebrew installation of IWDP isn't clear at first glance. Rather than the expected code block formatting with separate lines for each command, it appears in italics on a single line. This change cleans up the formatting to ensure that a first time visitor will be able to clearly identify the required commands.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
