### PR TITLE
chore(base-driver): remove non-W3C route which are already in W3C

### DIFF
--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { util } from '@appium/support';
-import { PROTOCOLS, DEFAULT_BASE_PATH } from '../constants';
+import { DEFAULT_BASE_PATH } from '../constants';
 
 
 const SET_ALERT_TEXT_PAYLOAD_PARAMS = {
@@ -33,17 +33,6 @@ const METHOD_MAP = {
   '/session/:sessionId/timeouts': {
     GET: {command: 'getTimeouts'}, // W3C route
     POST: {command: 'timeouts', payloadParams: {
-      validate: (jsonObj, protocolName) => {
-        if (protocolName === PROTOCOLS.W3C) {
-          if (!util.hasValue(jsonObj.script) && !util.hasValue(jsonObj.pageLoad) && !util.hasValue(jsonObj.implicit)) {
-            return 'W3C protocol expects any of script, pageLoad or implicit to be set';
-          }
-        } else {
-          if (!util.hasValue(jsonObj.type) || !util.hasValue(jsonObj.ms)) {
-            return 'MJSONWP protocol requires type and ms';
-          }
-        }
-      },
       optional: ['type', 'ms', 'script', 'pageLoad', 'implicit'],
     }}
   },
@@ -53,19 +42,9 @@ const METHOD_MAP = {
   '/session/:sessionId/timeouts/implicit_wait': {
     POST: {command: 'implicitWait', payloadParams: {required: ['ms']}}
   },
-  // JSONWP
-  '/session/:sessionId/window_handle': {
-    GET: {command: 'getWindowHandle'}
-  },
-  // W3C
   '/session/:sessionId/window/handle': {
     GET: {command: 'getWindowHandle'}
   },
-  // JSONWP
-  '/session/:sessionId/window_handles': {
-    GET: {command: 'getWindowHandles'}
-  },
-  // W3C
   '/session/:sessionId/window/handles': {
     GET: {command: 'getWindowHandles'}
   },
@@ -81,12 +60,6 @@ const METHOD_MAP = {
   },
   '/session/:sessionId/refresh': {
     POST: {command: 'refresh'}
-  },
-  '/session/:sessionId/execute': {
-    POST: {command: 'execute', payloadParams: {required: ['script', 'args']}}
-  },
-  '/session/:sessionId/execute_async': {
-    POST: {command: 'executeAsync', payloadParams: {required: ['script', 'args']}}
   },
   '/session/:sessionId/screenshot': {
     GET: {command: 'getScreenshot'}
@@ -612,27 +585,6 @@ const METHOD_MAP = {
     POST: {command: 'logCustomEvent', payloadParams: {required: ['vendor', 'event']}}
   },
 
-
-  /*
-   * The W3C spec has some changes to the wire protocol.
-   * https://w3c.github.io/webdriver/webdriver-spec.html
-   * Begin to add those changes here, keeping the old version
-   * since clients still implement them.
-   */
-  // old alerts
-  '/session/:sessionId/alert_text': {
-    GET: {command: 'getAlertText'},
-    POST: {
-      command: 'setAlertText',
-      payloadParams: SET_ALERT_TEXT_PAYLOAD_PARAMS,
-    }
-  },
-  '/session/:sessionId/accept_alert': {
-    POST: {command: 'postAcceptAlert'}
-  },
-  '/session/:sessionId/dismiss_alert': {
-    POST: {command: 'postDismissAlert'}
-  },
   // https://w3c.github.io/webdriver/webdriver-spec.html#user-prompts
   '/session/:sessionId/alert/text': {
     GET: {command: 'getAlertText'},
@@ -656,10 +608,6 @@ const METHOD_MAP = {
   },
   '/session/:sessionId/execute/async': {
     POST: {command: 'executeAsync', payloadParams: {required: ['script', 'args']}}
-  },
-  // Pre-W3C endpoint for element screenshot
-  '/session/:sessionId/screenshot/:elementId': {
-    GET: {command: 'getElementScreenshot'}
   },
   '/session/:sessionId/element/:elementId/screenshot': {
     GET: {command: 'getElementScreenshot'}

--- a/packages/base-driver/test/protocol/routes-specs.js
+++ b/packages/base-driver/test/protocol/routes-specs.js
@@ -38,7 +38,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('ff945c6d');
+      hash.should.equal('2ebb6a16');
     });
   });
 


### PR DESCRIPTION
## Proposed changes

We'd eventually remove non-W3C and not used by Appium commands for 2.0
Part of https://github.com/appium/appium/issues/15729

This PR removes duplicated routes with W3C and non-W3C.
We already accept only W3C protocol, so non-W3C routes but they are already in W3C can remove safely, I think.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
