### PR TITLE
fix: do not insert server for --help, -v and --version

### DIFF
--- a/lib/cli/parser.js
+++ b/lib/cli/parser.js
@@ -43,7 +43,7 @@ function getParser (debug = false) {
     if (_.isUndefined(args)) {
       args = [...process.argv.slice(2)];
     }
-    if (!_.includes([DRIVER_TYPE, PLUGIN_TYPE, 'server', '-h'], args[0])) {
+    if (!_.includes([DRIVER_TYPE, PLUGIN_TYPE, 'server', '-h', '--help', '-v', '--version'], args[0])) {
       args.splice(0, 0, 'server');
     }
     return this._parse_args(args, namespace);


### PR DESCRIPTION
## Proposed changes

Closes https://github.com/appium/appium/issues/14994
Do not insert `server` for `--help`, `-v` and `--version` arguments so that they work

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Will be:

```
% ./build/lib/main.js --help                                        
usage: main.js [-h] [-v] {server,driver,plugin} ...

A webdriver-compatible server for use with native and hybrid iOS and Android applications.

positional arguments:
  {server,driver,plugin}
    server              Run an Appium server
    driver              Access the driver management CLI commands
    plugin              Access the plugin management CLI commands

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit
```

```
% ./build/lib/main.js -v                                            
2.0.0-beta.6
% ./build/lib/main.js --version
2.0.0-beta.6
```

```
% ./build/lib/main.js server -h
sage: main.js server [-h] [-ah APPIUMHOME] [--log-filters] [--shell] [--plugins PLUGINS] [--allow-cors] [--reboot REBOOT] [-a ADDRESS] [-p PORT] [-pa BASEPATH] [-ka KEEPALIVETIMEOUT]
                      [-ca CALLBACKADDRESS] [-cp CALLBACKPORT] [--session-override] [-g LOGFILE]
                      [--log-level {info,info:debug,info:info,info:warn,info:error,warn,warn:debug,warn:info,warn:warn,warn:error,error,error:debug,error:info,error:warn,error:error,debug,debug:debug,debug:info,debug:warn,debug:error}]
                      [--log-timestamp] [--local-timezone] [--log-no-colors] [-G WEBHOOK] [--nodeconfig NODECONFIG] [--chromedriver-port CHROMEDRIVERPORT]
                      [--chromedriver-executable CHROMEDRIVEREXECUTABLE] [--show-config] [--no-perms-check] [--strict-caps] [--tmp TMPDIR] [--trace-dir TRACEDIR] [--debug-log-spacing]
                      [--suppress-adb-kill-server SUPPRESSKILLSERVER] [--long-stacktrace] [--webkit-debug-proxy-port WEBKITDEBUGPROXYPORT] [--webdriveragent-port WDALOCALPORT]
                      [-dc DEFAULTCAPABILITIES] [--relaxed-security] [--allow-insecure ALLOWINSECURE] [--deny-insecure DENYINSECURE]
...
```