### PR TITLE
fix(appium): remove extra logging from config-file

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/gulp": "4.0.9",
     "@types/json-schema": "7.0.9",
     "@types/mocha": "9.0.0",
+    "@types/node": "16.11.7",
     "@types/sinon": "10.0.6",
     "@types/sinon-chai": "3.2.5",
     "@types/through2": "2.0.36",

--- a/packages/appium/lib/schema/schema.js
+++ b/packages/appium/lib/schema/schema.js
@@ -247,7 +247,6 @@ class AppiumSchema {
    * - Sets the {@link AppiumSchema._finalized _finalized} flag to `false`
    *
    * If you need to call {@link AppiumSchema.finalize} again, you'll want to call this first.
-   * @public
    * @returns {void}
    */
   reset () {
@@ -351,14 +350,14 @@ class AppiumSchema {
    * module's `toParserArgs`, which converts the finalized schema to parameters
    * used by `argparse`.
    * @throws If {@link AppiumSchema.finalize} has not been called yet.
-   * @returns {{schema: SchemaObject, argSpec: ArgSpec}[]}
+   * @returns {FlattenedSchema}
    */
   flatten () {
     const schema = this.getSchema();
 
     /** @type {{properties: SchemaObject, prefix: string[]}[]} */
     const stack = [{properties: schema.properties, prefix: []}];
-    /** @type {{schema: SchemaObject, argSpec: ArgSpec}[]} */
+    /** @type {FlattenedSchema} */
     const flattened = [];
 
     // this bit is a recursive algorithm rewritten as a for loop.
@@ -568,4 +567,11 @@ export const {isAllowedSchemaFileExtension} = AppiumSchema;
 /**
  * A {@link SchemaObject} with `additionalProperties: false`
  * @typedef {SchemaObject & StrictProp} StrictSchemaObject
+ */
+
+/**
+ * A list of schemas associated with properties and their corresponding {@link ArgSpec} objects.
+ *
+ * Intermediate data structure used when converting the entire schema down to CLI arguments.
+ * @typedef {{schema: SchemaObject, argSpec: ArgSpec}[]} FlattenedSchema
  */

--- a/packages/appium/test/config-file-specs.js
+++ b/packages/appium/test/config-file-specs.js
@@ -350,19 +350,6 @@ describe('config-file', function () {
       });
     });
 
-    describe('when `opts.pretty` is `false`', function () {
-      it('should call `betterAjvErrors()` with option `format: "js"`', function () {
-        // @ts-ignore
-        configFileModule.formatErrors([{}], {}, {pretty: false});
-        expect(mocks['@sidvind/better-ajv-errors']).to.have.been.calledWith(
-          schema.getSchema(),
-          {},
-          [{}],
-          {format: 'js', json: undefined},
-        );
-      });
-    });
-
     describe('when `opts.json` is a string', function () {
       it('should call `betterAjvErrors()` with option `json: opts.json`', function () {
         // @ts-ignore

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "target": "es2015",
     "noEmit": true,
     "allowJs": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "types": ["node", "mocha", "chai", "sinon-chai", "chai-as-promised"]
   },
   "include": [
     "packages/*/**/*.d.ts",


### PR DESCRIPTION
Logging was happening here before the logger was properly initialized, which looked weird.  Just remove logs for now until we find a better solution.

In addition, fixed some typing problems:
- we need `@types/node` for node globals (like errors that have a `code` property)
- set various typings as globals: `node`, `mocha`, `chai` & its ilk
