### PR TITLE
fix: Only strip known prefixes from capability names

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,14 +73,14 @@ function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constrain
         // Check if the key is already present in firstMatch entries
         for (const firstMatchEntry of (w3cCapabilities.firstMatch || [])) {
           if (_.isPlainObject(firstMatchEntry)
-              && _.has(removeW3CPrefixes(firstMatchEntry), removeW3CPrefix(defaultCapKey))) {
+              && _.has(removeAppiumPrefixes(firstMatchEntry), removeAppiumPrefix(defaultCapKey))) {
             isCapAlreadySet = true;
             break;
           }
         }
         // Check if the key is already present in alwaysMatch entries
         isCapAlreadySet = isCapAlreadySet || (_.isPlainObject(w3cCapabilities.alwaysMatch)
-          && _.has(removeW3CPrefixes(w3cCapabilities.alwaysMatch), removeW3CPrefix(defaultCapKey)));
+          && _.has(removeAppiumPrefixes(w3cCapabilities.alwaysMatch), removeAppiumPrefix(defaultCapKey)));
         if (isCapAlreadySet) {
           // Skip if the key is already present in the provided caps
           continue;
@@ -95,7 +95,7 @@ function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constrain
       }
     }
     if (hasJSONWPCaps) {
-      jsonwpCapabilities = Object.assign({}, removeW3CPrefixes(defaultCapabilities), jsonwpCapabilities);
+      jsonwpCapabilities = Object.assign({}, removeAppiumPrefixes(defaultCapabilities), jsonwpCapabilities);
     }
   }
 
@@ -103,7 +103,7 @@ function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constrain
   if (hasJSONWPCaps) {
     protocol = MJSONWP;
     desiredCaps = jsonwpCapabilities;
-    processedJsonwpCapabilities = removeW3CPrefixes({...desiredCaps});
+    processedJsonwpCapabilities = {...jsonwpCapabilities};
   }
 
   // Get W3C caps
@@ -129,7 +129,7 @@ function parseCapsForInnerDriver (jsonwpCapabilities, w3cCapabilities, constrain
     }
 
     if (hasJSONWPCaps && !isFixingNeededForW3cCaps) {
-      const differingKeys = _.difference(_.keys(processedJsonwpCapabilities), _.keys(removeW3CPrefixes(desiredCaps)));
+      const differingKeys = _.difference(_.keys(removeAppiumPrefixes(processedJsonwpCapabilities)), _.keys(removeAppiumPrefixes(desiredCaps)));
       if (!_.isEmpty(differingKeys)) {
         logger.info(`The following capabilities were provided in the JSONWP desired capabilities that are missing ` +
           `in W3C capabilities: ${JSON.stringify(differingKeys)}`);
@@ -233,21 +233,21 @@ function insertAppiumPrefixes (caps) {
   return prefixedCaps;
 }
 
-function removeW3CPrefixes (caps) {
+function removeAppiumPrefixes (caps) {
   if (!_.isPlainObject(caps)) {
     return caps;
   }
 
   const fixedCaps = {};
   for (let [name, value] of _.toPairs(caps)) {
-    fixedCaps[removeW3CPrefix(name)] = value;
+    fixedCaps[removeAppiumPrefix(name)] = value;
   }
   return fixedCaps;
 }
 
-function removeW3CPrefix (key) {
-  const colonPos = key.indexOf(':');
-  return colonPos > 0 && key.length > colonPos ? key.substring(colonPos + 1) : key;
+function removeAppiumPrefix (key) {
+  const prefix = `${W3C_APPIUM_PREFIX}:`;
+  return _.startsWith(key, prefix) ? key.substring(prefix.length) : key;
 }
 
 function getPackageVersion (pkgName) {
@@ -293,5 +293,5 @@ const rootDir = findRoot(__dirname);
 
 export {
   inspectObject, parseCapsForInnerDriver, insertAppiumPrefixes, rootDir,
-  getPackageVersion, pullSettings,
+  getPackageVersion, pullSettings, removeAppiumPrefixes,
 };

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -90,7 +90,7 @@ describe('utils', function () {
         'appium:foo2': 'bar2',
       });
       desiredCaps.should.deep.equal({foo: 'baz', foo2: 'baz2', ...BASE_CAPS});
-      processedJsonwpCapabilities.should.deep.equal({foo: 'baz', foo2: 'baz2', ...BASE_CAPS});
+      processedJsonwpCapabilities.should.deep.equal({foo: 'baz', foo2: 'bar2', 'appium:foo2': 'baz2', ...BASE_CAPS});
       processedW3CCapabilities.alwaysMatch.should.deep.equal({'appium:foo': 'baz', 'appium:foo2': 'baz2', ...insertAppiumPrefixes(BASE_CAPS)});
     });
     it('should reject if W3C caps are not passing constraints', function () {

--- a/test/utils-specs.js
+++ b/test/utils-specs.js
@@ -1,7 +1,9 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {
-  parseCapsForInnerDriver, insertAppiumPrefixes, pullSettings } from '../lib/utils';
+  parseCapsForInnerDriver, insertAppiumPrefixes, pullSettings,
+  removeAppiumPrefixes,
+} from '../lib/utils';
 import { BASE_CAPS, W3C_CAPS } from './helpers';
 import _ from 'lodash';
 
@@ -169,6 +171,20 @@ describe('utils', function () {
       desiredCaps.should.eql({...BASE_CAPS, propertyName: 'PROP_NAME'});
       processedJsonwpCapabilities.should.eql(BASE_CAPS);
       protocol.should.equal('W3C');
+    });
+  });
+
+  describe('removeAppiumPrefixes()', function () {
+    it('should remove appium prefixes from cap names', function () {
+      removeAppiumPrefixes({
+        'appium:cap1': 'value1',
+        'ms:cap2': 'value2',
+        someCap: 'someCap',
+      }).should.eql({
+        'cap1': 'value1',
+        'ms:cap2': 'value2',
+        someCap: 'someCap',
+      });
     });
   });
 


### PR DESCRIPTION
## Proposed changes

We strip all prefixes from cap names, which is sometimes not something we'd like to achieve. It only makes sense to deal with the prefixes that we know about. Addresses https://github.com/appium/appium/issues/14490

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

