### PR TITLE
make --show-config better

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ examples/javascript-wd
 packages/*/build/**/*
 **/*.min.js
 sample-code
+**/*.d.ts

--- a/packages/appium/lib/config-file.js
+++ b/packages/appium/lib/config-file.js
@@ -113,10 +113,9 @@ export async function readConfigFile (filepath, opts = {}) {
     ? await loadConfigFile(lc, filepath)
     : await searchConfigFile(lc);
 
-  if (result && !result.isEmpty && result.filepath) {
-    const {normalize = true, pretty = true} = opts;
+  if (result?.filepath && !result?.isEmpty) {
+    const {pretty = true} = opts;
     try {
-      /** @type {ReadConfigFileResult} */
       let configResult;
       const errors = validate(result.config);
       if (_.isEmpty(errors)) {
@@ -131,12 +130,10 @@ export async function readConfigFile (filepath, opts = {}) {
           : {...result, errors};
       }
 
-      if (normalize) {
-        // normalize (to camel case) all top-level property names of the config file
-        configResult.config = normalizeConfig(
-          /** @type {AppiumConfig} */ (configResult.config),
-        );
-      }
+      // normalize (to camel case) all top-level property names of the config file
+      configResult.config = normalizeConfig(
+        /** @type {AppiumConfig} */ (configResult.config),
+      );
 
       return configResult;
     } finally {
@@ -152,11 +149,12 @@ export async function readConfigFile (filepath, opts = {}) {
  * @param {AppiumConfig} config - Configuration object
  * @returns {NormalizedAppiumConfig} New object with camel-cased keys (or `dest` keys).
  */
-function normalizeConfig (config) {
+export function normalizeConfig (config) {
   const schema = getSchema();
   /**
    * @param {AppiumConfig} config
    * @param {string} [section] - Keypath (lodash `_.get()` style) to section of config. If omitted, assume root Appium config schema
+   * @todo Rewrite as a loop
    * @returns Normalized section of config
    */
   const normalize = (config, section) => {
@@ -187,7 +185,7 @@ function normalizeConfig (config) {
  * @property {import('ajv').ErrorObject[]} [errors] - Validation errors
  * @property {string} [filepath] - The path to the config file, if found
  * @property {boolean} [isEmpty] - If `true`, the config file exists but is empty
- * @property {AppiumConfig} [config] - The parsed configuration
+ * @property {NormalizedAppiumConfig} [config] - The parsed configuration
  * @property {string|betterAjvErrors.IOutputError[]} [reason] - Human-readable error messages and suggestions. If the `pretty` option is `true`, this will be a nice string to print.
  */
 
@@ -195,7 +193,6 @@ function normalizeConfig (config) {
  * Options for {@link readConfigFile}.
  * @typedef {Object} ReadConfigFileOptions
  * @property {boolean} [pretty=true] If `false`, do not use color and fancy formatting in the `reason` property of the {@link ReadConfigFileResult}. The value of `reason` is then suitable for machine-reading.
- * @property {boolean} [normalize=true] If `false`, do not normalize key names to camel case.
  */
 
 /**

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -236,16 +236,17 @@ async function init (args) {
   if (preConfigParsedArgs.subcommand === SERVER_SUBCOMMAND) {
     defaults = getDefaultsForSchema(false);
 
-    if (preConfigParsedArgs.showConfig) {
-      showConfig(preConfigParsedArgs, configResult, defaults);
-      return {};
-    }
-
     parsedArgs = _.defaultsDeep(
       preConfigParsedArgs,
       configResult.config?.server,
       defaults
     );
+
+    if (preConfigParsedArgs.showConfig) {
+      showConfig(getNonDefaultServerArgs(preConfigParsedArgs), configResult, defaults, parsedArgs);
+      return {};
+    }
+
   } else {
     parsedArgs = preConfigParsedArgs;
   }

--- a/packages/appium/lib/schema/arg-spec.js
+++ b/packages/appium/lib/schema/arg-spec.js
@@ -176,7 +176,7 @@ export class ArgSpec {
   /**
    * When given the root ID of a schema for an extension (`<extType>-<normalizedExtName>.json`) Returns an object containing the extension type and the _normalized_ extension name.
    * @param {string} schemaId - Root schema ID
-   * @returns {{extType: ExtensionType|undefined, normalizedExtName: string|undefined}}
+   * @returns { {extType: ExtensionType|undefined, normalizedExtName: string|undefined} }
    */
   static extensionInfoFromRootSchemaId (schemaId) {
     const matches = schemaId.match(SCHEMA_ID_REGEXP);

--- a/packages/appium/lib/schema/schema.js
+++ b/packages/appium/lib/schema/schema.js
@@ -89,6 +89,7 @@ class AppiumSchema {
     _.bindAll(instance, [
       'finalize',
       'flatten',
+      'getAllArgSpecs',
       'getArgSpec',
       'getDefaults',
       'getDefaultsForExtension',
@@ -122,6 +123,10 @@ class AppiumSchema {
    */
   isFinalized () {
     return Boolean(this._finalizedSchemas);
+  }
+
+  getAllArgSpecs () {
+    return this._argSpecs;
   }
 
   /**
@@ -641,6 +646,7 @@ const appiumSchema = AppiumSchema.create();
 
 export const {
   registerSchema,
+  getAllArgSpecs,
   getArgSpec,
   hasArgSpec,
   isFinalized,

--- a/packages/appium/lib/schema/schema.js
+++ b/packages/appium/lib/schema/schema.js
@@ -403,7 +403,7 @@ class AppiumSchema {
   flatten () {
     const schema = this.getSchema();
 
-    /** @type {{properties: SchemaObject, prefix: string[]}[]} */
+    /** @type { {properties: SchemaObject, prefix: string[]}[] } */
     const stack = [{properties: schema.properties, prefix: []}];
     /** @type {FlattenedSchema} */
     const flattened = [];
@@ -678,7 +678,7 @@ export const {isAllowedSchemaFileExtension} = AppiumSchema;
  * A list of schemas associated with properties and their corresponding {@link ArgSpec} objects.
  *
  * Intermediate data structure used when converting the entire schema down to CLI arguments.
- * @typedef {{schema: SchemaObject, argSpec: ArgSpec}[]} FlattenedSchema
+ * @typedef { {schema: SchemaObject, argSpec: ArgSpec}[] } FlattenedSchema
  */
 
 /**

--- a/packages/appium/test/config-file-e2e-specs.js
+++ b/packages/appium/test/config-file-e2e-specs.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { readConfigFile } from '../lib/config-file';
+import { readConfigFile, normalizeConfig } from '../lib/config-file';
 import { finalizeSchema, registerSchema, resetSchema } from '../lib/schema/schema';
 import extSchema from './fixtures/driver.schema.js';
 import { resolveFixture } from './helpers';
@@ -45,12 +45,11 @@ describe('config file behavior', function () {
     resetSchema();
   });
 
+
   describe('when provided a path to a config file', function () {
     describe('when the config file is valid per the schema', function () {
       it('should return a valid config object', async function () {
-        const result = await readConfigFile(GOOD_FILEPATH, {
-          normalize: false,
-        });
+        const result = await readConfigFile(GOOD_FILEPATH);
         result.should.deep.equal({
           config: require(GOOD_FILEPATH),
           filepath: GOOD_FILEPATH,
@@ -61,9 +60,7 @@ describe('config file behavior', function () {
       describe('server.nodeconfig behavior', function () {
         describe('when a string', function () {
           it('should return errors', async function () {
-            const result = await readConfigFile(BAD_NODECONFIG_FILEPATH, {
-              normalize: false,
-            });
+            const result = await readConfigFile(BAD_NODECONFIG_FILEPATH);
             result.should.have.nested.property(
               'errors[0].instancePath',
               '/server/nodeconfig',
@@ -73,9 +70,7 @@ describe('config file behavior', function () {
 
         describe('when an object', function () {
           it('should return a valid config object', async function () {
-            const result = await readConfigFile(GOOD_FILEPATH, {
-              normalize: false,
-            });
+            const result = await readConfigFile(GOOD_FILEPATH);
             result.should.have.property('errors').that.is.empty;
           });
         });
@@ -84,9 +79,7 @@ describe('config file behavior', function () {
       describe('server.allow-insecure behavior', function () {
         describe('when a string path', function () {
           it('should return errors', async function () {
-            const result = await readConfigFile(SECURITY_PATH_FILEPATH, {
-              normalize: false,
-            });
+            const result = await readConfigFile(SECURITY_PATH_FILEPATH);
             result.should.have.nested.property(
               'errors[0].instancePath',
               '/server/allow-insecure',
@@ -96,9 +89,7 @@ describe('config file behavior', function () {
 
         describe('when a comma-delimited string', function () {
           it('should return errors', async function () {
-            const result = await readConfigFile(SECURITY_DELIMITED_FILEPATH, {
-              normalize: false,
-            });
+            const result = await readConfigFile(SECURITY_DELIMITED_FILEPATH);
             result.should.have.nested.property(
               'errors[0].instancePath',
               '/server/allow-insecure',
@@ -108,9 +99,7 @@ describe('config file behavior', function () {
 
         describe('when an array', function () {
           it('should return a valid config object', async function () {
-            const result = await readConfigFile(SECURITY_ARRAY_FILEPATH, {
-              normalize: false,
-            });
+            const result = await readConfigFile(SECURITY_ARRAY_FILEPATH);
             result.should.deep.equal({
               config: require(SECURITY_ARRAY_FILEPATH),
               filepath: SECURITY_ARRAY_FILEPATH,
@@ -124,10 +113,8 @@ describe('config file behavior', function () {
     describe('when the config file is invalid per the schema', function () {
       describe('without extensions', function () {
         it('should return an object containing errors', async function () {
-          const result = await readConfigFile(BAD_FILEPATH, {
-            normalize: false,
-          });
-          result.should.have.deep.property('config', require(BAD_FILEPATH));
+          const result = await readConfigFile(BAD_FILEPATH);
+          result.should.have.deep.property('config', normalizeConfig(require(BAD_FILEPATH)));
           result.should.have.property('filepath', BAD_FILEPATH);
           result.should.have.deep.property('errors').that.contains.members([
             {
@@ -235,9 +222,7 @@ describe('config file behavior', function () {
 
         describe('when provided a config file with unknown properties', function () {
           beforeEach(async function () {
-            result = await readConfigFile(UNKNOWN_PROPS_FILEPATH, {
-              normalize: false,
-            });
+            result = await readConfigFile(UNKNOWN_PROPS_FILEPATH);
           });
           it('should return an object containing errors', function () {
             result.should.have.deep.property('errors', [
@@ -256,9 +241,7 @@ describe('config file behavior', function () {
 
         describe('when provided a config file with valid properties', function () {
           beforeEach(async function () {
-            result = await readConfigFile(EXT_PROPS_FILEPATH, {
-              normalize: false,
-            });
+            result = await readConfigFile(EXT_PROPS_FILEPATH);
           });
           it('should return an object containing no errors', function () {
             result.should.have.deep.property('errors', []);


### PR DESCRIPTION
Ref: #16340

This fixes some shortcomings of `--show-config` where the result is basically just kind of unclear.


Using command `appium --driver-xcuitest-webdriveragent-port=1234 --show-config`, here's  the "before" behavior:

```
Appium Configuration

(no configuration file loaded)

via CLI or function call:

{ driver: { xcuitest: { wdaLocalPort: 1234 } }, showConfig: true }

via defaults:

{
  address: '0.0.0.0',
  allowCors: false,
  basePath: '',
  callbackPort: 4723,
  debugLogSpacing: false,
  keepAliveTimeout: 600,
  localTimezone: false,
  loglevel: 'debug',
  logNoColors: false,
  logTimestamp: false,
  longStacktrace: false,
  noPermsCheck: false,
  port: 4723,
  relaxedSecurityEnabled: false,
  sessionOverride: false,
  strictCaps: false,
  driver: {
    fake: { sillyWebServerHost: 'sillyhost' },
    xcuitest: { wdaLocalPort: 8100, webkitDebugProxyPort: 27753 }
  }
}
```

and here's the "after" behavior:

```Appium Configuration

from defaults:

{
  address: '0.0.0.0',
  allowCors: false,
  basePath: '',
  callbackPort: 4723,
  debugLogSpacing: false,
  keepAliveTimeout: 600,
  localTimezone: false,
  loglevel: 'debug',
  logNoColors: false,
  logTimestamp: false,
  longStacktrace: false,
  noPermsCheck: false,
  port: 4723,
  relaxedSecurityEnabled: false,
  sessionOverride: false,
  strictCaps: false,
  driver: {
    fake: { sillyWebServerHost: 'sillyhost' },
    xcuitest: { wdaLocalPort: 8100, webkitDebugProxyPort: 27753 }
  }
}

(no configuration file loaded)

via CLI or function call:

{ driver: { xcuitest: { wdaLocalPort: 1234 } } }

final configuration:

{
  address: '0.0.0.0',
  port: 4723,
  driver: {
    xcuitest: { wdaLocalPort: 1234, webkitDebugProxyPort: 27753 },
    fake: { sillyWebServerHost: 'sillyhost' }
  },
  showConfig: true,
  allowCors: false,
  basePath: '',
  callbackPort: 4723,
  debugLogSpacing: false,
  keepAliveTimeout: 600,
  localTimezone: false,
  loglevel: 'debug',
  logNoColors: false,
  logTimestamp: false,
  longStacktrace: false,
  noPermsCheck: false,
  relaxedSecurityEnabled: false,
  sessionOverride: false,
  strictCaps: false
}

```