### PR TITLE
feat: Make sure all active sessions are cleaned up properly after a termination signal is received

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -494,16 +494,20 @@ class AppiumDriver extends BaseDriver {
     } else {
       log.debug(`Cleaning up ${_.size(this.sessions)} active session` +
         (_.size(this.sessions) === 1 ? '' : 's'));
-      try {
-        if (force) {
-          await B.all(_.values(this.sessions)
-            .map((drv) => drv.startUnexpectedShutdown(reason && new Error(reason))));
-        } else {
-          await B.all(_.keys(this.sessions)
-            .map((id) => this.deleteSession(id)));
+      const cleanupPromises = [];
+      if (force) {
+        cleanupPromises.push(...(_.values(this.sessions)
+          .map((drv) => drv.startUnexpectedShutdown(reason && new Error(reason)))));
+      } else {
+        cleanupPromises.push(...(_.keys(this.sessions)
+          .map((id) => this.deleteSession(id))));
+      }
+      for (const cleanupPromise of cleanupPromises) {
+        try {
+          await cleanupPromise;
+        } catch (e) {
+          log.debug(e);
         }
-      } catch (e) {
-        log.debug(e);
       }
     }
   }

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -493,7 +493,7 @@ class AppiumDriver extends BaseDriver {
 
     const {
       force = false,
-      reason = null,
+      reason,
     } = opts;
     log.debug(`Cleaning up ${sessionsCount} active session` + (sessionsCount === 1 ? '' : 's'));
     const cleanupPromises = force

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -485,8 +485,9 @@ class AppiumDriver extends BaseDriver {
   }
 
   async deleteAllSessions (opts = {}) {
-    if (_.isEmpty(this.sessions)) {
-      log.debug(`There are no active sessions`);
+    const sessionsCount = _.size(this.sessions);
+    if (0 === sessionsCount) {
+      log.debug('There are no active sessions for cleanup');
       return;
     }
 
@@ -494,8 +495,7 @@ class AppiumDriver extends BaseDriver {
       force = false,
       reason = null,
     } = opts;
-    log.debug(`Cleaning up ${_.size(this.sessions)} active session` +
-      (_.size(this.sessions) === 1 ? '' : 's'));
+    log.debug(`Cleaning up ${sessionsCount} active session` + (sessionsCount === 1 ? '' : 's'));
     const cleanupPromises = force
       ? _.values(this.sessions).map((drv) => drv.startUnexpectedShutdown(reason && new Error(reason)))
       : _.keys(this.sessions).map((id) => this.deleteSession(id));

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -485,29 +485,25 @@ class AppiumDriver extends BaseDriver {
   }
 
   async deleteAllSessions (opts = {}) {
+    if (_.isEmpty(this.sessions)) {
+      log.debug(`There are no active sessions`);
+      return;
+    }
+
     const {
       force = false,
       reason = null,
     } = opts;
-    if (_.isEmpty(this.sessions)) {
-      log.debug(`There are no active sessions`);
-    } else {
-      log.debug(`Cleaning up ${_.size(this.sessions)} active session` +
-        (_.size(this.sessions) === 1 ? '' : 's'));
-      const cleanupPromises = [];
-      if (force) {
-        cleanupPromises.push(...(_.values(this.sessions)
-          .map((drv) => drv.startUnexpectedShutdown(reason && new Error(reason)))));
-      } else {
-        cleanupPromises.push(...(_.keys(this.sessions)
-          .map((id) => this.deleteSession(id))));
-      }
-      for (const cleanupPromise of cleanupPromises) {
-        try {
-          await cleanupPromise;
-        } catch (e) {
-          log.debug(e);
-        }
+    log.debug(`Cleaning up ${_.size(this.sessions)} active session` +
+      (_.size(this.sessions) === 1 ? '' : 's'));
+    const cleanupPromises = force
+      ? _.values(this.sessions).map((drv) => drv.startUnexpectedShutdown(reason && new Error(reason)))
+      : _.keys(this.sessions).map((id) => this.deleteSession(id));
+    for (const cleanupPromise of cleanupPromises) {
+      try {
+        await cleanupPromise;
+      } catch (e) {
+        log.debug(e);
       }
     }
   }

--- a/lib/appium.js
+++ b/lib/appium.js
@@ -311,13 +311,7 @@ class AppiumDriver extends BaseDriver {
       this.printNewSessionAnnouncement(InnerDriver.name, driverVersion);
 
       if (this.args.sessionOverride) {
-        const sessionIdsToDelete = await sessionsListGuard.acquire(AppiumDriver.name, () => _.keys(this.sessions));
-        if (sessionIdsToDelete.length) {
-          log.info(`Session override is on. Deleting other ${sessionIdsToDelete.length} active session${sessionIdsToDelete.length ? '' : 's'}.`);
-          try {
-            await B.map(sessionIdsToDelete, (id) => this.deleteSession(id));
-          } catch (ign) {}
-        }
+        await this.deleteAllSessions();
       }
 
       let runningDriversData, otherPendingDriversData;
@@ -487,6 +481,30 @@ class AppiumDriver extends BaseDriver {
         protocol,
         error: e,
       };
+    }
+  }
+
+  async deleteAllSessions (opts = {}) {
+    const {
+      force = false,
+      reason = null,
+    } = opts;
+    if (_.isEmpty(this.sessions)) {
+      log.debug(`There are no active sessions`);
+    } else {
+      log.debug(`Cleaning up ${_.size(this.sessions)} active session` +
+        (_.size(this.sessions) === 1 ? '' : 's'));
+      try {
+        if (force) {
+          await B.all(_.values(this.sessions)
+            .map((drv) => drv.startUnexpectedShutdown(reason && new Error(reason))));
+        } else {
+          await B.all(_.keys(this.sessions)
+            .map((id) => this.deleteSession(id)));
+        }
+      } catch (e) {
+        log.debug(e);
+      }
     }
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -149,6 +149,7 @@ async function main (args = null) {
         reason: `The process has received ${signal} signal`,
       });
       await server.close();
+      process.exit();
     });
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -144,12 +144,17 @@ async function main (args = null) {
   for (const signal of ['SIGINT', 'SIGTERM']) {
     process.once(signal, async function onSignal () {
       logger.info(`Received ${signal} - shutting down`);
-      await appiumDriver.deleteAllSessions({
-        force: true,
-        reason: `The process has received ${signal} signal`,
-      });
-      await server.close();
-      process.exit();
+      try {
+        await appiumDriver.deleteAllSessions({
+          force: true,
+          reason: `The process has received ${signal} signal`,
+        });
+        await server.close();
+        process.exit(0);
+      } catch (e) {
+        logger.warn(e);
+        process.exit(1);
+      }
     });
   }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -141,15 +141,16 @@ async function main (args = null) {
     throw err;
   }
 
-  process.once('SIGINT', async function onSigint () {
-    logger.info(`Received SIGINT - shutting down`);
-    await server.close();
-  });
-
-  process.once('SIGTERM', async function onSigterm () {
-    logger.info(`Received SIGTERM - shutting down`);
-    await server.close();
-  });
+  for (const signal of ['SIGINT', 'SIGTERM']) {
+    process.once(signal, async function onSignal () {
+      logger.info(`Received ${signal} - shutting down`);
+      await appiumDriver.deleteAllSessions({
+        force: true,
+        reason: `The process has received ${signal} signal`,
+      });
+      await server.close();
+    });
+  }
 
   logServerPort(args.address, args.port);
 


### PR DESCRIPTION
## Proposed changes

We need to make sure all sessions are terminated properly if one terminates Appium process.
Related to https://github.com/appium/appium-xcuitest-driver/pull/1153#issuecomment-582005789

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
