### PR TITLE
chore: remove unused wd

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "sinon": "11.1.1",
     "sync-monorepo-packages": "^0.3.4",
     "validate.js": "^0.13.0",
-    "wd": "^1.14.0",
     "webdriverio": "^6.12.0",
     "yaml-js": "^0.2.3"
   },


### PR DESCRIPTION
Since `fake-driver` was updated to use `webdriverio`, `wd` is no longer needed.