### PR TITLE
In python, the method self.driver.window_handles can't be called with '()'.

### DIFF
--- a/commands-yml/commands/web/window/get-handles.yml
+++ b/commands-yml/commands/web/window/get-handles.yml
@@ -8,7 +8,7 @@ example_usage:
       Set<String> windowHandles = driver.getWindowHandles();
   python:
     |
-      window_handles = self.driver.window_handles()
+      window_handles = self.driver.window_handles
   javascript_wd:
     |
       let windowHandle = await driver.windowHandles();


### PR DESCRIPTION
In python, the method can't be called with '()'. It can be called only as 
self.driver.window_handles

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
