### PR TITLE
docs: Address webkit debug proxy only for Appium 1.14.0- [skip ci]

### DIFF
--- a/docs/en/writing-running-appium/web/hybrid.md
+++ b/docs/en/writing-running-appium/web/hybrid.md
@@ -189,8 +189,8 @@ and started an Appium session, follow the generalized instructions above.
 
 When executing against an iOS real device, Appium is unable to access the web view
 directly. Therefore the connection has to be established through the USB cable.
-Appium can establish the connection natively with Appium 1.15+ via [appium-ios-device](https://github.com/appium/appium-ios-device).
-[ios-webkit-debugger-proxy](https://github.com/google/ios-webkit-debug-proxy) is necessary for Appium under 1.14.
+Appium can establish the connection natively since version 1.15 via [appium-ios-device](https://github.com/appium/appium-ios-device).
+[ios-webkit-debugger-proxy](https://github.com/google/ios-webkit-debug-proxy) is necessary for Appium below version 1.15.
 
 For instruction on how to install and run `ios-webkit-debugger-proxy` see the
 [iOS webkit debug proxy](/writing-running-appium/web/ios-webkit-debug-proxy.md)

--- a/docs/en/writing-running-appium/web/hybrid.md
+++ b/docs/en/writing-running-appium/web/hybrid.md
@@ -190,7 +190,7 @@ and started an Appium session, follow the generalized instructions above.
 When executing against an iOS real device, Appium is unable to access the web view
 directly. Therefore the connection has to be established through the USB cable.
 Appium can establish the connection natively since version 1.15 via [appium-ios-device](https://github.com/appium/appium-ios-device).
-[ios-webkit-debugger-proxy](https://github.com/google/ios-webkit-debug-proxy) is necessary for Appium below version 1.15.
+[ios-webkit-debugger-proxy](https://github.com/google/ios-webkit-debug-proxy) is only necessary for Appium below version 1.15.
 
 For instruction on how to install and run `ios-webkit-debugger-proxy` see the
 [iOS webkit debug proxy](/writing-running-appium/web/ios-webkit-debug-proxy.md)

--- a/docs/en/writing-running-appium/web/hybrid.md
+++ b/docs/en/writing-running-appium/web/hybrid.md
@@ -187,9 +187,10 @@ and started an Appium session, follow the generalized instructions above.
 
 #### Execution against an iOS real device
 
-When executing against an iOS real device Appium is unable to access the web view
+When executing against an iOS real device, Appium is unable to access the web view
 directly. Therefore the connection has to be established through the USB cable.
-To establish this connection we use the [ios-webkit-debugger-proxy](https://github.com/google/ios-webkit-debug-proxy).
+Appium can establish the connection natively with Appium 1.15+ via [appium-ios-device](https://github.com/appium/appium-ios-device).
+[ios-webkit-debugger-proxy](https://github.com/google/ios-webkit-debug-proxy) is necessary for Appium under 1.14.
 
 For instruction on how to install and run `ios-webkit-debugger-proxy` see the
 [iOS webkit debug proxy](/writing-running-appium/web/ios-webkit-debug-proxy.md)


### PR DESCRIPTION
## Proposed changes

I found `ios-webkit-debugger-proxy` in hybrid app page.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
