### PR TITLE
fix: npm 7+ removes info from json response, so don't rely on it anymore

### DIFF
--- a/lib/cli/npm.js
+++ b/lib/cli/npm.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import path from 'path';
 import semver from 'semver';
 import { exec } from 'teen_process';
@@ -124,14 +123,6 @@ export default class NPM {
       // message straightaway
       if (res.json.error) {
         throw new Error(res.json.error);
-      }
-
-      // if we tried to install a package via git/github, we might not have been
-      // certain of the package name, so if we can retrieve it unambiguously from
-      // the json report of the install, do so
-      const names = _.uniq([...res.json.added, ...res.json.updated].map((x) => x.name));
-      if (names.length === 1) {
-        pkgName = names[0];
       }
     }
 


### PR DESCRIPTION
Noticed the NPM 7 next release didn't work because the json response format changed. This fix works for npm 6 and 7. The previous behavior wasn't really doing anything useful anyway.