### PR TITLE
.endSession() replaced by .deleteSession()

### DIFF
--- a/commands-yml/commands/session/delete.yml
+++ b/commands-yml/commands/session/delete.yml
@@ -15,7 +15,7 @@ example_usage:
 
   javascript_wdio:
     |
-      driver.endSession();
+      driver.deleteSession();
   ruby:
     |
       quit


### PR DESCRIPTION
## Proposed changes
The latest Appium (version 1.15.1) doesn't have a function called `.endSession()`. It now uses `.deleteSession()`.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments
