### PR TITLE
chore: remove ./scripts/release.sh from release-branch.sh to avoid accidental release

### DIFF
--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -10,4 +10,4 @@ git commit -m 'add shrinkwrap'
 echo "* npm version $1.0-rc.0"
 npm version $1.0-rc.0
 git push origin releases/$1
-bash ./scripts/release.sh
+


### PR DESCRIPTION
## Proposed changes

We now have separated tasks to create a release branch and push its candidate, release.
https://github.com/appium/appium/blob/master/docs/en/contributing-to-appium/release-appium.md

So, current script in the release branch may cause accidental release.

This scripts/release-branch.sh should finish after pushing the branch.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
