### PR TITLE
chore(appium): split main module into more functions

### DIFF
--- a/ci-jobs/generate-docs.yml
+++ b/ci-jobs/generate-docs.yml
@@ -1,4 +1,3 @@
-# parameters: # No params yet, but may add later
 jobs:
   - job: generate_docs
     pool: 

--- a/packages/appium/lib/appium-config.schema.json
+++ b/packages/appium/lib/appium-config.schema.json
@@ -15,12 +15,12 @@
           "default": "0.0.0.0",
           "description": "IP address to listen on",
           "format": "hostname",
-          "title": "address config",
+          "title": "Server Address",
           "type": "string"
         },
         "allow-cors": {
           "description": "Whether the Appium server should allow web browser connections from any host",
-          "title": "allow-cors config",
+          "title": "Allow CORS",
           "type": "boolean",
           "default": false
         },
@@ -31,7 +31,7 @@
           "items": {
             "type": "string"
           },
-          "title": "allow-insecure config",
+          "title": "Allow Insecure Features",
           "type": "array",
           "uniqueItems": true
         },
@@ -41,7 +41,7 @@
           ],
           "default": "",
           "description": "Base path to use as the prefix for all webdriver routes running on the server",
-          "title": "base-path config",
+          "title": "Base Path for Webdriver Routes",
           "type": "string"
         },
         "callback-address": {
@@ -49,7 +49,7 @@
             "ca"
           ],
           "description": "Callback IP address (default: same as \"address\")",
-          "title": "callback-address config",
+          "title": "Callback Server Address",
           "type": "string"
         },
         "callback-port": {
@@ -60,13 +60,13 @@
           "description": "Callback port (default: same as \"port\")",
           "maximum": 65535,
           "minimum": 1,
-          "title": "callback-port config",
+          "title": "Callback Server Port",
           "type": "integer"
         },
         "debug-log-spacing": {
           "default": false,
           "description": "Add exaggerated spacing in logs to help with visual inspection",
-          "title": "debug-log-spacing config",
+          "title": "Enable \"Debug\" Log Spacing",
           "type": "boolean"
         },
         "default-capabilities": {
@@ -75,7 +75,7 @@
             "dc"
           ],
           "description": "Set the default desired capabilities, which will be set on each session unless overridden by received capabilities. If a string, a path to a JSON file containing the capabilities, or raw JSON.",
-          "title": "default-capabilities config",
+          "title": "Default Capabilities",
           "type": "object"
         },
         "deny-insecure": {
@@ -86,14 +86,14 @@
           "items": {
             "type": "string"
           },
-          "title": "deny-insecure config",
+          "title": "Deny Insecure Features",
           "type": "array",
           "uniqueItems": true
         },
         "driver": {
           "description": "Driver-specific configuration. Keys should correspond to driver package names",
           "properties": {},
-          "title": "driver config",
+          "title": "Driver-Specific Config",
           "type": "object"
         },
         "keep-alive-timeout": {
@@ -103,13 +103,13 @@
           "default": 600,
           "description": "Number of seconds the Appium server should apply as both the keep-alive timeout and the connection timeout for all requests. A value of 0 disables the timeout.",
           "minimum": 0,
-          "title": "keep-alive-timeout config",
+          "title": "Keep-Alive Timeout",
           "type": "integer"
         },
         "local-timezone": {
           "default": false,
           "description": "Use local timezone for timestamps",
-          "title": "local-timezone config",
+          "title": "Local Timezone",
           "type": "boolean"
         },
         "log": {
@@ -118,7 +118,7 @@
           ],
           "appiumCliDest": "logFile",
           "description": "Also send log output to this file",
-          "title": "log config",
+          "title": "Logfile Path",
           "type": "string"
         },
         "log-filters": {
@@ -127,7 +127,7 @@
           "items": {
             "type": "string"
           },
-          "title": "log-filters config",
+          "title": "Log Filtering Rules",
           "type": "array"
         },
         "log-level": {
@@ -156,43 +156,43 @@
             "debug:warn",
             "debug:error"
           ],
-          "title": "log-level config",
+          "title": "Log Level",
           "type": "string"
         },
         "log-no-colors": {
           "default": false,
           "description": "Do not use color in console output",
-          "title": "log-no-colors config",
+          "title": "Suppress Log Color",
           "type": "boolean"
         },
         "log-timestamp": {
           "default": false,
           "description": "Show timestamps in console output",
-          "title": "log-timestamp config",
+          "title": "Log Timestamps",
           "type": "boolean"
         },
         "long-stacktrace": {
           "default": false,
           "description": "Add long stack traces to log entries. Recommended for debugging only.",
-          "title": "long-stacktrace config",
+          "title": "Show Long Stacktraces",
           "type": "boolean"
         },
         "no-perms-check": {
           "default": false,
           "description": "Do not check that needed files are readable and/or writable",
-          "title": "no-perms-check config",
+          "title": "Disable Permission Checks",
           "type": "boolean"
         },
         "nodeconfig": {
           "$comment": "Selenium Grid 3 is unmaintained and Selenium Grid 4 no longer supports this file.",
           "description": "Path to configuration JSON file to register Appium as a node with Selenium Grid 3; otherwise the configuration itself",
-          "title": "nodeconfig config",
+          "title": "Node Config File Path",
           "type": "object"
         },
         "plugin": {
           "description": "Plugin-specific configuration. Keys should correspond to plugin package names",
           "properties": {},
-          "title": "plugin config",
+          "title": "Plugin-Specific Config",
           "type": "object"
         },
         "port": {
@@ -203,37 +203,37 @@
           "description": "Port to listen on",
           "maximum": 65535,
           "minimum": 1,
-          "title": "port config",
+          "title": "Server Port",
           "type": "integer"
         },
         "relaxed-security": {
           "default": false,
           "description": "Disable additional security checks, so it is possible to use some advanced features, provided by drivers supporting this option. Only enable it if all the clients are in the trusted network and it's not the case if a client could potentially break out of the session sandbox. Specific features can be overridden by using \"deny-insecure\"",
-          "title": "relaxed-security config",
+          "title": "Enable Relaxed Security",
           "type": "boolean",
           "appiumCliDest": "relaxedSecurityEnabled"
         },
         "session-override": {
           "default": false,
           "description": "Enables session override (clobbering)",
-          "title": "session-override config",
+          "title": "Allow Session Override",
           "type": "boolean"
         },
         "strict-caps": {
           "default": false,
           "description": "Cause sessions to fail if desired caps are sent in that Appium does not recognize as valid for the selected device",
-          "title": "strict-caps config",
+          "title": "Strict Caps Mode",
           "type": "boolean"
         },
         "tmp": {
           "appiumCliDest": "tmpDir",
           "description": "Absolute path to directory Appium can use to manage temp files. Defaults to C:\\Windows\\Temp on Windows and /tmp otherwise.",
-          "title": "tmp config",
+          "title": "Override Temp Path",
           "type": "string"
         },
         "trace-dir": {
           "description": "Absolute path to directory Appium can use to save iOS instrument traces; defaults to <tmp>/appium-instruments",
-          "title": "trace-dir config",
+          "title": "Trace Directory",
           "type": "string"
         },
         "use-drivers": {
@@ -243,7 +243,7 @@
           "items": {
             "type": "string"
           },
-          "title": "use-drivers config",
+          "title": "Enabled Drivers",
           "type": "array",
           "uniqueItems": true
         },
@@ -254,7 +254,7 @@
           "items": {
             "type": "string"
           },
-          "title": "use-plugins config",
+          "title": "Enabled Plugins",
           "type": "array",
           "uniqueItems": true
         },
@@ -265,11 +265,11 @@
           ],
           "description": "Also send log output to this http listener",
           "format": "uri",
-          "title": "webhook config",
+          "title": "Webhook URL",
           "type": "string"
         }
       },
-      "title": "server config",
+      "title": "Server Configuration",
       "type": "object"
     }
   },

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -75,7 +75,7 @@ class AppiumDriver extends BaseDriver {
   /** @type {import('./extension/driver-config').DriverConfig|undefined} */
   driverConfig;
 
-  /** @type {import('express').Express|undefined} */
+  /** @type {Omit<import('http').Server,'close'> & { close: () => Promise<void>} } */
   server;
 
   /**

--- a/packages/appium/lib/cli/parser.js
+++ b/packages/appium/lib/cli/parser.js
@@ -253,13 +253,14 @@ class ArgParser {
 }
 
 /**
- * Creates a {@link ArgParser} instance; finalizes the config schema.
+ * Creates a {@link ArgParser} instance; finalizes the config schema (if not yet finalized).
  *
  * @constructs ArgParser
  * @param {boolean} [debug] - If `true`, throw instead of exit upon parsing error
  * @returns {ArgParser}
  */
 function getParser (debug) {
+  // This may be finalized beforehand, but this is the last possible time we can do so.
   finalizeSchema();
 
   return new ArgParser(debug);

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -385,8 +385,8 @@ if (require.main === module) {
 
 // everything below here is intended to be a public API.
 export { readConfigFile } from './config-file';
-export { finalizeSchema, getSchema, validate, getDefaultsForSchema as getDefaultArgs } from './schema/schema';
-export { main, init, configure, resolveAppiumHome };
+export { finalizeSchema, getSchema, validate } from './schema/schema';
+export { main, init, configure, start, resolveAppiumHome };
 
 /**
  * @typedef {import('../types/types').ParsedArgs} ParsedArgs

--- a/packages/appium/lib/schema/appium-config-schema.js
+++ b/packages/appium/lib/schema/appium-config-schema.js
@@ -16,13 +16,13 @@ const schema = /** @type {const} */ ({
           default: '0.0.0.0',
           description: 'IP address to listen on',
           format: 'hostname',
-          title: 'address config',
+          title: 'Server Address',
           type: 'string',
         },
         'allow-cors': {
           description:
             'Whether the Appium server should allow web browser connections from any host',
-          title: 'allow-cors config',
+          title: 'Allow CORS',
           type: 'boolean',
           default: false,
         },
@@ -34,7 +34,7 @@ const schema = /** @type {const} */ ({
           items: {
             type: 'string',
           },
-          title: 'allow-insecure config',
+          title: 'Allow Insecure Features',
           type: 'array',
           uniqueItems: true,
         },
@@ -43,13 +43,13 @@ const schema = /** @type {const} */ ({
           default: '',
           description:
             'Base path to use as the prefix for all webdriver routes running on the server',
-          title: 'base-path config',
+          title: 'Base Path for Webdriver Routes',
           type: 'string',
         },
         'callback-address': {
           appiumCliAliases: ['ca'],
           description: 'Callback IP address (default: same as "address")',
-          title: 'callback-address config',
+          title: 'Callback Server Address',
           type: 'string',
         },
         'callback-port': {
@@ -58,14 +58,14 @@ const schema = /** @type {const} */ ({
           description: 'Callback port (default: same as "port")',
           maximum: 65535,
           minimum: 1,
-          title: 'callback-port config',
+          title: 'Callback Server Port',
           type: 'integer',
         },
         'debug-log-spacing': {
           default: false,
           description:
             'Add exaggerated spacing in logs to help with visual inspection',
-          title: 'debug-log-spacing config',
+          title: 'Enable "Debug" Log Spacing',
           type: 'boolean',
         },
         'default-capabilities': {
@@ -73,7 +73,7 @@ const schema = /** @type {const} */ ({
           appiumCliAliases: ['dc'],
           description:
             'Set the default desired capabilities, which will be set on each session unless overridden by received capabilities. If a string, a path to a JSON file containing the capabilities, or raw JSON.',
-          title: 'default-capabilities config',
+          title: 'Default Capabilities',
           type: 'object',
         },
         'deny-insecure': {
@@ -85,7 +85,7 @@ const schema = /** @type {const} */ ({
           items: {
             type: 'string',
           },
-          title: 'deny-insecure config',
+          title: 'Deny Insecure Features',
           type: 'array',
           uniqueItems: true,
         },
@@ -93,7 +93,7 @@ const schema = /** @type {const} */ ({
           description:
             'Driver-specific configuration. Keys should correspond to driver package names',
           properties: {},
-          title: 'driver config',
+          title: 'Driver-Specific Config',
           type: 'object',
         },
         'keep-alive-timeout': {
@@ -102,20 +102,20 @@ const schema = /** @type {const} */ ({
           description:
             'Number of seconds the Appium server should apply as both the keep-alive timeout and the connection timeout for all requests. A value of 0 disables the timeout.',
           minimum: 0,
-          title: 'keep-alive-timeout config',
+          title: 'Keep-Alive Timeout',
           type: 'integer',
         },
         'local-timezone': {
           default: false,
           description: 'Use local timezone for timestamps',
-          title: 'local-timezone config',
+          title: 'Local Timezone',
           type: 'boolean',
         },
         log: {
           appiumCliAliases: ['g'],
           appiumCliDest: 'logFile',
           description: 'Also send log output to this file',
-          title: 'log config',
+          title: 'Logfile Path',
           type: 'string',
         },
         'log-filters': {
@@ -124,7 +124,7 @@ const schema = /** @type {const} */ ({
           items: {
             type: 'string',
           },
-          title: 'log-filters config',
+          title: 'Log Filtering Rules',
           type: 'array',
         },
         'log-level': {
@@ -153,33 +153,33 @@ const schema = /** @type {const} */ ({
             'debug:warn',
             'debug:error',
           ],
-          title: 'log-level config',
+          title: 'Log Level',
           type: 'string',
         },
         'log-no-colors': {
           default: false,
           description: 'Do not use color in console output',
-          title: 'log-no-colors config',
+          title: 'Suppress Log Color',
           type: 'boolean',
         },
         'log-timestamp': {
           default: false,
           description: 'Show timestamps in console output',
-          title: 'log-timestamp config',
+          title: 'Log Timestamps',
           type: 'boolean',
         },
         'long-stacktrace': {
           default: false,
           description:
             'Add long stack traces to log entries. Recommended for debugging only.',
-          title: 'long-stacktrace config',
+          title: 'Show Long Stacktraces',
           type: 'boolean',
         },
         'no-perms-check': {
           default: false,
           description:
             'Do not check that needed files are readable and/or writable',
-          title: 'no-perms-check config',
+          title: 'Disable Permission Checks',
           type: 'boolean',
         },
         nodeconfig: {
@@ -187,14 +187,14 @@ const schema = /** @type {const} */ ({
             'Selenium Grid 3 is unmaintained and Selenium Grid 4 no longer supports this file.',
           description:
             'Path to configuration JSON file to register Appium as a node with Selenium Grid 3; otherwise the configuration itself',
-          title: 'nodeconfig config',
+          title: 'Node Config File Path',
           type: 'object',
         },
         plugin: {
           description:
             'Plugin-specific configuration. Keys should correspond to plugin package names',
           properties: {},
-          title: 'plugin config',
+          title: 'Plugin-Specific Config',
           type: 'object',
         },
         port: {
@@ -203,41 +203,41 @@ const schema = /** @type {const} */ ({
           description: 'Port to listen on',
           maximum: 65535,
           minimum: 1,
-          title: 'port config',
+          title: 'Server Port',
           type: 'integer',
         },
         'relaxed-security': {
           default: false,
           description:
             'Disable additional security checks, so it is possible to use some advanced features, provided by drivers supporting this option. Only enable it if all the clients are in the trusted network and it\'s not the case if a client could potentially break out of the session sandbox. Specific features can be overridden by using "deny-insecure"',
-          title: 'relaxed-security config',
+          title: 'Enable Relaxed Security',
           type: 'boolean',
           appiumCliDest: 'relaxedSecurityEnabled'
         },
         'session-override': {
           default: false,
           description: 'Enables session override (clobbering)',
-          title: 'session-override config',
+          title: 'Allow Session Override',
           type: 'boolean',
         },
         'strict-caps': {
           default: false,
           description:
             'Cause sessions to fail if desired caps are sent in that Appium does not recognize as valid for the selected device',
-          title: 'strict-caps config',
+          title: 'Strict Caps Mode',
           type: 'boolean',
         },
         tmp: {
           appiumCliDest: 'tmpDir',
           description:
             'Absolute path to directory Appium can use to manage temp files. Defaults to C:\\Windows\\Temp on Windows and /tmp otherwise.',
-          title: 'tmp config',
+          title: 'Override Temp Path',
           type: 'string',
         },
         'trace-dir': {
           description:
             'Absolute path to directory Appium can use to save iOS instrument traces; defaults to <tmp>/appium-instruments',
-          title: 'trace-dir config',
+          title: 'Trace Directory',
           type: 'string',
         },
         'use-drivers': {
@@ -249,7 +249,7 @@ const schema = /** @type {const} */ ({
           items: {
             type: 'string',
           },
-          title: 'use-drivers config',
+          title: 'Enabled Drivers',
           type: 'array',
           uniqueItems: true,
         },
@@ -262,7 +262,7 @@ const schema = /** @type {const} */ ({
           items: {
             type: 'string',
           },
-          title: 'use-plugins config',
+          title: 'Enabled Plugins',
           type: 'array',
           uniqueItems: true,
         },
@@ -272,11 +272,11 @@ const schema = /** @type {const} */ ({
           appiumCliAliases: ['G'],
           description: 'Also send log output to this http listener',
           format: 'uri',
-          title: 'webhook config',
+          title: 'Webhook URL',
           type: 'string',
         },
       },
-      title: 'server config',
+      title: 'Server Configuration',
       type: 'object',
     },
   },

--- a/packages/appium/test/fixtures/flattened-schema.js
+++ b/packages/appium/test/fixtures/flattened-schema.js
@@ -16,7 +16,7 @@ export default [
       default: '0.0.0.0',
       description: 'IP address to listen on',
       format: 'hostname',
-      title: 'address config',
+      title: 'Server Address',
       type: 'string',
     },
   },
@@ -35,7 +35,7 @@ export default [
       default: false,
       description:
         'Whether the Appium server should allow web browser connections from any host',
-      title: 'allow-cors config',
+      title: 'Allow CORS',
       type: 'boolean',
     },
   },
@@ -56,7 +56,7 @@ export default [
       description:
         'Set which insecure features are allowed to run in this server\'s sessions. Features are defined on a driver level; see documentation for more details. Note that features defined via "deny-insecure" will be disabled, even if also listed here. If string, a path to a text file containing policy or a comma-delimited list.',
       items: {type: 'string'},
-      title: 'allow-insecure config',
+      title: 'Allow Insecure Features',
       type: 'array',
       uniqueItems: true,
     },
@@ -77,7 +77,7 @@ export default [
       default: '',
       description:
         'Base path to use as the prefix for all webdriver routes running on the server',
-      title: 'base-path config',
+      title: 'Base Path for Webdriver Routes',
       type: 'string',
     },
   },
@@ -95,7 +95,7 @@ export default [
     schema: {
       appiumCliAliases: ['ca'],
       description: 'Callback IP address (default: same as "address")',
-      title: 'callback-address config',
+      title: 'Callback Server Address',
       type: 'string',
     },
   },
@@ -116,7 +116,7 @@ export default [
       description: 'Callback port (default: same as "port")',
       maximum: 65535,
       minimum: 1,
-      title: 'callback-port config',
+      title: 'Callback Server Port',
       type: 'integer',
     },
   },
@@ -135,7 +135,7 @@ export default [
       default: false,
       description:
         'Add exaggerated spacing in logs to help with visual inspection',
-      title: 'debug-log-spacing config',
+      title: 'Enable "Debug" Log Spacing',
       type: 'boolean',
     },
   },
@@ -155,7 +155,7 @@ export default [
       appiumCliAliases: ['dc'],
       description:
         'Set the default desired capabilities, which will be set on each session unless overridden by received capabilities. If a string, a path to a JSON file containing the capabilities, or raw JSON.',
-      title: 'default-capabilities config',
+      title: 'Default Capabilities',
       type: 'object',
     },
   },
@@ -177,7 +177,7 @@ export default [
       description:
         'Set which insecure features are not allowed to run in this server\'s sessions. Features are defined on a driver level; see documentation for more details. Features listed here will not be enabled even if also listed in "allow-insecure", and even if "relaxed-security" is enabled. If string, a path to a text file containing policy or a comma-delimited list.',
       items: {type: 'string'},
-      title: 'deny-insecure config',
+      title: 'Deny Insecure Features',
       type: 'array',
       uniqueItems: true,
     },
@@ -199,7 +199,7 @@ export default [
       description:
         'Number of seconds the Appium server should apply as both the keep-alive timeout and the connection timeout for all requests. A value of 0 disables the timeout.',
       minimum: 0,
-      title: 'keep-alive-timeout config',
+      title: 'Keep-Alive Timeout',
       type: 'integer',
     },
   },
@@ -217,7 +217,7 @@ export default [
     schema: {
       default: false,
       description: 'Use local timezone for timestamps',
-      title: 'local-timezone config',
+      title: 'Local Timezone',
       type: 'boolean',
     },
   },
@@ -236,7 +236,7 @@ export default [
       appiumCliAliases: ['g'],
       appiumCliDest: 'logFile',
       description: 'Also send log output to this file',
-      title: 'log config',
+      title: 'Logfile Path',
       type: 'string',
     },
   },
@@ -255,7 +255,7 @@ export default [
       $comment: 'TODO',
       description: 'One or more log filtering rules',
       items: {type: 'string'},
-      title: 'log-filters config',
+      title: 'Log Filtering Rules',
       type: 'array',
     },
   },
@@ -296,7 +296,7 @@ export default [
         'debug:warn',
         'debug:error',
       ],
-      title: 'log-level config',
+      title: 'Log Level',
       type: 'string',
     },
   },
@@ -314,7 +314,7 @@ export default [
     schema: {
       default: false,
       description: 'Do not use color in console output',
-      title: 'log-no-colors config',
+      title: 'Suppress Log Color',
       type: 'boolean',
     },
   },
@@ -332,7 +332,7 @@ export default [
     schema: {
       default: false,
       description: 'Show timestamps in console output',
-      title: 'log-timestamp config',
+      title: 'Log Timestamps',
       type: 'boolean',
     },
   },
@@ -351,7 +351,7 @@ export default [
       default: false,
       description:
         'Add long stack traces to log entries. Recommended for debugging only.',
-      title: 'long-stacktrace config',
+      title: 'Show Long Stacktraces',
       type: 'boolean',
     },
   },
@@ -370,7 +370,7 @@ export default [
       default: false,
       description:
         'Do not check that needed files are readable and/or writable',
-      title: 'no-perms-check config',
+      title: 'Disable Permission Checks',
       type: 'boolean',
     },
   },
@@ -390,7 +390,7 @@ export default [
         'Selenium Grid 3 is unmaintained and Selenium Grid 4 no longer supports this file.',
       description:
         'Path to configuration JSON file to register Appium as a node with Selenium Grid 3; otherwise the configuration itself',
-      title: 'nodeconfig config',
+      title: 'Node Config File Path',
       type: 'object',
     },
   },
@@ -411,7 +411,7 @@ export default [
       description: 'Port to listen on',
       maximum: 65535,
       minimum: 1,
-      title: 'port config',
+      title: 'Server Port',
       type: 'integer',
     },
   },
@@ -431,7 +431,7 @@ export default [
       default: false,
       description:
         'Disable additional security checks, so it is possible to use some advanced features, provided by drivers supporting this option. Only enable it if all the clients are in the trusted network and it\'s not the case if a client could potentially break out of the session sandbox. Specific features can be overridden by using "deny-insecure"',
-      title: 'relaxed-security config',
+      title: 'Enable Relaxed Security',
       type: 'boolean',
     },
   },
@@ -449,7 +449,7 @@ export default [
     schema: {
       default: false,
       description: 'Enables session override (clobbering)',
-      title: 'session-override config',
+      title: 'Allow Session Override',
       type: 'boolean',
     },
   },
@@ -468,7 +468,7 @@ export default [
       default: false,
       description:
         'Cause sessions to fail if desired caps are sent in that Appium does not recognize as valid for the selected device',
-      title: 'strict-caps config',
+      title: 'Strict Caps Mode',
       type: 'boolean',
     },
   },
@@ -487,7 +487,7 @@ export default [
       appiumCliDest: 'tmpDir',
       description:
         'Absolute path to directory Appium can use to manage temp files. Defaults to C:\\Windows\\Temp on Windows and /tmp otherwise.',
-      title: 'tmp config',
+      title: 'Override Temp Path',
       type: 'string',
     },
   },
@@ -505,7 +505,7 @@ export default [
     schema: {
       description:
         'Absolute path to directory Appium can use to save iOS instrument traces; defaults to <tmp>/appium-instruments',
-      title: 'trace-dir config',
+      title: 'Trace Directory',
       type: 'string',
     },
   },
@@ -527,7 +527,7 @@ export default [
       description:
         'A list of drivers to activate. By default, all installed drivers will be activated.',
       items: {type: 'string'},
-      title: 'use-drivers config',
+      title: 'Enabled Drivers',
       type: 'array',
       uniqueItems: true,
     },
@@ -550,7 +550,7 @@ export default [
       description:
         'A list of plugins to activate. To activate all plugins, the value should be an array with a single item "all".',
       items: {type: 'string'},
-      title: 'use-plugins config',
+      title: 'Enabled Plugins',
       type: 'array',
       uniqueItems: true,
     },
@@ -572,8 +572,8 @@ export default [
       appiumCliAliases: ['G'],
       description: 'Also send log output to this http listener',
       format: 'uri',
-      title: 'webhook config',
+      title: 'Webhook URL',
       type: 'string',
     },
-  }
+  },
 ];

--- a/packages/appium/types/appium-config.d.ts
+++ b/packages/appium/types/appium-config.d.ts
@@ -8,55 +8,55 @@
 /**
  * IP address to listen on
  */
-export type AddressConfig = string;
+export type ServerAddress = string;
 /**
  * Whether the Appium server should allow web browser connections from any host
  */
-export type AllowCorsConfig = boolean;
+export type AllowCORS = boolean;
 /**
  * Set which insecure features are allowed to run in this server's sessions. Features are defined on a driver level; see documentation for more details. Note that features defined via "deny-insecure" will be disabled, even if also listed here. If string, a path to a text file containing policy or a comma-delimited list.
  */
-export type AllowInsecureConfig = string[];
+export type AllowInsecureFeatures = string[];
 /**
  * Base path to use as the prefix for all webdriver routes running on the server
  */
-export type BasePathConfig = string;
+export type BasePathForWebdriverRoutes = string;
 /**
  * Callback IP address (default: same as "address")
  */
-export type CallbackAddressConfig = string;
+export type CallbackServerAddress = string;
 /**
  * Callback port (default: same as "port")
  */
-export type CallbackPortConfig = number;
+export type CallbackServerPort = number;
 /**
  * Add exaggerated spacing in logs to help with visual inspection
  */
-export type DebugLogSpacingConfig = boolean;
+export type EnableDebugLogSpacing = boolean;
 /**
  * Set which insecure features are not allowed to run in this server's sessions. Features are defined on a driver level; see documentation for more details. Features listed here will not be enabled even if also listed in "allow-insecure", and even if "relaxed-security" is enabled. If string, a path to a text file containing policy or a comma-delimited list.
  */
-export type DenyInsecureConfig = string[];
+export type DenyInsecureFeatures = string[];
 /**
  * Number of seconds the Appium server should apply as both the keep-alive timeout and the connection timeout for all requests. A value of 0 disables the timeout.
  */
-export type KeepAliveTimeoutConfig = number;
+export type KeepAliveTimeout = number;
 /**
  * Use local timezone for timestamps
  */
-export type LocalTimezoneConfig = boolean;
+export type LocalTimezone = boolean;
 /**
  * Also send log output to this file
  */
-export type LogConfig = string;
+export type LogfilePath = string;
 /**
  * One or more log filtering rules
  */
-export type LogFiltersConfig = string[];
+export type LogFilteringRules = string[];
 /**
  * Log level (console[:file])
  */
-export type LogLevelConfig =
+export type LogLevel =
   | "info"
   | "info:debug"
   | "info:info"
@@ -80,118 +80,118 @@ export type LogLevelConfig =
 /**
  * Do not use color in console output
  */
-export type LogNoColorsConfig = boolean;
+export type SuppressLogColor = boolean;
 /**
  * Show timestamps in console output
  */
-export type LogTimestampConfig = boolean;
+export type LogTimestamps = boolean;
 /**
  * Add long stack traces to log entries. Recommended for debugging only.
  */
-export type LongStacktraceConfig = boolean;
+export type ShowLongStacktraces = boolean;
 /**
  * Do not check that needed files are readable and/or writable
  */
-export type NoPermsCheckConfig = boolean;
+export type DisablePermissionChecks = boolean;
 /**
  * Port to listen on
  */
-export type PortConfig = number;
+export type ServerPort = number;
 /**
  * Disable additional security checks, so it is possible to use some advanced features, provided by drivers supporting this option. Only enable it if all the clients are in the trusted network and it's not the case if a client could potentially break out of the session sandbox. Specific features can be overridden by using "deny-insecure"
  */
-export type RelaxedSecurityConfig = boolean;
+export type EnableRelaxedSecurity = boolean;
 /**
  * Enables session override (clobbering)
  */
-export type SessionOverrideConfig = boolean;
+export type AllowSessionOverride = boolean;
 /**
  * Cause sessions to fail if desired caps are sent in that Appium does not recognize as valid for the selected device
  */
-export type StrictCapsConfig = boolean;
+export type StrictCapsMode = boolean;
 /**
  * Absolute path to directory Appium can use to manage temp files. Defaults to C:\Windows\Temp on Windows and /tmp otherwise.
  */
-export type TmpConfig = string;
+export type OverrideTempPath = string;
 /**
  * Absolute path to directory Appium can use to save iOS instrument traces; defaults to <tmp>/appium-instruments
  */
-export type TraceDirConfig = string;
+export type TraceDirectory = string;
 /**
  * A list of drivers to activate. By default, all installed drivers will be activated.
  */
-export type UseDriversConfig = string[];
+export type EnabledDrivers = string[];
 /**
  * A list of plugins to activate. To activate all plugins, the value should be an array with a single item "all".
  */
-export type UsePluginsConfig = string[];
+export type EnabledPlugins = string[];
 /**
  * Also send log output to this http listener
  */
-export type WebhookConfig = string;
+export type WebhookURL = string;
 
 /**
  * A schema for Appium configuration files
  */
 export interface AppiumConfiguration {
-  server?: ServerConfig;
+  server?: ServerConfiguration;
 }
 /**
  * Configuration when running Appium as a server
  */
-export interface ServerConfig {
-  address?: AddressConfig;
-  "allow-cors"?: AllowCorsConfig;
-  "allow-insecure"?: AllowInsecureConfig;
-  "base-path"?: BasePathConfig;
-  "callback-address"?: CallbackAddressConfig;
-  "callback-port"?: CallbackPortConfig;
-  "debug-log-spacing"?: DebugLogSpacingConfig;
-  "default-capabilities"?: DefaultCapabilitiesConfig;
-  "deny-insecure"?: DenyInsecureConfig;
-  driver?: DriverConfig;
-  "keep-alive-timeout"?: KeepAliveTimeoutConfig;
-  "local-timezone"?: LocalTimezoneConfig;
-  log?: LogConfig;
-  "log-filters"?: LogFiltersConfig;
-  "log-level"?: LogLevelConfig;
-  "log-no-colors"?: LogNoColorsConfig;
-  "log-timestamp"?: LogTimestampConfig;
-  "long-stacktrace"?: LongStacktraceConfig;
-  "no-perms-check"?: NoPermsCheckConfig;
-  nodeconfig?: NodeconfigConfig;
-  plugin?: PluginConfig;
-  port?: PortConfig;
-  "relaxed-security"?: RelaxedSecurityConfig;
-  "session-override"?: SessionOverrideConfig;
-  "strict-caps"?: StrictCapsConfig;
-  tmp?: TmpConfig;
-  "trace-dir"?: TraceDirConfig;
-  "use-drivers"?: UseDriversConfig;
-  "use-plugins"?: UsePluginsConfig;
-  webhook?: WebhookConfig;
+export interface ServerConfiguration {
+  address?: ServerAddress;
+  "allow-cors"?: AllowCORS;
+  "allow-insecure"?: AllowInsecureFeatures;
+  "base-path"?: BasePathForWebdriverRoutes;
+  "callback-address"?: CallbackServerAddress;
+  "callback-port"?: CallbackServerPort;
+  "debug-log-spacing"?: EnableDebugLogSpacing;
+  "default-capabilities"?: DefaultCapabilities;
+  "deny-insecure"?: DenyInsecureFeatures;
+  driver?: DriverSpecificConfig;
+  "keep-alive-timeout"?: KeepAliveTimeout;
+  "local-timezone"?: LocalTimezone;
+  log?: LogfilePath;
+  "log-filters"?: LogFilteringRules;
+  "log-level"?: LogLevel;
+  "log-no-colors"?: SuppressLogColor;
+  "log-timestamp"?: LogTimestamps;
+  "long-stacktrace"?: ShowLongStacktraces;
+  "no-perms-check"?: DisablePermissionChecks;
+  nodeconfig?: NodeConfigFilePath;
+  plugin?: PluginSpecificConfig;
+  port?: ServerPort;
+  "relaxed-security"?: EnableRelaxedSecurity;
+  "session-override"?: AllowSessionOverride;
+  "strict-caps"?: StrictCapsMode;
+  tmp?: OverrideTempPath;
+  "trace-dir"?: TraceDirectory;
+  "use-drivers"?: EnabledDrivers;
+  "use-plugins"?: EnabledPlugins;
+  webhook?: WebhookURL;
 }
 /**
  * Set the default desired capabilities, which will be set on each session unless overridden by received capabilities. If a string, a path to a JSON file containing the capabilities, or raw JSON.
  */
-export interface DefaultCapabilitiesConfig {
+export interface DefaultCapabilities {
   [k: string]: unknown;
 }
 /**
  * Driver-specific configuration. Keys should correspond to driver package names
  */
-export interface DriverConfig {
+export interface DriverSpecificConfig {
   [k: string]: unknown;
 }
 /**
  * Path to configuration JSON file to register Appium as a node with Selenium Grid 3; otherwise the configuration itself
  */
-export interface NodeconfigConfig {
+export interface NodeConfigFilePath {
   [k: string]: unknown;
 }
 /**
  * Plugin-specific configuration. Keys should correspond to plugin package names
  */
-export interface PluginConfig {
+export interface PluginSpecificConfig {
   [k: string]: unknown;
 }

--- a/packages/appium/types/types.d.ts
+++ b/packages/appium/types/types.d.ts
@@ -10,7 +10,7 @@ import {
 } from '../lib/constants';
 import appiumConfigSchema from '../lib/schema/appium-config-schema';
 import {transformers} from '../lib/schema/cli-transformers';
-import {AppiumConfiguration, ServerConfig} from './appium-config';
+import {AppiumConfiguration, ServerConfiguration} from './appium-config';
 
 /**
  * Converts a kebab-cased string into a camel-cased string.
@@ -88,7 +88,7 @@ type AppiumServerSchema =
 type NormalizedServerConfig = {
   [Prop in keyof ServerConfigMapping as AppiumServerSchema[Prop] extends WithDest
     ? AppiumServerSchema[Prop]['appiumCliDest']
-    : KebabToCamel<Prop>]: ServerConfig[Prop];
+    : KebabToCamel<Prop>]: ServerConfiguration[Prop];
 };
 
 /**
@@ -104,7 +104,7 @@ export type NormalizedAppiumConfig = {
  * {@link ServerConfig}.
  */
 type ServerConfigMapping = {
-  [Prop in keyof Required<ServerConfig>]: AppiumServerSchema[Prop];
+  [Prop in keyof Required<ServerConfiguration>]: AppiumServerSchema[Prop];
 };
 
 /**
@@ -123,8 +123,8 @@ type SetKeyForProp<Prop extends keyof ServerConfigMapping> =
  */
 type DefaultForProp<Prop extends keyof ServerConfigMapping> =
   AppiumServerSchema[Prop] extends WithDefault
-    ? NonNullable<ServerConfig[Prop]>
-    : ServerConfig[Prop];
+    ? NonNullable<ServerConfiguration[Prop]>
+    : ServerConfiguration[Prop];
 
 /**
  * The final shape of the parsed CLI arguments.


### PR DESCRIPTION
Per my work on appium/appium-desktop#1870, I needed to refactor this module to provide easier access to some internals; specifically, `appium-desktop` needs to gather argument metadata and display it to the user _before_ actually configuring and running the server.

In a nutshell:

- `init()` loads extensions and finalizes the config schema. after this, arg metadata can be retrieved
- `configure()` accepts `ExtensionConfig` objects and programmatic args; if we're in "server" mode, returns parsed args and an `AppiumDriver` instance
- `start()` accepts parsed args, `ExtensionConfig` objects and the `AppiumDriver`, and starts the server. It also calls...
- `setupProcessListeners()`, which sets listeners for `SIGINT` etc on `process` (and removes any old ones it had previously set).
- `main()` calls `init()`, `configure()` and `start()` in succession
- `init()`, `configure()` and `main()` are exported
- re-exported `getDefaultArgsForSchema()` as `getDefaultArgs()`

also

- fixed the type of `server` in `AppiumDriver` (which also needs to be fixed in `@appium/base-driver`)
- made a note about `finalizeSchema()` in `getParser()`.