### PR TITLE
Add troubleshooting ideas for Safari / WebView Automation

### DIFF
--- a/docs/en/drivers/ios-xcuitest-real-devices.md
+++ b/docs/en/drivers/ios-xcuitest-real-devices.md
@@ -236,6 +236,8 @@ for this).
 1. Make sure UDID is correct by checking it in Xcode Organizer or iTunes. It
    is a long string (20+ chars).
 1. Make sure that you can run your tests against the Simulator.
-1. Make sure UI Automation is enabled on your device. Settings -> Developer ->
-   Enable UI Automation
+1. Make sure the following settings are **enabled** on your device:
+    1. Settings -> Developer -> **Enable UI Automation**
+    1. Settings -> Safari -> Advanced -> **Web Inspector** and **Remote Automation**
+        1. Please read [Automating mobile web apps](docs/en/writing-running-appium/web/mobile-web/) for more details about WebView
 1. Consider generating a provisioning profile with `.xctrunner` identifier if you do not want to generate a wildcard one for manual configuration. The `.xctrunner` config support has been added since Xcode 11. [A reference](https://github.com/appium/appium/issues/13610)


### PR DESCRIPTION
## Proposed changes

As seen in #14178 both `Web Inspector` and `Remote Automation` need to be activated for `getContexts` to be working properly. This change will add a note to the troubleshooting ideas to remind the users to enable those settings, to avoid issues in the future.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
