### PR TITLE
Add white space to work issues of MkDocs tool

### DIFF
--- a/docs/en/writing-running-appium/android/android-appbundle.md
+++ b/docs/en/writing-running-appium/android/android-appbundle.md
@@ -12,6 +12,7 @@ We can get distributed apk files from the `.aab` file via the CLI. Using the gen
 2. Generate the `.apks` file from the `.aab` file
     - The `.aab` is available over Android Studio 3.2
     - You must sign correctly when you generate `.apks` from `.aab`. This step requires data signing.
+
         ```bash
         $ java -jar apks/bundletool.jar build-apks \
           --bundle apks/release/release/app.aab \ # A generated aab file
@@ -21,7 +22,9 @@ We can get distributed apk files from the `.aab` file via the CLI. Using the gen
           --ks-pass pass:kazucocoa \              # Password of the keystore
           --overwrite                             # Overwrite any existing apks files
         ```
+
 3. Use the path to the `.apks` file as your `app` capability.
+
     ```ruby
     desired_capability = caps: {
         platformName: :android,
@@ -42,7 +45,7 @@ You can find another way to get test APKs in https://developer.android.com/guide
 ## Tips
 ### Make `bundletool.jar` executable
 
-Make sure the bundletool is executable.
+Make sure the bundletool is executable.  
 `$ chmod 655 /path/to/bundletool.jar` can make it executable, for example.
 
 ### Test with different languages


### PR DESCRIPTION
When viewed as a discrete document, the formatting looks good. Within the documentation collection, however, embedded code does not render correctly. This appears to be a documented issue of `MkDocs`.

Discrete: https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/android/android-appbundle.md
Collection: http://appium.io/docs/en/writing-running-appium/android/android-appbundle/index.html

Here's the related MkDocs issue: https://github.com/mkdocs/mkdocs/issues/2163
These changes appear to enable to formatting of this document to be rendered correctly in the collection.

## Proposed changes

Add white space to enable embedded code blocks to render correctly.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
