### PR TITLE
add mpeg4 to start_recording_screen doc

### DIFF
--- a/commands-yml/commands/device/recording-screen/start-recording-screen.yml
+++ b/commands-yml/commands/device/recording-screen/start-recording-screen.yml
@@ -114,8 +114,7 @@ endpoint:
     - name: options.videoType
       type: string
       description: (iOS Only) The format of the screen capture to be recorded.
-                   Available formats "h264", "mp4" or "fmp4". Default is "mp4".
-                   Only works for Simulator.
+                   Available formats "h264", "mpeg4", "mp4" or "fmp4". Default is "mp4". If you have difficulties try "mpeg4"
     - name: options.videoQuality
       type: string
       description: (iOS Only) The video encoding quality (low, medium, high, photo - defaults to medium).


### PR DESCRIPTION
- I can do screen recording on real device, so I removed the part that says "Simulator Only"
- furthermore the .mp4 files do not play back at all, I've also tried h264.
- mpeg4 seems to work, and is the only one that works in my experience, but I have not tried fmp4

## Proposed changes

Update the screen recording documentation because some of the things aren't true, and there are some caveats to get it to work on iOS.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
