### PR TITLE
fix(appium): Increase the default limit of process listeners

### DIFF
--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -292,6 +292,10 @@ async function init (args) {
  * @returns {Promise<import('express').Express|undefined>}
  */
 async function main (args) {
+  // Appium drivers often use process events to schedule proper exit cleanup
+  // The default value of 10 causes an ugly warning to appear in logs on server startup
+  process.setMaxListeners(100);
+
   const {appiumDriver, parsedArgs} = await init(args);
 
   if (!appiumDriver || !parsedArgs) {


### PR DESCRIPTION
## Proposed changes

Appium drivers often use process events to schedule proper exit cleanup
The default value of 10 causes an ugly warning to appear in logs on server startup:
```
(node:4972) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [process]. Use emitter.setMaxListeners() to increase limit
(Use `node --trace-warnings ...` to show where the warning was created)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
