### PR TITLE
chore: Revert "chore: Bump appium-mac2-driver from 0.14.1 to 1.0.1 (#16307)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "appium-geckodriver": "^0.x",
     "appium-ios-driver": "4.x",
     "appium-mac-driver": "1.x",
-    "appium-mac2-driver": "^1.x",
+    "appium-mac2-driver": "^0.x",
     "appium-safari-driver": "^2.1.0",
     "appium-support": "2.x",
     "appium-tizen-driver": "^1.1.1-beta.4",


### PR DESCRIPTION
This reverts commit 7b5a0a8f67d7d78c64d5694b7810c5932acc6c24.

## Proposed changes

We should not bump the major version of mac2 driver as it depends on appium2 components

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
