### PR TITLE
fix: add node binary to the Appium bundle

### DIFF
--- a/ci-jobs/templates/bundle-template.yml
+++ b/ci-jobs/templates/bundle-template.yml
@@ -25,9 +25,17 @@ jobs:
       displayName: npm run build
     - script: npm prune --production
       displayName: Get rid of dev dependencies
+    - script: |
+        curl -o node-darwin.tar.gz https://nodejs.org/dist/v12.16.1/node-v12.16.1-darwin-x64.tar.gz
+        mkdir node-darwin-unpacked
+        tar -xzf node-darwin.tar.gz -C node-darwin-unpacked/ --strip-components 1
+        rm -f node-darwin.tar.gz
+        cp node-darwin-unpacked/bin/node node-darwin
+        rm -rf node-darwin-unpacked
+      displayName: Download NodeJS
     - script: npm run zip
       displayName: Create the bundle zip
-    - script: npm install 
+    - script: npm install
       displayName: Reinstall dev dependencies
     - task: PublishPipelineArtifact@0
       inputs:


### PR DESCRIPTION
## Proposed changes

First pass at adding a NodeJS binary to the Appium bundle. This is needed for running on Sauce.

Right now the Node version is hardcoded, just to see if the solution works. If it does, the latest LTS can be retrieved, but that is a bit of a process and not worth doing before the technique is verified.

Ought to fix the `appium-xcuitest-driver` nightly build (see https://travis-ci.org/appium/appium-xcuitest-driver/builds/654267232)

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

