### PR TITLE
Fix logsink.js being included after logger initilization

### DIFF
--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -3,6 +3,7 @@
 // transpile:main
 // @ts-check
 
+import { init as logsinkInit } from './logsink'; // logsink needs to come first to set up the global npmlog
 import logger from './logger'; // logger needs to remain first of imports
 // @ts-ignore
 import { routeConfiguringFunction as makeRouter, server as baseServer } from '@appium/base-driver';
@@ -17,7 +18,6 @@ import { APPIUM_VER, checkNodeOk, getGitRev, getNonDefaultServerArgs, showBuildI
 import { readConfigFile } from './config-file';
 import { DRIVER_TYPE, PLUGIN_TYPE } from './extension-config';
 import registerNode from './grid-register';
-import { init as logsinkInit } from './logsink';
 import { getDefaultsForSchema } from './schema/schema';
 import { inspect } from './utils';
 


### PR DESCRIPTION
## Proposed changes

Fixes #16519 . 

> The problem is caused by the import for logsink.js having moved down in the import list of main.js between beta18 and 25 causing this line global._global_npmlog = npmlog; to be executed waaaay to late. Essentially in @appium/support it will see _global_npmlog as undefined every time we ask for a logger and so it will create a fresh npmlog instead of using the one that is supposed to be hooked up to winston.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

