### PR TITLE
fix(appium): fix behavior of ReadonlyMap to be compatible with Map

### DIFF
--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -235,8 +235,8 @@ class ReadonlyMap extends Map {
     return super.set(key, value);
   }
 
-  delete (key) {
-    throw new Error(`${key} cannot be deleted`);
+  delete () {
+    return false;
   }
 
   clear () {

--- a/packages/appium/test/utils-specs.js
+++ b/packages/appium/test/utils-specs.js
@@ -226,7 +226,7 @@ describe('utils', function () {
 
     it('should not allow deletion', function () {
       const map = new ReadonlyMap([['foo', 'bar']]);
-      (() => map.delete('foo')).should.throw();
+      map.delete('foo').should.be.false;
     });
 
     it('should not allow clearing', function () {


### PR DESCRIPTION
`Map.prototype.delete` returns a `boolean`, so `ReadonlyMap.prototype.delete` should also return a `boolean`.
