### PR TITLE
fix: Update property name after lru-cache package bump

### DIFF
--- a/packages/base-driver/lib/basedriver/helpers.js
+++ b/packages/base-driver/lib/basedriver/helpers.js
@@ -35,7 +35,7 @@ const DEFAULT_BASENAME = 'appium-app';
 const APP_DOWNLOAD_TIMEOUT_MS = 120 * 1000;
 
 process.on('exit', () => {
-  if (APPLICATIONS_CACHE.itemCount === 0) {
+  if (APPLICATIONS_CACHE.size === 0) {
     return;
   }
 


### PR DESCRIPTION
## Proposed changes

In the recent version of lru-cache ItemCount property has been renamed to size

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
