### PR TITLE
[WIP] refactor: Move args constraints to a class property

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -166,8 +166,8 @@ class AppiumDriver extends BaseDriver {
 
       let runningDriversData, otherPendingDriversData;
       const parsedInnerDriverArgs = parseExtensionArgs(this.args.driverArgs, driverName);
-      if (!_.isEmpty(parsedInnerDriverArgs) && _.isFunction(InnerDriver.argsConstraints)) {
-        const driverArgsConstraints = InnerDriver.argsConstraints();
+      if (!_.isEmpty(parsedInnerDriverArgs) && _.has(InnerDriver.argsConstraints)) {
+        const driverArgsConstraints = InnerDriver.argsConstraints;
         if (!_.isEmpty(driverArgsConstraints)) {
           // TODO: parse/verify CLI args and merge them to this.args if OK or throw an exception
         }

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -166,7 +166,7 @@ class AppiumDriver extends BaseDriver {
 
       let runningDriversData, otherPendingDriversData;
       const parsedInnerDriverArgs = parseExtensionArgs(this.args.driverArgs, driverName);
-      if (!_.isEmpty(parsedInnerDriverArgs) && _.has(InnerDriver.argsConstraints)) {
+      if (!_.isEmpty(parsedInnerDriverArgs) && _.has(InnerDriver, 'argsConstraints')) {
         const driverArgsConstraints = InnerDriver.argsConstraints;
         if (!_.isEmpty(driverArgsConstraints)) {
           // TODO: parse/verify CLI args and merge them to this.args if OK or throw an exception

--- a/packages/base-driver/lib/basedriver/driver.js
+++ b/packages/base-driver/lib/basedriver/driver.js
@@ -37,7 +37,28 @@ class BaseDriver extends Protocol {
    */
   static baseVersion = BASEDRIVER_VER;
 
-  constructor (opts = {}, shouldValidateCaps = true, driverArgs = {}) {
+  /**
+   * Override this getter in child driver classes
+   * if you'd like to expose any command line arguments.
+   * These arguments take precedence over any opts.
+   *
+   * @returns {Object} The map which represents constraints over
+   * supported command line arguments. The map should look similar
+   * to the desired capabilities constraints one, for example:
+   * {
+   *   webkitDebugProxyPort: {
+   *     isNumber: true
+   *   },
+   *   wdaLocalPort: {
+   *     isNumber: true
+   *   },
+   * }
+   */
+  static get argsConstraints () {
+    return {};
+  }
+
+  constructor (opts = {}, shouldValidateCaps = true) {
     super();
 
     // setup state
@@ -46,9 +67,6 @@ class BaseDriver extends Protocol {
     this.caps = null;
     this.originalCaps = null; // To give the original capabilities to reset
     this.helpers = helpers;
-
-    // allow for cli args to be used by drivers
-    this.driverArgs = driverArgs;
 
     // basePath is used for several purposes, for example in setting up
     // proxying to other drivers, since we need to know what the base path


### PR DESCRIPTION
## Proposed changes

This is actually the example implementation of my proposal from https://github.com/appium/appium-xcuitest-driver/pull/1307/files#r672825746

Such implementation would have the following pros:
- We don't keep unnecessary/unused data in the driver instance (`driverArgs`)
- We only have to add minimal changes to the base driver and inherited ones (basically to define args constraints only). There is no need to change constructors
- This scheme would work perfectly for both v1 and v2 drivers
- All args handling logic is located in a single place - the umbrella driver

I'm happy to collaborate on this proposal further.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

cc @jlipps @ayvnkhan @KazuCocoa 