### PR TITLE
chore: ban direct usage of sinon

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,29 @@
       "parserOptions": {
         "sourceType": "script"
       }
+    },
+    {
+      "files": "./packages/*/test/**/*.js",
+      "rules": {
+        "no-restricted-properties": [
+          "error", 
+          {
+            "object": "sinon",
+            "property": "spy",
+            "message": "Use `sandbox = sinon.createSandbox()` and `sandbox.spy()` instead. Don't forget to call `sandbox.restore()` in `afterEach`"
+          },
+          {
+            "object": "sinon",
+            "property": "stub",
+            "message": "Use `sandbox = sinon.createSandbox()` and `sandbox.stub()` instead. Don't forget to call `sandbox.restore()` in `afterEach`"
+          },
+          {
+            "object": "sinon",
+            "property": "mock",
+            "message": "Use `sandbox = sinon.createSandbox()` and `sandbox.mock()` instead. Don't forget to call `sandbox.restore()` in `afterEach`"
+          }
+        ] 
+      }
     }
   ]
 }

--- a/packages/appium/test/e2e/config.e2e.spec.js
+++ b/packages/appium/test/e2e/config.e2e.spec.js
@@ -1,4 +1,4 @@
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import {
   getGitRev,
   getBuildInfo,
@@ -10,6 +10,16 @@ import { fs } from '@appium/support';
 
 
 describe('Config', function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   describe('getGitRev', function () {
     it('should get a reasonable git revision', async function () {
       let rev = await getGitRev();
@@ -34,8 +44,8 @@ describe('Config', function () {
     let mockFs;
     let getStub;
     beforeEach(function () {
-      mockFs = sinon.mock(fs);
-      getStub = sinon.stub(axios, 'get');
+      mockFs = sandbox.mock(fs);
+      getStub = sandbox.stub(axios, 'get');
     });
     afterEach(function () {
       getStub.restore();

--- a/packages/appium/test/e2e/driver.e2e.spec.js
+++ b/packages/appium/test/e2e/driver.e2e.spec.js
@@ -13,7 +13,7 @@ import { BaseDriver } from '@appium/base-driver';
 import { loadExtensions } from '../../lib/extension';
 import { runExtensionCommand } from '../../lib/cli/extension';
 import { removeAppiumPrefixes } from '../../lib/utils';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import { tempDir, fs } from '@appium/support';
 
 const should = chai.should();
@@ -50,7 +50,10 @@ describe('FakeDriver - via HTTP', function () {
   /** @type {string} */
   let testServerBaseSessionUrl;
 
+  let sandbox;
+
   before(async function () {
+    sandbox = createSandbox();
     appiumHome = await tempDir.openDir();
     wdOpts.port = port = await getTestPort();
     testServerBaseUrl = `http://${TEST_HOST}:${port}`;
@@ -77,6 +80,7 @@ describe('FakeDriver - via HTTP', function () {
   after(async function () {
     await serverClose();
     await fs.rimraf(appiumHome);
+    sandbox.restore();
   });
 
   /**
@@ -329,7 +333,7 @@ describe('FakeDriver - via HTTP', function () {
           },
         },
       };
-      const createSessionStub = sinon.stub(FakeDriver.prototype, 'createSession').callsFake(async function (jsonwpCaps) {
+      const createSessionStub = sandbox.stub(FakeDriver.prototype, 'createSession').callsFake(async function (jsonwpCaps) {
         const res = await BaseDriver.prototype.createSession.call(this, jsonwpCaps);
         this.protocol.should.equal('MJSONWP');
         return res;

--- a/packages/base-driver/test/basedriver/commands/log-specs.js
+++ b/packages/base-driver/test/basedriver/commands/log-specs.js
@@ -1,5 +1,5 @@
 import logCommands from '../../../lib/basedriver/commands/log';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import _ from 'lodash';
 
 
@@ -19,11 +19,19 @@ const SUPPORTED_LOG_TYPES = {
 };
 
 describe('log commands -', function () {
+  let sandbox;
+
   beforeEach(function () {
+    sandbox = createSandbox();
     // reset the supported log types
     logCommands.supportedLogTypes = {};
     logCommands.log = {debug: _.noop};
   });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   describe('getLogTypes', function () {
     it('should return empty array when no supported log types', async function () {
       (await logCommands.getLogTypes()).should.eql([]);
@@ -35,8 +43,8 @@ describe('log commands -', function () {
   });
   describe('getLog', function () {
     beforeEach(function () {
-      sinon.spy(SUPPORTED_LOG_TYPES.one, 'getter');
-      sinon.spy(SUPPORTED_LOG_TYPES.two, 'getter');
+      sandbox.spy(SUPPORTED_LOG_TYPES.one, 'getter');
+      sandbox.spy(SUPPORTED_LOG_TYPES.two, 'getter');
     });
     afterEach(function () {
       SUPPORTED_LOG_TYPES.one.getter.restore();

--- a/packages/base-driver/test/basedriver/driver-tests.js
+++ b/packages/base-driver/test/basedriver/driver-tests.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import B from 'bluebird';
 import { DeviceSettings } from '../../lib';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 
 
 // wrap these tests in a function so we can export the tests and re-use them
@@ -10,10 +10,14 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
   // to display the driver under test in report
   const className = DriverClass.name || '(unknown driver)';
 
+
   describe(`BaseDriver (as ${className})`, function () {
     let d, w3cCaps;
 
+    let sandbox;
+
     beforeEach(function () {
+      sandbox = createSandbox();
       d = new DriverClass();
       w3cCaps = {
         alwaysMatch: Object.assign({}, defaultCaps, {
@@ -25,6 +29,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
     });
     afterEach(async function () {
       await d.deleteSession();
+      sandbox.restore();
     });
 
     it('should report the version of BaseDriver used', function () {
@@ -345,7 +350,7 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
 
       describe('#proxyRouteIsAvoided', function () {
         it('should validate form of avoidance list', function () {
-          const avoidStub = sinon.stub(d, 'getProxyAvoidList');
+          const avoidStub = sandbox.stub(d, 'getProxyAvoidList');
           avoidStub.returns([['POST', /\/foo/], ['GET']]);
           (() => { d.proxyRouteIsAvoided(); }).should.throw;
           avoidStub.returns([['POST', /\/foo/], ['GET', /^foo/, 'bar']]);
@@ -353,31 +358,31 @@ function baseDriverUnitTests (DriverClass, defaultCaps = {}) {
           avoidStub.restore();
         });
         it('should reject bad http methods', function () {
-          const avoidStub = sinon.stub(d, 'getProxyAvoidList');
+          const avoidStub = sandbox.stub(d, 'getProxyAvoidList');
           avoidStub.returns([['POST', /^foo/], ['BAZETE', /^bar/]]);
           (() => { d.proxyRouteIsAvoided(); }).should.throw;
           avoidStub.restore();
         });
         it('should reject non-regex routes', function () {
-          const avoidStub = sinon.stub(d, 'getProxyAvoidList');
+          const avoidStub = sandbox.stub(d, 'getProxyAvoidList');
           avoidStub.returns([['POST', /^foo/], ['GET', '/bar']]);
           (() => { d.proxyRouteIsAvoided(); }).should.throw;
           avoidStub.restore();
         });
         it('should return true for routes in the avoid list', function () {
-          const avoidStub = sinon.stub(d, 'getProxyAvoidList');
+          const avoidStub = sandbox.stub(d, 'getProxyAvoidList');
           avoidStub.returns([['POST', /^\/foo/]]);
           d.proxyRouteIsAvoided(null, 'POST', '/foo/bar').should.be.true;
           avoidStub.restore();
         });
         it('should strip away any wd/hub prefix', function () {
-          const avoidStub = sinon.stub(d, 'getProxyAvoidList');
+          const avoidStub = sandbox.stub(d, 'getProxyAvoidList');
           avoidStub.returns([['POST', /^\/foo/]]);
           d.proxyRouteIsAvoided(null, 'POST', '/foo/bar').should.be.true;
           avoidStub.restore();
         });
         it('should return false for routes not in the avoid list', function () {
-          const avoidStub = sinon.stub(d, 'getProxyAvoidList');
+          const avoidStub = sandbox.stub(d, 'getProxyAvoidList');
           avoidStub.returns([['POST', /^\/foo/]]);
           d.proxyRouteIsAvoided(null, 'GET', '/foo/bar').should.be.false;
           d.proxyRouteIsAvoided(null, 'POST', '/boo').should.be.false;

--- a/packages/base-driver/test/basedriver/timeout-specs.js
+++ b/packages/base-driver/test/basedriver/timeout-specs.js
@@ -1,22 +1,17 @@
 import BaseDriver from '../../lib';
-import sinon from 'sinon';
-
-
-
+import { createSandbox } from 'sinon';
 
 describe('timeout', function () {
   let driver = new BaseDriver();
-  let implicitWaitSpy, newCommandTimeoutSpy;
-  before(function () {
-    implicitWaitSpy = sinon.spy(driver, 'setImplicitWait');
-    newCommandTimeoutSpy = sinon.spy(driver, 'setNewCommandTimeout');
-  });
+  let implicitWaitSpy;
+  let sandbox;
   beforeEach(function () {
+    sandbox = createSandbox();
     driver.implicitWaitMs = 0;
+    implicitWaitSpy = sandbox.spy(driver, 'setImplicitWait');
   });
   afterEach(function () {
-    implicitWaitSpy.resetHistory();
-    newCommandTimeoutSpy.resetHistory();
+    sandbox.restore();
   });
   describe('timeouts', function () {
     describe('errors', function () {

--- a/packages/base-driver/test/express/server-e2e-specs.js
+++ b/packages/base-driver/test/express/server-e2e-specs.js
@@ -2,7 +2,7 @@
 
 import { server } from '../../lib';
 import axios from 'axios';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import B from 'bluebird';
 import _ from 'lodash';
 import {TEST_HOST, getTestPort} from '../helpers';
@@ -10,11 +10,11 @@ import {TEST_HOST, getTestPort} from '../helpers';
 
 describe('server', function () {
   let hwServer;
-  let errorStub;
   let port;
+  let sandbox;
   before(async function () {
     port = await getTestPort(true);
-    errorStub = sinon.stub(console, 'error');
+
     function configureRoutes (app) {
       app.get('/', (req, res) => {
         res.header['content-type'] = 'text/html';
@@ -37,9 +37,15 @@ describe('server', function () {
       port,
     });
   });
+  beforeEach(function () {
+    sandbox = createSandbox();
+    sandbox.stub(console, 'error');
+  });
   after(async function () {
     await hwServer.close();
-    errorStub.restore();
+  });
+  afterEach(function () {
+    sandbox.restore();
   });
 
   it('should start up with our middleware', async function () {

--- a/packages/base-driver/test/express/server-specs.js
+++ b/packages/base-driver/test/express/server-specs.js
@@ -2,23 +2,8 @@
 
 import { server, routeConfiguringFunction } from '../../lib';
 import { configureServer, normalizeBasePath } from '../../lib/express/server';
-import sinon from 'sinon';
-import {getTestPort} from '../helpers';
-
-function fakeApp () {
-  const app = {
-    use: sinon.spy(),
-    all: sinon.spy(),
-    get: sinon.spy(),
-    post: sinon.spy(),
-    delete: sinon.spy(),
-    totalCount: () => (
-      app.use.callCount + app.all.callCount + app.get.callCount + app.post.callCount +
-      app.delete.callCount
-    )
-  };
-  return app;
-}
+import { createSandbox } from 'sinon';
+import { getTestPort } from '../helpers';
 
 const newMethodMap = {
   '/session/:sessionId/fake': {
@@ -39,8 +24,33 @@ function fakeDriver () {
 describe('server configuration', function () {
   let port;
 
+  let sandbox;
+
+  function fakeApp () {
+    const app = {
+      use: sandbox.spy(),
+      all: sandbox.spy(),
+      get: sandbox.spy(),
+      post: sandbox.spy(),
+      delete: sandbox.spy(),
+      totalCount: () => (
+        app.use.callCount + app.all.callCount + app.get.callCount + app.post.callCount +
+        app.delete.callCount
+      )
+    };
+    return app;
+  }
+
   before(async function () {
     port = await getTestPort(true);
+  });
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
   });
 
   it('should actually use the middleware', function () {

--- a/packages/base-driver/test/express/static-specs.js
+++ b/packages/base-driver/test/express/static-specs.js
@@ -1,14 +1,22 @@
 // transpile:mocha
 
 import { welcome } from '../../lib/express/static';
-import sinon from 'sinon';
-
-
+import { createSandbox } from 'sinon';
 
 describe('welcome', function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   it('should fill the template', async function () {
     let res = {
-      send: sinon.spy()
+      send: sandbox.stub()
     };
     await welcome({}, res);
 

--- a/packages/base-driver/test/protocol/protocol-e2e-specs.js
+++ b/packages/base-driver/test/protocol/protocol-e2e-specs.js
@@ -5,7 +5,7 @@ import {
 } from '../../lib';
 import { FakeDriver } from './fake-driver';
 import axios from 'axios';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import { StatusCodes as HTTPStatusCodes } from 'http-status-codes';
 import { createProxyServer } from './helpers';
 import {
@@ -17,6 +17,15 @@ let port;
 let baseUrl;
 
 describe('Protocol', function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
 
   before(async function () {
     port = await getTestPort();
@@ -363,7 +372,7 @@ describe('Protocol', function () {
         sessionId = data.value.sessionId;
       });
       it('should raise an error if the driver does not support W3C yet', async function () {
-        const createSessionStub = sinon.stub(driver, 'createSession').callsFake(function (capabilities) {
+        const createSessionStub = sandbox.stub(driver, 'createSession').callsFake(function (capabilities) {
           driver.sessionId = null;
           return BaseDriver.prototype.createSession.call(driver, capabilities);
         });
@@ -505,7 +514,7 @@ describe('Protocol', function () {
         });
 
         it(`should fail with a 408 error if it throws a TimeoutError exception`, async function () {
-          let setUrlStub = sinon.stub(driver, 'setUrl').callsFake(function () {
+          let setUrlStub = sandbox.stub(driver, 'setUrl').callsFake(function () {
             throw new errors.TimeoutError;
           });
           const {status, data} = await axios({
@@ -600,7 +609,7 @@ describe('Protocol', function () {
           it('should return W3C error if a proxied request returns a W3C error response', async function () {
             const error = new Error(`Some error occurred`);
             error.w3cStatus = 414;
-            const executeCommandStub = sinon.stub(driver, 'executeCommand').returns({
+            const executeCommandStub = sandbox.stub(driver, 'executeCommand').returns({
               protocol: 'W3C',
               error,
             });

--- a/packages/support/test/logger/helpers.js
+++ b/packages/support/test/logger/helpers.js
@@ -3,10 +3,12 @@ import _ from 'lodash';
 import { logger } from '../../lib';
 
 
+let sandbox;
 
 function setupWriters () {
-  return {'stdout': sinon.spy(process.stdout, 'write'),
-          'stderr': sinon.spy(process.stderr, 'write')};
+  sandbox = sinon.createSandbox();
+  return {'stdout': sandbox.spy(process.stdout, 'write'),
+          'stderr': sandbox.spy(process.stderr, 'write')};
 }
 
 function getDynamicLogger (testingMode, forceLogs, prefix = null) {
@@ -15,10 +17,8 @@ function getDynamicLogger (testingMode, forceLogs, prefix = null) {
   return logger.getLogger(prefix);
 }
 
-function restoreWriters (writers) {
-  for (let w of _.values(writers)) {
-    w.restore();
-  }
+function restoreWriters () {
+  sandbox.restore();
 }
 
 function someoneHadOutput (writers, output) {

--- a/packages/support/test/logger/helpers.js
+++ b/packages/support/test/logger/helpers.js
@@ -7,8 +7,10 @@ let sandbox;
 
 function setupWriters () {
   sandbox = sinon.createSandbox();
-  return {'stdout': sandbox.spy(process.stdout, 'write'),
-          'stderr': sandbox.spy(process.stderr, 'write')};
+  return {
+    stdout: sandbox.spy(process.stdout, 'write'),
+    stderr: sandbox.spy(process.stderr, 'write')
+  };
 }
 
 function getDynamicLogger (testingMode, forceLogs, prefix = null) {

--- a/packages/support/test/process-specs.js
+++ b/packages/support/test/process-specs.js
@@ -1,13 +1,21 @@
 import * as teenProcess from 'teen_process';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import { process } from '../lib/index.js';
 import { retryInterval } from 'asyncbox';
-
-
 
 const SubProcess = teenProcess.SubProcess;
 
 describe('process', function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   describe('getProcessIds', function () {
     let proc;
     before(async function () {
@@ -30,7 +38,7 @@ describe('process', function () {
       pids.should.have.length(0);
     });
     it('should throw an error if pgrep fails', async function () {
-      let tpMock = sinon.mock(teenProcess);
+      let tpMock = sandbox.mock(teenProcess);
       tpMock.expects('exec').throws({message: 'Oops', code: 2});
 
       await process.getProcessIds('tail').should.eventually.be.rejectedWith(/Oops/);
@@ -68,7 +76,7 @@ describe('process', function () {
       }).should.eventually.be.rejected;
     });
     it('should throw an error if pgrep fails', async function () {
-      let tpMock = sinon.mock(teenProcess);
+      let tpMock = sandbox.mock(teenProcess);
       tpMock.expects('exec').throws({message: 'Oops', code: 2});
 
       await process.killProcess('tail').should.eventually.be.rejectedWith(/Oops/);
@@ -76,7 +84,7 @@ describe('process', function () {
       tpMock.restore();
     });
     it('should throw an error if pkill fails', async function () {
-      let tpMock = sinon.mock(teenProcess);
+      let tpMock = sandbox.mock(teenProcess);
       tpMock.expects('exec').twice()
         .onFirstCall().returns({stdout: '42\n'})
         .onSecondCall().throws({message: 'Oops', code: 2});

--- a/packages/support/test/system-specs.js
+++ b/packages/support/test/system-specs.js
@@ -1,20 +1,29 @@
-
 import { system } from '../lib/index.js';
 import os from 'os';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import * as teen_process from 'teen_process';
 import _ from 'lodash';
 
 
-let sandbox, tpMock, osMock = null;
+let tpMock, osMock = null;
 let SANDBOX = Symbol();
 let mocks = {};
 let libs = {teen_process, os, system};
 
 describe('system', function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   describe('isX functions', function () {
     beforeEach(function () {
-      osMock = sinon.mock(os);
+      osMock = sandbox.mock(os);
     });
     afterEach(function () {
       osMock.verify();
@@ -38,7 +47,7 @@ describe('system', function () {
 
   describe('mac OSX version', function () {
     beforeEach(function () {
-      tpMock = sinon.mock(teen_process);
+      tpMock = sandbox.mock(teen_process);
     });
     afterEach(function () {
       tpMock.verify();
@@ -68,7 +77,7 @@ describe('system', function () {
 
   describe('architecture', function () {
     beforeEach(function () {
-      sandbox = sinon.createSandbox();
+      // this is weird as hell
       mocks[SANDBOX] = sandbox;
       for (let [key, value] of _.toPairs(libs)) {
         mocks[key] = sandbox.mock(value);

--- a/packages/support/test/timing-specs.js
+++ b/packages/support/test/timing-specs.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import { timing } from '../lib';
 
 
@@ -7,8 +7,15 @@ const expect = chai.expect;
 
 describe('timing', function () {
   let processMock;
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+  });
+
   afterEach(function () {
     processMock.verify();
+    sandbox.restore();
   });
 
   describe('no bigint', function () {
@@ -20,7 +27,7 @@ describe('timing', function () {
       }
     });
     beforeEach(function () {
-      processMock = sinon.mock(process);
+      processMock = sandbox.mock(process);
     });
     after(function () {
       if (_.isFunction(bigintFn)) {
@@ -84,7 +91,7 @@ describe('timing', function () {
       if (!_.isFunction(process.hrtime.bigint)) {
         return this.skip();
       }
-      processMock = sinon.mock(process.hrtime);
+      processMock = sandbox.mock(process.hrtime);
     });
 
     function setupMocks (once = false) {

--- a/packages/support/test/util-specs.js
+++ b/packages/support/test/util-specs.js
@@ -1,7 +1,7 @@
 
 import { util, fs, tempDir } from '../lib';
 import B from 'bluebird';
-import sinon from 'sinon';
+import { createSandbox } from 'sinon';
 import os from 'os';
 import path from 'path';
 import _ from 'lodash';
@@ -11,6 +11,16 @@ const {W3C_WEB_ELEMENT_IDENTIFIER} = util;
 
 
 describe('util', function () {
+  let sandbox;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
   describe('hasValue', function () {
     it('should exist', function () {
       should.exist(util.hasValue);
@@ -174,7 +184,7 @@ describe('util', function () {
             }
           ],
       };
-      let osMock = sinon.mock(os);
+      let osMock = sandbox.mock(os);
       osMock.expects('networkInterfaces').returns(ifConfigOut);
       ifConfigOut = '';
       let ip = util.localIp();


### PR DESCRIPTION
Calling `sinon.stub()`, `sinon.mock()` etc., directly is error-prone. Care must be taken to explicitly restore any stub created.

Using a sandbox (via `sinon.createSandbox()`), you don't need to remember to restore everything you fiddled with.

To that end, I've converted all direct `sinon` calls into sandbox calls and **BANNED** direct usage of `sinon` via ESLint.