### PR TITLE
docs: Fixed APK name conflict in getting-started.md

### DIFF
--- a/docs/en/about-appium/getting-started.md
+++ b/docs/en/about-appium/getting-started.md
@@ -177,7 +177,7 @@ const opts = {
     platformName: "Android",
     platformVersion: "8",
     deviceName: "Android Emulator",
-    app: "/path/to/the/downloaded/ApiDemos.apk",
+    app: "/path/to/the/downloaded/ApiDemos-debug.apk",
     appPackage: "io.appium.android.apis",
     appActivity: ".view.TextFields",
     automationName: "UiAutomator2"
@@ -232,7 +232,7 @@ const opts = {
     platformName: "Android",
     platformVersion: "8",
     deviceName: "Android Emulator",
-    app: "/path/to/the/downloaded/ApiDemos.apk",
+    app: "/path/to/the/downloaded/ApiDemos-debug.apk",
     appPackage: "io.appium.android.apis",
     appActivity: ".view.TextFields",
     automationName: "UiAutomator2"


### PR DESCRIPTION
## Proposed changes

The downloaded file from https://github.com/appium/appium/raw/master/sample-code/apps/ApiDemos-debug.apk is named `ApiDemos-debug.apk` but the docs use `ApiDemos.apk` for the path which might create unnecessary confusion for developers.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
