### PR TITLE
test(base-driver): replace direct calls to sinon with a sandbox

### DIFF
--- a/packages/base-driver/test/basedriver/capability-specs.js
+++ b/packages/base-driver/test/basedriver/capability-specs.js
@@ -1,18 +1,20 @@
 import { default as BaseDriver, errors } from '../../lib';
 import logger from '../../lib/basedriver/logger';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 
 
 describe('Desired Capabilities', function () {
   let d;
+  let sandbox;
 
   beforeEach(function () {
     d = new BaseDriver();
-    sinon.spy(logger, 'warn');
+    sandbox = createSandbox();
+    sandbox.spy(logger, 'warn');
   });
 
   afterEach(function () {
-    logger.warn.restore();
+    sandbox.restore();
   });
 
   it('should require platformName and deviceName', async function () {


### PR DESCRIPTION
This is safer, because test failures can happen due to lack of isolation and order in which tests are executed
