### PR TITLE
chore: update 'clean' script to remove any stray package lockfiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "https://github.com/appium",
   "scripts": {
     "build": "lerna exec gulp transpile",
-    "clean": "lerna clean -y && npx rimraf node_modules package-lock.json \"packages/*/build\"",
+    "clean": "lerna clean -y && npx rimraf node_modules package-lock.json \"packages/*/build\" \"packages/*/package-lock.json\"",
     "coverage": "lerna exec gulp coveralls",
     "dev": "lerna exec --parallel -- gulp dev --no-notif",
     "doctor": "node ./packages/doctor",


### PR DESCRIPTION
`packages/*/package-lock.json` _should not exist_, but if it does, it will prevent proper versioning.  This fixes that problem.
