### PR TITLE
refactor plugin handling to fix interaction with proxies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@appium/eslint-config-appium": "file:./packages/eslint-config-appium",
-    "@appium/fake-plugin": "1.2.2",
+    "@appium/fake-plugin": "1.3.0",
     "@babel/core": "7.16.0",
     "@babel/eslint-parser": "7.16.0",
     "@babel/plugin-transform-runtime": "7.16.0",

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -391,19 +391,17 @@ class AppiumDriver extends BaseDriver {
    * @returns {Array} - array of plugin instances
    */
   pluginsForSession (sessionId = null) {
-    let plugins = [];
     if (sessionId) {
       if (!this.sessionPlugins[sessionId]) {
         this.sessionPlugins[sessionId] = this.createPluginInstances();
       }
-      plugins = this.sessionPlugins[sessionId];
-    } else {
-      if (_.isEmpty(this.sessionlessPlugins)) {
-        this.sessionlessPlugins = this.createPluginInstances();
-      }
-      plugins = this.sessionlessPlugins;
+      return this.sessionPlugins[sessionId];
     }
-    return plugins;
+
+    if (_.isEmpty(this.sessionlessPlugins)) {
+      this.sessionlessPlugins = this.createPluginInstances();
+    }
+    return this.sessionlessPlugins;
   }
 
   /**
@@ -423,16 +421,11 @@ class AppiumDriver extends BaseDriver {
       .filter((p) => _.isFunction(p[cmd]) || _.isFunction(p.handle));
   }
 
-  createPluginInstances (sessionId) {
-    if (!sessionId) {
-      sessionId = 'sessionless';
-    }
-    sessionId = _.truncate(sessionId, {length: 11});
+  createPluginInstances () {
     return this.pluginClasses.map((PluginClass) => {
-      const generalName = PluginClass.pluginName;
-      const name = `${generalName} (${sessionId})`;
+      const name = PluginClass.pluginName;
       const plugin = new PluginClass(name);
-      this.assignCliArgsToExtension('plugin', generalName, plugin);
+      this.assignCliArgsToExtension('plugin', name, plugin);
       return plugin;
     });
   }

--- a/packages/base-driver/index.js
+++ b/packages/base-driver/index.js
@@ -21,7 +21,7 @@ const {
   Protocol, routeConfiguringFunction, errors, isErrorType,
   errorFromMJSONWPStatusCode, errorFromW3CJsonCode, ALL_COMMANDS, METHOD_MAP,
   routeToCommandName, NO_SESSION_ID_COMMANDS, isSessionCommand,
-  normalizeBasePath, determineProtocol
+  normalizeBasePath, determineProtocol, CREATE_SESSION_COMMAND, DELETE_SESSION_COMMAND,
 } = protocol;
 
 export {
@@ -29,7 +29,7 @@ export {
   errorFromMJSONWPStatusCode, errorFromW3CJsonCode, determineProtocol,
   errorFromMJSONWPStatusCode as errorFromCode, ALL_COMMANDS, METHOD_MAP,
   routeToCommandName, NO_SESSION_ID_COMMANDS, isSessionCommand,
-  DEFAULT_BASE_PATH, normalizeBasePath
+  DEFAULT_BASE_PATH, normalizeBasePath, CREATE_SESSION_COMMAND, DELETE_SESSION_COMMAND
 };
 
 // Express exports

--- a/packages/base-driver/lib/basedriver/driver.js
+++ b/packages/base-driver/lib/basedriver/driver.js
@@ -306,6 +306,7 @@ class BaseDriver extends Protocol {
   async executeCommand (cmd, ...args) {
     // get start time for this command, and log in special cases
     let startTime = Date.now();
+
     if (cmd === 'createSession') {
       // If creating a session determine if W3C or MJSONWP protocol was requested and remember the choice
       this.protocol = determineProtocol(...args);

--- a/packages/base-driver/lib/protocol/index.js
+++ b/packages/base-driver/lib/protocol/index.js
@@ -1,7 +1,8 @@
 // transpile:main
 
 import {
-  Protocol, isSessionCommand, routeConfiguringFunction, determineProtocol
+  Protocol, isSessionCommand, routeConfiguringFunction, determineProtocol,
+  CREATE_SESSION_COMMAND, DELETE_SESSION_COMMAND,
 } from './protocol';
 import {
   NO_SESSION_ID_COMMANDS, ALL_COMMANDS, METHOD_MAP,
@@ -15,4 +16,5 @@ export {
   Protocol, routeConfiguringFunction, errors, isErrorType,
   errorFromMJSONWPStatusCode, errorFromW3CJsonCode, ALL_COMMANDS, METHOD_MAP,
   routeToCommandName, NO_SESSION_ID_COMMANDS, isSessionCommand, determineProtocol,
+  CREATE_SESSION_COMMAND, DELETE_SESSION_COMMAND,
 };

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -283,11 +283,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
         `${driver.constructor.name}.${spec.command}() with args: ` +
         _.truncate(JSON.stringify(args), {length: MAX_LOG_BODY_LENGTH}));
 
-      if (driver.executeCommand) {
-        driverRes = await driver.executeCommand(spec.command, ...args);
-      } else {
-        driverRes = await driver.execute(spec.command, ...args);
-      }
+      driverRes = await driver.executeCommand(spec.command, ...args);
 
       // Get the protocol after executeCommand
       currentProtocol = extractProtocol(driver, req.params.sessionId) || currentProtocol;

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -239,7 +239,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
       // this command should never be proxied (which is useful for plugin developers who add
       // commands and generally would not want that command to be proxied instead of handled by the
       // plugin)
-      let pluginOverrodeProxy = false;
+      let didPluginOverrideProxy = false;
       if (isSessCmd && !spec.neverProxy && driverShouldDoJwpProxy(driver, req, spec.command)) {
         if (!driver.pluginsToHandleCmd ||
             driver.pluginsToHandleCmd(spec.command, req.params.sessionId).length === 0) {
@@ -249,7 +249,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
         SESSIONS_CACHE.getLogger(req.params.sessionId, currentProtocol).debug(`Would have proxied ` +
           `command directly, but a plugin exists which might require its value, so will let ` +
           `its value be collected internally and made part of plugin chain`);
-        pluginOverrodeProxy = true;
+        didPluginOverrideProxy = true;
       }
 
       // if a command is not in our method map, it's because we
@@ -291,7 +291,7 @@ function buildHandler (app, method, path, spec, driver, isSessCmd) {
         `${driver.constructor.name}.${spec.command}() with args: ` +
         _.truncate(JSON.stringify(args), {length: MAX_LOG_BODY_LENGTH}));
 
-      if (pluginOverrodeProxy) {
+      if (didPluginOverrideProxy) {
         // TODO for now we add this information on the args list, but that's mixing purposes here.
         // We really should add another 'options' parameter to 'executeCommand', but this would be
         // a breaking change for all drivers so would need to be handled carefully.
@@ -469,5 +469,5 @@ async function doJwpProxy (driver, req, res) {
 
 export {
   Protocol, routeConfiguringFunction, isSessionCommand,
-  driverShouldDoJwpProxy, determineProtocol
+  driverShouldDoJwpProxy, determineProtocol, CREATE_SESSION_COMMAND, DELETE_SESSION_COMMAND,
 };

--- a/packages/base-driver/test/basedriver/driver-tests.js
+++ b/packages/base-driver/test/basedriver/driver-tests.js
@@ -336,7 +336,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
           d.canProxy.should.be.an.instanceof(Function);
         });
         it('should return a boolean from #canProxy', function () {
-          [true, false].should.include(d.canProxy(sessId));
+          d.canProxy(sessId).should.be.a('boolean');
         });
         it('should throw an error when sessionId is wrong', function () {
           (() => { d.canProxy(); }).should.throw;

--- a/packages/base-driver/test/basedriver/driver-tests.js
+++ b/packages/base-driver/test/basedriver/driver-tests.js
@@ -335,8 +335,8 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
         it('should have a #canProxy method', function () {
           d.canProxy.should.be.an.instanceof(Function);
         });
-        it('should return false from #canProxy', function () {
-          d.canProxy(sessId).should.be.false;
+        it('should return a boolean from #canProxy', function () {
+          [true, false].should.include(d.canProxy(sessId));
         });
         it('should throw an error when sessionId is wrong', function () {
           (() => { d.canProxy(); }).should.throw;

--- a/packages/fake-driver/lib/commands/contexts.js
+++ b/packages/fake-driver/lib/commands/contexts.js
@@ -4,7 +4,7 @@ import { errors } from '@appium/base-driver';
 let commands = {}, helpers = {}, extensions = {};
 
 helpers.getRawContexts = function getRawContexts () {
-  let contexts = {'NATIVE_APP': null};
+  let contexts = {NATIVE_APP: null, PROXY: null};
   let wvs = this.appModel.getWebviews();
   for (let i = 1; i < wvs.length + 1; i++) {
     contexts[`WEBVIEW_${i}`] = wvs[i - 1];
@@ -32,8 +32,12 @@ commands.setContext = async function setContext (context) {
     this.curContext = context;
     if (context === 'NATIVE_APP') {
       this.appModel.deactivateWebview();
+      this._proxyActive = false;
+    } else if (context === 'PROXY') {
+      this._proxyActive = true;
     } else {
       this.appModel.activateWebview(contexts[context]);
+      this._proxyActive = false;
     }
   } else {
     throw new errors.NoSuchContextError();

--- a/packages/fake-driver/lib/driver.js
+++ b/packages/fake-driver/lib/driver.js
@@ -15,6 +15,7 @@ class FakeDriver extends BaseDriver {
     this.caps = {};
     this.fakeThing = null;
     this.cliArgs = {};
+    this._proxyActive = false;
 
     this.desiredCapConstraints = {
       'app': {
@@ -22,6 +23,27 @@ class FakeDriver extends BaseDriver {
         isString: true
       }
     };
+  }
+
+  proxyActive () {
+    return this._proxyActive;
+  }
+
+  canProxy () {
+    return true;
+  }
+
+  proxyReqRes (req, res) {
+    // fake implementation of jwp proxy req res
+    res.set('content-type', 'application/json');
+    const resBodyObj = {value: 'proxied via proxyReqRes'};
+    const match = req.originalUrl.match(/\/session\/([^/]+)/);
+    resBodyObj.sessionId = match ? match[1] : null;
+    res.status(200).send(JSON.stringify(resBodyObj));
+  }
+
+  proxyCommand (/*url, method, body*/) {
+    return 'proxied via proxyCommand';
   }
 
   async createSession (jsonwpDesiredCapabilities, jsonwpRequiredCaps, w3cCapabilities, otherSessionData = []) {

--- a/packages/fake-driver/test/context-tests.js
+++ b/packages/fake-driver/test/context-tests.js
@@ -15,7 +15,7 @@ function contextTests () {
     });
     it('should get contexts', async function () {
       await driver.getContexts()
-              .should.eventually.become(['NATIVE_APP', 'WEBVIEW_1']);
+              .should.eventually.become(['NATIVE_APP', 'PROXY', 'WEBVIEW_1']);
     });
     it('should not set context that is not there', async function () {
       await driver.switchContext('WEBVIEW_FOO')


### PR DESCRIPTION
In the past, it was actually not possible to use plugins well with drivers that proxied commands. This was because Appium chose whether or not to proxy a request before it set up the plugin management chain. This pull request tries to make things work by deferring proxying until a later point if a plugin is going to handle the command. The net result is that if and when a plugin calls `await next()`, the proxying will happen at that point, and it will take place 'internally' to the driver/plugin system rather than writing directly to the HTTP response object. This increases the complexity and requires that drivers expose more than the current `proxyReqRes` function (which writes directly to the HTTP response object and as such doesn't work in our case). They now need to also expose a `proxyCommand` function, which is typically a matter of assigning a new alias to the jwproxy object.

Related PRs:
- [x] https://github.com/appium/appium-espresso-driver/pull/719 (espresso driver update)
- [x] https://github.com/appium/appium-android-driver/pull/715 (android driver update, for chrome webview)
- [x] https://github.com/appium/appium-uiautomator2-driver/pull/480 (uiauto2 driver update)
- [x] https://github.com/appium/appium-plugins/pull/64 (plugins repo update)

The XCUITest driver doesn't an update since it already exposes `proxyCommand` as required.

Other drivers might also need updates. I just focused on the core mobile ones right now. I added a nice error message so it should be clear if and when a user tries to use a plugin with a driver that needs to be updated.