### PR TITLE
Move mocha.opts into package.json

### DIFF
--- a/sample-code/javascript-wd/package.json
+++ b/sample-code/javascript-wd/package.json
@@ -6,6 +6,10 @@
     "test": "mocha test/**/*.test.js",
     "clean": "rm -rf node_modules && rm -f package-lock.json && npm install"
   },
+  "mocha": {
+    "require": "@babel/register",
+    "timeout": "1800000"
+  },
   "author": "Dan Graham",
   "license": "Apache-2.0",
   "engines": {

--- a/sample-code/javascript-wd/test/mocha.opts
+++ b/sample-code/javascript-wd/test/mocha.opts
@@ -1,2 +1,0 @@
---require @babel/register
---timeout 1800000


### PR DESCRIPTION
## Proposed changes
As per https://github.com/appium/appium/pull/15149 mocha.opts is no longer supported since mocha 8.0.0
This PR makes the same change to the `wd` sample code.

Prior to this change running `npm test` in `sample-code/javascript-wd` would fail with 
```
import wd from 'wd';
^^^^^^

SyntaxError: Cannot use import statement outside a module
```
As reported here https://github.com/appium/appium/issues/13860#issuecomment-891663244
## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
