### PR TITLE
chore: lint the code once per build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,13 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
-name: Node.js CI
+name: Appium Build
 on: [push, pull_request]
 
 jobs:
-  build:
+  test:
+    name: Test
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x]
@@ -23,18 +23,29 @@ jobs:
       - name: Install dependencies
         run: npm install
       - name: Run unit tests
-        run: npm test
+        run: npm run test:ci
+      - name: Install @appium/fake-driver
+        run: npm run install-fake-driver
       - name: Run E2E tests
-        run: |
-          npm run install-fake-driver
-          npm run e2e-test
+        run: npm run e2e-test
 
-  generate_docs:
-    needs: [build]
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          npm install
-          npm run generate-docs
+      - name: Install dependencies
+        run: npm install
+      - name: ESLint
+        run: npm run lint
+
+  docs:
+    name: Build Command Documentation
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Generate docs
+        run: npm run generate-docs

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "test": "lerna run test",
     "test:appium": "lerna run --scope=appium test",
     "test:base-driver": "lerna run --scope=@appium/base-driver test",
+    "pretest:ci": "npm run build",
+    "test:ci": "lerna run test",
     "test:doctor": "lerna run --scope=@appium/doctor test",
     "test:e2e:appium": "lerna run --scope=appium test:e2e",
     "test:e2e:base-driver": "lerna run --scope=@appium/base-driver test:e2e",


### PR DESCRIPTION
~~This adopts the `bahmutov/npm-install` action, which also does some caching for us~~

This may speed up builds.

**UPDATE:** Unfortunately, we're going to need to hand-roll our caching if we want it. The action I tried before (which I've used elsewhere) won't work well because `package-lock.json` is not under version control.  Without this file, the action will be unable to determine if the dependencies of a package (e.g., `@appium/support`) have changed, because it will only look at the root `package.json`.