### PR TITLE
refactor: Allow any of createSession arguments to be W3C capabilities object

### DIFF
--- a/packages/base-driver/lib/basedriver/capabilities.js
+++ b/packages/base-driver/lib/basedriver/capabilities.js
@@ -24,6 +24,26 @@ function mergeCaps (primary = {}, secondary = {}) {
   return result;
 }
 
+function isW3cCaps (caps) {
+  if (!_.isPlainObject(caps)) {
+    return false;
+  }
+
+  const isFirstMatchValid = () => _.isArray(caps.firstMatch)
+    && !_.isEmpty(caps.firstMatch) && _.every(caps.firstMatch, _.isPlainObject);
+  const isAlwaysMatchValid = () => _.isPlainObject(caps.alwaysMatch);
+  if (_.has(caps, 'firstMatch') && _.has(caps, 'alwaysMatch')) {
+    return isFirstMatchValid() && isAlwaysMatchValid();
+  }
+  if (_.has(caps, 'firstMatch')) {
+    return isFirstMatchValid();
+  }
+  if (_.has(caps, 'alwaysMatch')) {
+    return isAlwaysMatchValid();
+  }
+  return false;
+}
+
 // Validates caps against a set of constraints
 function validateCaps (caps, constraints = {}, opts = {}) {
 
@@ -272,4 +292,5 @@ function promoteAppiumOptions (originalCaps) {
 export {
   parseCaps, processCapabilities, validateCaps, mergeCaps, APPIUM_VENDOR_PREFIX, APPIUM_OPTS_CAP,
   findNonPrefixedCaps, isStandardCap, stripAppiumPrefixes, promoteAppiumOptions, PREFIXED_APPIUM_OPTS_CAP,
+  isW3cCaps,
 };

--- a/packages/base-driver/test/basedriver/capabilities-specs.js
+++ b/packages/base-driver/test/basedriver/capabilities-specs.js
@@ -1,5 +1,7 @@
-import { parseCaps, validateCaps, mergeCaps, processCapabilities, findNonPrefixedCaps,
-         promoteAppiumOptions, APPIUM_OPTS_CAP, stripAppiumPrefixes } from '../../lib/basedriver/capabilities';
+import {
+  parseCaps, validateCaps, mergeCaps, processCapabilities, findNonPrefixedCaps,
+  promoteAppiumOptions, APPIUM_OPTS_CAP, stripAppiumPrefixes, isW3cCaps
+} from '../../lib/basedriver/capabilities';
 import _ from 'lodash';
 import { desiredCapabilityConstraints } from '../../lib/basedriver/desired-caps';
 
@@ -500,6 +502,35 @@ describe('caps', function () {
         ...simpleCaps,
         foo: 'baz',
       });
+    });
+  });
+
+  describe('#isW3cCaps', function () {
+    it('should drop invalid W3C capabilities', function () {
+      for (const invalidCaps of [
+        null, undefined, [], {},
+        {firstMatch: null},
+        {firtMatch: [{}]},
+        {alwaysMatch: null},
+        {firstMatch: [{}], alwaysMatch: null},
+        {firstMatch: [], alwaysMatch: {}},
+        {firstMatch: []},
+        {firstMatch: {}},
+        {alwaysMatch: []},
+      ]) {
+        isW3cCaps(invalidCaps).should.be.false;
+      }
+    });
+
+    it('should accept valid W3C capabilities', function () {
+      for (const validCaps of [
+        {firstMatch: [{}]},
+        {firstMatch: [{}], alaysMatch: {}},
+        {firtMatch: [{}], alwaysMatch: {}},
+        {alwaysMatch: {}},
+      ]) {
+        isW3cCaps(validCaps).should.be.true;
+      }
     });
   });
 });

--- a/packages/base-driver/test/basedriver/capability-specs.js
+++ b/packages/base-driver/test/basedriver/capability-specs.js
@@ -17,7 +17,9 @@ describe('Desired Capabilities', function () {
 
   it('should require platformName and deviceName', async function () {
     try {
-      await d.createSession(null, null, {});
+      await d.createSession({
+        firstMatch: [{}]
+      });
     } catch (e) {
       e.should.be.instanceof(errors.SessionNotCreatedError);
       e.message.should.contain('platformName');
@@ -30,7 +32,11 @@ describe('Desired Capabilities', function () {
 
   it('should require platformName', async function () {
     try {
-      await d.createSession(null, null, {'deviceName': 'Delorean'});
+      await d.createSession({
+        alwaysMatch: {
+          'appium:deviceName': 'Delorean'
+        }
+      });
     } catch (e) {
       e.should.be.instanceof(errors.SessionNotCreatedError);
       e.message.should.contain('platformName');
@@ -353,28 +359,36 @@ describe('Desired Capabilities', function () {
       }
     }).should.eventually.be.rejectedWith(/blank/);
 
-    await d.createSession(null, null, {
-      platformName: 'iOS',
-      'appium:deviceName': 'Dumb',
-      'appium:foo': ''
+    await d.createSession(null, {
+      alwaysMatch: {
+        platformName: 'iOS',
+        'appium:deviceName': 'Dumb',
+        'appium:foo': ''
+      }
     }).should.eventually.be.rejectedWith(/blank/);
 
-    await d.createSession(null, null, {
-      platformName: 'iOS',
-      'appium:deviceName': 'Dumb',
-      'appium:foo': {}
+    await d.createSession({
+      firstMatch: [{
+        platformName: 'iOS',
+        'appium:deviceName': 'Dumb',
+        'appium:foo': {}
+      }]
     }).should.eventually.be.rejectedWith(/blank/);
 
-    await d.createSession(null, null, {
-      platformName: 'iOS',
-      'appium:deviceName': 'Dumb',
-      'appium:foo': []
+    await d.createSession({
+      alwaysMatch: {
+        platformName: 'iOS',
+        'appium:deviceName': 'Dumb',
+        'appium:foo': []
+      }
     }).should.eventually.be.rejectedWith(/blank/);
 
-    await d.createSession(null, null, {
-      platformName: 'iOS',
-      'appium:deviceName': 'Dumb',
-      'appium:foo': '  '
+    await d.createSession({
+      alwaysMatch: {
+        platformName: 'iOS',
+        'appium:deviceName': 'Dumb',
+        'appium:foo': '  '
+      }
     }).should.eventually.be.rejectedWith(/blank/);
   });
 


### PR DESCRIPTION
## Proposed changes

Historically the first two arguments were reserved for JSONWP capabilities.
Appium 2 has dropped the support of these, so now we only accept capability objects in W3C format and thus allow any of the three arguments to represent the latter.

## Types of changes

What types of changes does your code introduce to Appium?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
