### PR TITLE
feat: Add Safari driver to the list of available automation names

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -34,6 +34,7 @@ const AUTOMATION_NAMES = {
   WINDOWS: 'Windows',
   MAC: 'Mac',
   FLUTTER: 'Flutter',
+  SAFARI: 'Safari',
 };
 const DRIVER_MAP = {
   [AUTOMATION_NAMES.UIAUTOMATOR2.toLowerCase()]: {
@@ -79,6 +80,10 @@ const DRIVER_MAP = {
   [AUTOMATION_NAMES.FLUTTER.toLowerCase()]: {
     driverClassName: 'FlutterDriver',
     driverPackage: 'appium-flutter-driver'
+  },
+  [AUTOMATION_NAMES.SAFARI.toLowerCase()]: {
+    driverClassName: 'SafariDriver',
+    driverPackage: 'appium-safari-driver'
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "appium-flutter-driver": "^0",
     "appium-ios-driver": "4.x",
     "appium-mac-driver": "1.x",
+    "appium-safari-driver": "2.x",
     "appium-support": "2.x",
     "appium-tizen-driver": "^1.1.1-beta.4",
     "appium-uiautomator2-driver": "^1.37.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "appium-flutter-driver": "^0",
     "appium-ios-driver": "4.x",
     "appium-mac-driver": "1.x",
-    "appium-safari-driver": "2.x",
+    "appium-safari-driver": "^2.1.0",
     "appium-support": "2.x",
     "appium-tizen-driver": "^1.1.1-beta.4",
     "appium-uiautomator2-driver": "^1.37.1",


### PR DESCRIPTION
## Proposed changes

https://github.com/appium/appium-safari-driver

This driver could be useful if one wants to automate web pages in Safari either on Desktop or Mobile platform. It will also be necessary to update some documents, but I'm not quite sure where to...

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
