### PR TITLE
Fix the problematic code snippet for Java.

### DIFF
--- a/commands-yml/commands/session/settings/update-settings.yml
+++ b/commands-yml/commands/session/settings/update-settings.yml
@@ -4,7 +4,7 @@ short_description: Update the current setting on the device
 example_usage:
   java:
     |
-      driver.setSetting(Setting.WAIT_FOR_IDLE_TIMEOUT, Duration.ofSeconds(5));
+      driver.setSetting(Setting.WAIT_FOR_IDLE_TIMEOUT, 5000);
   javascript_wd:
     |
       await driver.updateSettings({nativeWebTap: true});


### PR DESCRIPTION
The given code won't in the real world and the user will get an error when running the given code snippet with uiautomation=uiautomator2.  The setting ```waitForIdleTimeout``` only works with Integer/Long value. 
Ref: http://appium.io/docs/en/advanced-concepts/settings/index.html
