### PR TITLE
fix: make cli flag set correct chromedriverPort

### DIFF
--- a/docs/en/advanced-concepts/parallel-tests.md
+++ b/docs/en/advanced-concepts/parallel-tests.md
@@ -7,7 +7,7 @@ Note, that it is not possible to have more than one session running on the *same
 The important capabilities:
 
 - `udid` the device id
-- `chromeDriverPort` the chromedriver port (if using webviews or chrome)
+- `chromedriverPort` the chromedriver port (if using webviews or chrome)
 - `systemPort` If you are using [appium-uiautomator2-driver](https://github.com/appium/appium-uiautomator2-driver), set a unique system port for each parallel session. Otherwise you might get a port conflict such as in [this issue](https://github.com/appium/appium/issues/7745).
 
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -255,15 +255,6 @@ const args = [
     help: 'port for robot',
   }],
 
-  [['--chromedriver-port'], {
-    defaultValue: null,
-    dest: 'chromeDriverPort',
-    required: false,
-    type: 'int',
-    example: '9515',
-    help: 'Port upon which ChromeDriver will run. If not given, Android driver will pick a random available port.',
-  }],
-
   [['--chromedriver-executable'], {
     defaultValue: null,
     dest: 'chromedriverExecutable',
@@ -789,6 +780,16 @@ const deprecatedArgs = [
     action: 'storeTrue',
     deprecatedFor: '--long-stacktrace',
     help: '[DEPRECATED] - Add long stack traces to log entries. Recommended for debugging only.',
+  }],
+
+  [['--chromedriver-port'], {
+    defaultValue: null,
+    dest: 'chromedriverPort',
+    required: false,
+    type: 'int',
+    example: '9515',
+    deprecatedFor: '--default-capabilities',
+    help: '[DEPRECATED] - Port upon which ChromeDriver will run. If not given, Android driver will pick a random available port.',
   }],
 ];
 


### PR DESCRIPTION
## Proposed changes

The `--chromedriver-port` command line option should set `chromedriverPort` not `chromeDriverPort`, though the latter is handled in the driver (see https://github.com/appium/appium-android-driver/blob/d8685916a452a2f205d4d945d806015cc29bb4d8/lib/commands/context.js#L344-L347). 

This also moved the flag into the deprecated section, and deprecates in favor of `--default-capabilities`.

Fixes https://github.com/appium/appium/issues/13767

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
