### PR TITLE
feat: Add Mac2Driver

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -33,6 +33,7 @@ const AUTOMATION_NAMES = {
   INSTRUMENTS: 'Instruments',
   WINDOWS: 'Windows',
   MAC: 'Mac',
+  MAC2: 'Mac2',
   FLUTTER: 'Flutter',
   SAFARI: 'Safari',
   GECKO: 'Gecko',
@@ -69,6 +70,10 @@ const DRIVER_MAP = {
   [AUTOMATION_NAMES.MAC.toLowerCase()]: {
     driverClassName: 'MacDriver',
     driverPackage: 'appium-mac-driver',
+  },
+  [AUTOMATION_NAMES.MAC2.toLowerCase()]: {
+    driverClassName: 'Mac2Driver',
+    driverPackage: 'appium-mac2-driver',
   },
   [AUTOMATION_NAMES.ESPRESSO.toLowerCase()]: {
     driverClassName: 'EspressoDriver',

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "appium-geckodriver": "^0.3.0",
     "appium-ios-driver": "4.x",
     "appium-mac-driver": "1.x",
+    "appium-mac2-driver": "^0",
     "appium-safari-driver": "^2.1.0",
     "appium-support": "2.x",
     "appium-tizen-driver": "^1.1.1-beta.4",


### PR DESCRIPTION
## Proposed changes

Add XCTest based macOS UI automation driver from https://github.com/appium/appium-mac2-driver
The only hing left would be to add a documentation entry that describes the new driver

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
