### PR TITLE
chore: Add 'docs' in commit message by bot

### DIFF
--- a/ci-jobs/generate-docs.yml
+++ b/ci-jobs/generate-docs.yml
@@ -33,7 +33,7 @@ jobs:
         if [[ -n $(git status -s) ]]; then
           git commit -a -n -m 'Update generated docs [ci skip]'
           git push triager generate-docs-$BUILD_SOURCEVERSION
-          hub pull-request -b "appium:master" -h "appium:generate-docs-$BUILD_SOURCEVERSION" -m "Update auto-generated docs"
+          hub pull-request -b "appium:master" -h "appium:generate-docs-$BUILD_SOURCEVERSION" -m "docs: Update auto-generated docs"
         fi
       displayName: Generate Docs and Make PR
       env:


### PR DESCRIPTION
## Proposed changes

The bot commits at 'Update auto-generated docs' to update documentation.
We now follow conventional messages as commit messages. So, we can add `docs:` as such comment.

The new line in the bottom was added by GitHub Web Editor

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
