### PR TITLE
fix: issue with driver/plugin install and plugin driver access

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -421,7 +421,9 @@ class AppiumDriver extends BaseDriver {
     };
 
     // now take our default behavior, wrap it with any number of plugin behaviors, and run it
-    const wrappedCmd = this.wrapCommandWithPlugins({cmd, args, plugins, cmdHandledBy, next: defaultBehavior});
+    const wrappedCmd = this.wrapCommandWithPlugins({
+      driver: dstSession, cmd, args, plugins, cmdHandledBy, next: defaultBehavior
+    });
     const res = await this.executeWrappedCommand({wrappedCmd, protocol});
 
     // if we had plugins, make sure to log out the helpful report about which plugins ended up
@@ -431,7 +433,7 @@ class AppiumDriver extends BaseDriver {
     return res;
   }
 
-  wrapCommandWithPlugins ({cmd, args, next, cmdHandledBy, plugins}) {
+  wrapCommandWithPlugins ({driver, cmd, args, next, cmdHandledBy, plugins}) {
     plugins.length && log.info(`Plugins which can handle cmd '${cmd}': ${plugins.map((p) => p.name)}`);
 
     // now we can go through each plugin and wrap `next` around its own handler, passing the *old*
@@ -444,7 +446,7 @@ class AppiumDriver extends BaseDriver {
       next = ((_next) => async () => {
         log.info(`Plugin ${plugin.name} is now handling cmd '${cmd}'`);
         cmdHandledBy[plugin.name] = true; // if we make it here, this plugin has attempted to handle cmd
-        return await plugin.handle(_next, this, cmd, ...args);
+        return await plugin.handle(_next, driver, cmd, ...args);
       })(next);
     }
 

--- a/lib/cli/npm.js
+++ b/lib/cli/npm.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import semver from 'semver';
 import { exec } from 'teen_process';
-import { mkdirp, util, system } from 'appium-support';
+import { fs, mkdirp, util, system } from 'appium-support';
 
 const INSTALL_LOCKFILE = '.appium.install.lock';
 const LINK_LOCKFILE = '.appium.link.lock';
@@ -19,6 +19,14 @@ export default class NPM {
     }
     // ensure the directory we want to install inside of exists
     await mkdirp(cwd);
+
+    // not only this, this directory needs a 'package.json' inside of it, otherwise, if any
+    // directory in the filesystem tree ABOVE cwd happens to have a package.json or a node_modules
+    // dir in it, NPM will install the module up there instead (silly NPM)
+    const dummyPkgJson = path.resolve(cwd, 'package.json');
+    if (!await fs.exists(dummyPkgJson)) {
+      await fs.writeFile(dummyPkgJson, '{}');
+    }
 
     // make sure we perform the current operation in cwd
     execOpts = {...execOpts, cwd};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "firefoxos",
     "testing"
   ],
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "author": "https://github.com/appium",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Extension install was failing mysteriously if someone happened to have a package.json or node_modules dir higher up in the directory tree than the appium home dir.

Also, plugins were getting references to the Appium umbrella driver, when they should have gotten access to the inner driver, so fix that.