### PR TITLE
feat: define appium home for plugins to handle multiple drivers

### DIFF
--- a/lib/cli/args.js
+++ b/lib/cli/args.js
@@ -24,6 +24,13 @@ const sharedArgs = [
     dest: 'appiumHome',
   }],
 
+  [['-aph', '--appium-plugin-home'], {
+    required: false,
+    default: null,
+    help: 'The path to the directory where Appium will keep installed plugins. "--appium-home" is more general configuration. This argument can be used when you want to manage plugins separately.',
+    dest: 'appiumPluginHome',
+  }],
+
   [['--log-filters'], {
     dest: 'logFilters',
     default: null,

--- a/lib/cli/extension.js
+++ b/lib/cli/extension.js
@@ -22,14 +22,13 @@ async function runExtensionCommand (args, type) {
   if (!extCmd) {
     throw new TypeError(`Cannot call ${type} command without a subcommand like 'install'`);
   }
-  let {json, suppressOutput, appiumHome} = args;
+  let {json, suppressOutput, appiumHome, appiumPluginHome} = args;
   if (suppressOutput) {
     json = true;
   }
   const logFn = (msg) => log(json, msg);
-  const ConfigClass = type === DRIVER_TYPE ? DriverConfig : PluginConfig;
+  const config = type === DRIVER_TYPE ? new DriverConfig(appiumHome, logFn) : new PluginConfig(appiumPluginHome || appiumHome, logFn);
   const CommandClass = type === DRIVER_TYPE ? DriverCommand : PluginCommand;
-  const config = new ConfigClass(appiumHome, logFn);
   const cmd = new CommandClass({config, json});
   try {
     await config.read();

--- a/lib/main.js
+++ b/lib/main.js
@@ -198,7 +198,7 @@ async function main (args = null) {
   const driverConfig = new DriverConfig(args.appiumHome);
   // set the config on the umbrella driver so it can match drivers to caps
   appiumDriver.driverConfig = driverConfig;
-  const pluginConfig = new PluginConfig(args.appiumHome);
+  const pluginConfig = new PluginConfig(args.appiumPluginHome || args.appiumHome);
   await preflightChecks({parser, args, driverConfig, pluginConfig, throwInsteadOfExit});
   await logStartupInfo(parser, args);
   let routeConfiguringFunction = makeRouter(appiumDriver);


### PR DESCRIPTION
## Proposed changes

This issue is still WIP.

When I managed different versions' drivers and plugins on a host, I got a use case I wanted to use a particular driver version with plugins. To reduce installation time, we can have multiple `appium-home` on a host for drivers and can switch them when an appium server starts. 

For now, plugins could have multiple modules in a session, but drivers could be used only one module in a session.
So, like the below case could do.

```
appium --appium-home=/path/to/driver/home --appium-plugin-home=/path/to/plugin/home
```

```
appium --appium-home=/path/to/driver/which/has/another/version --appium-plugin-home=/path/to/plugin/home
```

This case may help to reduce installation time to manage multiple driver versions on a host and use the same plugin versions across them. This case may happen frequently than managing a plugin as various versions.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
