### PR TITLE
fix(base-driver): follow W3C capabilities more strictly (warning log)

### DIFF
--- a/packages/base-driver/lib/basedriver/capabilities.js
+++ b/packages/base-driver/lib/basedriver/capabilities.js
@@ -144,9 +144,9 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
     throw new errors.InvalidArgumentError('The capabilities.firstMatch argument was not valid for the following reason(s): "capabilities.firstMatch" must be a JSON array or undefined');
   }
 
-  // If an empty array as provided, we'll be forgiving and make it an array of one empty object
+  // Reject 'firstMatch' argument if its array did not have one or more entries (#3.2)
   if (allFirstMatchCaps.length === 0) {
-    allFirstMatchCaps.push({});
+    throw new errors.InvalidArgumentError('The capabilities.firstMatch argument was not valid for the following reason(s): "capabilities.firstMatch" must have one ore more entries');
   }
 
   // Check for non-prefixed, non-standard capabilities and log warnings if they are found

--- a/packages/base-driver/lib/basedriver/capabilities.js
+++ b/packages/base-driver/lib/basedriver/capabilities.js
@@ -146,7 +146,7 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
 
   // Reject 'firstMatch' argument if its array did not have one or more entries (#3.2)
   if (allFirstMatchCaps.length === 0) {
-    throw new errors.InvalidArgumentError('The capabilities.firstMatch argument was not valid for the following reason(s): "capabilities.firstMatch" must have one ore more entries');
+    throw new errors.InvalidArgumentError('The capabilities.firstMatch argument was not valid for the following reason(s): "capabilities.firstMatch" must have one or more entries');
   }
 
   // Check for non-prefixed, non-standard capabilities and log warnings if they are found

--- a/packages/base-driver/lib/basedriver/capabilities.js
+++ b/packages/base-driver/lib/basedriver/capabilities.js
@@ -144,9 +144,12 @@ function parseCaps (caps, constraints = {}, shouldValidateCaps = true) {
     throw new errors.InvalidArgumentError('The capabilities.firstMatch argument was not valid for the following reason(s): "capabilities.firstMatch" must be a JSON array or undefined');
   }
 
-  // Reject 'firstMatch' argument if its array did not have one or more entries (#3.2)
+  // If an empty array as provided, we'll be forgiving and make it an array of one empty object
+  // In the future, reject 'firstMatch' argument if its array did not have one or more entries (#3.2)
   if (allFirstMatchCaps.length === 0) {
-    throw new errors.InvalidArgumentError('The capabilities.firstMatch argument was not valid for the following reason(s): "capabilities.firstMatch" must have one or more entries');
+    log.warn(`The firstMatch array in the given capabilities has no entries. Adding an empty entry fo rnow, ` +
+      `but it will require one or more entries as W3C spec.`);
+    allFirstMatchCaps.push({});
   }
 
   // Check for non-prefixed, non-standard capabilities and log warnings if they are found

--- a/packages/base-driver/test/basedriver/capabilities-specs.js
+++ b/packages/base-driver/test/basedriver/capabilities-specs.js
@@ -137,6 +137,11 @@ describe('caps', function () {
       }
     });
 
+    it('returns invalid argument error if "firstMatch" does not have one or more entries (3.2)', function () {
+      caps.firstMatch = [];
+      (function () { parseCaps(caps); }).should.throw(/must have one ore more entries/);
+    });
+
     it('has "validatedFirstMatchCaps" property that is empty by default if no valid firstMatch caps were found (4)', function () {
       parseCaps(caps, {foo: {presence: true}}).validatedFirstMatchCaps.should.deep.equal([]);
     });

--- a/packages/base-driver/test/basedriver/capabilities-specs.js
+++ b/packages/base-driver/test/basedriver/capabilities-specs.js
@@ -139,7 +139,7 @@ describe('caps', function () {
 
     it('returns invalid argument error if "firstMatch" does not have one or more entries (3.2)', function () {
       caps.firstMatch = [];
-      (function () { parseCaps(caps); }).should.throw(/must have one ore more entries/);
+      (function () { parseCaps(caps); }).should.throw(/must have one or more entries/);
     });
 
     it('has "validatedFirstMatchCaps" property that is empty by default if no valid firstMatch caps were found (4)', function () {

--- a/packages/base-driver/test/basedriver/capabilities-specs.js
+++ b/packages/base-driver/test/basedriver/capabilities-specs.js
@@ -137,11 +137,6 @@ describe('caps', function () {
       }
     });
 
-    it('returns invalid argument error if "firstMatch" does not have one or more entries (3.2)', function () {
-      caps.firstMatch = [];
-      (function () { parseCaps(caps); }).should.throw(/must have one or more entries/);
-    });
-
     it('has "validatedFirstMatchCaps" property that is empty by default if no valid firstMatch caps were found (4)', function () {
       parseCaps(caps, {foo: {presence: true}}).validatedFirstMatchCaps.should.deep.equal([]);
     });


### PR DESCRIPTION
## Proposed changes

According to the W3C spec, an empty array in firstMatch should return an error. Currently we allow the empty array case by adding `{}` by us.

I think it's a good time to follow W3C more strictly since Appium 2.0.

https://www.w3.org/TR/webdriver/#processing-capabilities

> If all first match capabilities is not a JSON List with one or more entries, return error with error code invalid argument.

I need to check other appium clients.
Python is ok. Ruby needs https://github.com/appium/ruby_lib_core/pull/360.  [Java](https://github.com/appium/java-client/blob/811a66d9f790b67261dbb82e0bb9183232d8995e/src/main/java/io/appium/java_client/remote/AppiumProtocolHandshake.java#L55-L59) is ok. dotnet probably ok (selenium client-side was ok)

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
