### PR TITLE
fix(fake-driver): copy non-JS files into build dir at transpile time; closes #15471

### DIFF
--- a/packages/fake-driver/gulpfile.js
+++ b/packages/fake-driver/gulpfile.js
@@ -3,8 +3,13 @@
 const gulp = require('gulp');
 const boilerplate = require('@appium/gulp-plugins').boilerplate.use(gulp);
 
+gulp.task('copy-screen.png', () => gulp.src('./screen.png').pipe(gulp.dest('./build/')));
+
+gulp.task('copy-app.xml', () => gulp.src('./test/fixtures/app.xml').pipe(gulp.dest('./build/test/fixtures/')));
+
 boilerplate({
   build: '@appium/fake-driver',
   testTimeout: 15000,
   watchE2E: true,
+  postTranspile: ['copy-screen.png', 'copy-app.xml']
 });

--- a/packages/fake-driver/lib/fake-app.js
+++ b/packages/fake-driver/lib/fake-app.js
@@ -1,13 +1,12 @@
 import { fs } from '@appium/support';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync } from 'fs';
 import path from 'path';
 import XMLDom from 'xmldom';
 import xpath from 'xpath';
 import log from './logger';
 import { FakeElement } from './fake-element';
 
-const screenShotPath = path.join(__dirname, '..', 'screen.png');
-const SCREENSHOT = existsSync(screenShotPath) ? screenShotPath : path.join(__dirname, '..', '..', 'screen.png');
+const SCREENSHOT = path.join(__dirname, '..', 'screen.png');
 
 class FakeApp {
   constructor () {

--- a/packages/fake-driver/test/helpers.js
+++ b/packages/fake-driver/test/helpers.js
@@ -1,14 +1,10 @@
 import path from 'path';
-import {remote as wdio} from 'webdriverio';
-import {existsSync} from 'fs';
+import { remote as wdio } from 'webdriverio';
 
 const TEST_HOST = '127.0.0.1';
 const TEST_PORT = 4774;
 
-// XXX: what dir are we in? it depends on how we're running this test. the .xml file doesn't move, but we do!
-// we may be running with @babel/register; otherwise, we're probably in `build/test/` which _does not_ contain the xml file.
-const appFixturePath = path.join(__dirname, 'fixtures', 'app.xml');
-const TEST_APP = existsSync(appFixturePath) ? appFixturePath : path.join(__dirname, '..', '..', 'test', 'fixtures', 'app.xml');
+const TEST_APP = path.join(__dirname, 'fixtures', 'app.xml');
 
 const BASE_CAPS = {
   platformName: 'Fake',


### PR DESCRIPTION
## Proposed changes

In `fake-driver`, configured Gulp to copy `app.xml` and `screen.png` into appropriate directories as a post-transpilation step.  

Closes #15471

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
