### PR TITLE
refactor(base-driver): Tune the logic for the destination logger extraction

### DIFF
--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -42,13 +42,16 @@ function isSessionCommand (command) {
 }
 
 function getLogger (driver, sessionId = null) {
-  if (_.isFunction(driver?.log?.info)) {
-    return driver.log;
+  const dstDriver = _.isFunction(driver.driverForSession)
+    ? (driver.driverForSession(sessionId) ?? driver)
+    : driver;
+  if (_.isFunction(dstDriver.log?.info)) {
+    return dstDriver.log;
   }
 
   let logPrefix = 'AppiumDriver';
-  if (driver && driver.constructor) {
-    logPrefix = driver.constructor.name;
+  if (dstDriver.constructor) {
+    logPrefix = dstDriver.constructor.name;
   }
   if (sessionId) {
     logPrefix += ` (${sessionId.substring(0, 8)})`;

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -42,7 +42,7 @@ function isSessionCommand (command) {
 }
 
 function getLogger (driver, sessionId = null) {
-  const dstDriver = _.isFunction(driver.driverForSession)
+  const dstDriver = sessionId && _.isFunction(driver.driverForSession)
     ? (driver.driverForSession(sessionId) ?? driver)
     : driver;
   if (_.isFunction(dstDriver.log?.info)) {

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { util, logger } from '@appium/support';
+import { util, logger, node } from '@appium/support';
 import { validators } from './validators';
 import {
   errors, isErrorType, getResponseForW3CError,
@@ -49,10 +49,9 @@ function getLogger (driver, sessionId = null) {
     return dstDriver.log;
   }
 
-  let logPrefix = 'AppiumDriver';
-  if (dstDriver.constructor) {
-    logPrefix = dstDriver.constructor.name;
-  }
+  let logPrefix = dstDriver.constructor
+    ? `${dstDriver.constructor.name}@${node.getObjectId(dstDriver).substring(0, 8)}`
+    : 'AppiumDriver';
   if (sessionId) {
     logPrefix += ` (${sessionId.substring(0, 8)})`;
   }


### PR DESCRIPTION
## Proposed changes

It is easier to read logs when a destination driver name is present in the prefix rather than the umbrella one

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
