### PR TITLE
docs: fix broken links in documentation

### DIFF
--- a/docs/cn/advanced-concepts/grid.md
+++ b/docs/cn/advanced-concepts/grid.md
@@ -8,7 +8,7 @@
 > node . --nodeconfig /path/to/nodeconfig.json
 ```
 
-在 Selenium 节点（Node）的配置文件里，你需要定义 `browserName`、`version` 和 `platform`，然后 Grid 会通过这些参数将你的测试重定向到正确的设备上。你还需要配置 `host` 和 `selenium grid` 的详细信息。详细的参数列表和描述信息，请查看 [这里](https://www.selenium.dev/documentation/en/grid/setting_up_your_own_grid/) 。
+在 Selenium 节点（Node）的配置文件里，你需要定义 `browserName`、`version` 和 `platform`，然后 Grid 会通过这些参数将你的测试重定向到正确的设备上。你还需要配置 `host` 和 `selenium grid` 的详细信息。详细的参数列表和描述信息，请查看 这里。
 
 一旦你启动了 appium 服务器并且在 grid 里注册了信息，就可以在 grid 控制台看到你的设备：
 

--- a/docs/en/drivers/windows.md
+++ b/docs/en/drivers/windows.md
@@ -38,7 +38,7 @@ should be used specifically with the Windows driver.
 ### Setup
 
 To test a Windows app, simply make sure you have turned [developer
-mode](https://msdn.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development)
+mode](https://docs.microsoft.com/en-us/windows/uwp/get-started/enable-your-device-for-development)
 on.
 
 When running Appium (whether Appium Desktop or from the command line), ensure


### PR DESCRIPTION
## Proposed changes

Fix links in documentation.
The grid link was removed so 404, the Windows link was redirected to the new one.
https://travis-ci.org/github/appium/appium.io/jobs/704873414

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
