### PR TITLE
chore: add node.js v16 to build matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -18,10 +18,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
-      - run: npm test
-      - run: npm run install-fake-driver
-      - run: npm run e2e-test
+      - run: |
+          npm install
+          npm test
+          npm run install-fake-driver
+          npm run e2e-test
 
   generate_docs:
     needs: [build]
@@ -29,9 +30,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12.x
-      - run: npm install
-      - run: npm run generate-docs
+      - run: |
+          npm install
+          npm run generate-docs


### PR DESCRIPTION
...because we should.

also:

- run `generate_docs` build with default Node.js which may provide a small perf boost
- multiline yaml
