### PR TITLE
chore: use appium2 version of base driver

### DIFF
--- a/commands-yml/commands/session/create.yml
+++ b/commands-yml/commands/session/create.yml
@@ -19,7 +19,7 @@ example_usage:
         desiredCapabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME, "XCUITest");
         desiredCapabilities.setCapability(MobileCapabilityType.APP, "/path/to/ios/app.zip");
 
-        URL url = new URL("http://127.0.0.1:4723/wd/hub");
+        URL url = new URL("http://127.0.0.1:4723");
 
         IOSDriver driver = new IOSDriver(url, desiredCapabilities);
         String sessionId = driver.getSessionId().toString();
@@ -33,7 +33,7 @@ example_usage:
         'automationName': 'UiAutomator2',
         'app': PATH('/path/to/app')
       }
-      self.driver = webdriver.Remote('http://127.0.0.1:4723/wd/hub', desired_caps)
+      self.driver = webdriver.Remote('http://127.0.0.1:4723', desired_caps)
   javascript_wd:
     |
       let driver = await wd.promiseChainRemote({
@@ -87,7 +87,7 @@ example_usage:
       appiumOptions.AddAdditionalCapability("appPackage", "com.instagram.android");
       appiumOptions.AddAdditionalCapability("appActivity", "com.instagram.android.activity.MainTabActivity");
 
-      AndroidDriver<AndroidElement> driver = new AndroidDriver<AndroidElement>(new Uri("http://127.0.0.1:4723/wd/hub"), appiumOptions);
+      AndroidDriver<AndroidElement> driver = new AndroidDriver<AndroidElement>(new Uri("http://127.0.0.1:4723"), appiumOptions);
 
 client_docs:
   java: "https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/remote/server/DefaultSession.html#createSession-org.openqa.selenium.remote.server.DriverFactory-org.openqa.selenium.remote.server.Clock-org.openqa.selenium.remote.SessionId-org.openqa.selenium.Capabilities-"

--- a/docs/en/about-appium/getting-started.md
+++ b/docs/en/about-appium/getting-started.md
@@ -184,7 +184,7 @@ So here is how we begin to construct a session in our test file:
 ```js
 // javascript
 const opts = {
-  path: '/wd/hub',
+  path: '',
   port: 4723,
   capabilities: {
     platformName: "Android",
@@ -239,7 +239,7 @@ const wdio = require("webdriverio");
 const assert = require("assert");
 
 const opts = {
-  path: '/wd/hub',
+  path: '',
   port: 4723,
   capabilities: {
     platformName: "Android",

--- a/docs/en/writing-running-appium/server-args.md
+++ b/docs/en/writing-running-appium/server-args.md
@@ -18,7 +18,7 @@ All flags are optional, but some are required in conjunction with certain others
 |`--ipa`|null|(IOS-only) abs path to compiled .ipa file|`--ipa /abs/path/to/my.ipa`|
 |`-a`, `--address`|0.0.0.0|IP Address to listen on|`--address 0.0.0.0`|
 |`-p`, `--port`|4723|port to listen on|`--port 4723`|
-|`-pa`, `--base-path`|/wd/hub|Initial path segment where the Appium/WebDriver API will be hosted. Every endpoint will be behind this segment.|`--base-path /my/path/prefix`|
+|`-pa`, `--base-path`|null|Initial path segment where the Appium/WebDriver API will be hosted. Every endpoint will be behind this segment.|`--base-path /wd/hub`|
 |`-ca`, `--callback-address`|null|callback IP Address (default: same as --address)|`--callback-address 127.0.0.1`|
 |`-cp`, `--callback-port`|null|callback port (default: same as port)|`--callback-port 4723`|
 |`-bp`, `--bootstrap-port`|4724|(Android-only) port to use on device to talk to Appium|`--bootstrap-port 4724`|

--- a/docs/en/writing-running-appium/web/hybrid.md
+++ b/docs/en/writing-running-appium/web/hybrid.md
@@ -1,4 +1,4 @@
-## Automating hybrid apps
+;# Automating hybrid apps
 
 One of the core principles of Appium is that you shouldn't have to change your
 app to test it. In line with that methodology, it is possible to test hybrid
@@ -63,7 +63,7 @@ driver
 ```java
 // java
 // assuming we have a set of capabilities
-driver = new AppiumDriver(new URL("http://127.0.0.1:4723/wd/hub"), capabilities);
+driver = new AppiumDriver(new URL("http://127.0.0.1:4723"), capabilities);
 
 Set<String> contextNames = driver.getContextHandles();
 for (String contextName : contextNames) {

--- a/docs/en/writing-running-appium/web/mobile-web.md
+++ b/docs/en/writing-running-appium/web/mobile-web.md
@@ -128,7 +128,7 @@ To configure you test to run against safari simply set the `"browserName"` to be
 DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
 desiredCapabilities.setCapability(MobileCapabilityType.BROWSER_NAME, "Safari");
 desiredCapabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME, "XCUITest");
-URL url = new URL("http://127.0.0.1:4723/wd/hub");
+URL url = new URL("http://127.0.0.1:4723");
 AppiumDriver driver = new AppiumDriver(url, desiredCapabilities);
 
 // Navigate to the page and interact with the elements on the guinea-pig page using id.
@@ -145,7 +145,7 @@ driver.quit();
 # python
 # setup the web driver and launch the webview app.
 capabilities = { 'browserName': 'Safari', 'automationName': 'XCUITest' }
-driver = webdriver.Remote('http://localhost:4723/wd/hub', capabilities)
+driver = webdriver.Remote('http://localhost:4723', capabilities)
 
 # Navigate to the page and interact with the elements on the guinea-pig page using id.
 driver.get('http://saucelabs.com/test/guinea-pig');

--- a/lib/grid-register.js
+++ b/lib/grid-register.js
@@ -9,7 +9,7 @@ const hubUri = (config) => {
   return `${protocol}://${config.hubHost}:${config.hubPort}`;
 };
 
-async function registerNode (configFile, addr, port) {
+async function registerNode (configFile, addr, port, basePath) {
   let data;
   try {
     data = await fs.readFile(configFile, 'utf-8');
@@ -23,7 +23,7 @@ async function registerNode (configFile, addr, port) {
     logger.error('No data found in the node configuration file to send to the grid');
     return;
   }
-  postRequest(data, addr, port);
+  postRequest(data, addr, port, basePath);
 }
 
 async function registerToGrid (postOptions, configHolder) {
@@ -39,7 +39,7 @@ async function registerToGrid (postOptions, configHolder) {
   }
 }
 
-function postRequest (data, addr, port) {
+function postRequest (data, addr, port, basePath) {
   // parse json to get hub host and port
   let configHolder;
   try {
@@ -66,7 +66,7 @@ function postRequest (data, addr, port) {
   // because we will always set localhost/127.0.0.1. this won't work if your
   // node and grid aren't in the same place
   if (!configHolder.configuration.url || !configHolder.configuration.host || !configHolder.configuration.port) {
-    configHolder.configuration.url = `http://${addr}:${port}/wd/hub`;
+    configHolder.configuration.url = `http://${addr}:${port}${basePath}`;
     configHolder.configuration.host = addr;
     configHolder.configuration.port = port;
   }

--- a/lib/main.js
+++ b/lib/main.js
@@ -178,7 +178,7 @@ async function main (args = null) {
 
     // configure as node on grid, if necessary
     if (args.nodeconfig !== null) {
-      await registerNode(args.nodeconfig, args.address, args.port);
+      await registerNode(args.nodeconfig, args.address, args.port, args.basePath);
     }
   } catch (err) {
     await server.close();

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@appium/base-plugin": "^1.0.0",
     "@babel/runtime": "^7.6.0",
-    "appium-base-driver": "^7.0.0",
+    "appium-base-driver": "8.0.0-beta.0",
     "appium-support": "2.x",
     "argparse": "^1.0.10",
     "async-lock": "^1.0.0",

--- a/test/driver-e2e-specs.js
+++ b/test/driver-e2e-specs.js
@@ -17,6 +17,7 @@ import sinon from 'sinon';
 
 chai.use(chaiAsPromised);
 
+const TEST_SERVER = `http://${TEST_HOST}:${TEST_PORT}`;
 const FAKE_DRIVER_DIR = path.resolve(__dirname, '..', '..', 'node_modules', 'appium-fake-driver');
 
 const should = chai.should();
@@ -34,7 +35,7 @@ describe('FakeDriver - via HTTP', function () {
   // since we update the FakeDriver.prototype below, make sure we update the FakeDriver which is
   // actually going to be required by Appium
   let FakeDriver = null;
-  const baseUrl = `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`;
+  const baseUrl = `http://${TEST_HOST}:${TEST_PORT}/session`;
   before(async function () {
     const config = new DriverConfig(appiumHome);
     await config.read();
@@ -69,7 +70,7 @@ describe('FakeDriver - via HTTP', function () {
 
   describe('session handling', function () {
     it('should start and stop a session', async function () {
-      let driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+      let driver = wd.promiseChainRemote(TEST_SERVER);
       let [sessionId] = await driver.init(caps);
       should.exist(sessionId);
       sessionId.should.be.a('string');
@@ -78,11 +79,11 @@ describe('FakeDriver - via HTTP', function () {
     });
 
     it('should be able to run two FakeDriver sessions simultaneously', async function () {
-      let driver1 = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+      let driver1 = wd.promiseChainRemote(TEST_SERVER);
       let [sessionId1] = await driver1.init(caps);
       should.exist(sessionId1);
       sessionId1.should.be.a('string');
-      let driver2 = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+      let driver2 = wd.promiseChainRemote(TEST_SERVER);
       let [sessionId2] = await driver2.init(caps);
       should.exist(sessionId2);
       sessionId2.should.be.a('string');
@@ -94,17 +95,17 @@ describe('FakeDriver - via HTTP', function () {
     it('should not be able to run two FakeDriver sessions simultaneously when one is unique', async function () {
       let uniqueCaps = _.clone(caps);
       uniqueCaps.uniqueApp = true;
-      let driver1 = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+      let driver1 = wd.promiseChainRemote(TEST_SERVER);
       let [sessionId1] = await driver1.init(uniqueCaps);
       should.exist(sessionId1);
       sessionId1.should.be.a('string');
-      let driver2 = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+      let driver2 = wd.promiseChainRemote(TEST_SERVER);
       await driver2.init(caps).should.eventually.be.rejected;
       await driver1.quit();
     });
 
     it('should use the newCommandTimeout of the inner Driver on session creation', async function () {
-      let driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+      let driver = wd.promiseChainRemote(TEST_SERVER);
 
       let localCaps = Object.assign({
         newCommandTimeout: 0.25,

--- a/test/plugin-e2e-specs.js
+++ b/test/plugin-e2e-specs.js
@@ -15,6 +15,7 @@ chai.should();
 chai.use(chaiAsPromised);
 const FAKE_PLUGIN_DIR = path.resolve(__dirname, '..', '..', 'node_modules', '@appium', 'fake-plugin');
 const FAKE_DRIVER_DIR = path.resolve(__dirname, '..', '..', 'node_modules', 'appium-fake-driver');
+const TEST_SERVER = `http://${TEST_HOST}:${TEST_PORT}`;
 
 const caps = {
   automationName: 'Fake',
@@ -25,7 +26,7 @@ const caps = {
 
 describe('FakePlugin', function () {
   const appiumHome = DEFAULT_APPIUM_HOME;
-  const baseUrl = `http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`;
+  const baseUrl = `http://${TEST_HOST}:${TEST_PORT}/session`;
   before(async function () {
     // first ensure we have fakedriver installed
     const driverList = await runExtensionCommand({
@@ -73,7 +74,7 @@ describe('FakePlugin', function () {
       await axios.post(`http://${TEST_HOST}:${TEST_PORT}/fake`).should.eventually.be.rejectedWith(/404/);
     });
     it('should not update method map if plugin is not activated', async function () {
-      const driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+      const driver = wd.promiseChainRemote(TEST_SERVER);
       const [sessionId] = await driver.init(caps);
       try {
         await axios.post(`${baseUrl}/${sessionId}/fake_data`, {data: {fake: 'data'}}).should.eventually.be.rejectedWith(/404/);
@@ -82,7 +83,7 @@ describe('FakePlugin', function () {
       }
     });
     it('should not handle commands if plugin is not activated', async function () {
-      const driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+      const driver = wd.promiseChainRemote(TEST_SERVER);
       const [sessionId] = await driver.init(caps);
       try {
         const el = (await axios.post(`${baseUrl}/${sessionId}/element`, {using: 'xpath', value: '//MockWebView'})).data.value;
@@ -113,7 +114,7 @@ describe('FakePlugin', function () {
       });
 
       it('should modify the method map with new commands', async function () {
-        const driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+        const driver = wd.promiseChainRemote(TEST_SERVER);
         const [sessionId] = await driver.init(caps);
         try {
           await axios.post(`${baseUrl}/${sessionId}/fake_data`, {data: {fake: 'data'}});
@@ -124,7 +125,7 @@ describe('FakePlugin', function () {
       });
 
       it('should handle commands and not call the original', async function () {
-        const driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+        const driver = wd.promiseChainRemote(TEST_SERVER);
         const [sessionId] = await driver.init(caps);
         try {
           await driver.source().should.eventually.eql(`<Fake>${JSON.stringify([sessionId])}</Fake>`);
@@ -134,7 +135,7 @@ describe('FakePlugin', function () {
       });
 
       it('should handle commands and call the original if designed', async function () {
-        const driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
+        const driver = wd.promiseChainRemote(TEST_SERVER);
         const [sessionId] = await driver.init(caps);
         try {
           const el = (await axios.post(`${baseUrl}/${sessionId}/element`, {using: 'xpath', value: '//MockWebView'})).data.value;


### PR DESCRIPTION
Want to pull in the breaking change regarding default base path, for the 2.0 branch.