### PR TITLE
feat(fake-driver): add a schema [cfg-file-support]

### DIFF
--- a/packages/fake-driver/lib/driver.js
+++ b/packages/fake-driver/lib/driver.js
@@ -101,8 +101,6 @@ class FakeDriver extends BaseDriver {
 
 }
 
-for (let [cmd, fn] of _.toPairs(commands)) {
-  FakeDriver.prototype[cmd] = fn;
-}
+Object.assign(FakeDriver.prototype, commands);
 
 export { FakeDriver };

--- a/packages/fake-driver/lib/fake-driver-schema.js
+++ b/packages/fake-driver/lib/fake-driver-schema.js
@@ -1,0 +1,36 @@
+// this could be a .json file, too:
+// {
+//   "$schema": "http://json-schema.org/draft-07/schema",
+//   "$id": "https://appium.io/fake-driver.json",
+//   "type": "object",
+//   "title": "Fake Driver Configuration",
+//   "description": "A schema for Fake Driver arguments",
+//   "properties": {
+//     "answer": {
+//       "type": "number",
+//       "description": "The answer to life, the universe, and everything",
+//       "default": 42
+//     }
+//   }
+// }
+
+
+export default {
+  type: 'object',
+  title: 'Fake Driver Configuration',
+  description: 'A schema for Fake Driver arguments',
+  properties: {
+    // the prop name will always be normalized to camelCase
+    'silly-web-server-port': {
+      type: 'integer',
+      minimum: 1,
+      maximum: 65535,
+      description: 'The port to use for the fake web server',
+    },
+    sillyWebServerHost: {
+      type: 'string',
+      description: 'The host to use for the fake web server',
+      default: 'sillyhost'
+    }
+  }
+};

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -62,6 +62,7 @@
       "Fake"
     ],
     "mainClass": "FakeDriver",
+    "schema": "./build/lib/fake-driver-schema.js",
     "scripts": {
       "fake-error": "./build/lib/scripts/fake-error.js",
       "fake-success": "./build/lib/scripts/fake-success.js"

--- a/packages/gulp-plugins/lib/boilerplate.js
+++ b/packages/gulp-plugins/lib/boilerplate.js
@@ -86,9 +86,6 @@ const boilerplate = function (gulp, opts) {
   if (opts.transpile && !opts.test) {
     defaultSequence.push('transpile');
   }
-  if (opts.postTranspile) {
-    defaultSequence.push(...opts.postTranspile);
-  }
   if (opts.test) {
     if (opts.watchE2E) {
       defaultSequence.push('test');
@@ -113,8 +110,8 @@ const boilerplate = function (gulp, opts) {
     spawnWatcher.configure('watch', opts.files, watchSequence);
   }
 
+  spawnWatcher.configure('dev', opts.files, ['transpile']);
   gulp.task('once', gulp.series(...defaultSequence));
-
   gulp.task('default', gulp.series(opts.watch ? 'watch' : 'once'));
 };
 

--- a/packages/gulp-plugins/lib/tasks/test.js
+++ b/packages/gulp-plugins/lib/tasks/test.js
@@ -10,10 +10,6 @@ const configure = function configure (gulp, opts, env) {
     ...env
   };
 
-  if (opts.postTranspile) {
-    testEnv.testDeps.push(...opts.postTranspile);
-  }
-
   let testTasks = [];
   if (opts.test) {
     unitTest.configure(gulp, opts, testEnv);

--- a/packages/gulp-plugins/lib/tasks/transpile.js
+++ b/packages/gulp-plugins/lib/tasks/transpile.js
@@ -11,18 +11,30 @@ const JSON_SOURCES = [
   'test/**/*.json',
 ];
 
+/**
+ * @param {import('gulp').Gulp} gulp - The gulp instance.
+ */
 const configure = function configure (gulp, opts, env) {
-  gulp.task('transpile', function () {
-    // json files can be copied as is, they don't need to be transpiled
-    const firstPath = gulp.src(JSON_SOURCES, {base: './'})
-      .pipe(gulp.dest(opts.transpileOut));
-    const secondPath = gulp.src(opts.files, {base: './'})
-      .pipe(gulpIf(isVerbose(), debug()))
-      .pipe(new Transpiler(opts).stream())
-      .on('error', env.spawnWatcher.handleError.bind(env.spawnWatcher))
-      .pipe(gulp.dest(opts.transpileOut));
-    return merge(firstPath, secondPath);
-  });
+  const tasks = [
+    function transpileSources () {
+      // json files can be copied as is, they don't need to be transpiled
+      const firstPath = gulp.src(JSON_SOURCES, {base: './'})
+        .pipe(gulp.dest(opts.transpileOut));
+      const secondPath = gulp.src(opts.files, {base: './'})
+        .pipe(gulpIf(isVerbose(), debug()))
+        .pipe(new Transpiler(opts).stream())
+        .on('error', env.spawnWatcher.handleError.bind(env.spawnWatcher))
+        .pipe(gulp.dest(opts.transpileOut));
+      return merge(firstPath, secondPath);
+    }
+  ];
+
+  if (opts.postTranspile && opts.postTranspile.length) {
+    gulp.task('post-transpile', gulp.parallel(opts.postTranspile));
+    tasks.push('post-transpile');
+  }
+
+  gulp.task('transpile', gulp.series(tasks));
 };
 
 module.exports = {

--- a/packages/support/test/node-e2e-specs.js
+++ b/packages/support/test/node-e2e-specs.js
@@ -7,7 +7,8 @@ describe('node utilities', function () {
     it('should be able to require a local package', async function () {
       await node.requirePackage('chai').should.not.be.rejected;
     });
-    it('should be able to require a global package', async function () {
+    // XXX: see #15951
+    it.skip('should be able to require a global package', async function () {
       await node.requirePackage('npm').should.not.be.rejected;
     });
     it('should fail to find uninstalled package', async function () {


### PR DESCRIPTION
Adds an example schema to `fake-driver`. This is used for testing.
Also simplify assignment of commands to `FakeDriver.prototype`.

(Part of original #15664)
<!---GHSTACKOPEN-->
### Stacked PR Chain: cfg-file-support
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#15935|chore(eslint-config-appium): dev & test env improvements |Pending|-|
|#15936|👉 feat(fake-driver): add a schema |Pending|#15935|
|#15937|chore(gulp-plugins): postTranspile task always runs after transpile task; add dev task |Pending|#15936|
|#15938|feat(appium): configuration file and schema support |Pending|#15937|

<!---GHSTACKCLOSE-->
