### PR TITLE
feat: add --drivers to load particular drivers

### DIFF
--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -38,7 +38,7 @@ const serverArgs = [
     required: false,
     default: [],
     help: `A comma-separated list of installed drivers names that should be active for this ` +
-          `server. All drivers will be active if no this argument are given.`,
+          `server. All drivers will be active by default.`,
     type: parseDriverNames,
     dest: 'drivers',
   }],

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -1,5 +1,5 @@
 import { DEFAULT_BASE_PATH } from 'appium-base-driver';
-import { parseSecurityFeatures, parseDefaultCaps, parsePluginNames, parseInstallTypes } from './parser-helpers';
+import { parseSecurityFeatures, parseDefaultCaps, parsePluginNames, parseInstallTypes, parseDriverNames } from './parser-helpers';
 import { INSTALL_TYPES, DEFAULT_APPIUM_HOME, DRIVER_TYPE, PLUGIN_TYPE } from '../extension-config';
 import { DEFAULT_CAPS_ARG, StoreDeprecatedDefaultCapabilityAction } from './argparse-actions';
 
@@ -32,6 +32,15 @@ const serverArgs = [
     help: 'Enter REPL mode',
     action: 'store_true',
     dest: 'shell',
+  }],
+
+  [['--drivers'], {
+    required: false,
+    default: [],
+    help: `A comma-separated list of installed drivers names that should be active for this ` +
+          `server. All drivers are activated if no this argument are given.`,
+    type: parseDriverNames,
+    dest: 'drivers',
   }],
 
   [['--plugins'], {

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -1,7 +1,15 @@
 import { DEFAULT_BASE_PATH } from 'appium-base-driver';
-import { parseSecurityFeatures, parseDefaultCaps, parsePluginNames, parseInstallTypes, parseDriverNames } from './parser-helpers';
-import { INSTALL_TYPES, DEFAULT_APPIUM_HOME, DRIVER_TYPE, PLUGIN_TYPE } from '../extension-config';
-import { DEFAULT_CAPS_ARG, StoreDeprecatedDefaultCapabilityAction } from './argparse-actions';
+import {
+  parseSecurityFeatures, parseDefaultCaps,
+  parsePluginNames, parseInstallTypes, parseDriverNames
+} from './parser-helpers';
+import {
+  INSTALL_TYPES, DEFAULT_APPIUM_HOME,
+  DRIVER_TYPE, PLUGIN_TYPE
+} from '../extension-config';
+import {
+  DEFAULT_CAPS_ARG, StoreDeprecatedDefaultCapabilityAction
+} from './argparse-actions';
 
 const DRIVER_EXAMPLE = 'xcuitest';
 const PLUGIN_EXAMPLE = 'find_by_image';
@@ -37,7 +45,7 @@ const serverArgs = [
   [['--drivers'], {
     required: false,
     default: [],
-    help: `A comma-separated list of installed drivers names that should be active for this ` +
+    help: `A comma-separated list of installed driver names that should be active for this ` +
           `server. All drivers will be active by default.`,
     type: parseDriverNames,
     dest: 'drivers',

--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -38,7 +38,7 @@ const serverArgs = [
     required: false,
     default: [],
     help: `A comma-separated list of installed drivers names that should be active for this ` +
-          `server. All drivers are activated if no this argument are given.`,
+          `server. All drivers will be active if no this argument are given.`,
     type: parseDriverNames,
     dest: 'drivers',
   }],

--- a/lib/cli/parser-helpers.js
+++ b/lib/cli/parser-helpers.js
@@ -30,6 +30,20 @@ function parseSecurityFeatures (features) {
   return parsedFeatures;
 }
 
+function parseDriverNames (names) {
+  if (!_.isString(names)) {
+    throw new TypeError('To parse driver names, names must be a CSV string');
+  }
+
+  try {
+    return names.split(',').map((s) => s.trim()).filter(Boolean);
+  } catch (err) {
+    throw new TypeError('Could not parse value of --drivers. Should be a list of driver names ' +
+                    'separated by commas. Driver names are those found when running `appium ' +
+                    'driver list`');
+  }
+}
+
 function parsePluginNames (names) {
   if (!_.isString(names)) {
     throw new TypeError('To parse plugin names, names must be a CSV string');
@@ -88,4 +102,5 @@ export {
   parseDefaultCaps,
   parseInstallTypes,
   parsePluginNames,
+  parseDriverNames,
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -120,11 +120,15 @@ function getActivePlugins (args, pluginConfig) {
 /**
  * Find any driver name which has been installed, and turn each one into its class, so we can send
  * them as objects to the server init in case they need to add methods/routes or update the server.
+ * If the --drivers flag was given, this method only loadd the given drivers.
  *
+ * @param {Object} args - argparser parsed dict
  * @param {DriverConfig} driverConfig - a driver extension config
  */
-function getActiveDrivers (driverConfig) {
-  return Object.keys(driverConfig.installedExtensions).map((driverName) => {
+function getActiveDrivers (args, driverConfig) {
+  return Object.keys(driverConfig.installedExtensions).filter((driverName) =>
+    _.includes(args.drivers, driverName) || args.drivers.length === 0
+  ).map((driverName) => {
     try {
       logger.info(`Attempting to load driver ${driverName}...`);
       return driverConfig.require(driverName);
@@ -199,7 +203,7 @@ async function main (args = null) {
   await logStartupInfo(parser, args);
   let routeConfiguringFunction = makeRouter(appiumDriver);
 
-  const driverClasses = getActiveDrivers(driverConfig);
+  const driverClasses = getActiveDrivers(args, driverConfig);
   const pluginClasses = getActivePlugins(args, pluginConfig);
   // set the active plugins on the umbrella driver so it can use them for commands
   appiumDriver.pluginClasses = pluginClasses;

--- a/lib/main.js
+++ b/lib/main.js
@@ -120,7 +120,7 @@ function getActivePlugins (args, pluginConfig) {
 /**
  * Find any driver name which has been installed, and turn each one into its class, so we can send
  * them as objects to the server init in case they need to add methods/routes or update the server.
- * If the --drivers flag was given, this method only loadd the given drivers.
+ * If the --drivers flag was given, this method only loads the given drivers.
  *
  * @param {Object} args - argparser parsed dict
  * @param {DriverConfig} driverConfig - a driver extension config


### PR DESCRIPTION
## Proposed changes

Currently `appium` loads alls installed drivers. It increases the initial load time.
`--drivers` argument allows users to load only particular drivers. It will help to reduce such initial load time.

```
% node . --drivers=uiautomator2                            
[Appium] Welcome to Appium v2.0.0-beta.12 (REV cc8ea3bb458f2326f8e9871bad43af036a3f54a0)
[Appium] Non-default server args:
[Appium]   drivers: {
[Appium]     0: uiautomator2
[Appium]   }
[Appium]   tmpDir: /var/folders/y6/524wp8fx0xj5q1rf6fktjrb00000gn/T
[Appium] Attempting to load driver uiautomator2...
[Appium] Appium REST http interface listener started on 0.0.0.0:4723
[Appium] Available drivers:
[Appium]   - xcuitest@3.42.0 (automationName 'XCUITest')
[Appium]   - uiautomator2@1.65.1 (automationName 'UiAutomator2')
[Appium] Available plugins:
[Appium]   - fake@0.2.0
[Appium] No plugins activated. Use the --plugins flag with names of plugins to activate
```

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
