### PR TITLE
chore: Make attachUnexpectedShutdownHandler method more forgivable

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -426,9 +426,15 @@ class AppiumDriver extends BaseDriver {
             removeSessionFromMasterList(e);
           }
         }); // this is a cancellable promise
-    } else {
+    } else if (_.isFunction(driver.onUnexpectedShutdown)) {
       // since base driver v 5.0.0
       driver.onUnexpectedShutdown(removeSessionFromMasterList);
+    } else {
+      log.warn(`Failed to attach the unexpected shutdown listener. ` +
+        `Is 'onUnexpectedShutdown' method available for '${driver.constructor.name}'?`);
+      log.debug(`The current state of 'onUnexpectedShutdown' property: ` +
+        (typeof driver.onUnexpectedShutdown) + ' -> ' +
+        JSON.stringify(_.toPairs(driver.onUnexpectedShutdown)));
     }
   }
 

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -409,7 +409,8 @@ class AppiumDriver extends BaseDriver {
       delete this.sessions[innerSessionId];
     };
 
-    if (_.has(driver.onUnexpectedShutdown, 'then')) {
+    // eslint-disable-next-line promise/prefer-await-to-then
+    if (_.isFunction((driver.onUnexpectedShutdown || {}).then)) {
       // TODO: Remove this block after all the drivers use base driver above v 5.0.0
       // Remove the session on unexpected shutdown, so that we are in a position
       // to open another session later on.
@@ -432,9 +433,6 @@ class AppiumDriver extends BaseDriver {
     } else {
       log.warn(`Failed to attach the unexpected shutdown listener. ` +
         `Is 'onUnexpectedShutdown' method available for '${driver.constructor.name}'?`);
-      log.debug(`The current state of 'onUnexpectedShutdown' property: ` +
-        (typeof driver.onUnexpectedShutdown) + ' -> ' +
-        JSON.stringify(_.toPairs(driver.onUnexpectedShutdown)));
     }
   }
 


### PR DESCRIPTION
## Proposed changes

It looks like sometimes the onUnexpectedShutdown handler could have an [unexpected](https://gist.github.com/sebinjoseph1994/c0026eaddb015b4ed5b7064fd5ce60aa#file-appiumlogs-txt-L294) value, which makes the whole session creation to fail. This PR makes the check more forgivable and adds more debug output

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
