### PR TITLE
feat(appium): add --show-config

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -53,6 +53,7 @@ class AppiumDriver extends BaseDriver {
     // It is not recommended to access this property directly from the outside
     this.pendingDrivers = {};
 
+    /** @type {PluginExtensionClass[]} */
     this.pluginClasses = []; // list of which plugins are active
     this.sessionPlugins = {}; // map of sessions to actual plugin instances per session
     this.sessionlessPlugins = []; // some commands are sessionless, so we need a set of plugins for them
@@ -61,8 +62,11 @@ class AppiumDriver extends BaseDriver {
     updateBuildInfo();
   }
 
-  /** @type {DriverConfig|undefined} */
+  /** @type {import('./driver-config').default|undefined} */
   driverConfig;
+
+  /** @type {import('express').Express|undefined} */
+  server;
 
   /**
    * Cancel commands queueing for the umbrella Appium driver
@@ -670,3 +674,23 @@ export class NoDriverProxyCommandError extends Error {
 }
 
 export { AppiumDriver };
+
+
+/**
+ * @typedef {Object} StaticExtMembers
+ * @property {(app: import('express').Express, httpServer: import('http').Server) => import('type-fest').Promisable<void>} [updateServer]
+ * @property {import('@appium/base-driver').MethodMap} [newMethodMap]
+ */
+
+/**
+ * @typedef {Object} StaticPluginMembers
+ * @property {string} pluginName
+ */
+
+/**
+ * @typedef {import('type-fest').Class<unknown> & StaticPluginMembers & StaticExtMembers} PluginExtensionClass
+ */
+
+/**
+ * @typedef {import('type-fest').Class<unknown> & StaticExtMembers} DriverExtensionClass
+ */

--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -202,13 +202,13 @@ const serverArgsDisallowedInConfig = new Map([
     },
   ],
   [
-    ['--show-config'],
+    ['--show-build-info'],
     {
       default: false,
-      dest: 'showConfig',
+      dest: 'showBuildInfo',
       action: 'store_true',
       required: false,
-      help: 'Show info about the appium server configuration and exit',
+      help: 'Show info about the Appium build and exit',
     },
   ],
   [

--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 // @ts-ignore
-import { DEFAULT_BASE_PATH } from '@appium/base-driver';
 import _ from 'lodash';
 import DriverConfig from '../driver-config';
 import { APPIUM_HOME, DRIVER_TYPE, INSTALL_TYPES, PLUGIN_TYPE } from '../extension-config';
@@ -175,13 +174,7 @@ function makeRunArgs (type) {
  */
 function getServerArgs () {
   return new Map([
-    ...toParserArgs({
-      overrides: {
-        basePath: {
-          default: DEFAULT_BASE_PATH
-        },
-      }
-    }),
+    ...toParserArgs(),
     ...serverArgsDisallowedInConfig,
   ]);
 }
@@ -195,21 +188,31 @@ const serverArgsDisallowedInConfig = new Map([
     ['--shell'],
     {
       required: false,
-      default: null,
       help: 'Enter REPL mode',
-      action: 'store_true',
+      action: 'store_const',
+      const: true,
       dest: 'shell',
     },
   ],
   [
     ['--show-build-info'],
     {
-      default: false,
       dest: 'showBuildInfo',
-      action: 'store_true',
+      action: 'store_const',
+      const: true,
       required: false,
       help: 'Show info about the Appium build and exit',
     },
+  ],
+  [
+    ['--show-config'],
+    {
+      dest: 'showConfig',
+      action: 'store_const',
+      const: true,
+      required: false,
+      help: 'Show the current Appium configuration and exit',
+    }
   ],
   [
     ['--config'],

--- a/packages/appium/lib/cli/parser.js
+++ b/packages/appium/lib/cli/parser.js
@@ -146,7 +146,7 @@ class ArgParser {
     return _.reduce(
       args,
       (unpacked, value, key) => {
-        if (hasArgSpec(key)) {
+        if (!_.isUndefined(value) && hasArgSpec(key)) {
           const {dest} = /** @type {import('../schema/arg-spec').ArgSpec} */(getArgSpec(key));
           _.set(unpacked, dest, value);
         } else {

--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -144,7 +144,7 @@ function warnNodeDeprecations () {
   // }
 }
 
-async function showConfig () {
+async function showBuildInfo () {
   await updateBuildInfo(true);
   console.log(JSON.stringify(getBuildInfo())); // eslint-disable-line no-console
 }
@@ -219,7 +219,7 @@ async function validateTmpDir (tmpDir) {
 }
 
 export {
-  getBuildInfo, checkNodeOk, showConfig,
+  getBuildInfo, checkNodeOk, showBuildInfo,
   warnNodeDeprecations, validateTmpDir, getNonDefaultServerArgs,
   getGitRev, APPIUM_VER, updateBuildInfo
 };

--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -159,8 +159,8 @@ async function showBuildInfo () {
 
 /**
  * Returns k/v pairs of server arguments which are _not_ the defaults.
- * @param {import('../types/types').ParsedArgs} args
- * @returns {Partial<import('../types/types').ParsedArgs>}
+ * @param {ParsedArgs} args
+ * @returns {Partial<ParsedArgs>}
  */
 function getNonDefaultServerArgs (args) {
   // hopefully these function names are descriptive enough
@@ -227,14 +227,18 @@ function getNonDefaultServerArgs (args) {
 const compactConfig = _.partial(
   _.omitBy,
   _,
-  (value, key) => key === 'subcommand' || _.isUndefined(value) || (!_.isBoolean(value) && _.isEmpty(value))
+  (value, key) => key === 'subcommand' || _.isUndefined(value) || (_.isObject(value) && _.isEmpty(value))
 );
 
 /**
  * Shows a breakdown of the current config after CLI params, config file loaded & defaults applied.
- * @param {import('../types/types').ParsedArgs} preConfigParsedArgs - Parsed CLI args (or param to `init()`) before config & defaults applied
+ *
+ * The actual shape of `preConfigParsedArgs` and `defaults` does not matter for the purposes of this function,
+ * but it's intended to be called with values of type {@link ParsedArgs} and `DefaultValues<true>`, respectively.
+ *
+ * @param {object} preConfigParsedArgs - Parsed CLI args (or param to `init()`) before config & defaults applied
  * @param {import('./config-file').ReadConfigFileResult} configResult - Result of attempting to load a config file
- * @param {import('./schema/schema').DefaultValues<true>} defaults - Configuration defaults from schemas
+ * @param {object} defaults - Configuration defaults from schemas
  */
 function showConfig (preConfigParsedArgs, configResult, defaults) {
   console.log('Appium Configuration\n');
@@ -267,3 +271,7 @@ export {
   warnNodeDeprecations, validateTmpDir, getNonDefaultServerArgs,
   getGitRev, APPIUM_VER, updateBuildInfo, showConfig
 };
+
+/**
+ * @typedef {import('../types/types').ParsedArgs} ParsedArgs
+ */

--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -1,3 +1,6 @@
+// @ts-check
+
+/* eslint-disable no-console */
 import _ from 'lodash';
 import { mkdirp, system, fs } from '@appium/support';
 import axios from 'axios';
@@ -22,7 +25,7 @@ const BUILD_INFO = {
 };
 
 function getNodeVersion () {
-  return semver.coerce(process.version);
+  return /** @type {import('semver').SemVer} */(semver.coerce(process.version));
 }
 
 async function updateBuildInfo (useGithubApiFallback = false) {
@@ -42,7 +45,7 @@ async function updateBuildInfo (useGithubApiFallback = false) {
  *
  * This is needed because Appium cannot assume `package.json` and `.git` are in the same
  * directory.  Monorepos, see?
- * @returns {string|void} Path to dir or `undefined` if not found
+ * @returns {Promise<string|undefined>} Path to dir or `undefined` if not found
  */
 async function findGitRoot () {
   return await findUp(GIT_META_ROOT, {cwd: rootDir, type: 'directory'});
@@ -80,6 +83,11 @@ async function getGitRev (useGithubApiFallback = false) {
   return null;
 }
 
+/**
+ * @param {string} commitSha
+ * @param {boolean} [useGithubApiFallback]
+ * @returns {Promise<number?>}
+ */
 async function getGitTimestamp (commitSha, useGithubApiFallback = false) {
   const gitRoot = await findGitRoot();
   if (gitRoot) {
@@ -157,17 +165,17 @@ async function showBuildInfo () {
 function getNonDefaultServerArgs (args) {
   // hopefully these function names are descriptive enough
 
-  const typesDiffer = (dest) => typeof args[dest] !== typeof defaultsFromSchema[dest];
+  const typesDiffer = /** @param {string} dest */(dest) => typeof args[dest] !== typeof defaultsFromSchema[dest];
 
-  const defaultValueIsArray = (dest) => _.isArray(defaultsFromSchema[dest]);
+  const defaultValueIsArray = /** @param {string} dest */(dest) => _.isArray(defaultsFromSchema[dest]);
 
-  const argsValueIsArray = (dest) => _.isArray(args[dest]);
+  const argsValueIsArray = /** @param {string} dest */(dest) => _.isArray(args[dest]);
 
-  const arraysDiffer = (dest) => _.size(_.difference(args[dest], defaultsFromSchema[dest])) > 0;
+  const arraysDiffer = /** @param {string} dest */(dest) => _.gt(_.size(_.difference(args[dest], defaultsFromSchema[dest])), 0);
 
-  const valuesDiffer = (dest) => args[dest] !== defaultsFromSchema[dest];
+  const valuesDiffer = /** @param {string} dest */(dest) => args[dest] !== defaultsFromSchema[dest];
 
-  const defaultIsDefined = (dest) => !_.isUndefined(defaultsFromSchema[dest]);
+  const defaultIsDefined = /** @param {string} dest */(dest) => !_.isUndefined(defaultsFromSchema[dest]);
 
   // note that `_.overEvery` is like an "AND", and `_.overSome` is like an "OR"
 
@@ -209,6 +217,42 @@ function getNonDefaultServerArgs (args) {
   return _.pickBy(args, (__, key) => isNotDefault(key));
 }
 
+/**
+ * Compacts an object for {@link showConfig}:
+ * 1. Removes `subcommand` key/value
+ * 2. Removes `undefined` values
+ * 3. Removes empty objects (but not `false` values)
+ * Does not operate recursively.
+ */
+const compactConfig = _.partial(
+  _.omitBy,
+  _,
+  (value, key) => key === 'subcommand' || _.isUndefined(value) || (!_.isBoolean(value) && _.isEmpty(value))
+);
+
+/**
+ * Shows a breakdown of the current config after CLI params, config file loaded & defaults applied.
+ * @param {import('../types/types').ParsedArgs} preConfigParsedArgs - Parsed CLI args (or param to `init()`) before config & defaults applied
+ * @param {import('./config-file').ReadConfigFileResult} configResult - Result of attempting to load a config file
+ * @param {import('./schema/schema').DefaultValues<true>} defaults - Configuration defaults from schemas
+ */
+function showConfig (preConfigParsedArgs, configResult, defaults) {
+  console.log('Appium Configuration\n');
+  if (configResult.config) {
+    console.log(`via config file at ${configResult.filepath}:\n`);
+    console.dir(compactConfig(configResult.config));
+  } else {
+    console.log(`(no configuration file loaded)\n`);
+  }
+  console.log('via CLI or function call:\n');
+  console.dir(compactConfig(preConfigParsedArgs));
+  console.log('\nvia defaults:\n');
+  console.dir(compactConfig(defaults));
+}
+
+/**
+ * @param {string} tmpDir
+ */
 async function validateTmpDir (tmpDir) {
   try {
     await mkdirp(tmpDir);
@@ -221,5 +265,5 @@ async function validateTmpDir (tmpDir) {
 export {
   getBuildInfo, checkNodeOk, showBuildInfo,
   warnNodeDeprecations, validateTmpDir, getNonDefaultServerArgs,
-  getGitRev, APPIUM_VER, updateBuildInfo
+  getGitRev, APPIUM_VER, updateBuildInfo, showConfig
 };

--- a/packages/appium/lib/extension-config.js
+++ b/packages/appium/lib/extension-config.js
@@ -270,7 +270,7 @@ export default class ExtensionConfig {
   /**
    * Loads extension and returns its main class
    * @param {string} extName
-   * @returns {(...args: any[]) => object }
+   * @returns {import('type-fest').Class<unknown>}
    */
   require (extName) {
     const {mainClass} = this.installedExtensions[extName];

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -12,7 +12,7 @@ import { AppiumDriver } from './appium';
 import { driverConfig, pluginConfig, USE_ALL_PLUGINS } from './cli/args';
 import { runExtensionCommand } from './cli/extension';
 import { default as getParser, SERVER_SUBCOMMAND } from './cli/parser';
-import { APPIUM_VER, checkNodeOk, getGitRev, getNonDefaultServerArgs, showConfig, validateTmpDir, warnNodeDeprecations } from './config';
+import { APPIUM_VER, checkNodeOk, getGitRev, getNonDefaultServerArgs, showBuildInfo, validateTmpDir, warnNodeDeprecations } from './config';
 import { readConfigFile } from './config-file';
 import { DRIVER_TYPE, PLUGIN_TYPE } from './extension-config';
 import registerNode from './grid-register';
@@ -32,8 +32,8 @@ async function preflightChecks (args, throwInsteadOfExit = false) {
     if (args.longStacktrace) {
       require('longjohn').async_trace_limit = -1;
     }
-    if (args.showConfig) {
-      await showConfig();
+    if (args.showBuildInfo) {
+      await showBuildInfo();
       process.exit(0);
     }
     warnNodeDeprecations();

--- a/packages/appium/lib/schema/cli-args.js
+++ b/packages/appium/lib/schema/cli-args.js
@@ -98,11 +98,9 @@ function makeDescription (schema) {
  * as understood by `argparse`.
  * @param {AppiumJSONSchema} subSchema - JSON schema for the option
  * @param {ArgSpec} argSpec - Argument spec tuple
- * @param {SubSchemaToArgDefOptions} [opts] - Options
  * @returns {[string[], import('argparse').ArgumentOptions]} Tuple of flag and options
  */
-function subSchemaToArgDef (subSchema, argSpec, opts = {}) {
-  const {overrides = {}} = opts;
+function subSchemaToArgDef (subSchema, argSpec) {
   let {
     type,
     appiumCliAliases,
@@ -110,7 +108,7 @@ function subSchemaToArgDef (subSchema, argSpec, opts = {}) {
     enum: enumValues,
   } = subSchema;
 
-  const {name, arg, dest} = argSpec;
+  const {name, arg} = argSpec;
 
   const aliases = [
     aliasToFlag(argSpec),
@@ -228,16 +226,6 @@ function subSchemaToArgDef (subSchema, argSpec, opts = {}) {
     }
   }
 
-  // overrides override anything we computed here.  usually this involves "custom types",
-  // which are really just transform functions.
-  argOpts = _.merge(
-    argOpts,
-    /** should the override keys correspond to the prop name or the prop dest?
-     * the prop dest is computed by {@link aliasToDest}.
-     */
-    overrides[dest] ?? {},
-  );
-
   return [aliases, argOpts];
 }
 
@@ -245,31 +233,18 @@ function subSchemaToArgDef (subSchema, argSpec, opts = {}) {
  * Converts the finalized, flattened schema representation into
  * ArgumentDefinitions for handoff to `argparse`.
  *
- * @param {ToParserArgsOptions} opts - Options
  * @throws If schema has not been added to ajv (via `finalizeSchema()`)
  * @returns {import('../cli/args').ArgumentDefinitions} A map of arryas of
  * aliases to `argparse` arguments; empty if no schema found
  */
-export function toParserArgs (opts = {}) {
+export function toParserArgs () {
   const flattened = flattenSchema().filter(({schema}) => !schema.appiumCliIgnored);
   return new Map(
     _.map(flattened, ({schema, argSpec}) =>
-      subSchemaToArgDef(schema, argSpec, opts),
+      subSchemaToArgDef(schema, argSpec),
     ),
   );
 }
-
-/**
- * Options for {@link toParserArgs}
- * @typedef {SubSchemaToArgDefOptions} ToParserArgsOptions
- */
-
-/**
- * Options for {@link subSchemaToArgDef}.
- * @typedef {Object} SubSchemaToArgDefOptions
- * @property {string} [prefix] - The prefix to use for the flag, if any
- * @property {{[key: string]: import('argparse').ArgumentOptions}} [overrides] - An object of key/value pairs to override the default values
- */
 
 /**
  * @template T

--- a/packages/appium/lib/schema/cli-args.js
+++ b/packages/appium/lib/schema/cli-args.js
@@ -142,7 +142,8 @@ function subSchemaToArgDef (subSchema, argSpec, opts = {}) {
   switch (type) {
     // booleans do not have a type per `ArgumentOptions`, just an "action"
     case TYPENAMES.BOOLEAN: {
-      argOpts.action = 'store_true';
+      argOpts.action = 'store_const';
+      argOpts.const = true;
       break;
     }
 

--- a/packages/appium/test/cli/cli-helpers.js
+++ b/packages/appium/test/cli/cli-helpers.js
@@ -144,6 +144,14 @@ export const installLocalExtension = _.curry(
  */
 
 /**
+ * @typedef {import('../../lib/cli/npm').TeenProcessExecResult} TeenProcessExecResult
+ */
+
+/**
+ * @typedef {import('../../lib/cli/npm').TeenProcessExecError} TeenProcessExecError
+ */
+
+/**
  * Wraps the error returned by {@link exec}.
  * @typedef {Object} AppiumRunErrorProps
  * @property {string} originalMessage - Original error message

--- a/packages/appium/test/config-specs.js
+++ b/packages/appium/test/config-specs.js
@@ -177,6 +177,7 @@ describe('Config', function () {
       validateTmpDir('/private/if_you_run_with_sudo_this_wont_fail').should.be.rejectedWith(/could not ensure/);
     });
     it('should fail to use an undefined tmp dir', function () {
+      // @ts-expect-error
       validateTmpDir().should.be.rejectedWith(/could not ensure/);
     });
     it('should be able to use a tmp dir with correct permissions', function () {
@@ -200,7 +201,7 @@ describe('Config', function () {
     });
 
     it('should not fail if process.argv[1] is undefined', async function () {
-      process.argv[1] = undefined;
+      delete process.argv[1];
       let args = await getParser();
       args.prog.should.be.equal('appium');
     });

--- a/packages/appium/test/config-specs.js
+++ b/packages/appium/test/config-specs.js
@@ -2,19 +2,19 @@
 import _ from 'lodash';
 import sinon from 'sinon';
 import getParser from '../lib/cli/parser';
-import { checkNodeOk, getBuildInfo, getNonDefaultServerArgs, showConfig, validateTmpDir, warnNodeDeprecations } from '../lib/config';
+import { checkNodeOk, getBuildInfo, getNonDefaultServerArgs, showBuildInfo, validateTmpDir, warnNodeDeprecations } from '../lib/config';
 import logger from '../lib/logger';
 import { getDefaultsForSchema, resetSchema, registerSchema, finalizeSchema } from '../lib/schema/schema';
 
 describe('Config', function () {
   describe('Appium config', function () {
-    describe('showConfig', function () {
+    describe('showBuildInfo', function () {
       before(function () {
         sinon.spy(console, 'log');
       });
       it('should log the config to console', async function () {
         const config = getBuildInfo();
-        await showConfig();
+        await showBuildInfo();
         console.log.calledOnce.should.be.true; // eslint-disable-line no-console
         console.log.getCall(0).args[0].should.contain(JSON.stringify(config)); // eslint-disable-line no-console
       });

--- a/packages/appium/test/config-specs.js
+++ b/packages/appium/test/config-specs.js
@@ -22,9 +22,11 @@ describe('Config', function () {
   describe('Appium config', function () {
     /** @type {import('sinon').SinonSpy<[message?: any, ...extra: any[]],void>} */
     let log;
-
+    /** @type {import('sinon').SinonSpy<[message?: any, ...extra: any[]],void>} */
+    let dir;
     beforeEach(function () {
       log = sandbox.spy(console, 'log');
+      dir = sandbox.spy(console, 'dir');
     });
 
     describe('showBuildInfo()', function () {
@@ -39,14 +41,18 @@ describe('Config', function () {
     describe('showConfig', function () {
       describe('when a config file is present', function () {
         it('should dump the current Appium config', function () {
-          // @ts-expect-error
-          showConfig({foo: 'bar'}, {config: {baz: 'quux'}}, {spam: 'food'});
+          showConfig({foo: 'bar'}, {config: {server: {address: 'quux'}}}, {spam: 'food'});
           log.should.have.been.calledWith('Appium Configuration\n');
         });
+
+        it('should skip empty objects', function () {
+          showConfig({foo: 'bar', cows: {}, pigs: [], sheep: 0, ducks: false}, {config: {server: {address: 'quux'}}}, {spam: 'food'});
+          dir.should.have.been.calledWith({foo: 'bar', sheep: 0, ducks: false});
+        });
       });
+
       describe('when a config file is not present', function () {
         it('should dump the current Appium config sans config file contents', function () {
-          // @ts-expect-error
           showConfig({foo: 'bar'}, {}, {spam: 'food'});
           log.should.have.been.calledWith('(no configuration file loaded)\n');
         });

--- a/packages/appium/test/parser-specs.js
+++ b/packages/appium/test/parser-specs.js
@@ -94,7 +94,7 @@ describe('parser', function () {
       });
 
       it('should parse --allow-insecure correctly', function () {
-        p.parseArgs([]).should.have.property('allowInsecure', undefined);
+        p.parseArgs([]).should.not.have.property('allowInsecure');
         p.parseArgs(['--allow-insecure', '']).allowInsecure.should.eql([]);
         p.parseArgs(['--allow-insecure', 'foo']).allowInsecure.should.eql(['foo']);
         p.parseArgs(['--allow-insecure', 'foo,bar']).allowInsecure.should.eql(['foo', 'bar']);
@@ -102,7 +102,7 @@ describe('parser', function () {
       });
 
       it('should parse --deny-insecure correctly', function () {
-        p.parseArgs([]).should.have.property('denyInsecure', undefined);
+        p.parseArgs([]).should.not.have.property('denyInsecure');
         p.parseArgs(['--deny-insecure', '']).denyInsecure.should.eql([]);
         p.parseArgs(['--deny-insecure', 'foo']).denyInsecure.should.eql(['foo']);
         p.parseArgs(['--deny-insecure', 'foo,bar']).denyInsecure.should.eql(['foo', 'bar']);
@@ -161,7 +161,7 @@ describe('parser', function () {
 
       it('should not yet apply defaults', function () {
         const args = p.parseArgs([]);
-        args.driver.fake.should.eql({sillyWebServerHost: undefined, sillyWebServerPort: undefined});
+        args.should.not.have.property('driver');
       });
 
       it('should nicely handle extensions w/ dashes in them', async function () {

--- a/packages/appium/test/schema/cli-args-specs.js
+++ b/packages/appium/test/schema/cli-args-specs.js
@@ -40,10 +40,10 @@ describe('cli-args', function () {
             result = getArgs({schema, extName, extType});
           });
 
-          it('should return options containing `action` prop of `store_true` and no `type`', function () {
+          it('should return options containing `action` prop of `store_const` and no `type`', function () {
             expect(result['--plugin-blob-foo']).to.have.property(
               'action',
-              'store_true',
+              'store_const',
             );
           });
 

--- a/packages/appium/test/schema/cli-args-specs.js
+++ b/packages/appium/test/schema/cli-args-specs.js
@@ -20,7 +20,7 @@ describe('cli-args', function () {
         registerSchema(extType, extName, schema);
       }
       finalizeSchema();
-      return _.fromPairs([...toParserArgs(opts)]);
+      return _.fromPairs([...toParserArgs()]);
     }
 
     beforeEach(resetSchema);
@@ -341,32 +341,6 @@ describe('cli-args', function () {
               ['herp', 'derp'],
             );
           });
-        });
-      });
-
-      describe('overrides', function () {
-        // this might be better some other way, IDK.  I suspect this will be rarely used.
-        // since extensions can't actually call `toParserArgs()`, they can't set `overrides` anyway.
-        it('should set them via "dest" key', function () {
-          const schema = {
-            properties: {
-              foo: {
-                type: 'string',
-              },
-            },
-            type: 'object',
-          };
-
-          const result = getArgs({
-            schema,
-            extName,
-            extType,
-            overrides: {'plugin.blob.foo': {enum: ['slug', 'snail']}},
-          });
-          expect(result['--plugin-blob-foo']).to.have.deep.property('enum', [
-            'slug',
-            'snail',
-          ]);
         });
       });
     });

--- a/packages/appium/types/types.d.ts
+++ b/packages/appium/types/types.d.ts
@@ -160,7 +160,7 @@ interface MoreArgs {
   /**
    * If true, show the build info and exit
    */
-  showConfig: boolean;
+  showBuildInfo: boolean;
 
   /**
    * If true, open a REPL

--- a/packages/appium/types/types.d.ts
+++ b/packages/appium/types/types.d.ts
@@ -163,6 +163,11 @@ interface MoreArgs {
   showBuildInfo: boolean;
 
   /**
+   * If true, show config and exit
+   */
+  showConfig: boolean;
+
+  /**
    * If true, open a REPL
    */
   shell: boolean;


### PR DESCRIPTION
This adds a new CLI flag: `--show-config`.  When called, this will dump the values of a) arguments to the `init()` function of `main.js` _or_ args passed thru CLI, b) any config pulled from a config file, and c) the defaults as defined in schemas.

Each section is separated, and `undefined` values are omitted.

Instead of a JSON blob, the output just uses `console.dir()`.

To make this work, some refactors were needed:

- Use of `store_true` "action" for `argparse` in are now `store_const` with `const: true` because `store_true` sets the value to `false` if the flag is not present.  This essentially assigns the default value of the flag (`false`) before it should; default values must come from the schemas.
- Along those lines, removed default values from the "extra" boolean args in `args.js`
- The CLI parser now ignores `undefined` values of arguments

Other:

- Created some types for extension classes and added the `server` prop to `AppiumDriver`.
- Enabled TS checks on `lib/config.js` (where `showConfig()` lives) and `test/config-specs.js`
- Removed unnecessary call to `validate()` in `preflightChecks()`; CLI arguments are validated individually (defined in `lib/schema/cli-args.js`) and the config file is validated separately (defined in `lib/config-file.js`).
- Add more types to `main.js`; rewrite `getServerUpdaters` in lodashese for fun (which I am happy to revert)
- Fix missing type aliases in `test/cli/cli-helpers.js`
- Misc types/refactors in `config-specs.js`
- Update parser tests to reflect that `undefined` values and empty objects are eliminated from the parsed arguments

Notes:

- The `showBuildInfo()` test in `config-specs.js` (which is ostensibly a unit test) forks `git` and also seems to require network connectivity, at least on my box. This stuff should be stubbed out or moved into an E2E test.

Resolves #15672

* * *

BREAKING CHANGE:

The old `--show-config` is now `--show-build-info`.
