### PR TITLE
feat: add --keep-alive-timeout CLI arg to adjust server connection timeout

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -130,13 +130,17 @@ async function main (args = null) {
   await logStartupInfo(parser, args);
   let appiumDriver = new AppiumDriver(args);
   let routeConfiguringFunction = makeRouter(appiumDriver);
-  let server = await baseServer({
+  const serverOpts = {
     routeConfiguringFunction,
     port: args.port,
     hostname: args.address,
     allowCors: args.allowCors,
     basePath: args.basePath,
-  });
+  };
+  if (args.keepAliveTimeout) {
+    serverOpts.keepAliveTimeout = args.keepAliveTimeout * 1000;
+  }
+  let server = await baseServer(serverOpts);
   if (args.allowCors) {
     logger.warn('You have enabled CORS requests from any host. Be careful not ' +
                 'to visit sites which could maliciously try to start Appium ' +

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -66,6 +66,15 @@ const args = [
           'on this server'
   }],
 
+  [['-ka', '--keep-alive-timeout'], {
+    required: false,
+    default: null,
+    dest: 'keepAliveTimeout',
+    type: 'int',
+    help: 'Number of seconds the Appium server should apply as both the keep-alive timeout ' +
+          'and the connection timeout for all requests. Defaults to 600 (10 minutes).'
+  }],
+
   [['-ca', '--callback-address'], {
     required: false,
     dest: 'callbackAddress',


### PR DESCRIPTION
This is the Appium server side of https://github.com/appium/appium-base-driver/pull/443