### PR TITLE
Update wdio touchScroll arguments

### DIFF
--- a/commands-yml/commands/interactions/touch/scroll.yml
+++ b/commands-yml/commands/interactions/touch/scroll.yml
@@ -38,7 +38,7 @@ example_usage:
 client_docs:
   java: "https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/interactions/touch/TouchActions.html#scroll-int-int-"
   python: "https://seleniumhq.github.io/selenium/docs/api/py/webdriver/selenium.webdriver.common.touch_actions.html#selenium.webdriver.common.touch_actions.TouchActions.scroll"
-  javascript_wdio: "http://webdriver.io/api/protocol/touchScroll.html"
+  javascript_wdio: "https://webdriver.io/docs/api/jsonwp.html#touchscroll"
   javascript_wd: "https://github.com/admc/wd/blob/master/lib/commands.js#L425"
   ruby: "https://www.rubydoc.info/gems/selenium-webdriver/Selenium%2FWebDriver%2FTouchActionBuilder:scroll"
   ruby_core: "https://www.rubydoc.info/gems/selenium-webdriver/Selenium%2FWebDriver%2FTouchActionBuilder:scroll"

--- a/commands-yml/commands/interactions/touch/scroll.yml
+++ b/commands-yml/commands/interactions/touch/scroll.yml
@@ -21,11 +21,7 @@ example_usage:
       await driver.scroll(10, 100);
   javascript_wdio:
     |
-      driver.touchScroll({
-        el: element,
-        xOffset: 10,
-        yOffset: 100
-      });
+      driver.touchScroll(10, 100, element);
   ruby:
     |
       touch_actions.scroll(element, 10, 100).perform


### PR DESCRIPTION
## Proposed changes

wdio `touchScroll` accepts 3 arguments `xoffset, yoffset, element` reference docs https://webdriver.io/docs/api/jsonwp.html#touchscroll

the current documents shows an Object as a argument which is incorrect.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
