### PR TITLE
chore: update @appium/fake-driver to use @appium/base-driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "babel-plugin-source-map-support": "^2.0.1",
     "chai": "4.x",
     "chai-as-promised": "7.x",
+    "chai-webdriverio-async": "^2.6.0",
     "colors": "^1.4.0",
     "eslint-find-rules": "^3.6.1",
     "fancy-log": "^1.3.2",

--- a/packages/base-driver/lib/jsonwp-proxy/protocol-converter.js
+++ b/packages/base-driver/lib/jsonwp-proxy/protocol-converter.js
@@ -190,6 +190,10 @@ class ProtocolConverter {
       : await this.proxyFunc(url, method, body);
   }
 
+  async proxyReleaseActions (url, method) {
+    return await this.proxyFunc(url, method);
+  }
+
   /**
    * Handle "crossing" endpoints for the case
    * when upstream and downstream drivers operate different protocols
@@ -218,6 +222,8 @@ class ProtocolConverter {
         return await this.proxySetValue(url, method, body);
       case 'performActions':
         return await this.proxyPerformActions(url, method, body);
+      case 'releaseActions':
+        return await this.proxyReleaseActions(url, method, body);
       case 'setFrame':
         return await this.proxySetFrame(url, method, body);
       default:

--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -280,6 +280,7 @@ const METHOD_MAP = {
   },
   '/session/:sessionId/actions': {
     POST: {command: 'performActions', payloadParams: {required: ['actions']}},
+    DELETE: {command: 'releaseActions'}
   },
   '/session/:sessionId/touch/longclick': {
     POST: {command: 'touchLongClick', payloadParams: {required: ['elements']}}

--- a/packages/base-driver/test/basedriver/capabilities-specs.js
+++ b/packages/base-driver/test/basedriver/capabilities-specs.js
@@ -99,7 +99,7 @@ describe('caps', function () {
     });
   });
 
-  // Tests based on: https://www.w3.org/TR/webdriver/#processing-caps
+  // Tests based on: https://www.w3.org/TR/webdriver/#processing-capabilities
   describe('#parseCaps', function () {
     let caps;
 

--- a/packages/base-driver/test/basedriver/driver-e2e-tests.js
+++ b/packages/base-driver/test/basedriver/driver-e2e-tests.js
@@ -10,22 +10,19 @@ import B from 'bluebird';
 import getPort from 'get-port';
 
 const should = chai.should();
-const DEFAULT_ARGS = {
-  address: 'localhost',
-  port: null
-};
 chai.use(chaiAsPromised);
 
 function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
-  let port;
+  let address = defaultCaps['appium:address'] ?? '127.0.0.1';
+  let port = defaultCaps['appium:port'];
   const className = DriverClass.name || '(unknown driver)';
 
   describe(`BaseDriver E2E (as ${className})`, function () {
     let baseServer, d;
     before(async function () {
-      port = await getPort();
-      DEFAULT_ARGS.port = port;
-      d = new DriverClass(DEFAULT_ARGS);
+      port = port ?? await getPort();
+      defaultCaps = {...defaultCaps, 'appium:port': port};
+      d = new DriverClass({port, address});
       baseServer = await server({
         routeConfiguringFunction: routeConfiguringFunction(d),
         port
@@ -37,7 +34,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
 
     async function startSession (caps) {
       return (await axios({
-        url: `http://localhost:${port}/session`,
+        url: `http://${address}:${port}/session`,
         method: 'POST',
         data: {capabilities: {alwaysMatch: caps, firstMatch: [{}]}},
       })).data.value;
@@ -45,7 +42,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
 
     async function endSession (id) {
       return (await axios({
-        url: `http://localhost:${port}/session/${id}`,
+        url: `http://${address}:${port}/session/${id}`,
         method: 'DELETE',
         validateStatus: null,
       })).data.value;
@@ -53,7 +50,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
 
     async function getSession (id) {
       return (await axios({
-        url: `http://localhost:${port}/session/${id}`,
+        url: `http://${address}:${port}/session/${id}`,
       })).data.value;
     }
 
@@ -63,7 +60,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         let times = 0;
         do {
           const {sessionId} = (await axios({
-            url: `http://localhost:${port}/session`,
+            url: `http://${address}:${port}/session`,
             headers: {
               'X-Idempotency-Key': '123456',
             },
@@ -79,7 +76,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         _.uniq(sessionIds).length.should.equal(1);
 
         const {status, data} = await axios({
-          url: `http://localhost:${port}/session/${sessionIds[0]}`,
+          url: `http://${address}:${port}/session/${sessionIds[0]}`,
           method: 'DELETE',
         });
         status.should.equal(200);
@@ -91,7 +88,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         let times = 0;
         do {
           reqs.push(axios({
-            url: `http://localhost:${port}/session`,
+            url: `http://${address}:${port}/session`,
             headers: {
               'X-Idempotency-Key': '12345',
             },
@@ -104,7 +101,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         _.uniq(sessionIds).length.should.equal(1);
 
         const {status, data} = await axios({
-          url: `http://localhost:${port}/session/${sessionIds[0]}`,
+          url: `http://${address}:${port}/session/${sessionIds[0]}`,
           method: 'DELETE',
         });
         status.should.equal(200);
@@ -113,18 +110,18 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
 
       it('should create session and retrieve a session id, then delete it', async function () {
         let {status, data} = await axios({
-          url: `http://localhost:${port}/session`,
+          url: `http://${address}:${port}/session`,
           method: 'POST',
           data: {capabilities: {alwaysMatch: defaultCaps, firstMatch: [{}]}},
         });
 
         status.should.equal(200);
         should.exist(data.value.sessionId);
-        data.value.capabilities.platformName.should.equal('iOS');
-        data.value.capabilities.deviceName.should.equal('Delorean');
+        data.value.capabilities.platformName.should.equal(defaultCaps.platformName);
+        data.value.capabilities.deviceName.should.equal(defaultCaps['appium:deviceName']);
 
         ({status, data} = await axios({
-          url: `http://localhost:${port}/session/${d.sessionId}`,
+          url: `http://${address}:${port}/session/${d.sessionId}`,
           method: 'DELETE',
         }));
 
@@ -174,13 +171,13 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         let newSession = await startTimeoutSession(0.25);
 
         await axios({
-          url: `http://localhost:${port}/session/${d.sessionId}/element`,
+          url: `http://${address}:${port}/session/${d.sessionId}/element`,
           method: 'POST',
           data: {using: 'name', value: 'foo'},
         });
         await B.delay(400);
         const {data} = await axios({
-          url: `http://localhost:${port}/session/${d.sessionId}`,
+          url: `http://${address}:${port}/session/${d.sessionId}`,
           validateStatus: null,
         });
         should.equal(data.value.error, 'invalid session id');
@@ -193,7 +190,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         let newSession = await startTimeoutSession(0.1);
         let start = Date.now();
         const {value} = (await axios({
-          url: `http://localhost:${port}/session/${d.sessionId}/elements`,
+          url: `http://${address}:${port}/session/${d.sessionId}/elements`,
           method: 'POST',
           data: {using: 'name', value: 'foo'},
         })).data;
@@ -207,15 +204,15 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
         let newSession = await startTimeoutSession(0);
 
         await axios({
-          url: `http://localhost:${port}/session/${d.sessionId}/element`,
+          url: `http://${address}:${port}/session/${d.sessionId}/element`,
           method: 'POST',
           data: {using: 'name', value: 'foo'},
         });
         await B.delay(400);
         const {value} = (await axios({
-          url: `http://localhost:${port}/session/${d.sessionId}`,
+          url: `http://${address}:${port}/session/${d.sessionId}`,
         })).data;
-        value.platformName.should.equal('iOS');
+        value.platformName.should.equal(defaultCaps.platformName);
         const resp = await endSession(newSession.sessionId);
         should.equal(resp, null);
 
@@ -225,13 +222,13 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
       it('should not timeout if its just the command taking awhile', async function () {
         let newSession = await startTimeoutSession(0.25);
         await axios({
-          url: `http://localhost:${port}/session/${d.sessionId}/element`,
+          url: `http://${address}:${port}/session/${d.sessionId}/element`,
           method: 'POST',
           data: {using: 'name', value: 'foo'},
         });
         await B.delay(400);
         const {value} = (await axios({
-          url: `http://localhost:${port}/session/${d.sessionId}`,
+          url: `http://${address}:${port}/session/${d.sessionId}`,
           validateStatus: null,
         })).data;
         value.error.should.equal('invalid session id');
@@ -276,7 +273,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
             await B.delay(5000);
           }.bind(d);
           const reqPromise = axios({
-            url: `http://localhost:${port}/status`,
+            url: `http://${address}:${port}/status`,
             validateStatus: null,
           });
           // make sure that the request gets to the server before our shutdown
@@ -349,7 +346,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           d.allowInsecure = [];
           const script = `return 'foo'`;
           await axios({
-            url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+            url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
             method: 'POST',
             data: {script, type: 'wd'},
           }).should.eventually.be.rejected;
@@ -366,7 +363,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           return [timeouts, status];
         `;
         const {value} = (await axios({
-          url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+          url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
           method: 'POST',
           data: {script, type: 'webdriverio'},
         })).data;
@@ -378,7 +375,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
       it('should fail with any script type other than webdriverio currently', async function () {
         const script = `return 'foo'`;
         await axios({
-          url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+          url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
           method: 'POST',
           data: {script, type: 'wd'},
         }).should.eventually.be.rejected;
@@ -389,7 +386,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           return await driver.$("~amazing");
         `;
         const {value} = (await axios({
-          url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+          url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
           method: 'POST',
           data: {script},
         })).data;
@@ -405,7 +402,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           return {element: el, elements: [el, el]};
         `;
         const {value} = (await axios({
-          url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+          url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
           method: 'POST',
           data: {script},
         })).data;
@@ -425,7 +422,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           return null;
         `;
         const {value} = (await axios({
-          url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+          url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
           method: 'POST',
           data: {script},
         })).data;
@@ -437,7 +434,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           return typeof driver.lock;
         `;
         const {value} = (await axios({
-          url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+          url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
           method: 'POST',
           data: {script},
         })).data;
@@ -449,7 +446,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           return await driver.$("~notfound");
         `;
         const {data} = await axios({
-          url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+          url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
           method: 'POST',
           validateStatus: null,
           data: {script},
@@ -466,7 +463,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           return {;
         `;
         const {data} = await axios({
-          url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+          url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
           method: 'POST',
           validateStatus: null,
           data: {script},
@@ -481,7 +478,7 @@ function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
           return true;
         `;
         const {value} = (await axios({
-          url: `http://localhost:${port}/session/${sessionId}/appium/execute_driver`,
+          url: `http://${address}:${port}/session/${sessionId}/appium/execute_driver`,
           method: 'POST',
           validateStatus: null,
           data: {script, timeout: 50},

--- a/packages/base-driver/test/basedriver/driver-e2e-tests.js
+++ b/packages/base-driver/test/basedriver/driver-e2e-tests.js
@@ -18,7 +18,9 @@ chai.use(chaiAsPromised);
 
 function baseDriverE2ETests (DriverClass, defaultCaps = {}) {
   let port;
-  describe('BaseDriver (e2e)', function () {
+  const className = DriverClass.name || '(unknown driver)';
+
+  describe(`BaseDriver E2E (as ${className})`, function () {
     let baseServer, d;
     before(async function () {
       port = await getPort();

--- a/packages/base-driver/test/basedriver/driver-tests.js
+++ b/packages/base-driver/test/basedriver/driver-tests.js
@@ -12,7 +12,10 @@ chai.use(chaiAsPromised);
 // wrap these tests in a function so we can export the tests and re-use them
 // for actual driver implementations
 function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
-  describe('BaseDriver', function () {
+  // to display the driver under test in report
+  const className = DriverClass.name || '(unknown driver)';
+
+  describe(`BaseDriver (as ${className})`, function () {
     let d, w3cCaps;
 
     beforeEach(function () {
@@ -75,12 +78,12 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       let sessions = await d.getSessions();
 
       sessions.length.should.equal(1);
-      sessions[0].should.eql({
-        id: d.sessionId,
-        capabilities: {
-          'deviceName': 'Commodore 64',
-          'platformName': 'Fake'
-        }
+      sessions[0].should.include({
+        id: d.sessionId
+      });
+      sessions[0].capabilities.should.include({
+        'deviceName': 'Commodore 64',
+        'platformName': 'Fake'
       });
     });
 
@@ -393,7 +396,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
       beforeEach(async function () {
         beforeStartTime = Date.now();
         d.shouldValidateCaps = false;
-        await d.executeCommand('createSession', null, null, defaultCaps);
+        await d.executeCommand('createSession', null, null, {alwaysMatch: {...defaultCaps}, firstMatch: [{}]});
       });
       describe('#eventHistory', function () {
         it('should have an eventHistory property', function () {

--- a/packages/base-driver/test/basedriver/driver-tests.js
+++ b/packages/base-driver/test/basedriver/driver-tests.js
@@ -82,8 +82,8 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         id: d.sessionId
       });
       sessions[0].capabilities.should.include({
-        'deviceName': 'Commodore 64',
-        'platformName': 'Fake'
+        deviceName: 'Commodore 64',
+        platformName: 'Fake'
       });
     });
 

--- a/packages/base-driver/test/protocol/routes-specs.js
+++ b/packages/base-driver/test/protocol/routes-specs.js
@@ -40,7 +40,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('54bc3911');
+      hash.should.equal('3351a966');
     });
   });
 

--- a/packages/fake-driver/lib/commands/alert.js
+++ b/packages/fake-driver/lib/commands/alert.js
@@ -1,4 +1,4 @@
-import { errors } from 'appium-base-driver';
+import { errors } from '@appium/base-driver';
 
 let commands = {}, helpers = {}, extensions = {};
 

--- a/packages/fake-driver/lib/commands/contexts.js
+++ b/packages/fake-driver/lib/commands/contexts.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { errors } from 'appium-base-driver';
+import { errors } from '@appium/base-driver';
 
 let commands = {}, helpers = {}, extensions = {};
 

--- a/packages/fake-driver/lib/commands/element.js
+++ b/packages/fake-driver/lib/commands/element.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { errors } from 'appium-base-driver';
+import { errors } from '@appium/base-driver';
 
 let commands = {}, helpers = {}, extensions = {};
 

--- a/packages/fake-driver/lib/commands/element.js
+++ b/packages/fake-driver/lib/commands/element.js
@@ -72,9 +72,9 @@ commands.getAttribute = async function getAttribute (attr, elementId) {
   return el.getAttr(attr);
 };
 
-commands.getLocation = function getLocation (elementId) {
+commands.getElementRect = function getElementRect (elementId) {
   let el = this.getElement(elementId);
-  return el.getLocation();
+  return el.getElementRect();
 };
 
 commands.getSize = function getSize (elementId) {

--- a/packages/fake-driver/lib/commands/find.js
+++ b/packages/fake-driver/lib/commands/find.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { errors } from 'appium-base-driver';
+import { errors } from '@appium/base-driver';
 import { FakeElement } from '../fake-element';
 
 let commands = {}, helpers = {}, extensions = {};

--- a/packages/fake-driver/lib/commands/find.js
+++ b/packages/fake-driver/lib/commands/find.js
@@ -32,7 +32,8 @@ helpers.findElOrEls = async function findElOrEls (strategy, selector, mult, ctx)
     'id': 'idQuery',
     'accessibility id': 'idQuery',
     'class name': 'classQuery',
-    'tag name': 'classQuery'
+    'tag name': 'classQuery',
+    'css selector': 'cssQuery'
   };
   // TODO this error checking should probably be part of MJSONWP?
   if (!_.includes(_.keys(qMap), strategy)) {

--- a/packages/fake-driver/lib/commands/general.js
+++ b/packages/fake-driver/lib/commands/general.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { errors } from 'appium-base-driver';
+import { errors } from '@appium/base-driver';
 
 let commands = {}, helpers = {}, extensions = {};
 

--- a/packages/fake-driver/lib/commands/general.js
+++ b/packages/fake-driver/lib/commands/general.js
@@ -56,6 +56,9 @@ commands.performActions = async function performActions (actions) {
   this.appModel.actionLog.push(actions);
 };
 
+commands.releaseActions = async function releaseActions () {
+};
+
 commands.getLog = async function getLog (type) {
   switch (type) {
     case 'actions':

--- a/packages/fake-driver/lib/driver.js
+++ b/packages/fake-driver/lib/driver.js
@@ -1,6 +1,6 @@
 import B from 'bluebird';
 import _ from 'lodash';
-import { BaseDriver, errors } from 'appium-base-driver';
+import { BaseDriver, errors } from '@appium/base-driver';
 import { FakeApp } from './fake-app';
 import commands from './commands';
 
@@ -17,14 +17,14 @@ class FakeDriver extends BaseDriver {
     this.fakeThing = null;
 
     this.desiredCapConstraints = {
-      app: {
+      'app': {
         presence: true,
         isString: true
       }
     };
   }
 
-  async createSession (desiredCaps, requiredCaps, capabilities, otherSessionData = []) {
+  async createSession (jsonwpDesiredCapabilities, jsonwpRequiredCaps, w3cCapabilities, otherSessionData = []) {
 
     // TODO add validation on caps.app that we will get for free from
     // BaseDriver
@@ -38,7 +38,7 @@ class FakeDriver extends BaseDriver {
       }
     }
 
-    let [sessionId, caps] = await super.createSession(desiredCaps, requiredCaps, capabilities, otherSessionData);
+    let [sessionId, caps] = await super.createSession(jsonwpDesiredCapabilities, jsonwpRequiredCaps, w3cCapabilities, otherSessionData);
     this.appModel = new FakeApp();
     if (_.isArray(caps) === true && caps.length === 1) {
       caps = caps[0];

--- a/packages/fake-driver/lib/fake-app.js
+++ b/packages/fake-driver/lib/fake-app.js
@@ -1,5 +1,5 @@
-import {fs} from '@appium/support';
-import {readFileSync, existsSync} from 'fs';
+import { fs } from '@appium/support';
+import { readFileSync, existsSync } from 'fs';
 import path from 'path';
 import XMLDom from 'xmldom';
 import xpath from 'xpath';

--- a/packages/fake-driver/lib/fake-app.js
+++ b/packages/fake-driver/lib/fake-app.js
@@ -1,12 +1,10 @@
-import B from 'bluebird';
-import fs from 'fs';
+import {readFile} from 'fs/promises';
+import {readFileSync} from 'fs';
 import path from 'path';
 import XMLDom from 'xmldom';
 import xpath from 'xpath';
 import log from './logger';
 import { FakeElement } from './fake-element';
-
-const readFile = B.promisify(fs.readFile);
 
 const SCREENSHOT = path.resolve(__dirname, '..', '..', 'screen.png');
 
@@ -71,7 +69,7 @@ class FakeApp {
   }
 
   async loadApp (appPath) {
-    log.info('Loading Mock app model');
+    log.info(`Loading Mock app model at ${appPath}`);
     let data = await readFile(appPath);
     log.info('Parsing Mock app XML');
     this.rawXml = data.toString();
@@ -151,7 +149,7 @@ class FakeApp {
   }
 
   getScreenshot () {
-    return fs.readFileSync(SCREENSHOT, 'base64');
+    return readFileSync(SCREENSHOT, 'base64');
   }
 
 }

--- a/packages/fake-driver/lib/fake-app.js
+++ b/packages/fake-driver/lib/fake-app.js
@@ -1,12 +1,13 @@
 import {readFile} from 'fs/promises';
-import {readFileSync} from 'fs';
+import {readFileSync, existsSync} from 'fs';
 import path from 'path';
 import XMLDom from 'xmldom';
 import xpath from 'xpath';
 import log from './logger';
 import { FakeElement } from './fake-element';
 
-const SCREENSHOT = path.resolve(__dirname, '..', '..', 'screen.png');
+const screenShotPath = path.join(__dirname, '..', 'screen.png');
+const SCREENSHOT = existsSync(screenShotPath) ? screenShotPath : path.join(__dirname, '..', '..', 'screen.png');
 
 class FakeApp {
   constructor () {

--- a/packages/fake-driver/lib/fake-app.js
+++ b/packages/fake-driver/lib/fake-app.js
@@ -1,4 +1,4 @@
-import {readFile} from 'fs/promises';
+import {fs} from '@appium/support';
 import {readFileSync, existsSync} from 'fs';
 import path from 'path';
 import XMLDom from 'xmldom';
@@ -71,7 +71,7 @@ class FakeApp {
 
   async loadApp (appPath) {
     log.info(`Loading Mock app model at ${appPath}`);
-    let data = await readFile(appPath);
+    let data = await fs.readFile(appPath);
     log.info('Parsing Mock app XML');
     this.rawXml = data.toString();
     this.rawXml = this.rawXml.replace('<app ', '<AppiumAUT><app ');

--- a/packages/fake-driver/lib/fake-app.js
+++ b/packages/fake-driver/lib/fake-app.js
@@ -120,6 +120,16 @@ class FakeApp {
     return this.xpathQuery(`//${className}`, ctx);
   }
 
+  cssQuery (css, ctx) {
+    if (css.startsWith('#')) {
+      return this.idQuery(css.slice(1), ctx);
+    }
+    if (css.startsWith('.')) {
+      return this.classQuery(css.slice(1), ctx);
+    }
+    return this.classQuery(css, ctx);
+  }
+
   hasAlert () {
     return this.activeAlert !== null;
   }

--- a/packages/fake-driver/lib/fake-element.js
+++ b/packages/fake-driver/lib/fake-element.js
@@ -58,6 +58,10 @@ class FakeElement {
     };
   }
 
+  getElementRect () {
+    return {...this.getLocation(), ...this.getSize()};
+  }
+
   getSize () {
     return {
       width: parseFloat(this.nodeAttrs.width || 0),

--- a/packages/fake-driver/lib/logger.js
+++ b/packages/fake-driver/lib/logger.js
@@ -1,4 +1,4 @@
-import { logger } from 'appium-support';
+import { logger } from '@appium/support';
 
 
 const log = logger.getLogger('FakeDriver');

--- a/packages/fake-driver/lib/server.js
+++ b/packages/fake-driver/lib/server.js
@@ -1,5 +1,5 @@
 import log from './logger';
-import { server as baseServer, routeConfiguringFunction } from 'appium-base-driver';
+import { server as baseServer, routeConfiguringFunction } from '@appium/base-driver';
 import { FakeDriver } from './driver';
 
 

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -30,9 +30,9 @@
     "screen.png"
   ],
   "dependencies": {
+    "@appium/base-driver": "^8.0.0-beta.6",
     "@appium/support": "^2.11.1",
     "@babel/runtime": "^7.0.0",
-    "appium-base-driver": "^7.6.0",
     "asyncbox": "^2.3.2",
     "bluebird": "^3.5.1",
     "lodash": "^4.17.4",

--- a/packages/fake-driver/test/alert-tests.js
+++ b/packages/fake-driver/test/alert-tests.js
@@ -1,43 +1,43 @@
-import { initSession, deleteSession, DEFAULT_CAPS } from './helpers';
+import { initSession, deleteSession, W3C_PREFIXED_CAPS } from './helpers';
 
 function alertTests () {
   describe('alerts', function () {
     let driver;
     before (async function () {
-      driver = await initSession(DEFAULT_CAPS);
+      driver = await initSession(W3C_PREFIXED_CAPS);
     });
     after(async function () {
-      await deleteSession();
+      return await deleteSession(driver);
     });
 
     it('should not work with alerts when one is not present', async function () {
-      await driver.alertText().should.eventually.be.rejectedWith(/27/);
-      await driver.alertKeys('foo').should.eventually.be.rejectedWith(/27/);
-      await driver.acceptAlert().should.eventually.be.rejectedWith(/27/);
-      await driver.dismissAlert().should.eventually.be.rejectedWith(/27/);
+      await driver.getAlertText().should.eventually.be.rejectedWith({code: 27});
+      await driver.sendAlertText('foo').should.eventually.be.rejectedWith({code: 27});
+      await driver.acceptAlert().should.eventually.be.rejectedWith({code: 27});
+      await driver.dismissAlert().should.eventually.be.rejectedWith({code: 27});
     });
     it('should get text of an alert', async function () {
-      await driver.elementById('AlertButton').click();
-      (await driver.alertText()).should.equal('Fake Alert');
+      await (await driver.$('#AlertButton')).click();
+      (await driver.getAlertText()).should.equal('Fake Alert');
     });
     it('should set the text of an alert', async function () {
-      await driver.alertKeys('foo');
-      (await driver.alertText()).should.equal('foo');
+      await driver.sendAlertText('foo');
+      (await driver.getAlertText()).should.equal('foo');
     });
     it('should not do other things while an alert is there', async function () {
-      await driver.elementById('nav').click()
-              .should.eventually.be.rejectedWith(/26/);
+      await (await driver.$('#nav')).click()
+              .should.eventually.be.rejectedWith({code: 26});
     });
     it.skip('should accept an alert', function () {
       driver
         .acceptAlert()
-        .elementById('nav')
+        .$('nav')
         .click()
         .nodeify();
     });
     it.skip('should not set the text of the wrong kind of alert', function () {
       driver
-        .elementById('AlertButton2')
+        .$('AlertButton2')
         .click()
         .alertText()
           .should.eventually.become('Fake Alert 2')
@@ -48,7 +48,7 @@ function alertTests () {
     it.skip('should dismiss an alert', function () {
       driver
         .acceptAlert()
-        .elementById('nav')
+        .$('nav')
         .click()
         .nodeify();
     });

--- a/packages/fake-driver/test/context-tests.js
+++ b/packages/fake-driver/test/context-tests.js
@@ -1,51 +1,52 @@
-import { initSession, deleteSession, DEFAULT_CAPS } from './helpers';
+import { initSession, deleteSession, W3C_PREFIXED_CAPS } from './helpers';
 
 function contextTests () {
   describe('contexts, webviews, frames', function () {
     let driver;
     before (async function () {
-      driver = await initSession(DEFAULT_CAPS);
+      driver = await initSession(W3C_PREFIXED_CAPS);
     });
     after(async function () {
-      await deleteSession();
+      return await deleteSession(driver);
     });
     it('should get current context', async function () {
-      await driver.currentContext()
+      await driver.getContext()
               .should.eventually.become('NATIVE_APP');
     });
     it('should get contexts', async function () {
-      await driver.contexts()
+      await driver.getContexts()
               .should.eventually.become(['NATIVE_APP', 'WEBVIEW_1']);
     });
     it('should not set context that is not there', async function () {
-      await driver.context('WEBVIEW_FOO')
-              .should.eventually.be.rejectedWith(/35/);
+      await driver.switchContext('WEBVIEW_FOO')
+              .should.eventually.be.rejectedWith(/No such context found/);
     });
     it('should set context', async function () {
-      await driver.context('WEBVIEW_1').currentContext()
-              .should.eventually.become('WEBVIEW_1');
+      await driver.switchContext('WEBVIEW_1');
+      await driver.getContext().should.eventually.become('WEBVIEW_1');
     });
     it('should find webview elements in a webview', async function () {
-      await driver.elementByXPath('//*').getTagName()
+      await (await driver.$('//*')).getTagName()
               .should.eventually.become('html');
     });
     it('should not switch to a frame that is not there', async function () {
-      await driver.frame('foo').should.eventually.be.rejectedWith(/8/);
+      await driver.switchToFrame(2).should.eventually.be.rejectedWith(/frame could not be found/);
     });
     it('should switch to an iframe', async function () {
-      await driver.frame('iframe1').title()
-              .should.eventually.become('Test iFrame');
+      await driver.switchToFrame(1);
+      await driver.getTitle().should.eventually.become('Test iFrame');
     });
     it('should switch back to default frame', async function () {
-      await driver.frame(null).title()
-              .should.eventually.become('Test Webview');
+      await driver.switchToFrame(null);
+      await driver.getTitle().should.eventually.become('Test Webview');
     });
     it('should go back to native context', async function () {
-      await driver.context('NATIVE_APP').elementByXPath('//*').getTagName()
-              .should.eventually.become('AppiumAUT');
+      await driver.switchContext('NATIVE_APP');
+      await (await driver.$('//*')).getTagName().should.eventually.become('AppiumAUT');
     });
     it('should not set a frame in a native context', async function () {
-      await driver.frame('iframe1').should.eventually.be.rejectedWith(/36/);
+      await driver.switchContext('NATIVE_APP');
+      await driver.switchToFrame(1).should.eventually.be.rejectedWith(/could not be executed in the current context/);
     });
   });
 }

--- a/packages/fake-driver/test/driver-e2e-specs.js
+++ b/packages/fake-driver/test/driver-e2e-specs.js
@@ -2,11 +2,10 @@
 
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import wd from 'wd';
 import axios from 'axios';
 import { baseDriverE2ETests } from '@appium/base-driver/build/test/basedriver';
-import { FakeDriver, startServer } from '..';
-import { DEFAULT_CAPS, TEST_HOST, TEST_PORT } from './helpers';
+import { FakeDriver, startServer } from '../index.js';
+import { BASE_CAPS, deleteSession, initSession, TEST_HOST, TEST_PORT, W3C_PREFIXED_CAPS } from './helpers';
 import contextTests from './context-tests';
 import findElementTests from './find-element-tests';
 import elementInteractionTests from './element-interaction-tests';
@@ -18,8 +17,9 @@ const should = chai.should();
 chai.use(chaiAsPromised);
 const shouldStartServer = process.env.USE_RUNNING_SERVER !== '0';
 
+
 // test the same things as for base driver
-baseDriverE2ETests(FakeDriver, DEFAULT_CAPS);
+baseDriverE2ETests(FakeDriver, W3C_PREFIXED_CAPS);
 
 describe('FakeDriver - via HTTP', function () {
   let server = null;
@@ -36,14 +36,12 @@ describe('FakeDriver - via HTTP', function () {
 
   describe('session handling', function () {
     it('should start and stop a session', async function () {
-      let driver = wd.promiseChainRemote(TEST_HOST, TEST_PORT);
-      let [sessionId] = await driver.init(DEFAULT_CAPS);
-      should.exist(sessionId);
-      sessionId.should.be.a('string');
-      await driver.quit();
-      await driver.title().should.eventually.be.rejectedWith(/terminated/);
+      let driver = await initSession(W3C_PREFIXED_CAPS);
+      should.exist(driver.sessionId);
+      driver.sessionId.should.be.a('string');
+      await deleteSession(driver);
+      await driver.getTitle().should.eventually.be.rejectedWith(/terminated/);
     });
-
   });
 
   describe('session-based tests', function () {
@@ -56,32 +54,24 @@ describe('FakeDriver - via HTTP', function () {
 
   describe('w3c', function () {
     it('should return value.capabilities object for W3C', async function () {
-      const res = await axios.post(`http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, {
+      const res = await axios.post(`http://${TEST_HOST}:${TEST_PORT}/session`, {
         capabilities: {
-          alwaysMatch: DEFAULT_CAPS,
-          firstMatch: [{
-            'appium:fakeCap': 'Foo',
-          }],
-        }
-      });
+          alwaysMatch: W3C_PREFIXED_CAPS,
+          firstMatch: [
+            {'appium:fakeCap': 'Foo', }
+          ]
+        }});
       const {value, status} = res.data;
-      value.capabilities.should.deep.equal(Object.assign({}, DEFAULT_CAPS, {
-        fakeCap: 'Foo',
-      }));
+      value.capabilities.should.deep.equal({...BASE_CAPS, fakeCap: 'Foo'});
       value.sessionId.should.exist;
       should.not.exist(status);
-      await axios.delete(`http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${value.sessionId}`);
+      await axios.delete(`http://${TEST_HOST}:${TEST_PORT}/session/${value.sessionId}`);
     });
 
-    it('should return value object for MJSONWP as desiredCapabilities', async function () {
-      const res = await axios.post(`http://${TEST_HOST}:${TEST_PORT}/wd/hub/session`, {
-        desiredCapabilities: DEFAULT_CAPS
-      });
-      const {value, status, sessionId} = res.data;
-      value.should.deep.equal(DEFAULT_CAPS);
-      status.should.equal(0);
-      sessionId.should.exist;
-      await axios.delete(`http://${TEST_HOST}:${TEST_PORT}/wd/hub/session/${sessionId}`);
+    it('should fail if given unsupported desiredCapabilities', async function () {
+      await axios.post(`http://${TEST_HOST}:${TEST_PORT}/session`, {
+        desiredCapabilities: W3C_PREFIXED_CAPS
+      }).should.eventually.be.rejectedWith(/500/);
     });
   });
 

--- a/packages/fake-driver/test/driver-e2e-specs.js
+++ b/packages/fake-driver/test/driver-e2e-specs.js
@@ -4,7 +4,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import wd from 'wd';
 import axios from 'axios';
-import { baseDriverE2ETests } from 'appium-base-driver/build/test/basedriver';
+import { baseDriverE2ETests } from '@appium/base-driver/build/test/basedriver';
 import { FakeDriver, startServer } from '..';
 import { DEFAULT_CAPS, TEST_HOST, TEST_PORT } from './helpers';
 import contextTests from './context-tests';

--- a/packages/fake-driver/test/driver-specs.js
+++ b/packages/fake-driver/test/driver-specs.js
@@ -1,12 +1,10 @@
 // transpile:mocha
 
-import _ from 'lodash';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { FakeDriver } from '..';
 import { DEFAULT_CAPS } from './helpers';
-import { baseDriverUnitTests } from 'appium-base-driver/build/test/basedriver';
-
+import { baseDriverUnitTests } from '@appium/base-driver/build/test/basedriver';
 
 chai.use(chaiAsPromised);
 chai.should();
@@ -17,23 +15,41 @@ baseDriverUnitTests(FakeDriver, DEFAULT_CAPS);
 describe('FakeDriver', function () {
   it('should not start a session when a unique session is already running', async function () {
     let d1 = new FakeDriver();
-    let caps1 = _.clone(DEFAULT_CAPS);
-    caps1.uniqueApp = true;
-    let [uniqueSession] = await d1.createSession(caps1, {});
+    let [uniqueSession] = await d1.createSession(null, null, {
+      alwaysMatch: { ...DEFAULT_CAPS, 'appium:uniqueApp': true },
+      firstMatch: [{}],
+    });
     uniqueSession.should.be.a('string');
     let d2 = new FakeDriver();
     let otherSessionData = [d1.driverData];
-    await d2.createSession(DEFAULT_CAPS, {}, null, otherSessionData)
-            .should.eventually.be.rejectedWith(/unique/);
-    await d1.deleteSession(uniqueSession);
+    try {
+      await d2
+        .createSession(
+          null,
+          null,
+          {
+            alwaysMatch: { ...DEFAULT_CAPS },
+            firstMatch: [{}],
+          },
+          otherSessionData,
+        )
+        .should.eventually.be.rejectedWith(/unique/);
+    } finally {
+      await d1.deleteSession(uniqueSession);
+    }
   });
   it('should start a new session when another non-unique session is running', async function () {
     let d1 = new FakeDriver();
-    let [session1Id] = await d1.createSession(DEFAULT_CAPS, {});
+    let [session1Id] = await d1.createSession(null, null, {
+      alwaysMatch: { ...DEFAULT_CAPS },
+      firstMatch: [{}],
+    },);
     session1Id.should.be.a('string');
     let d2 = new FakeDriver();
-    let otherSessionData = [d1.driverData];
-    let [session2Id] = await d2.createSession(DEFAULT_CAPS, {}, null, otherSessionData);
+    let [session2Id] = await d2.createSession(null, null, {
+      alwaysMatch: { ...DEFAULT_CAPS },
+      firstMatch: [{}],
+    });
     session2Id.should.be.a('string');
     session1Id.should.not.equal(session2Id);
     await d1.deleteSession(session1Id);

--- a/packages/fake-driver/test/driver-specs.js
+++ b/packages/fake-driver/test/driver-specs.js
@@ -1,22 +1,23 @@
 // transpile:mocha
 
+import _ from 'lodash';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { FakeDriver } from '..';
-import { DEFAULT_CAPS } from './helpers';
+import { W3C_CAPS, W3C_PREFIXED_CAPS } from './helpers';
 import { baseDriverUnitTests } from '@appium/base-driver/build/test/basedriver';
 
 chai.use(chaiAsPromised);
 chai.should();
 
 // test the same things as for base driver
-baseDriverUnitTests(FakeDriver, DEFAULT_CAPS);
+baseDriverUnitTests(FakeDriver, _.cloneDeep(W3C_PREFIXED_CAPS));
 
 describe('FakeDriver', function () {
   it('should not start a session when a unique session is already running', async function () {
     let d1 = new FakeDriver();
     let [uniqueSession] = await d1.createSession(null, null, {
-      alwaysMatch: { ...DEFAULT_CAPS, 'appium:uniqueApp': true },
+      alwaysMatch: { ..._.cloneDeep(W3C_PREFIXED_CAPS), 'appium:uniqueApp': true },
       firstMatch: [{}],
     });
     uniqueSession.should.be.a('string');
@@ -27,10 +28,7 @@ describe('FakeDriver', function () {
         .createSession(
           null,
           null,
-          {
-            alwaysMatch: { ...DEFAULT_CAPS },
-            firstMatch: [{}],
-          },
+          _.cloneDeep(W3C_CAPS),
           otherSessionData,
         )
         .should.eventually.be.rejectedWith(/unique/);
@@ -40,16 +38,10 @@ describe('FakeDriver', function () {
   });
   it('should start a new session when another non-unique session is running', async function () {
     let d1 = new FakeDriver();
-    let [session1Id] = await d1.createSession(null, null, {
-      alwaysMatch: { ...DEFAULT_CAPS },
-      firstMatch: [{}],
-    },);
+    let [session1Id] = await d1.createSession(null, null, _.cloneDeep(W3C_CAPS));
     session1Id.should.be.a('string');
     let d2 = new FakeDriver();
-    let [session2Id] = await d2.createSession(null, null, {
-      alwaysMatch: { ...DEFAULT_CAPS },
-      firstMatch: [{}],
-    });
+    let [session2Id] = await d2.createSession(null, null, _.cloneDeep(W3C_CAPS));
     session2Id.should.be.a('string');
     session1Id.should.not.equal(session2Id);
     await d1.deleteSession(session1Id);

--- a/packages/fake-driver/test/find-element-tests.js
+++ b/packages/fake-driver/test/find-element-tests.js
@@ -1,119 +1,97 @@
 import chai from 'chai';
-import { initSession, deleteSession, DEFAULT_CAPS } from './helpers';
+import { initSession, deleteSession, W3C_PREFIXED_CAPS } from './helpers';
+import chaiWebdriverIOAsync from 'chai-webdriverio-async';
 
-const should = chai.should();
+chai.should();
 
 function findElementTests () {
   describe('finding elements', function () {
     let driver;
     before (async function () {
-      driver = await initSession(DEFAULT_CAPS);
+      driver = await initSession(W3C_PREFIXED_CAPS);
+      chai.use(chaiWebdriverIOAsync(driver));
     });
     after(async function () {
-      await deleteSession();
+      return await deleteSession(driver);
     });
 
-    it('should find a single element by xpath', async function () {
-      let el = await driver.elementByXPath('//MockWebView');
-      should.exist(el.value);
-    });
-    it('should not find a single element that is not there', async function () {
-      await driver.elementByXPath('//dontexist')
-              .should.eventually.be.rejectedWith(/7/);
-    });
-    it('should find multiple elements', async function () {
-      let els = await driver.elementsByXPath('//MockListItem');
-      els.should.have.length(3);
-    });
-    it('should not find multiple elements that are not there', async function () {
-      let els = await driver.elementsByXPath('//dontexist');
-      els.should.eql([]);
+    describe('by XPath', function () {
+      it('should find a single element by xpath', async function () {
+        await driver.$('//MockWebView').should.be.existing();
+      });
+      it('should not find a single element that is not there', async function () {
+        await driver.$('//dontexist').should.not.be.existing();
+      });
+      it('should find multiple elements', async function () {
+        await driver.$$('//MockListItem').should.have.count(3);
+      });
+      it('should not find multiple elements that are not there', async function () {
+        await driver.$$('//dontexist').should.have.count(0);
+      });
     });
 
-    it('should find a single element by id', async function () {
-      let el = await driver.elementById('wv');
-      should.exist(el.value);
-    });
-    it('should not find a single element by id that is not there', async function () {
-      await driver.elementById('dontexist')
-              .should.eventually.be.rejectedWith(/7/);
-    });
-    it('should find multiple elements by id', async function () {
-      let els = await driver.elementsById('li');
-      els.should.have.length(2);
-    });
-    it('should not find multiple elements by id that are not there', async function () {
-      let els = await driver.elementsById('dontexist');
-      els.should.eql([]);
+    describe('by id', function () {
+      it('should find a single element by id', async function () {
+        await driver.$('#wv').should.be.existing();
+      });
+
+      it('should not find a single element by id that is not there', async function () {
+        await driver.$('#dontexist').should.not.be.existing();
+      });
+
+      it('should find multiple elements by id', async function () {
+        await driver.$$('#li').should.have.count(2);
+      });
+      it('should not find multiple elements by id that are not there', async function () {
+        await driver.$$('#dontexist').should.have.count(0);
+      });
     });
 
-    it('should find a single element by class', async function () {
-      let el = await driver.elementByClassName('MockWebView');
-      should.exist(el.value);
-    });
-    it('should not find a single element by class that is not there', async function () {
-      await driver.elementById('dontexist')
-              .should.eventually.be.rejectedWith(/7/);
-    });
-    it('should find multiple elements by class', async function () {
-      let els = await driver.elementsByClassName('MockListItem');
-      els.should.have.length(3);
-    });
-    it('should not find multiple elements by class that are not there', async function () {
-      let els = await driver.elementsByClassName('dontexist');
-      els.should.eql([]);
+    describe('by classname', function () {
+      it('should find a single element by class', async function () {
+        await driver.$('.MockWebView').should.be.existing();
+      });
+
+      it('should not find a single element by class that is not there', async function () {
+        await driver.$('.dontexist').should.not.be.existing();
+      });
     });
 
-    it('should not find a single element with bad strategy', async function () {
-      await driver.elementByCss('.sorry')
-              .should.eventually.be.rejectedWith(/9/);
-    });
-    it('should not find a single element with bad selector', async function () {
-      await driver.elementByXPath('badsel')
-              .should.eventually.be.rejectedWith(/32/);
-    });
-    it('should not find multiple elements with bad strategy', async function () {
-      await driver.elementsByCss('.sorry')
-              .should.eventually.be.rejectedWith(/9/);
-    });
-    it('should not find multiple elements with bad selector', async function () {
-      await driver.elementsByXPath('badsel')
-              .should.eventually.be.rejectedWith(/32/);
+    describe('using bad selectors', function () {
+      it('should not find a single element with bad selector', async function () {
+        await driver.$('badsel')
+                .should.eventually.be.rejectedWith({code: 32});
+      });
+
+      it('should not find multiple elements with bad selector', async function () {
+        await driver.$$('badsel')
+                .should.eventually.be.rejectedWith({code: 32});
+      });
     });
 
-    it('should find an element from another element', async function () {
-      let el = await driver.elementById('iframe1');
-      let title = await el.elementByTagName('title');
-      let earlierTitle = await driver.elementByTagName('title');
-      (await earlierTitle.equals(title)).should.equal(false);
-    });
-    it('should find multiple elements from another element', async function () {
-      let el = await driver.elementByTagName('html');
-      let titles = await el.elementsByTagName('title');
-      titles.length.should.equal(2);
-    });
-    it('should not find an element that doesnt exist from another element', async function () {
-      let el = await driver.elementByTagName('html');
-      await el.elementByTagName('marquee')
-              .should.eventually.be.rejectedWith(/7/);
-
-    });
-    it('should not find multiple elements that dont exist from another element', async function () {
-      let el = await driver.elementByTagName('html');
-      (await el.elementsByTagName('marquee')).should.eql([]);
-    });
-    it('should not find an element with bad strategy from another element', async function () {
-      await driver.elementByTagName('html').elementByCss('.sorry')
-              .should.eventually.be.rejectedWith(/9/);
-    });
-    it('should not find elements with bad strategy from another element', async function () {
-      await driver.elementByTagName('html').elementsByCss('.sorry')
-              .should.eventually.be.rejectedWith(/9/);
-    });
-    it('should error if root element is not valid', async function () {
-      let el = await driver.elementByTagName('html');
-      el.value = 'foobar';
-      await el.elementByTagName('body').should.eventually.be.rejectedWith(/10/);
+    describe('via element selectors', function () {
+      it('should find an element from another element', async function () {
+        let el = await driver.$('#1');
+        let title = await el.$('title');
+        let earlierTitle = await driver.$('title');
+        await earlierTitle.isEqual(title).should.eventually.equal(false);
+      });
+      it('should find multiple elements from another element', async function () {
+        let el = await driver.$('html');
+        await el.$$('title').should.have.count(2);
+      });
+      it(`should not find an element that doesn't exist from another element`, async function () {
+        let el = await driver.$('#1');
+        await el.$('marquee').should.not.be.existing();
+      });
+      it(`should not find multiple elements that don't exist from another element`, async function () {
+        let el = await driver.$('#1');
+        (await el.$$('marquee')).should.have.count(0);
+      });
+      it('should not find elements if root element does not exist', async function () {
+        let el = await driver.$('#blub');
+        await el.$('body').should.eventually.be.rejectedWith(/Can't call \$/);
+      });
     });
   });
 }

--- a/packages/fake-driver/test/find-element-tests.js
+++ b/packages/fake-driver/test/find-element-tests.js
@@ -25,26 +25,6 @@ function findElementTests () {
       it('should find multiple elements', async function () {
         await driver.$$('//MockListItem').should.have.count(3);
       });
-      it('should not find multiple elements that are not there', async function () {
-        await driver.$$('//dontexist').should.have.count(0);
-      });
-    });
-
-    describe('by id', function () {
-      it('should find a single element by id', async function () {
-        await driver.$('#wv').should.be.existing();
-      });
-
-      it('should not find a single element by id that is not there', async function () {
-        await driver.$('#dontexist').should.not.be.existing();
-      });
-
-      it('should find multiple elements by id', async function () {
-        await driver.$$('#li').should.have.count(2);
-      });
-      it('should not find multiple elements by id that are not there', async function () {
-        await driver.$$('#dontexist').should.have.count(0);
-      });
     });
 
     describe('by classname', function () {

--- a/packages/fake-driver/test/fixtures/app.xml
+++ b/packages/fake-driver/test/fixtures/app.xml
@@ -10,7 +10,7 @@
             </head>
             <body style="background-color: #000">
               <h1>Hello</h1>
-              <iframe id="iframe1">
+              <iframe id="1">
                 <html>
                   <head>
                     <title value="iframe title">Test iFrame</title>

--- a/packages/fake-driver/test/general-tests.js
+++ b/packages/fake-driver/test/general-tests.js
@@ -29,7 +29,7 @@ function generalTests () {
       should.exist(geo.longitude);
     });
     it('should get app source', async function () {
-      let source = await driver.source();
+      let source = await driver.getPageSource();
       source.should.contain('<MockNavBar id="nav"');
     });
     // TODO do we want to test driver.pageIndex? probably not
@@ -58,28 +58,28 @@ function generalTests () {
     });
 
     it('should set implicit wait timeout', async function () {
-      await driver.setImplicitWaitTimeout(1000);
+      await driver.setTimeout({implicit: 1000});
     });
     it('should not set invalid implicit wait timeout', async function () {
-      await driver.setImplicitWaitTimeout('foo')
-              .should.eventually.be.rejectedWith(/ms/);
+      await driver.setTimeout({implicit: 'foo'})
+              .should.eventually.be.rejectedWith(/values are not valid/);
     });
 
     // skip these until basedriver supports these timeouts
     it.skip('should set async script timeout', async function () {
-      await driver.setAsyncScriptTimeout(1000);
+      await driver.setTimeout({script: 1000});
     });
     it.skip('should not set invalid async script timeout', async function () {
-      await driver.setAsyncScriptTimeout('foo')
-              .should.eventually.be.rejectedWith(/ms/);
+      await driver.setTimeout({script: 'foo'})
+              .should.eventually.be.rejectedWith(/values are not valid/);
     });
 
     it.skip('should set page load timeout', async function () {
-      await driver.setPageLoadTimeout(1000);
+      await driver.setTimeout({pageLoad: 1000});
     });
     it.skip('should not set page load script timeout', async function () {
-      await driver.setPageLoadTimeout('foo')
-              .should.eventually.be.rejectedWith(/ms/);
+      await driver.setTimeout({pageLoad: 'foo'})
+              .should.eventually.be.rejectedWith(/values are not valid/);
     });
 
     it('should allow performing actions that do nothing but save them', async function () {

--- a/packages/fake-driver/test/general-tests.js
+++ b/packages/fake-driver/test/general-tests.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { initSession, deleteSession, DEFAULT_CAPS } from './helpers';
-import { W3CActions } from 'wd';
+import chaiWebdriverIOAsync from 'chai-webdriverio-async';
+import { initSession, deleteSession, W3C_PREFIXED_CAPS } from './helpers';
 
 const should = chai.should();
 chai.use(chaiAsPromised);
@@ -11,22 +11,14 @@ function generalTests () {
     let driver;
 
     before(async function () {
-      driver = await initSession(DEFAULT_CAPS);
+      driver = await initSession(W3C_PREFIXED_CAPS);
+      chai.use(chaiWebdriverIOAsync(driver));
     });
 
     after(async function () {
-      await deleteSession();
+      return await deleteSession(driver);
     });
 
-    it('should not send keys without a focused element', async function () {
-      await driver.keys('test').should.eventually.be.rejectedWith(/12/);
-    });
-    it('should send keys to a focused element', async function () {
-      let el = await driver.elementById('input');
-      await el.click();
-      await driver.keys('test');
-      (await el.text()).should.equal('test');
-    });
     it.skip('should set geolocation', async function () {
       // TODO unquarantine when WD fixes what it sends the server
       await driver.setGeoLocation(-30, 30);
@@ -91,16 +83,30 @@ function generalTests () {
     });
 
     it('should allow performing actions that do nothing but save them', async function () {
-      const actions = new W3CActions(driver);
-      const touch = actions.addTouchInput();
-      touch.pointerDown();
-      touch.pointerUp();
-      await driver.performW3CActions(actions);
-      const [res] = await driver.log('actions');
+      const actions = [
+        {
+          type: 'pointer',
+          id: 'finger1',
+          parameters: {
+            pointerType: 'touch'
+          },
+          actions: [
+            {
+              type: 'pointerDown',
+              button: 0
+            },
+            {
+              type: 'pointerUp',
+              button: 0
+            }
+          ]
+        }
+      ];
+      await driver.performActions(actions);
+      const [res] = await driver.getLogs('actions');
       res[0].type.should.eql('pointer');
       res[0].actions.should.have.length(2);
     });
-
   });
 }
 

--- a/packages/fake-driver/test/helpers.js
+++ b/packages/fake-driver/test/helpers.js
@@ -1,17 +1,21 @@
 import path from 'path';
 import wd from 'wd';
+import {existsSync} from 'fs';
 
-
-const TEST_HOST = 'localhost';
+const TEST_HOST = '127.0.0.1';
 const TEST_PORT = 4774;
-const TEST_APP = path.resolve(__dirname, '..', '..', 'test', 'fixtures', 'app.xml');
+
+// XXX: what dir are we in? it depends on how we're running this test. the .xml file doesn't move, but we do!
+// we may be running with @babel/register; otherwise, we're probably in `build/test/` which _does not_ contain the xml file.
+const appFixturePath = path.join(__dirname, 'fixtures', 'app.xml');
+const TEST_APP = existsSync(appFixturePath) ? appFixturePath : path.join(__dirname, '..', '..', 'test', 'fixtures', 'app.xml');
 
 const DEFAULT_CAPS = {
   platformName: 'Fake',
-  deviceName: 'Fake',
-  app: TEST_APP,
-  address: 'localhost',
-  port: 8181,
+  'appium:deviceName': 'Commodore 64',
+  'appium:app': TEST_APP,
+  'appium:address': TEST_HOST,
+  'appium:port': 8181,
 };
 
 let driver;

--- a/packages/fake-driver/test/helpers.js
+++ b/packages/fake-driver/test/helpers.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import wd from 'wd';
+import {remote as wdio} from 'webdriverio';
 import {existsSync} from 'fs';
 
 const TEST_HOST = '127.0.0.1';
@@ -10,26 +10,41 @@ const TEST_PORT = 4774;
 const appFixturePath = path.join(__dirname, 'fixtures', 'app.xml');
 const TEST_APP = existsSync(appFixturePath) ? appFixturePath : path.join(__dirname, '..', '..', 'test', 'fixtures', 'app.xml');
 
-const DEFAULT_CAPS = {
+const BASE_CAPS = {
   platformName: 'Fake',
-  'appium:deviceName': 'Commodore 64',
-  'appium:app': TEST_APP,
-  'appium:address': TEST_HOST,
-  'appium:port': 8181,
+  deviceName: 'Commodore 64',
+  app: TEST_APP,
+  address: TEST_HOST,
+  port: 8181,
 };
 
-let driver;
+const W3C_PREFIXED_CAPS = {
+  'appium:deviceName': BASE_CAPS.deviceName,
+  'appium:app': BASE_CAPS.app,
+  'appium:address': BASE_CAPS.address,
+  'appium:port': BASE_CAPS.port,
+  platformName: BASE_CAPS.platformName
+};
 
-async function initSession (caps) {
-  driver = wd.promiseChainRemote({host: TEST_HOST, port: TEST_PORT});
-  await driver.init(caps);
-  return driver;
+const W3C_CAPS = {
+  alwaysMatch: {...W3C_PREFIXED_CAPS},
+  firstMatch: [{}],
+};
+
+const WD_OPTS = {
+  hostname: TEST_HOST,
+  port: TEST_PORT,
+  connectionRetryCount: 0
+};
+
+async function initSession (w3cPrefixedCaps) {
+  return await wdio({...WD_OPTS, capabilities: w3cPrefixedCaps});
 }
 
-async function deleteSession () {
+async function deleteSession (driver) {
   try {
-    await driver.quit();
+    await driver.deleteSession();
   } catch (ign) {}
 }
 
-export { initSession, deleteSession, TEST_APP, TEST_HOST, TEST_PORT, DEFAULT_CAPS };
+export { initSession, deleteSession, TEST_APP, TEST_HOST, TEST_PORT, BASE_CAPS, W3C_CAPS, W3C_PREFIXED_CAPS, WD_OPTS };


### PR DESCRIPTION
BREAKING CHANGE: `fake-driver` now depends upon `@appium/base-driver@8.x`

## `@appium/fake-driver`

- need to use w3c capabilities only
- switch from `wd` to `wdio` in tests
- many, many fixes to support these

## `@appium/base-driver`

- fixed a dead URL in a comment
- updated the "logging" tests to manually supply w3c capabilities.  `createSession()` does it for you, but `executeCommand('createSession')` does not.
- display the name of the driver under test when executing base driver's test suite with other drivers
- add missing `releaseActions` endpoint
 
Ref: #15436 
