### PR TITLE
chore: Remove replace-ext dependency

### DIFF
--- a/commands-yml/parse.js
+++ b/commands-yml/parse.js
@@ -31,8 +31,6 @@ const appiumRanges = {
   mac: ['1.6.4'],
 };
 
-const FILENAME_PATTERN = /(.*)\.[^.]+$/;
-
 const rootFolder = findRoot(__dirname);
 
 // Create Handlebars helper that shows a version range
@@ -205,7 +203,8 @@ async function generateCommands () {
     const markdown = template(inputJSON);
 
     // Write the markdown to its right place
-    const markdownPath = `${relativeFilename.replace(FILENAME_PATTERN, '$1')}.md`;
+    const ext = path.extname(relativeFilename);
+    const markdownPath = `${relativeFilename.substring(0, relativeFilename.length - ext.length)}.md`;
     const outfile = path.resolve(rootFolder, 'docs', 'en', markdownPath);
     log(`    Writing to: ${outfile}`);
     await mkdirp(path.dirname(outfile));

--- a/commands-yml/parse.js
+++ b/commands-yml/parse.js
@@ -3,7 +3,6 @@ import yaml from 'yaml-js';
 import { fs, mkdirp, util } from 'appium-support';
 import validate from 'validate.js';
 import Handlebars from 'handlebars';
-import replaceExt from 'replace-ext';
 import _ from 'lodash';
 import { asyncify } from 'asyncbox';
 import { validator, CLIENT_URL_TYPES } from './validator';
@@ -31,6 +30,8 @@ const appiumRanges = {
   windows: ['1.6.0'],
   mac: ['1.6.4'],
 };
+
+const FILENAME_PATTERN = /(.*)\.[^.]+$/;
 
 const rootFolder = findRoot(__dirname);
 
@@ -204,7 +205,7 @@ async function generateCommands () {
     const markdown = template(inputJSON);
 
     // Write the markdown to its right place
-    const markdownPath = replaceExt(relativeFilename, '.md');
+    const markdownPath = `${relativeFilename.replace(FILENAME_PATTERN, '$1')}.md`;
     const outfile = path.resolve(rootFolder, 'docs', 'en', markdownPath);
     log(`    Writing to: ${outfile}`);
     await mkdirp(path.dirname(outfile));

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "handlebars": "^4.2.0",
     "mocha": "^7.0.1",
     "pre-commit": "1.x",
-    "replace-ext": "^1.0.0",
     "rimraf": "^3.0.0",
     "sinon": "^9.0.0",
     "validate.js": "^0.13.0",


### PR DESCRIPTION
## Proposed changes

There is no point in importing of solutions, which could be implemented as a single regexp replacement

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)