### PR TITLE
fix(appium): update references to @appium/support

### DIFF
--- a/packages/appium/check-pruned-shrinkwrap.js
+++ b/packages/appium/check-pruned-shrinkwrap.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const { asyncify } = require('asyncbox');
-const { fs, logger } = require('appium-support');
+const { fs, logger } = require('@appium/support');
 const path = require('path');
 
 const log = new logger.getLogger('ShrinkwrapValidator');

--- a/packages/appium/commands-yml/parse.js
+++ b/packages/appium/commands-yml/parse.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import yaml from 'yaml-js';
-import { fs, mkdirp, util } from 'appium-support';
+import { fs, mkdirp, util } from '@appium/support';
 import validate from 'validate.js';
 import Handlebars from 'handlebars';
 import _ from 'lodash';


### PR DESCRIPTION
these imports didn't fail because `@appium/fake-plugin` pulls in `appium-support`, so it's available in `node_modules`.