### PR TITLE
chore: update to the latest espresso-driver for 1.19

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2441,9 +2441,9 @@
       }
     },
     "appium-espresso-driver": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/appium-espresso-driver/-/appium-espresso-driver-1.38.1.tgz",
-      "integrity": "sha512-8cX4dPKYZIlKOmYpr/F2wwf1WlmrPaVorfNBDewMme1ADlXkUaFqUOEg+W1adoV52nOQo/V6UDhlVeQCshV0jg==",
+      "version": "1.38.2",
+      "resolved": "https://registry.npmjs.org/appium-espresso-driver/-/appium-espresso-driver-1.38.2.tgz",
+      "integrity": "sha512-TskW6PIClXcPP7UGyD8j2WTRjJCWoAfgZjNrAnUVONHR/omc5gpi7Cx7H5Rqq48Zn7mD0glFCpqs57NoyMyKVA==",
       "requires": {
         "@babel/runtime": "^7.4.3",
         "appium-adb": "^8.0.0",


### PR DESCRIPTION
## Proposed changes

I've updated appium-espresso-driver since it has a fix for a regression in 1.19.0 development.

I found the error in ruby_lib_core's test.
With this update, https://dev.azure.com/kazucocoa/ruby_lib_core/_build/results?buildId=2072&view=results passed.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
