### PR TITLE
docs: Add a note about Android Q+ WiFi limitation

### DIFF
--- a/commands-yml/commands/device/network/toggle-wifi.yml
+++ b/commands-yml/commands/device/network/toggle-wifi.yml
@@ -1,6 +1,14 @@
 ---
 name: Toggle WiFi
-short_description: Switch the state of the wifi service
+short_description: Switch the state of the WiFi service
+
+description:
+  >
+    Switch the state of the WiFi service.
+
+    Since Android Q, a method to change the WiFi service state has been restricted. [#12327](https://github.com/appium/appium/issues/12327)
+    Please toggle the state via UI instead of this method.
+    The UI flow depends on devices. Please make sure the UI flow on your target devices under test.
 
 example_usage:
   java:

--- a/commands-yml/commands/device/network/toggle-wifi.yml
+++ b/commands-yml/commands/device/network/toggle-wifi.yml
@@ -8,7 +8,7 @@ description:
 
     Since Android Q, a method to change the WiFi service state has been restricted. [#12327](https://github.com/appium/appium/issues/12327)
     Please toggle the state via UI instead of this method.
-    The UI flow depends on devices. Please make sure the UI flow on your target devices under test.
+    The UI flow depends on devices. Please make sure to encode the correct UI flow on your target device under test.
 
 example_usage:
   java:


### PR DESCRIPTION
## Proposed changes

Add a note about WiFi state change since Android Q.
Appium can get the UI flow for Android Q+ in android driver, but it would be better to add this not since the UI flow depends on devices.

Related to https://github.com/appium/appium/issues/12327

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
