### PR TITLE
chore(gulp-plugins): postTranspile task always runs after transpile task; add dev task [cfg-file-support]

### DIFF
--- a/packages/gulp-plugins/lib/boilerplate.js
+++ b/packages/gulp-plugins/lib/boilerplate.js
@@ -86,9 +86,6 @@ const boilerplate = function (gulp, opts) {
   if (opts.transpile && !opts.test) {
     defaultSequence.push('transpile');
   }
-  if (opts.postTranspile) {
-    defaultSequence.push(...opts.postTranspile);
-  }
   if (opts.test) {
     if (opts.watchE2E) {
       defaultSequence.push('test');
@@ -113,8 +110,8 @@ const boilerplate = function (gulp, opts) {
     spawnWatcher.configure('watch', opts.files, watchSequence);
   }
 
+  spawnWatcher.configure('dev', opts.files, ['transpile']);
   gulp.task('once', gulp.series(...defaultSequence));
-
   gulp.task('default', gulp.series(opts.watch ? 'watch' : 'once'));
 };
 

--- a/packages/gulp-plugins/lib/tasks/test.js
+++ b/packages/gulp-plugins/lib/tasks/test.js
@@ -10,10 +10,6 @@ const configure = function configure (gulp, opts, env) {
     ...env
   };
 
-  if (opts.postTranspile) {
-    testEnv.testDeps.push(...opts.postTranspile);
-  }
-
   let testTasks = [];
   if (opts.test) {
     unitTest.configure(gulp, opts, testEnv);

--- a/packages/gulp-plugins/lib/tasks/transpile.js
+++ b/packages/gulp-plugins/lib/tasks/transpile.js
@@ -11,18 +11,30 @@ const JSON_SOURCES = [
   'test/**/*.json',
 ];
 
+/**
+ * @param {import('gulp').Gulp} gulp - The gulp instance.
+ */
 const configure = function configure (gulp, opts, env) {
-  gulp.task('transpile', function () {
-    // json files can be copied as is, they don't need to be transpiled
-    const firstPath = gulp.src(JSON_SOURCES, {base: './'})
-      .pipe(gulp.dest(opts.transpileOut));
-    const secondPath = gulp.src(opts.files, {base: './'})
-      .pipe(gulpIf(isVerbose(), debug()))
-      .pipe(new Transpiler(opts).stream())
-      .on('error', env.spawnWatcher.handleError.bind(env.spawnWatcher))
-      .pipe(gulp.dest(opts.transpileOut));
-    return merge(firstPath, secondPath);
-  });
+  const tasks = [
+    function transpileSources () {
+      // json files can be copied as is, they don't need to be transpiled
+      const firstPath = gulp.src(JSON_SOURCES, {base: './'})
+        .pipe(gulp.dest(opts.transpileOut));
+      const secondPath = gulp.src(opts.files, {base: './'})
+        .pipe(gulpIf(isVerbose(), debug()))
+        .pipe(new Transpiler(opts).stream())
+        .on('error', env.spawnWatcher.handleError.bind(env.spawnWatcher))
+        .pipe(gulp.dest(opts.transpileOut));
+      return merge(firstPath, secondPath);
+    }
+  ];
+
+  if (opts.postTranspile && opts.postTranspile.length) {
+    gulp.task('post-transpile', gulp.parallel(opts.postTranspile));
+    tasks.push('post-transpile');
+  }
+
+  gulp.task('transpile', gulp.series(tasks));
 };
 
 module.exports = {


### PR DESCRIPTION
- `postTranspile` would only run from certain _other_ tasks (like `test`).  This seemed incorrect, so now it runs after `transpile`, regardless of what task (or human) runs `transpile`.
- Added a `dev` task, which is like `watch`, except does not run tests (only transpiles)

(Part of original #15664)
<!---GHSTACKOPEN-->
### Stacked PR Chain: cfg-file-support
| PR | Title | Status |  Merges Into  |
|:--:|:------|:-------|:-------------:|
|#15935|chore(eslint-config-appium): dev & test env improvements |Pending|-|
|#15936|feat(fake-driver): add a schema |Pending|#15935|
|#15937|👉 chore(gulp-plugins): postTranspile task always runs after transpile task; add dev task |Pending|#15936|
|#15938|feat(appium): configuration file and schema support |Pending|#15937|

<!---GHSTACKCLOSE-->
