### PR TITLE
chore(base): Enable system unzip usage also in Windows by default

### DIFF
--- a/packages/base-driver/lib/basedriver/helpers.js
+++ b/packages/base-driver/lib/basedriver/helpers.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import path from 'path';
 import url from 'url';
 import logger from './logger';
-import { system, tempDir, fs, util, zip, net, timing } from '@appium/support';
+import { tempDir, fs, util, zip, net, timing } from '@appium/support';
 import LRU from 'lru-cache';
 import AsyncLock from 'async-lock';
 import axios from 'axios';
@@ -329,7 +329,7 @@ async function unzipApp (zipPath, dstRoot, supportedAppExtensions) {
      * @type {import('@appium/support/lib/zip').ExtractAllOptions}
      */
     const extractionOpts = {
-      useSystemUnzip: !system.isWindows(),
+      useSystemUnzip: true,
     };
     // https://github.com/appium/appium/issues/14100
     if (path.extname(zipPath) === IPA_EXT) {


### PR DESCRIPTION
https://github.com/appium/appium-base-driver/pull/510/ for 2.0 branch.

This requires https://github.com/appium/appium/pull/15882.
So, probably we need to do:

1. bump the support version
2. update this package.json

How should I do to release a new support version...? @jlipps 
