### PR TITLE
ci: use latest in auto docs gen

### DIFF
--- a/ci-jobs/generate-docs.yml
+++ b/ci-jobs/generate-docs.yml
@@ -2,7 +2,7 @@
 jobs:
   - job: generate_docs
     pool:
-      vmImage: "macOS 10.15"
+      vmImage: "macOS-latest"
     variables:
       CC: gcc
       CXX: g++


### PR DESCRIPTION
https://dev.azure.com/AppiumCI/Appium%20CI/_build/results?buildId=20100&view=logs&j=b2463b90-2bc4-5971-e74e-d59127bbc69a
Let me try latest macOS.