### PR TITLE
fix: when sending driver to plugins, send umbrella driver for umbrella commands

### DIFF
--- a/lib/appium.js
+++ b/lib/appium.js
@@ -383,6 +383,7 @@ class AppiumDriver extends BaseDriver {
     let sessionId = null;
     let dstSession = null;
     let protocol = null;
+    let driver = this;
     if (isSessionCmd) {
       sessionId = _.last(args);
       dstSession = await sessionsListGuard.acquire(AppiumDriver.name, () => this.sessions[sessionId]);
@@ -391,6 +392,7 @@ class AppiumDriver extends BaseDriver {
       }
       // now save the response protocol given that the session driver's protocol might differ
       protocol = dstSession.protocol;
+      driver = dstSession;
     }
 
     // now we define a 'cmdHandledBy' object which will keep track of which plugins have handled this
@@ -430,7 +432,7 @@ class AppiumDriver extends BaseDriver {
 
     // now take our default behavior, wrap it with any number of plugin behaviors, and run it
     const wrappedCmd = this.wrapCommandWithPlugins({
-      driver: dstSession, cmd, args, plugins, cmdHandledBy, next: defaultBehavior
+      driver, cmd, args, plugins, cmdHandledBy, next: defaultBehavior
     });
     const res = await this.executeWrappedCommand({wrappedCmd, protocol});
 


### PR DESCRIPTION
I realized that if a plugin is handling `createSession`, the `driver` object it has access to should be AppiumDriver, not the inner driver (it can still access the inner driver, but usually with the umbrella commands the intent is to modify those commands that are actually going to be run, which are on AppiumDriver).