### PR TITLE
docs: add Deprecated in touch actions

### DIFF
--- a/commands-yml/commands/interactions/touch/multi-touch-perform.yml
+++ b/commands-yml/commands/interactions/touch/multi-touch-perform.yml
@@ -4,7 +4,7 @@ short_description: Perform a multi touch action sequence
 
 description:
   |
-    Deprecated. Please consider to use [W3C Actions](/docs/en/commands/interactions/actions.md)
+    Deprecated. Please consider using [W3C Actions](/docs/en/commands/interactions/actions.md)
 
 example_usage:
   java:

--- a/commands-yml/commands/interactions/touch/multi-touch-perform.yml
+++ b/commands-yml/commands/interactions/touch/multi-touch-perform.yml
@@ -2,6 +2,10 @@
 name: Multi Touch Perform
 short_description: Perform a multi touch action sequence
 
+description:
+  |
+    Deprecated. Please consider to use [W3C Actions](/docs/en/commands/interactions/actions.md)
+
 example_usage:
   java:
     |

--- a/commands-yml/commands/interactions/touch/touch-perform.yml
+++ b/commands-yml/commands/interactions/touch/touch-perform.yml
@@ -4,7 +4,9 @@ short_description: Perform a touch action sequence
 
 description:
   |
-    This functionality is only available from within a native context
+    Deprecated. Please consider to use [W3C Actions](/docs/en/commands/interactions/actions.md).
+
+    This functionality is only available from within a native context.
 
     'Touch Perform' works similarly to the other singular touch interactions, except that this allows you to chain together more than one touch action as one
     command. This is useful because Appium commands are sent over the network and there's latency between commands. This latency can make certain touch

--- a/commands-yml/commands/interactions/touch/touch-perform.yml
+++ b/commands-yml/commands/interactions/touch/touch-perform.yml
@@ -4,7 +4,7 @@ short_description: Perform a touch action sequence
 
 description:
   |
-    Deprecated. Please consider to use [W3C Actions](/docs/en/commands/interactions/actions.md).
+    Deprecated. Please consider using [W3C Actions](/docs/en/commands/interactions/actions.md).
 
     This functionality is only available from within a native context.
 


### PR DESCRIPTION
## Proposed changes

It would be nice to address "deprecated" in TouchActions and MultiTouchActions since we'd like to maintain W3C actions mainly.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
