### PR TITLE
fix(doctor): update reference to @appium/idb README

### DIFF
--- a/packages/doctor/lib/ios.js
+++ b/packages/doctor/lib/ios.js
@@ -200,9 +200,12 @@ class OptionalIdbCommandCheck extends DoctorCheck {
   }
 
   async fix () { // eslint-disable-line require-await
-    return `Why ${'idb'.bold} is needed and how to install it: https://github.com/appium/appium-idb`;
+    return `Why ${'idb'.bold} is needed and how to install it: ${OptionalIdbCommandCheck.idbReadmeURL}`;
   }
 }
+// link to idb README.md
+// https://github.com/appium/appium-ios/blob/main/packages/idb/README.md
+OptionalIdbCommandCheck.idbReadmeURL = 'https://git.io/JnxQc';
 checks.push(new OptionalIdbCommandCheck());
 
 class OptionalApplesimutilsCommandCheck extends DoctorCheck {

--- a/packages/doctor/test/ios-specs.js
+++ b/packages/doctor/test/ios-specs.js
@@ -360,7 +360,7 @@ describe('ios', function () {
       mocks.verify();
     });
     it('fix', async function () {
-      removeColors(await check.fix()).should.equal('Why idb is needed and how to install it: https://github.com/appium/appium-idb');
+      removeColors(await check.fix()).should.equal('Why idb is needed and how to install it: https://git.io/JnxQc');
     });
   }));
 


### PR DESCRIPTION
## Proposed changes

Update the reference from `appium/appium-idb` repo to `appium/appium-ios/blob/packages/idb/README.md`.

Uses a `git.io` shortened URL, because this URL is long and ugly and may not fit in a terminal.

adjacent to #15478 