### PR TITLE
feat(base-driver): Add the size validation of the passed settings object

### DIFF
--- a/packages/base-driver/lib/basedriver/device-settings.js
+++ b/packages/base-driver/lib/basedriver/device-settings.js
@@ -1,5 +1,9 @@
 import _ from 'lodash';
 import log from './logger';
+import { node, util } from '@appium/support';
+import { errors } from '../protocol/errors';
+
+const MAX_SETTINGS_SIZE = 20 * 1024 * 1024; // 20 MB
 
 class DeviceSettings {
 
@@ -11,9 +15,14 @@ class DeviceSettings {
   // calls updateSettings from implementing driver every time a setting is changed.
   async update (newSettings) {
     if (!_.isPlainObject(newSettings)) {
-      throw new Error(`Settings update should be called with valid JSON. Got ` +
+      throw new errors.InvalidArgumentError(`Settings update should be called with valid JSON. Got ` +
         `${JSON.stringify(newSettings)} instead`);
     }
+    if (node.getObjectSize({...this._settings, ...newSettings}) >= MAX_SETTINGS_SIZE) {
+      throw new errors.InvalidArgumentError(`New settings cannot be applied, because the overall ` +
+        `object size exceeds the allowed limit of ${util.toReadableSizeString(MAX_SETTINGS_SIZE)}`);
+    }
+
     for (const prop of _.keys(newSettings)) {
       if (!_.isUndefined(this._settings[prop])) {
         if (this._settings[prop] === newSettings[prop]) {

--- a/packages/support/test/node-specs.js
+++ b/packages/support/test/node-specs.js
@@ -1,0 +1,21 @@
+import { node } from '../lib';
+
+describe('node utilities', function () {
+  describe('getObjectSize', function () {
+    it('should be able to calculate size of different object types', function () {
+      node.getObjectSize(1).should.eql(8);
+      node.getObjectSize(true).should.eql(4);
+      node.getObjectSize('yolo').should.eql(8);
+      node.getObjectSize(null).should.eql(0);
+      node.getObjectSize({}).should.eql(0);
+      node.getObjectSize(Buffer.from([1, 2, 3])).should.eql(3);
+      node.getObjectSize({
+        'a': 1,
+        'b': 2,
+        'c': {
+          'd': 4,
+        }
+      }).should.eql(32);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

In theory Appium allows to pass data chunks up to 1GB as POST request body. Also, every time these settings are added they get appended into the existing object and stored inside the driver. This change prevents settings to reach 20MB limit and potentially abuse driver memory usage.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
