### PR TITLE
chore(appium): rename package.json config prop to appiumConfig

### DIFF
--- a/packages/appium/lib/config-file.js
+++ b/packages/appium/lib/config-file.js
@@ -106,6 +106,7 @@ export async function readConfigFile (filepath, opts = {}) {
       '.json': jsonLoader,
       noExt: jsonLoader,
     },
+    packageProp: 'appiumConfig'
   });
 
   const result = filepath


### PR DESCRIPTION
- update `configuration-system.md` docs to reflect this and a bunch of other things while I was in there

* * *

**Problem**: We're using the `appium` property in `package.json` for the extension manifest.  We're using the same property name for storing Appium server configuration in an Appium-consuming project.  This can theoretically cause problems, though it's an edge-case only likely to be encountered by Appium contributors. 😄 

**Solution**:  Rename one of them. 