### PR TITLE
chore(gulp-plugins): enable consumers to use mocha's "exit" flag

### DIFF
--- a/packages/gulp-plugins/lib/tasks/unit-test.js
+++ b/packages/gulp-plugins/lib/tasks/unit-test.js
@@ -14,7 +14,8 @@ const configure = function configure (gulp, opts, env) {
       timeout: opts.testTimeout,
       traceWarnings: opts.test.traceWarnings,
       traceDeprecation: opts.test.traceWarnings,
-      color: true
+      color: true,
+      exit: Boolean(opts.test.exit)
     };
     // set env so our code knows when it's being run in a test env
     process.env._TESTING = 1;


### PR DESCRIPTION
unit tests _should_ not need `--exit`, but this is real life, so things aren't perfect.

boilerplate configs can pass `{test: {exit: true}}` to cause Mocha to force-exit.

note that this is enabled by default for e2e tests (which _also_ shouldn't be necessary, but one thing at a time...)
