### PR TITLE
print npm output upon error

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/json-schema": "7.0.9",
     "@types/mocha": "9.0.0",
     "@types/node": "16.11.9",
+    "@types/semver": "7.3.9",
     "@types/sinon": "10.0.6",
     "@types/sinon-chai": "3.2.5",
     "@types/through2": "2.0.36",

--- a/packages/appium/test/cli/cli-helpers.js
+++ b/packages/appium/test/cli/cli-helpers.js
@@ -137,30 +137,10 @@ export const installLocalExtension = _.curry(
  * @property {boolean} [raw] - Whether to return the raw output from `teen_process`
  */
 
-/**
- * Result from a non-zero-exit execution of `appium`
- * @typedef {Object} TeenProcessExecResult
- * @property {string} stdout - Stdout
- * @property {string} stderr - Stderr
- * @property {number?} code - Exit code
- */
-
-/**
- * Extra props `teen_process.exec` adds to its error objects
- * @typedef {Object} TeenProcessExecErrorProps
- * @property {string} stdout - STDOUT
- * @property {string} stderr - STDERR
- * @property {number?} code - Exit code
- */
-
-/**
- * Error thrown by `teen_process.exec`
- * @typedef {Error & TeenProcessExecErrorProps} TeenProcessExecError
- */
 
 /**
  * Error thrown by all of the functions in this file which execute `appium`.
- * @typedef {Error & AppiumRunErrorProps & TeenProcessExecErrorProps} AppiumRunError
+ * @typedef {Error & AppiumRunErrorProps & import('../../lib/cli/npm').TeenProcessExecErrorProps} AppiumRunError
  */
 
 /**


### PR DESCRIPTION
I'm not sure if this is desirable or not from a user perspective.  In general, `npm` should not _expectedly_ fail for an end-user when using it.  But I can tell you that eating its output makes `npm` issues painful to debug!  And we've been having a few of those...

Also added some type checks to `npm.js`

This is not a `fix`, so I'll need to amend the commit message.

Related: #16073 