### PR TITLE
configure lerna for publishing; closes #15403

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,30 +1,23 @@
 {
+  "ci": false,
+  "command": {
+    "exec": {
+      "ignore": "@appium/eslint-config-appium"
+    },
+    "version": {
+      "push": false,
+      "conventionalCommits": true
+    }
+  },
+  "ignoreChanges": [
+    "**/test/**",
+    "**/*.md"
+  ],
+  "npmClientArgs": [
+    "--no-package-lock"
+  ],
   "packages": [
     "packages/*"
   ],
-  "version": "2.0.0-beta.1",
-  "command": {
-    "bootstrap": {
-      "npmClientArgs": [
-        "--no-package-lock"
-      ],
-      "ci": false
-    },
-    "exec": {
-      "ignore": "@appium/eslint-config-appium"
-    }
-  },
-  "changelog": {
-    "repo": "appium/appium",
-    "cacheDir": ".changelog",
-    "labels": {
-      "PR: Spec Compliancy :eyeglasses:": ":eyeglasses: Spec Compliancy",
-      "PR: Breaking Change :boom:": ":boom: Breaking Change",
-      "PR: New Feature :rocket:": ":rocket: New Feature",
-      "PR: Bug Fix :bug:": ":bug: Bug Fix",
-      "PR: Polish :nail_care:": ":nail_care: Polish",
-      "PR: Docs :memo:": ":memo: Documentation",
-      "PR: Internal :house:": ":house: Internal"
-    }
-  }
+  "version": "independent"
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,17 @@
   "version": "0.0.0",
   "private": true,
   "description": "Automation for Apps.",
+  "keywords": [
+    "automation",
+    "javascript",
+    "selenium",
+    "webdriver",
+    "ios",
+    "android",
+    "firefoxos",
+    "testing"
+  ],
+  "homepage": "https://appium.io",
   "bugs": {
     "url": "https://github.com/appium/appium/issues"
   },
@@ -27,6 +38,10 @@
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "reinstall": "npm run clean && npm install",
     "start": "node ./packages/appium",
+    "sync-pkgs": "npm run sync-pkgs:appium-readme && npm run sync-pkgs:common-fields && npm run sync-pkgs:keywords",
+    "sync-pkgs:appium-readme": "sync-monorepo-packages --force --no-package-json --packages=packages/appium README.md",
+    "sync-pkgs:common-fields": "sync-monorepo-packages --fields=author,license,repository,bugs,homepage,engines",
+    "sync-pkgs:keywords": "sync-monorepo-packages --field=keywords --packages='packages/*' --packages='!packages/eslint-config-appium'",
     "test": "lerna exec gulp once",
     "test:appium": "lerna exec --scope=appium gulp once",
     "test:base-driver": "lerna exec --scope=@appium/base-driver gulp once",
@@ -40,6 +55,7 @@
     "test:gulp-plugins": "lerna exec --scope=@appium/gulp-plugins gulp once",
     "test:support": "lerna exec --scope=@appium/support gulp once",
     "test:test-support": "lerna exec --scope=@appium/test-support gulp once",
+    "preversion": "npm run sync-pkgs && git add -A packages/appium/README.md packages/*/package.json",
     "watch": "lerna exec watch"
   },
   "pre-commit": [
@@ -86,6 +102,7 @@
     "querystring": "^0.2.0",
     "serve-static": "^1.13.1",
     "sinon": "^9.0.0",
+    "sync-monorepo-packages": "^0.3.2",
     "validate.js": "^0.13.0",
     "wd": "^1.14.0",
     "webdriverio": "^6.12.0",
@@ -94,5 +111,8 @@
   "engines": {
     "node": ">=12",
     "npm": ">=6"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/appium/README.md
+++ b/packages/appium/README.md
@@ -1,5 +1,121 @@
-# appium
+## Appium
 
-## TODO
+[![NPM version](https://badge.fury.io/js/appium.svg)](https://npmjs.org/package/appium)
+[![Dependency Status](https://david-dm.org/appium/appium.svg)](https://david-dm.org/appium/appium)
+[![devDependency Status](https://david-dm.org/appium/appium/dev-status.svg)](https://david-dm.org/appium/appium#info=devDependencies)
 
-- Either add a specific `README.md` here or copy it from the root as a prepublish step.
+[![Monthly Downloads](https://img.shields.io/npm/dm/appium.svg)](https://npmjs.org/package/appium)
+
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fappium%2Fappium.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fappium%2Fappium?ref=badge_shield)
+
+Appium is an open-source, cross-platform test automation tool for native,
+hybrid, and mobile web and desktop apps. We support simulators (iOS), emulators
+(Android), and real devices (iOS, Android, Windows, Mac).
+
+Want to skip straight to the action? Check out our [getting
+started](/docs/en/about-appium/getting-started.md) doc.
+
+### Supported Platforms
+
+Appium supports app automation across a variety of platforms, like iOS,
+Android, and Windows. Each platform is supported by one or more "drivers",
+which know how to automate that particular platform. Choose a driver below for
+specific information about how that driver works and how to set it up:
+
+* iOS
+    * The [XCUITest Driver](/docs/en/drivers/ios-xcuitest.md)
+    * (DEPRECATED) The [UIAutomation Driver](/docs/en/drivers/ios-uiautomation.md)
+* Android
+    * The [Espresso Driver](/docs/en/drivers/android-espresso.md)
+    * The [UiAutomator2 Driver](/docs/en/drivers/android-uiautomator2.md)
+    * (DEPRECATED) The [UiAutomator Driver](/docs/en/drivers/android-uiautomator.md)
+* The [Windows Driver](/docs/en/drivers/windows.md) (for Windows Desktop apps)
+* The [Mac Driver](/docs/en/drivers/mac.md) (for Mac Desktop apps)
+
+### Why Appium?
+
+1. You don't have to recompile your app or modify it in any way, due
+   to the use of standard automation APIs on all platforms.
+2. You can write tests with your favorite dev tools using any
+   [WebDriver](https://w3c.github.io/webdriver/webdriver-spec.html)-compatible
+   language such as Java, Objective-C, JavaScript (Node), PHP, Python, Ruby,
+   C#, Clojure, or Perl with the Selenium WebDriver API and [language-specific
+   client libraries](/docs/en/about-appium/appium-clients.md).
+3. You can use any testing framework.
+4. Appium has built-in mobile web and hybrid app support. Within the same
+   script, you can switch seamlessly between native app automation and webview
+   automation, all using the WebDriver model that's already the standard for
+   web automation.
+
+Investing in the
+[WebDriver](https://w3c.github.io/webdriver/webdriver-spec.html) protocol means
+you are betting on a single, free, and open protocol for testing that has become
+a web standard. Don't lock yourself into a proprietary stack.
+
+For example, if you use Apple's XCUITest library without Appium you can only
+write tests using Obj-C/Swift, and you can only run tests through Xcode.
+Similarly, with Google's UiAutomator or Espresso, you can only write tests in
+Java/Kotlin. Appium opens up the possibility of true cross-platform native app
+automation, for mobile and beyond. Finally!
+
+If you're new to Appium or want a more comprehensive description of what this is all
+about, please read our [Introduction to Appium
+Concepts](/docs/en/about-appium/intro.md).
+
+### Requirements
+
+Your environment needs to be set up for the particular platforms that you want
+to run tests on. Each of the drivers above documents the requirements for their
+particular brand of automation. At a minimum, you will need to be able to run
+Node.js 10+.
+
+### Get Started
+
+Check out our [Getting Started](/docs/en/about-appium/getting-started.md) guide
+to get going with Appium.
+
+There is also a sample code that contains [many examples of tests in a variety
+of different languages](https://github.com/appium/appium/tree/master/sample-code)!
+
+### Documentation
+
+For prettily-rendered docs, please visit [appium.io](http://appium.io). You can
+always find the full list of Appium doc pages at [Appium's GitHub
+Repo](https://github.com/appium/appium/tree/master/docs/en/) as well.
+
+[update-appium-io.yml](https://github.com/appium/appium/blob/master/ci-jobs/update-appium-io.yml) creates a PR
+by [CI job](https://dev.azure.com/AppiumCI/Appium%20CI/_build?definitionId=37).
+in the appium.io repository with the documentation update.
+
+Once the PR has been merged, the latest documentation will be in [appium.io](http://appium.io)
+
+### Contributing
+
+Please take a look at our [contribution documentation](CONTRIBUTING.md)
+for instructions on how to build, test, and run Appium from the source.
+
+### Roadmap
+
+Interested in where Appium is heading in the future? Check out the [Roadmap](ROADMAP.md)
+
+### Project History, Credits & Inspiration
+
+* [History](http://appium.io/history)
+* [Credits](/docs/en/contributing-to-appium/credits.md)
+
+### User Forums
+
+Announcements and debates often take place on the [Discussion
+Group](https://discuss.appium.io), be sure to sign up!
+
+### Troubleshooting
+
+We put together a [troubleshooting
+guide](/docs/en/writing-running-appium/other/troubleshooting.md).  Please have a look
+here first if you run into any problems. It contains instructions for checking
+a lot of common errors and how to get in touch with the community if you're
+stumped.
+
+### License
+
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fappium%2Fappium.svg?type=large)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Fappium%2Fappium?ref=badge_large)

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -36,24 +36,25 @@
     "postinstall.js"
   ],
   "scripts": {
-    "backup-shrinkwrap": "mv npm-shrinkwrap.json npm-shrinkwrap-backup.json",
-    "check-pruned-shrinkwrap": "node check-pruned-shrinkwrap.js",
     "generate-docs": "gulp transpile && node ./build/commands-yml/parse.js",
     "postinstall": "node ./postinstall.js",
     "install-fake-driver": "node . driver install --source=npm appium-fake-driver",
-    "prepublishOnly": "npm run prune-shrinkwrap && gulp fixShrinkwrap",
-    "prune-shrinkwrap": "!(test -e npm-shrinkwrap.json) || (npm ci --production --ignore-scripts && npm run backup-shrinkwrap && npm shrinkwrap)",
-    "postpublish": "npm run restore-shrinkwrap",
-    "restore-shrinkwrap": "!(test -e npm-shrinkwrap.json) || (mv npm-shrinkwrap-backup.json npm-shrinkwrap.json)",
+    "prepublishOnly": "npm run shrinkwrap:prune && npm run shrinkwrap:fix",
+    "postpublish": "npm run shrinkwrap:restore",
+    "shrinkwrap:backup": "mv npm-shrinkwrap.json npm-shrinkwrap-backup.json",
+    "shrinkwrap:check-pruned": "node check-pruned-shrinkwrap.js",
+    "shrinkwrap:fix": "gulp fixShrinkwrap",
+    "shrinkwrap:prune": "!(test -e npm-shrinkwrap.json) || (npm ci --production --ignore-scripts && npm run backup-shrinkwrap && npm shrinkwrap)",
+    "shrinkwrap:restore": "(test -e npm-shrinkwrap.json) || (mv npm-shrinkwrap-backup.json npm-shrinkwrap.json)",
     "upload": "gulp github-upload",
     "zip": "zip -qr appium.zip .",
     "zip-and-upload": "npm run zip && npm run upload"
   },
   "dependencies": {
-    "@appium/base-plugin": "^1.0.0",
-    "@babel/runtime": "^7.6.0",
     "@appium/base-driver": "^8.0.0-beta.6",
+    "@appium/base-plugin": "^1.0.0",
     "@appium/support": "2.x",
+    "@babel/runtime": "^7.6.0",
     "argparse": "^2.0.1",
     "async-lock": "^1.0.0",
     "asyncbox": "2.x",
@@ -73,12 +74,16 @@
     "word-wrap": "^1.2.3",
     "yaml": "^1.7.2"
   },
+  "devDependencies": {
+    "@appium/fake-driver": "^2.2.0",
+    "@appium/gulp-plugins": "^5.5.0"
+  },
   "engines": {
     "node": ">=12",
     "npm": ">=6"
   },
-  "devDependencies": {
-    "@appium/fake-driver": "^2.2.0",
-    "@appium/gulp-plugins": "^5.5.0"
+  "publishConfig": {
+    "access": "public",
+    "tag": "next"
   }
 }

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -53,9 +53,12 @@
     "validate.js": "^0.13.0",
     "webdriverio": "^6.0.2",
     "ws": "^7.0.0"
-  },  
+  },
   "devDependencies": {
     "@appium/gulp-plugins": "^5.4.0",
     "@appium/eslint-config-appium": "^4.7.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -59,6 +59,7 @@
     "@appium/eslint-config-appium": "^4.7.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "beta"
   }
 }

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -50,5 +50,8 @@
   "engines": {
     "node": ">=10",
     "npm": ">=6"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/eslint-config-appium/package.json
+++ b/packages/eslint-config-appium/package.json
@@ -35,5 +35,8 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-mocha": "^8.0.0",
     "eslint-plugin-promise": "^4.1.1"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -61,5 +61,8 @@
   },
   "greenkeeper": {
     "ignore": []
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -87,5 +87,8 @@
   },
   "peerDependencies": {
     "gulp": "^4.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -64,5 +64,8 @@
   },
   "engines": {
     "node": ">=12"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -47,5 +47,8 @@
   },
   "greenkeeper": {
     "ignore": []
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
1. Uses `sync-monorepo-packages` to keep `README.md` and `packages/appium/README.md` in sync.  Since `README` gets published to npm but _also_ shows in the GitHub repo, both places need a `README`. In lieu of a custom `README`, we can just sync it for now.  This is called via a `preversion` script.
1. Various fields are synced in `package.json`.  This does not include dependencies—but those _in common_ should probably be kept in sync as well.
1. Lerna uses conventional commits and Git tags to figure out what to do.  It should automatically determine what needs releasing and what version it should be released as.
1. Tags have been pushed to the repo for Lerna to use.  In the case where the changesets are functionally identical to the latest code in the old repositories, the version number has been retained, and the tag is of the format `[@scope/]<package-name>@<version>`.  In the case where the old repos had _unreleased_ changesets, I’ve tagged with a new patch release and adopted the `-rc.0` suffix.  So if we were at v5.5.0 in `appium-gulp-plugins`, `@appium/gulp-plugins` is tagged as `@appium/gulp-plugins@5.5.1-rc.0`.  I have not modified the version in `package.json`.
 1. As with adopting any new release/publishing strategy, we should be meticulous about what we’re doing until we’re comfortable with how it works.  Lerna supports dry runs; we should use them.
1. Documentation on usage will arrive in next changes to this PR.
1. We should try to use `lerna-changelog`; I was unsuccessful at getting it to do anything on my first try, so that can be a separate PR.
