### PR TITLE
chore(fake-driver): Bump xmldom version

### DIFF
--- a/packages/fake-driver/lib/fake-app.js
+++ b/packages/fake-driver/lib/fake-app.js
@@ -1,7 +1,7 @@
 import { fs } from '@appium/support';
 import { readFileSync } from 'fs';
 import path from 'path';
-import XMLDom from 'xmldom';
+import XMLDom from '@xmldom/xmldom';
 import xpath from 'xpath';
 import log from './logger';
 import { FakeElement } from './fake-element';

--- a/packages/fake-driver/lib/fake-element.js
+++ b/packages/fake-driver/lib/fake-element.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import XMLDom from 'xmldom';
+import XMLDom from '@xmldom/xmldom';
 
 class FakeElement {
   constructor (xmlNode, app) {

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -38,11 +38,11 @@
     "@appium/base-driver": "file:../base-driver",
     "@appium/support": "file:../support",
     "@babel/runtime": "7.16.3",
+    "@xmldom/xmldom": "0.7.5",
     "asyncbox": "2.9.2",
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
     "source-map-support": "0.5.21",
-    "xmldom": "0.6.0",
     "xpath": "0.0.32"
   },
   "engines": {


### PR DESCRIPTION
## Proposed changes

The original xmldom NPM package has been abandoned and is not maintained anymore, but rather was moved under `@xmldom/xmldom`

