### PR TITLE
fix: Cleanup the logsink before closing the server

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 // transpile:main
 
-import { init as logsinkInit } from './logsink';
+import { init as logsinkInit, clear as logsinkClear } from './logsink';
 import logger from './logger'; // logger needs to remain first of imports
 import _ from 'lodash';
 import { server as baseServer, routeConfiguringFunction as makeRouter } from 'appium-base-driver';
@@ -164,14 +164,18 @@ async function main (args = null) {
     process.once(signal, async function onSignal () {
       logger.info(`Received ${signal} - shutting down`);
       try {
-        await appiumDriver.deleteAllSessions({
-          force: true,
-          reason: `The process has received ${signal} signal`,
-        });
-        await server.close();
+        try {
+          await appiumDriver.deleteAllSessions({
+            force: true,
+            reason: `The process has received ${signal} signal`,
+          });
+          logsinkClear();
+        } finally {
+          await server.close();
+        }
         process.exit(0);
       } catch (e) {
-        logger.warn(e);
+        logger.error(e.message);
         process.exit(1);
       }
     });


### PR DESCRIPTION
## Proposed changes

I was sometimes observing random EPIPE errors from winston on server close.  

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
