### PR TITLE
fix(appium): make object dumps less weird

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@types/bluebird": "3.5.36",
     "@types/chai": "4.2.22",
     "@types/chai-as-promised": "7.1.4",
+    "@types/express": "4.17.13",
     "@types/fancy-log": "1.3.1",
     "@types/gulp": "4.0.9",
     "@types/json-schema": "7.0.9",

--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -149,32 +149,25 @@ async function showConfig () {
   console.log(JSON.stringify(getBuildInfo())); // eslint-disable-line no-console
 }
 
-function getNonDefaultServerArgs (parser, args) {
+/**
+ * Returns k/v pairs of server arguments which are _not_ the defaults.
+ * @param {import('../types/types').ParsedArgs} args
+ * @returns {Partial<import('../types/types').ParsedArgs>}
+ */
+function getNonDefaultServerArgs (args) {
   // hopefully these function names are descriptive enough
 
-  function typesDiffer (dest) {
-    return typeof args[dest] !== typeof defaultsFromSchema[dest];
-  }
+  const typesDiffer = (dest) => typeof args[dest] !== typeof defaultsFromSchema[dest];
 
-  function defaultValueIsArray (dest) {
-    return _.isArray(defaultsFromSchema[dest]);
-  }
+  const defaultValueIsArray = (dest) => _.isArray(defaultsFromSchema[dest]);
 
-  function argsValueIsArray (dest) {
-    return _.isArray(args[dest]);
-  }
+  const argsValueIsArray = (dest) => _.isArray(args[dest]);
 
-  function arraysDiffer (dest) {
-    return _.difference(args[dest], defaultsFromSchema[dest]).length > 0;
-  }
+  const arraysDiffer = (dest) => _.size(_.difference(args[dest], defaultsFromSchema[dest])) > 0;
 
-  function valuesUnequal (dest) {
-    return args[dest] !== defaultsFromSchema[dest];
-  }
+  const valuesDiffer = (dest) => args[dest] !== defaultsFromSchema[dest];
 
-  function defaultIsDefined (dest) {
-    return !_.isUndefined(defaultsFromSchema[dest]);
-  }
+  const defaultIsDefined = (dest) => !_.isUndefined(defaultsFromSchema[dest]);
 
   // note that `_.overEvery` is like an "AND", and `_.overSome` is like an "OR"
 
@@ -183,8 +176,8 @@ function getNonDefaultServerArgs (parser, args) {
     arraysDiffer
   ]);
 
-  const defaultValueNotArrayAndValuesUnequal = _.overEvery([
-    _.negate(defaultValueIsArray), valuesUnequal
+  const defaultValueNotArrayAndValuesDiffer = _.overEvery([
+    _.negate(defaultValueIsArray), valuesDiffer
   ]);
 
   /**
@@ -197,8 +190,7 @@ function getNonDefaultServerArgs (parser, args) {
    * - if so, and the default is an array:
    *   - ensures the args value is an array
    *   - ensures the args values do not differ from the default values
-   * @param {string} dest - argument name (`dest` value)
-   * @returns {boolean}
+   * @type {(dest: string) => boolean}
    */
   const isNotDefault = _.overEvery([
     defaultIsDefined,
@@ -208,7 +200,7 @@ function getNonDefaultServerArgs (parser, args) {
         defaultValueIsArray,
         argValueNotArrayOrArraysDiffer
       ]),
-      defaultValueNotArrayAndValuesUnequal
+      defaultValueNotArrayAndValuesDiffer
     ])
   ]);
 

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -1,37 +1,36 @@
+// @ts-check
+
 import _ from 'lodash';
 import logger from './logger';
+// @ts-ignore
 import { processCapabilities, PROTOCOLS } from '@appium/base-driver';
 import { fs } from '@appium/support';
+import { inspect as dump } from 'util';
 
 const W3C_APPIUM_PREFIX = 'appium';
 
-function inspectObject (args) {
-  function getValueArray (obj, indent = '  ') {
-    if (!_.isObject(obj)) {
-      return [obj];
-    }
+/**
+ *
+ * If `stdout` is a TTY, this is `true`.
+ *
+ * Used for tighter control over log output.
+ * @type {boolean}
+ */
+const isStdoutTTY = process.stdout.isTTY;
 
-    let strArr = ['{'];
-    for (let [arg, value] of _.toPairs(obj)) {
-      if (!_.isObject(value)) {
-        strArr.push(`${indent}  ${arg}: ${value}`);
-      } else {
-        value = getValueArray(value, `${indent}  `);
-        strArr.push(`${indent}  ${arg}: ${value.shift()}`);
-        strArr.push(...value);
-      }
-    }
-    strArr.push(`${indent}}`);
-    return strArr;
-  }
-  for (let [arg, value] of _.toPairs(args)) {
-    value = getValueArray(value);
-    logger.info(`  ${arg}: ${value.shift()}`);
-    for (let val of value) {
-      logger.info(val);
-    }
-  }
-}
+/**
+ * Dumps to value to the console using `info` logger.
+ *
+ * @todo May want to force color to be `false` if {@link isStdoutTTY} is `false`.
+ */
+const inspect = _.flow(
+  _.partialRight(
+    /** @type {(object: any, options: import('util').InspectOptions) => string} */(dump),
+    {colors: true, depth: null, compact: !isStdoutTTY}
+  ),
+  (...args) => {
+    logger.info(...args);
+  });
 
 /**
  * Takes the caps that were provided in the request and translates them
@@ -246,6 +245,6 @@ class ReadonlyMap extends Map {
 }
 
 export {
-  inspectObject, parseCapsForInnerDriver, insertAppiumPrefixes, rootDir,
+  inspect, parseCapsForInnerDriver, insertAppiumPrefixes, rootDir,
   getPackageVersion, pullSettings, removeAppiumPrefixes, ReadonlyMap
 };

--- a/packages/appium/test/config-specs.js
+++ b/packages/appium/test/config-specs.js
@@ -104,13 +104,19 @@ describe('Config', function () {
     });
     describe('getNonDefaultServerArgs', function () {
       it('should show none if we have all the defaults', function () {
-        let nonDefaultArgs = getNonDefaultServerArgs(parser, args);
+        let nonDefaultArgs = getNonDefaultServerArgs(args);
         nonDefaultArgs.should.be.empty;
       });
       it('should catch a non-default argument', function () {
         args.allowCors = true;
-        let nonDefaultArgs = getNonDefaultServerArgs(parser, args);
+        let nonDefaultArgs = getNonDefaultServerArgs(args);
         nonDefaultArgs.should.eql({allowCors: true});
+      });
+      describe('when arg is an array', function () {
+        it('should return the arg as an array', function () {
+          args.usePlugins = ['all'];
+          getNonDefaultServerArgs(args).should.eql({usePlugins: ['all']});
+        });
       });
     });
 

--- a/packages/appium/test/utils-specs.js
+++ b/packages/appium/test/utils-specs.js
@@ -1,9 +1,12 @@
 import {
   parseCapsForInnerDriver, insertAppiumPrefixes, pullSettings,
-  removeAppiumPrefixes, ReadonlyMap
+  removeAppiumPrefixes, ReadonlyMap, inspect
 } from '../lib/utils';
 import { BASE_CAPS, W3C_CAPS } from './helpers';
 import _ from 'lodash';
+import { stripColors } from 'colors';
+import sinon from 'sinon';
+import logger from '../lib/logger';
 
 describe('utils', function () {
   describe('parseCapsForInnerDriver()', function () {
@@ -234,6 +237,28 @@ describe('utils', function () {
     it('should not allow updating', function () {
       const map = new ReadonlyMap([['foo', 'bar']]);
       (() => map.set('foo', 'baz')).should.throw();
+    });
+  });
+
+  describe('inspect()', function () {
+
+    /**
+     * @type {import('sinon').SinonSandbox}
+     */
+    let sandbox;
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      sandbox.spy(logger, 'info');
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('should log the result of inspecting a value', function () {
+      inspect({foo: 'bar'});
+      stripColors(/** @type {import('sinon').SinonStub} */(logger.info).firstCall.firstArg)
+        .should.equal('{ foo: \'bar\' }');
     });
   });
 });


### PR DESCRIPTION
The `inspectObject()` function in `utils` was doing... stuff... to display both the default caps and non-default arguments.  Arrays, in particular, wound up looking like objects.  I found this objectionable; I hope there isn't a good reason it's this way.

`inspectObject()` was used for both dumping non-default args and default capabilities.

- Remove `utils.inspectObject()` and replace it with `inspect()`, which delegates to Node.js' built-in `util.inspect()` function (which does a bang-up job of dumping objects, including color!)
- Remove the `parser` argument (and return value!) from various functions where it was used.  e.g., `init()` in `main.js` was returning the `parser` instance, but now we don't need it, since it was only needed for `getNonDefaultServerArgs()`, which doesn't need it.  `parser` was being passed through several functions this way.
- Add a dumb test for `utils.inspect()`
- Add another dumb test for `getNonDefaultServerArgs()`
- Add `@types/express` since it was missing.
- More types in various associated places; fix other types
- Consistent naming in impl of `getNonDefaultServerArgs()`
