### PR TITLE
docs: remove beta status for Espresso driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ specific information about how that driver works and how to set it up:
     * The [XCUITest Driver](/docs/en/drivers/ios-xcuitest.md)
     * (DEPRECATED) The [UIAutomation Driver](/docs/en/drivers/ios-uiautomation.md)
 * Android
-    * (BETA) The [Espresso Driver](/docs/en/drivers/android-espresso.md)
+    * The [Espresso Driver](/docs/en/drivers/android-espresso.md)
     * The [UiAutomator2 Driver](/docs/en/drivers/android-uiautomator2.md)
     * (DEPRECATED) The [UiAutomator Driver](/docs/en/drivers/android-uiautomator.md)
 * The [Windows Driver](/docs/en/drivers/windows.md) (for Windows Desktop apps)

--- a/docs/en/about-appium/getting-started.md
+++ b/docs/en/about-appium/getting-started.md
@@ -46,10 +46,10 @@ At some point, make sure you review the driver documentation for the platform
 you want to automate, so your system is set up correctly:
 
 - The [XCUITest Driver](/docs/en/drivers/ios-xcuitest.md) (for iOS and tvOS apps)
+- The [Espresso Driver](/docs/en/drivers/android-espresso.md) (for Android apps)
 - The [UiAutomator2 Driver](/docs/en/drivers/android-uiautomator2.md) (for Android apps)
 - The [Windows Driver](/docs/en/drivers/windows.md) (for Windows Desktop apps)
 - The [Mac Driver](/docs/en/drivers/mac.md) (for Mac Desktop apps)
-- (BETA) The [Espresso Driver](/docs/en/drivers/android-espresso.md) (for Android apps)
 
 ### Verifying the Installation
 

--- a/docs/en/drivers/android-espresso.md
+++ b/docs/en/drivers/android-espresso.md
@@ -11,8 +11,8 @@ Development of the Espresso driver happens at the
 [appium-espresso-driver](https://github.com/appium/appium-espresso-driver)
 repo.
 
-(If you don't want a beta driver, Appium's current standard Android automation
-driver is the [UiAutomator2 Driver](/docs/en/drivers/android-uiautomator2.md).)
+Appium also supports Android automation using the
+[UiAutomator2 Driver](/docs/en/drivers/android-uiautomator2.md).)
 
 ### Requirements and Support
 


### PR DESCRIPTION
## Proposed changes

It has been rightly [pointed out](https://github.com/appium/appium-espresso-driver/issues/508) by @iChip, `appium-espresso-driver` has been marked, at least in the docs, as **beta** for a long time, despite being announced as **non-beta** [as of Appium 1.10.0](https://github.com/appium/appium/blob/master/CHANGELOG.md#changes-in-version-1100-from-191). 

This PR removes the references to it being beta in the docs. I could not find any reference to its status in the actual `appium-espresso-driver` repo.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

