### PR TITLE
fix(appium): correctly apply extension defaults

### DIFF
--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -6,7 +6,7 @@ import { rootDir } from './utils';
 import logger from './logger';
 import semver from 'semver';
 import findUp from 'find-up';
-import { getDefaultsFromSchema } from './schema/schema';
+import { getDefaultsForSchema } from './schema/schema';
 
 const npmPackage = fs.readPackageJsonFrom(__dirname);
 
@@ -204,7 +204,7 @@ function getNonDefaultServerArgs (args) {
     ])
   ]);
 
-  const defaultsFromSchema = getDefaultsFromSchema();
+  const defaultsFromSchema = getDefaultsForSchema();
 
   return _.pickBy(args, (__, key) => isNotDefault(key));
 }

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -18,7 +18,7 @@ import { DRIVER_TYPE, PLUGIN_TYPE } from './extension-config';
 import registerNode from './grid-register';
 import logger from './logger'; // logger needs to remain first of imports
 import { init as logsinkInit } from './logsink';
-import { getDefaultsFromSchema, validate } from './schema/schema';
+import { getDefaultsForSchema, validate } from './schema/schema';
 import { inspect } from './utils';
 
 /**
@@ -219,14 +219,9 @@ async function init (args) {
     parsedArgs = _.defaultsDeep(
       parsedArgs,
       configResult.config?.server,
-      getDefaultsFromSchema()
+      getDefaultsForSchema(false)
     );
   }
-
-  parsedArgs = _.defaultsDeep(
-    parsedArgs,
-    configResult.config ?? {},
-  );
 
   await logsinkInit(parsedArgs);
 

--- a/packages/appium/lib/schema/arg-spec.js
+++ b/packages/appium/lib/schema/arg-spec.js
@@ -74,6 +74,11 @@ export class ArgSpec {
   dest;
 
   /**
+   * The same as {@link ArgSpec.dest} but without the leading `<extType>.<extName>.` prefix.
+   */
+  rawDest;
+
+  /**
    * Whatever the default value of this argument is, as specified by the
    * `default` property of the schema.
    * @type {D}
@@ -100,10 +105,10 @@ export class ArgSpec {
 
     // if no explicit `dest` provided, just camelCase the name to avoid needing
     // to use bracket syntax when accessing props on the parsed args object.
-    const baseDest = _.camelCase(dest ?? name);
+    const rawDest = _.camelCase(dest ?? name);
 
     const destKeypath =
-      extType && extName ? [extType, extName, baseDest].join('.') : baseDest;
+      extType && extName ? [extType, extName, rawDest].join('.') : rawDest;
 
     this.defaultValue = defaultValue;
     this.name = name;
@@ -112,6 +117,7 @@ export class ArgSpec {
     this.arg = arg;
     this.dest = destKeypath;
     this.ref = ref;
+    this.rawDest = rawDest;
   }
 
   /**

--- a/packages/appium/test/fixtures/flattened-schema.js
+++ b/packages/appium/test/fixtures/flattened-schema.js
@@ -7,6 +7,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'address',
+      rawDest: 'address',
       ref: 'appium.json#/properties/server/properties/address',
     },
     schema: {
@@ -27,6 +28,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'allow-cors',
+      rawDest: 'allowCors',
       ref: 'appium.json#/properties/server/properties/allow-cors',
     },
     schema: {
@@ -45,6 +47,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'allow-insecure',
+      rawDest: 'allowInsecure',
       ref: 'appium.json#/properties/server/properties/allow-insecure',
     },
     schema: {
@@ -66,6 +69,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'base-path',
+      rawDest: 'basePath',
       ref: 'appium.json#/properties/server/properties/base-path',
     },
     schema: {
@@ -85,6 +89,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'callback-address',
+      rawDest: 'callbackAddress',
       ref: 'appium.json#/properties/server/properties/callback-address',
     },
     schema: {
@@ -102,6 +107,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'callback-port',
+      rawDest: 'callbackPort',
       ref: 'appium.json#/properties/server/properties/callback-port',
     },
     schema: {
@@ -122,6 +128,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'debug-log-spacing',
+      rawDest: 'debugLogSpacing',
       ref: 'appium.json#/properties/server/properties/debug-log-spacing',
     },
     schema: {
@@ -140,6 +147,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'default-capabilities',
+      rawDest: 'defaultCapabilities',
       ref: 'appium.json#/properties/server/properties/default-capabilities',
     },
     schema: {
@@ -159,6 +167,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'deny-insecure',
+      rawDest: 'denyInsecure',
       ref: 'appium.json#/properties/server/properties/deny-insecure',
     },
     schema: {
@@ -181,6 +190,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'keep-alive-timeout',
+      rawDest: 'keepAliveTimeout',
       ref: 'appium.json#/properties/server/properties/keep-alive-timeout',
     },
     schema: {
@@ -201,6 +211,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'local-timezone',
+      rawDest: 'localTimezone',
       ref: 'appium.json#/properties/server/properties/local-timezone',
     },
     schema: {
@@ -218,6 +229,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'log',
+      rawDest: 'logFile',
       ref: 'appium.json#/properties/server/properties/log',
     },
     schema: {
@@ -236,6 +248,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'log-filters',
+      rawDest: 'logFilters',
       ref: 'appium.json#/properties/server/properties/log-filters',
     },
     schema: {
@@ -254,6 +267,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'log-level',
+      rawDest: 'loglevel',
       ref: 'appium.json#/properties/server/properties/log-level',
     },
     schema: {
@@ -294,6 +308,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'log-no-colors',
+      rawDest: 'logNoColors',
       ref: 'appium.json#/properties/server/properties/log-no-colors',
     },
     schema: {
@@ -311,6 +326,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'log-timestamp',
+      rawDest: 'logTimestamp',
       ref: 'appium.json#/properties/server/properties/log-timestamp',
     },
     schema: {
@@ -328,6 +344,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'long-stacktrace',
+      rawDest: 'longStacktrace',
       ref: 'appium.json#/properties/server/properties/long-stacktrace',
     },
     schema: {
@@ -346,6 +363,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'no-perms-check',
+      rawDest: 'noPermsCheck',
       ref: 'appium.json#/properties/server/properties/no-perms-check',
     },
     schema: {
@@ -364,6 +382,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'nodeconfig',
+      rawDest: 'nodeconfig',
       ref: 'appium.json#/properties/server/properties/nodeconfig',
     },
     schema: {
@@ -383,6 +402,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'port',
+      rawDest: 'port',
       ref: 'appium.json#/properties/server/properties/port',
     },
     schema: {
@@ -403,15 +423,16 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'relaxed-security',
+      rawDest: 'relaxedSecurityEnabled',
       ref: 'appium.json#/properties/server/properties/relaxed-security',
     },
     schema: {
+      appiumCliDest: 'relaxedSecurityEnabled',
       default: false,
       description:
         'Disable additional security checks, so it is possible to use some advanced features, provided by drivers supporting this option. Only enable it if all the clients are in the trusted network and it\'s not the case if a client could potentially break out of the session sandbox. Specific features can be overridden by using "deny-insecure"',
       title: 'relaxed-security config',
       type: 'boolean',
-      appiumCliDest: 'relaxedSecurityEnabled'
     },
   },
   {
@@ -422,6 +443,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'session-override',
+      rawDest: 'sessionOverride',
       ref: 'appium.json#/properties/server/properties/session-override',
     },
     schema: {
@@ -439,6 +461,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'strict-caps',
+      rawDest: 'strictCaps',
       ref: 'appium.json#/properties/server/properties/strict-caps',
     },
     schema: {
@@ -457,6 +480,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'tmp',
+      rawDest: 'tmpDir',
       ref: 'appium.json#/properties/server/properties/tmp',
     },
     schema: {
@@ -475,6 +499,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'trace-dir',
+      rawDest: 'traceDir',
       ref: 'appium.json#/properties/server/properties/trace-dir',
     },
     schema: {
@@ -492,6 +517,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'use-drivers',
+      rawDest: 'useDrivers',
       ref: 'appium.json#/properties/server/properties/use-drivers',
     },
     schema: {
@@ -514,6 +540,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'use-plugins',
+      rawDest: 'usePlugins',
       ref: 'appium.json#/properties/server/properties/use-plugins',
     },
     schema: {
@@ -536,6 +563,7 @@ export default [
       extName: undefined,
       extType: undefined,
       name: 'webhook',
+      rawDest: 'webhook',
       ref: 'appium.json#/properties/server/properties/webhook',
     },
     schema: {
@@ -547,5 +575,5 @@ export default [
       title: 'webhook config',
       type: 'string',
     },
-  },
+  }
 ];

--- a/packages/appium/test/parser-specs.js
+++ b/packages/appium/test/parser-specs.js
@@ -20,11 +20,11 @@ describe('parser', function () {
     });
 
     it('should accept only server and driver subcommands', function () {
-      p.parse_args([]);
-      p.parse_args(['server']);
-      p.parse_args(['driver', 'list']);
-      (() => p.parse_args(['foo'])).should.throw();
-      (() => p.parse_args(['foo --bar'])).should.throw();
+      p.parseArgs([]);
+      p.parseArgs(['server']);
+      p.parseArgs(['driver', 'list']);
+      (() => p.parseArgs(['foo'])).should.throw();
+      (() => p.parseArgs(['foo --bar'])).should.throw();
     });
   });
 
@@ -35,12 +35,12 @@ describe('parser', function () {
       });
 
       it('should return an arg parser', function () {
-        should.exist(p.parse_args);
-        p.parse_args([]).should.have.property('port');
+        should.exist(p.parseArgs);
+        p.parseArgs([]).should.have.property('port');
       });
       it('should default to the server subcommand', function () {
-        p.parse_args([]).subcommand.should.eql('server');
-        p.parse_args([]).should.eql(p.parse_args(['server']));
+        p.parseArgs([]).subcommand.should.eql('server');
+        p.parseArgs([]).should.eql(p.parseArgs(['server']));
       });
       it('should keep the raw server flags array', function () {
         should.exist(p.rawArgs);
@@ -54,63 +54,63 @@ describe('parser', function () {
       // TODO: figure out how best to suppress color in error message
       describe('invalid arguments', function () {
         it('should throw an error with unknown argument', function () {
-          (() => {p.parse_args(['--apple']);}).should.throw(/unrecognized arguments: --apple/i);
+          (() => {p.parseArgs(['--apple']);}).should.throw(/unrecognized arguments: --apple/i);
         });
 
         it('should throw an error for an invalid value ("hostname")', function () {
-          (() => {p.parse_args(['--address', '-42']);}).should.throw(/must match format "hostname"/i);
+          (() => {p.parseArgs(['--address', '-42']);}).should.throw(/must match format "hostname"/i);
         });
 
         it('should throw an error for an invalid value ("uri")', function () {
-          (() => {p.parse_args(['--webhook', 'blub']);}).should.throw(/must match format "uri"/i);
+          (() => {p.parseArgs(['--webhook', 'blub']);}).should.throw(/must match format "uri"/i);
         });
 
         it('should throw an error for an invalid value (using "enum")', function () {
-          (() => {p.parse_args(['--log-level', '-42']);}).should.throw(/must be equal to one of the allowed values/i);
+          (() => {p.parseArgs(['--log-level', '-42']);}).should.throw(/must be equal to one of the allowed values/i);
         });
 
         it('should throw an error for incorrectly formatted arg (matching "dest")', function () {
-          (() => {p.parse_args(['--loglevel', '-42']);}).should.throw(/unrecognized arguments: --loglevel/i);
+          (() => {p.parseArgs(['--loglevel', '-42']);}).should.throw(/unrecognized arguments: --loglevel/i);
         });
       });
 
       it('should parse default capabilities correctly from a string', function () {
         let defaultCapabilities = {a: 'b'};
-        let args = p.parse_args(['--default-capabilities', JSON.stringify(defaultCapabilities)]);
+        let args = p.parseArgs(['--default-capabilities', JSON.stringify(defaultCapabilities)]);
         args.defaultCapabilities.should.eql(defaultCapabilities);
       });
 
       it('should parse default capabilities correctly from a file', function () {
         let defaultCapabilities = {a: 'b'};
-        let args = p.parse_args(['--default-capabilities', CAPS_FIXTURE]);
+        let args = p.parseArgs(['--default-capabilities', CAPS_FIXTURE]);
         args.defaultCapabilities.should.eql(defaultCapabilities);
       });
 
       it('should throw an error with invalid arg to default capabilities', function () {
-        (() => {p.parse_args(['-dc', '42']);}).should.throw();
-        (() => {p.parse_args(['-dc', 'false']);}).should.throw();
-        (() => {p.parse_args(['-dc', 'null']);}).should.throw();
-        (() => {p.parse_args(['-dc', 'does/not/exist.json']);}).should.throw();
+        (() => {p.parseArgs(['-dc', '42']);}).should.throw();
+        (() => {p.parseArgs(['-dc', 'false']);}).should.throw();
+        (() => {p.parseArgs(['-dc', 'null']);}).should.throw();
+        (() => {p.parseArgs(['-dc', 'does/not/exist.json']);}).should.throw();
       });
 
       it('should parse --allow-insecure correctly', function () {
-        p.parse_args([]).should.have.property('allowInsecure', undefined);
-        p.parse_args(['--allow-insecure', '']).allowInsecure.should.eql([]);
-        p.parse_args(['--allow-insecure', 'foo']).allowInsecure.should.eql(['foo']);
-        p.parse_args(['--allow-insecure', 'foo,bar']).allowInsecure.should.eql(['foo', 'bar']);
-        p.parse_args(['--allow-insecure', 'foo ,bar']).allowInsecure.should.eql(['foo', 'bar']);
+        p.parseArgs([]).should.have.property('allowInsecure', undefined);
+        p.parseArgs(['--allow-insecure', '']).allowInsecure.should.eql([]);
+        p.parseArgs(['--allow-insecure', 'foo']).allowInsecure.should.eql(['foo']);
+        p.parseArgs(['--allow-insecure', 'foo,bar']).allowInsecure.should.eql(['foo', 'bar']);
+        p.parseArgs(['--allow-insecure', 'foo ,bar']).allowInsecure.should.eql(['foo', 'bar']);
       });
 
       it('should parse --deny-insecure correctly', function () {
-        p.parse_args([]).should.have.property('denyInsecure', undefined);
-        p.parse_args(['--deny-insecure', '']).denyInsecure.should.eql([]);
-        p.parse_args(['--deny-insecure', 'foo']).denyInsecure.should.eql(['foo']);
-        p.parse_args(['--deny-insecure', 'foo,bar']).denyInsecure.should.eql(['foo', 'bar']);
-        p.parse_args(['--deny-insecure', 'foo ,bar']).denyInsecure.should.eql(['foo', 'bar']);
+        p.parseArgs([]).should.have.property('denyInsecure', undefined);
+        p.parseArgs(['--deny-insecure', '']).denyInsecure.should.eql([]);
+        p.parseArgs(['--deny-insecure', 'foo']).denyInsecure.should.eql(['foo']);
+        p.parseArgs(['--deny-insecure', 'foo,bar']).denyInsecure.should.eql(['foo', 'bar']);
+        p.parseArgs(['--deny-insecure', 'foo ,bar']).denyInsecure.should.eql(['foo', 'bar']);
       });
 
       it('should parse --allow-insecure & --deny-insecure from files', function () {
-        const parsed = p.parse_args([
+        const parsed = p.parseArgs([
           '--allow-insecure', ALLOW_FIXTURE, '--deny-insecure', DENY_FIXTURE
         ]);
         parsed.allowInsecure.should.eql(['feature1', 'feature2', 'feature3']);
@@ -118,16 +118,16 @@ describe('parser', function () {
       });
 
       it('should allow a string for --use-drivers', function () {
-        p.parse_args(['--use-drivers', 'fake']).useDrivers.should.eql(['fake']);
+        p.parseArgs(['--use-drivers', 'fake']).useDrivers.should.eql(['fake']);
       });
 
 
       it('should allow multiple --use-drivers', function () {
-        p.parse_args(['--use-drivers', 'fake,phony']).useDrivers.should.eql(['fake', 'phony']);
+        p.parseArgs(['--use-drivers', 'fake,phony']).useDrivers.should.eql(['fake', 'phony']);
       });
 
       it('should respect --relaxed-security', function () {
-        p.parse_args(['--relaxed-security']).should.have.property('relaxedSecurityEnabled', true);
+        p.parseArgs(['--relaxed-security']).should.have.property('relaxedSecurityEnabled', true);
       });
     });
 
@@ -149,7 +149,7 @@ describe('parser', function () {
         // the result should be that the parsed args should match the config file.
         const {config} = await readConfigFile(resolveFixture('config', 'driver-fake.config.json'));
         const fakeDriverArgs = {fake: {sillyWebServerPort: 1234, sillyWebServerHost: 'hey'}};
-        const args = p.parse_args([
+        const args = p.parseArgs([
           '--driver-fake-silly-web-server-port',
           fakeDriverArgs.fake.sillyWebServerPort,
           '--driver-fake-silly-web-server-host',
@@ -159,13 +159,17 @@ describe('parser', function () {
         args.driver.fake.should.eql(config.driver.fake);
       });
 
+      it('should not yet apply defaults', function () {
+        const args = p.parseArgs([]);
+        args.driver.fake.should.eql({sillyWebServerHost: undefined, sillyWebServerPort: undefined});
+      });
+
       it('should nicely handle extensions w/ dashes in them', async function () {
         schema.resetSchema();
-        schema.registerSchema('plugin', 'crypto-fiend', {properties: {elite: {type: 'boolean'}}});
+        schema.registerSchema('plugin', 'crypto-fiend', {type: 'object', properties: {elite: {type: 'boolean'}}});
         schema.finalizeSchema();
         p = await getParser(true);
-        // const fakePluginArgs = {'xxx-crypt0-fiend-xxx': {elite: true}};
-        const args = p.parse_args([
+        const args = p.parseArgs([
           '--plugin-crypto-fiend-elite'
         ]);
 
@@ -174,16 +178,16 @@ describe('parser', function () {
 
       describe('when user supplies invalid args', function () {
         it('should error out', function () {
-          (() => p.parse_args(['--driver-fake-silly-web-server-port', 'foo'])).should.throw(/must be integer/i);
+          (() => p.parseArgs(['--driver-fake-silly-web-server-port', 'foo'])).should.throw(/must be integer/i);
         });
       });
 
       it('should not support --driver-args', function () {
-        (() => p.parse_args(['--driver-args', '/some/file.json'])).should.throw(/unrecognized arguments/i);
+        (() => p.parseArgs(['--driver-args', '/some/file.json'])).should.throw(/unrecognized arguments/i);
       });
 
       it('should not support --plugin-args', function () {
-        (() => p.parse_args(['--plugin-args', '/some/file.json'])).should.throw(/unrecognized arguments/i);
+        (() => p.parseArgs(['--plugin-args', '/some/file.json'])).should.throw(/unrecognized arguments/i);
       });
 
     });
@@ -191,11 +195,11 @@ describe('parser', function () {
 
   describe('Driver Parser', function () {
     it('should not allow random sub-subcommands', function () {
-      (() => p.parse_args(['driver', 'foo'])).should.throw();
+      (() => p.parseArgs(['driver', 'foo'])).should.throw();
     });
     describe('list', function () {
       it('should allow an empty argument list', function () {
-        const args = p.parse_args(['driver', 'list']);
+        const args = p.parseArgs(['driver', 'list']);
         args.subcommand.should.eql('driver');
         args.driverCommand.should.eql('list');
         args.showInstalled.should.eql(false);
@@ -203,24 +207,24 @@ describe('parser', function () {
         args.json.should.eql(false);
       });
       it('should allow json format', function () {
-        const args = p.parse_args(['driver', 'list', '--json']);
+        const args = p.parseArgs(['driver', 'list', '--json']);
         args.json.should.eql(true);
       });
       it('should allow --installed', function () {
-        const args = p.parse_args(['driver', 'list', '--installed']);
+        const args = p.parseArgs(['driver', 'list', '--installed']);
         args.showInstalled.should.eql(true);
       });
       it('should allow --updates', function () {
-        const args = p.parse_args(['driver', 'list', '--updates']);
+        const args = p.parseArgs(['driver', 'list', '--updates']);
         args.showUpdates.should.eql(true);
       });
     });
     describe('install', function () {
       it('should not allow an empty argument list', function () {
-        (() => p.parse_args(['driver', 'install'])).should.throw();
+        (() => p.parseArgs(['driver', 'install'])).should.throw();
       });
       it('should take a driver name to install', function () {
-        const args = p.parse_args(['driver', 'install', 'foobar']);
+        const args = p.parseArgs(['driver', 'install', 'foobar']);
         args.subcommand.should.eql('driver');
         args.driverCommand.should.eql('install');
         args.driver.should.eql('foobar');
@@ -228,60 +232,60 @@ describe('parser', function () {
         args.json.should.eql(false);
       });
       it('should allow json format', function () {
-        const args = p.parse_args(['driver', 'install', 'foobar', '--json']);
+        const args = p.parseArgs(['driver', 'install', 'foobar', '--json']);
         args.json.should.eql(true);
       });
       it('should allow --source', function () {
         for (const source of INSTALL_TYPES) {
-          const args = p.parse_args(['driver', 'install', 'foobar', '--source', source]);
+          const args = p.parseArgs(['driver', 'install', 'foobar', '--source', source]);
           args.installType.should.eql(source);
         }
       });
       it('should not allow unknown --source', function () {
-        (() => p.parse_args(['driver', 'install', 'fobar', '--source', 'blah'])).should.throw();
+        (() => p.parseArgs(['driver', 'install', 'fobar', '--source', 'blah'])).should.throw();
       });
     });
     describe('uninstall', function () {
       it('should not allow an empty argument list', function () {
-        (() => p.parse_args(['driver', 'uninstall'])).should.throw();
+        (() => p.parseArgs(['driver', 'uninstall'])).should.throw();
       });
       it('should take a driver name to uninstall', function () {
-        const args = p.parse_args(['driver', 'uninstall', 'foobar']);
+        const args = p.parseArgs(['driver', 'uninstall', 'foobar']);
         args.subcommand.should.eql('driver');
         args.driverCommand.should.eql('uninstall');
         args.driver.should.eql('foobar');
         args.json.should.eql(false);
       });
       it('should allow json format', function () {
-        const args = p.parse_args(['driver', 'uninstall', 'foobar', '--json']);
+        const args = p.parseArgs(['driver', 'uninstall', 'foobar', '--json']);
         args.json.should.eql(true);
       });
     });
     describe('update', function () {
       it('should not allow an empty argument list', function () {
-        (() => p.parse_args(['driver', 'update'])).should.throw();
+        (() => p.parseArgs(['driver', 'update'])).should.throw();
       });
       it('should take a driver name to update', function () {
-        const args = p.parse_args(['driver', 'update', 'foobar']);
+        const args = p.parseArgs(['driver', 'update', 'foobar']);
         args.subcommand.should.eql('driver');
         args.driverCommand.should.eql('update');
         args.driver.should.eql('foobar');
         args.json.should.eql(false);
       });
       it('should allow json format', function () {
-        const args = p.parse_args(['driver', 'update', 'foobar', '--json']);
+        const args = p.parseArgs(['driver', 'update', 'foobar', '--json']);
         args.json.should.eql(true);
       });
     });
     describe('run', function () {
       it('should not allow an empty driver argument list', function () {
-        (() => p.parse_args(['driver', 'run'])).should.throw();
+        (() => p.parseArgs(['driver', 'run'])).should.throw();
       });
       it('should not allow no driver scriptName', function () {
-        (() => p.parse_args(['driver', 'run', 'foo'])).should.throw();
+        (() => p.parseArgs(['driver', 'run', 'foo'])).should.throw();
       });
       it('should take a driverName and scriptName to run', function () {
-        const args = p.parse_args(['driver', 'run', 'foo', 'bar']);
+        const args = p.parseArgs(['driver', 'run', 'foo', 'bar']);
         args.subcommand.should.eql('driver');
         args.driverCommand.should.eql('run');
         args.driver.should.eql('foo');
@@ -289,17 +293,17 @@ describe('parser', function () {
         args.json.should.eql(false);
       });
       it('should allow json format for driver', function () {
-        const args = p.parse_args(['driver', 'run', 'foo', 'bar', '--json']);
+        const args = p.parseArgs(['driver', 'run', 'foo', 'bar', '--json']);
         args.json.should.eql(true);
       });
       it('should not allow an empty plugin argument list', function () {
-        (() => p.parse_args(['plugin', 'run'])).should.throw();
+        (() => p.parseArgs(['plugin', 'run'])).should.throw();
       });
       it('should not allow no plugin scriptName', function () {
-        (() => p.parse_args(['plugin', 'run', 'foo'])).should.throw();
+        (() => p.parseArgs(['plugin', 'run', 'foo'])).should.throw();
       });
       it('should take a pluginName and scriptName to run', function () {
-        const args = p.parse_args(['plugin', 'run', 'foo', 'bar']);
+        const args = p.parseArgs(['plugin', 'run', 'foo', 'bar']);
         args.subcommand.should.eql('plugin');
         args.pluginCommand.should.eql('run');
         args.plugin.should.eql('foo');
@@ -307,7 +311,7 @@ describe('parser', function () {
         args.json.should.eql(false);
       });
       it('should allow json format for plugin', function () {
-        const args = p.parse_args(['plugin', 'run', 'foo', 'bar', '--json']);
+        const args = p.parseArgs(['plugin', 'run', 'foo', 'bar', '--json']);
         args.json.should.eql(true);
       });
     });

--- a/packages/appium/test/schema/schema-specs.js
+++ b/packages/appium/test/schema/schema-specs.js
@@ -33,11 +33,6 @@ describe('schema', function () {
     sandbox = sinon.createSandbox();
 
     mocks = {
-      '../../lib/extension-config': {
-        DRIVER_TYPE: 'driver',
-        PLUGIN_TYPE: 'plugin',
-      },
-
       'resolve-from': sandbox.stub(),
 
       '@sidvind/better-ajv-errors': sandbox.stub(),
@@ -222,10 +217,10 @@ describe('schema', function () {
     });
   });
 
-  describe('getDefaultsFromSchema()', function () {
+  describe('getDefaultsForSchema()', function () {
     describe('when schema not yet compiled', function () {
       it('should throw', function () {
-        expect(() => schema.getDefaultsFromSchema()).to.throw(
+        expect(() => schema.getDefaultsForSchema()).to.throw(
           SchemaFinalizationError,
         );
       });
@@ -234,7 +229,7 @@ describe('schema', function () {
     describe('when schema already compiled', function () {
       it('should return a Record object with only defined default values', function () {
         schema.finalizeSchema();
-        const defaults = schema.getDefaultsFromSchema();
+        const defaults = schema.getDefaultsForSchema();
         expect(defaults).to.eql(defaultArgsFixture);
       });
 
@@ -242,7 +237,7 @@ describe('schema', function () {
         it('should return a Record object containing defaults for the extensions', function () {
           schema.registerSchema('driver', 'stuff', DRIVER_SCHEMA_FIXTURE);
           schema.finalizeSchema();
-          const defaults = schema.getDefaultsFromSchema();
+          const defaults = schema.getDefaultsForSchema();
           // extensions have a key that looks like a keypath. we may want to change that
           expect(defaults).to.have.property('driver.stuff.answer', 50);
         });
@@ -298,6 +293,7 @@ describe('schema', function () {
               ref: 'driver-fake.json#/properties/silly-web-server-port',
               arg: 'driver-fake-silly-web-server-port',
               dest: 'driver.fake.sillyWebServerPort',
+              rawDest: 'sillyWebServerPort',
               defaultValue: undefined,
             },
           },
@@ -314,6 +310,7 @@ describe('schema', function () {
               ref: 'driver-fake.json#/properties/sillyWebServerHost',
               arg: 'driver-fake-silly-web-server-host',
               dest: 'driver.fake.sillyWebServerHost',
+              rawDest: 'sillyWebServerHost',
               defaultValue: 'sillyhost',
             },
           },


### PR DESCRIPTION
Extensions were not correctly receiving the default values as specified in their schemas.  For example, in `xcuitest` driver, the `wdaLocalPort` option has a default value of `8100`, but this value would never make it to the driver.

The root cause was that `getDefaultsForSchema()` returns a _flattened_ object (which is useful for displaying to users as part of `getNonDefaultServerArgs()`), but by the time defaults should get assigned to parsed arguments in `main.js`, the parsed arguments object has already been expanded to a deeply-nested, non-flattened object.  So `"driver.driverName.argName": "value"` would be set in the args, but  not `{"driver": {"driverName": {"argName": "value"}}}`.

This change fixes the issue by iterating over the result of `getDefaultsForSchema()` and using `_.set()` to build a deeply-nested object from the defaults, which is then applied to the parsed arguments.

Closes #16165.