### PR TITLE
chore: add release-latest script

### DIFF
--- a/docs/en/contributing-to-appium/release-appium.md
+++ b/docs/en/contributing-to-appium/release-appium.md
@@ -15,9 +15,11 @@ Appium follows the GitLab flow approach. Releases are made on release branches t
 
 ## Publish to GA
 1. Checkout the release branch (e.g.: `git checkout releases/1.21 && git pull origin releases/1.21`)
-1. `bash ./scripts/release.sh latest`
+1. `bash ./scripts/release-latest.sh 1.21.0`
+    - The `1.21.0` must be proper version name
 1. Update the site docs by going to https://github.com/appium/appium.io/pulls and merging the latest pull request that was opened by the Triager bot. Close any other pull requests opened by Triager bot.
 1. Create a new release on GitHub: go to `https://github.com/appium/appium/releases/tag/v<VERSION>` and hit "Edit Tag". Make the release name `<VERSION>` (e.g., `2.0.5`), then paste in the changelog (but not the changelog header for this version). If it's a beta release, mark as pre-release.
+    - Please check _Create a discussion for this release_ and select _Release_ category
 1. Create a new post on discuss.appium.io announcing the release. Post it in the "News" category. Paste in the changelog and any choice comments. Pin it and unpin the previous release post.
 1. Begin process of releasing `appium-desktop`.
 1. Notify @jlipps to so he can tweet a link to the discuss post.

--- a/scripts/release-latest.sh
+++ b/scripts/release-latest.sh
@@ -1,3 +1,5 @@
+#! /bin/sh
+
 npm version $1
 git push
 git push --tags

--- a/scripts/release-latest.sh
+++ b/scripts/release-latest.sh
@@ -1,0 +1,4 @@
+npm version $1
+git push
+git push --tags
+npm publish --tag latest

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,3 +1,5 @@
+#! /bin/sh
+
 npm version prerelease --preid=$1
 git push
 git push --tags


### PR DESCRIPTION
## Proposed changes

`scripts/release.sh` has `prerelease` so it should not be a stable release.

I also found a discussion category in creating `release` tag. https://github.com/appium/appium/discussions/15315
Let me try it. (Will remove it if no effort)


## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
