### PR TITLE
Mention -allowProvisioningUpdates flag in XCUITest docs for real devices (#16212)

### DIFF
--- a/docs/en/drivers/ios-xcuitest-real-devices.md
+++ b/docs/en/drivers/ios-xcuitest-real-devices.md
@@ -175,6 +175,10 @@ If this was successful, the output should end with something like:
         t =     0.00s     Start Test at 2017-01-23 15:49:12.588
         t =     0.00s     Set Up
 ```
+If the command fails, try passing the `-allowProvisioningUpdates` flag like this (see [#16212](https://github.com/appium/appium/issues/16212)):
+```
+    xcodebuild -project WebDriverAgent.xcodeproj -scheme WebDriverAgentRunner -destination 'id=<udid>' -allowProvisioningUpdates test
+```
 *   To completely verify, you can try accessing the WebDriverAgent server status
     (**note:** you _must_ be on the same network as the device, and know its IP
     address, from Settings => Wi-Fi => Current Network):


### PR DESCRIPTION
## Proposed changes

As per the discussion in #16212, I have added a small note to the XCUITest docs for real devices to try passing `-allowProvisioningUpdates` if the `xcodebuild` command fails.

As we're not sure whether that's related to the type of developer account used, I have not mentioned anything about that.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)

  I unfortunately can't as the site seems to be broken:

  ![image](https://user-images.githubusercontent.com/4048809/144935989-81ce6bc0-1fcd-455e-b05c-2a332347849b.png)
  
  Edit: It did work through the link by the bot.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
