### PR TITLE
chore: fix lerna publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "e2e-test": "lerna exec \"gulp e2e-test\"",
     "generate-docs": "lerna run --scope=appium generate-docs",
     "generate-schema-declarations": "node ./scripts/generate-schema-declarations.mjs",
-    "postinstall": "lerna bootstrap && lerna exec --parallel \"gulp prepublish\"",
+    "postinstall": "lerna exec --parallel \"gulp prepublish\"",
     "install-fake-driver": "lerna run --scope=appium install-fake-driver",
     "lint": "lerna exec --parallel \"gulp lint\" && lerna run --scope=@appium/eslint-config-appium lint",
     "lint:fix": "eslint --fix .",
@@ -69,8 +69,11 @@
     "./packages/appium/lib/schema/appium-config-schema.js": "npm run generate-schema-declarations"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium": "file:./packages/eslint-config-appium",
+    "@appium/eslint-config-appium": "file:packages/eslint-config-appium",
+    "@appium/fake-driver": "file:packages/fake-driver",
     "@appium/fake-plugin": "1.3.0",
+    "@appium/gulp-plugins": "file:packages/gulp-plugins",
+    "@appium/test-support": "file:packages/test-support",
     "@babel/core": "7.16.0",
     "@babel/eslint-parser": "7.16.3",
     "@babel/plugin-transform-runtime": "7.16.0",
@@ -127,5 +130,11 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@appium/base-driver": "file:packages/base-driver",
+    "@appium/doctor": "file:packages/doctor",
+    "@appium/support": "file:packages/support",
+    "appium": "file:packages/appium"
   }
 }

--- a/packages/appium/appium.js
+++ b/packages/appium/appium.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const {asyncify} = require('asyncbox');
+const appium = require('./build/lib/main.js');
+
+if (require.main === module) {
+  asyncify(appium.main);
+}
+

--- a/packages/appium/lib/cli/npm.js
+++ b/packages/appium/lib/cli/npm.js
@@ -166,7 +166,7 @@ export default class NPM {
     const pkgHome = path.resolve(this.appiumHome, pkgName);
 
     // call link with --no-package-lock to ensure no corruption while installing local packages
-    const res = await this.exec('link', ['--no-package-lock', pkgPath], {cwd: pkgHome, lockFile: LINK_LOCKFILE});
+    const res = await this.exec('install', ['--no-package-lock', pkgPath], {cwd: pkgHome, lockFile: LINK_LOCKFILE});
     if (res.json && res.json.error) {
       throw new Error(res.json.error);
     }

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -21,14 +21,15 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
-  "main": "./build/lib/main.js",
+  "main": "appium.js",
   "bin": {
-    "appium": "./build/lib/main.js"
+    "appium": "appium.js"
   },
   "directories": {
     "lib": "./lib"
   },
   "files": [
+    "appium.js",
     "bin",
     "lib",
     "build/lib",
@@ -44,9 +45,9 @@
     "zip-and-upload": "npm run zip && npm run upload"
   },
   "dependencies": {
-    "@appium/base-driver": "^8.2.0",
+    "@appium/base-driver": "file:../base-driver",
     "@appium/base-plugin": "1.8.0",
-    "@appium/support": "^2.55.1",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.16.3",
     "@sidvind/better-ajv-errors": "0.9.2",
     "ajv": "8.8.0",
@@ -72,8 +73,8 @@
     "yaml": "1.10.2"
   },
   "devDependencies": {
-    "@appium/fake-driver": "^3.2.0",
-    "@appium/gulp-plugins": "^5.5.5"
+    "@appium/fake-driver": "file:../fake-driver",
+    "@appium/gulp-plugins": "file:../gulp-plugins"
   },
   "engines": {
     "node": ">=12",

--- a/packages/base-driver/base-driver.js
+++ b/packages/base-driver/base-driver.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+module.exports = require('./build/index.js');

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -25,11 +25,12 @@
     "node": ">=12",
     "npm": ">=6"
   },
-  "main": "./build/index.js",
+  "main": "base-driver.js",
   "directories": {
     "lib": "lib"
   },
   "files": [
+    "base-driver.js",
     "index.js",
     "index.d.ts",
     "lib",
@@ -42,7 +43,7 @@
     "!build/test/basedriver/fixtures"
   ],
   "dependencies": {
-    "@appium/support": "^2.55.1",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.16.3",
     "async-lock": "1.3.0",
     "asyncbox": "2.9.2",
@@ -64,8 +65,8 @@
     "ws": "7.5.5"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium": "^4.7.4",
-    "@appium/gulp-plugins": "^5.5.5"
+    "@appium/eslint-config-appium": "file:../eslint-config-appium",
+    "@appium/gulp-plugins": "file:../gulp-plugins"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -38,7 +38,7 @@
     "build/lib"
   ],
   "dependencies": {
-    "@appium/support": "^2.55.1",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.16.3",
     "appium-adb": "8.16.2",
     "authorize-ios": "1.2.1",
@@ -51,8 +51,8 @@
     "yargs": "17.2.1"
   },
   "devDependencies": {
-    "@appium/gulp-plugins": "^5.5.5",
-    "@appium/test-support": "^1.3.8"
+    "@appium/gulp-plugins": "file:../gulp-plugins",
+    "@appium/test-support": "file:../test-support"
   },
   "engines": {
     "node": ">=12",

--- a/packages/fake-driver/fake-driver.js
+++ b/packages/fake-driver/fake-driver.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+module.exports = require('./build/index.js');

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -21,15 +21,16 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
-  "main": "./build/index.js",
+  "main": "fake-driver.js",
   "bin": {
-    "appium-fake-driver": "./build/index.js"
+    "appium-fake-driver": "fake-driver.js"
   },
   "directories": {
     "lib": "lib"
   },
   "files": [
     "index.js",
+    "fake-driver.js",
     "lib",
     "build/index.js",
     "build/lib",
@@ -37,8 +38,8 @@
     "screen.png"
   ],
   "dependencies": {
-    "@appium/base-driver": "^8.2.0",
-    "@appium/support": "^2.55.1",
+    "@appium/base-driver": "file:../base-driver",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.16.3",
     "asyncbox": "2.9.2",
     "bluebird": "3.7.2",
@@ -48,7 +49,7 @@
     "xpath": "0.0.32"
   },
   "devDependencies": {
-    "@appium/gulp-plugins": "^5.5.5"
+    "@appium/gulp-plugins": "file:../gulp-plugins"
   },
   "engines": {
     "node": ">=12",

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -35,7 +35,7 @@
     "build"
   ],
   "dependencies": {
-    "@appium/eslint-config-appium": "^4.7.4",
+    "@appium/eslint-config-appium": "file:../eslint-config-appium",
     "@babel/core": "7.16.0",
     "@babel/plugin-transform-runtime": "7.16.0",
     "@babel/preset-env": "7.16.0",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -67,9 +67,6 @@
     "which": "2.0.2",
     "yauzl": "2.10.0"
   },
-  "devDependencies": {
-    "@appium/gulp-plugins": "^5.5.5"
-  },
   "engines": {
     "node": ">=12",
     "npm": ">=6"

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -37,17 +37,13 @@
     "build/lib"
   ],
   "dependencies": {
-    "@appium/support": "^2.55.1",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.16.3",
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
     "loud-rejection": "2.2.0",
     "sinon": "12.0.1",
     "source-map-support": "0.5.20"
-  },
-  "devDependencies": {
-    "@appium/eslint-config-appium": "^4.7.4",
-    "@appium/gulp-plugins": "^5.5.5"
   },
   "engines": {
     "node": ">=12",


### PR DESCRIPTION
hopefully.

here's what I did:

1. ran `lerna link convert` which converts all packages which reference _other_ packages to `file:..` urls and adds the same kind of urls to these packages as "dependencies" in the root monorepo.  the upshot here is that we no longer need `lerna bootstrap` because `npm install` from the root will get everything.
2. update packages whose `bin` or `main` fields reference a build artifact; these now use a file in the root which just re-exports whatever the built file was.  otherwise, npm would refuse to install these packages w/o having built the projects first... which would put a monkeywrench in 1.
3. remove `lerna bootstrap` from `postinstall`

so, now, _NO_ `package-lock.json` files should ever be generated in `packages/*`; only the root one.

and hopefully, `lerna publish` will figure out the names of the dependencies (converting `file:` urls to the actual package name) when it's time to do that.  that'd be pretty broken if it didn't!
