### PR TITLE
chore: add directory prop to repository prop of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "start": "appium",
     "sync-pkgs": "npm run sync-pkgs:appium-readme && npm run sync-pkgs:common-fields && npm run sync-pkgs:keywords",
     "sync-pkgs:appium-readme": "sync-monorepo-packages --force --no-package-json --packages=packages/appium README.md",
-    "sync-pkgs:common-fields": "sync-monorepo-packages --fields=author,license,repository,bugs,homepage,engines",
+    "sync-pkgs:common-fields": "sync-monorepo-packages --fields=author,license,bugs,homepage,engines",
     "sync-pkgs:keywords": "sync-monorepo-packages --field=keywords --packages=\"packages/*\" --packages=\"!packages/eslint-config-appium\"",
     "pretest": "npm run build && npm run lint",
     "test": "lerna run test",

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/appium/appium.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/appium"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/appium/appium.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/base-driver"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/appium/appium.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/doctor"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",

--- a/packages/eslint-config-appium/package.json
+++ b/packages/eslint-config-appium/package.json
@@ -10,7 +10,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/appium/appium.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/eslint-config-appium"
   },
   "bugs": {
     "url": "https://github.com/appium/appium/issues"

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/appium/appium.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/fake-driver"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/appium/appium.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/gulp-plugins"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/appium/appium.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "pacakges/opencv"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/appium/appium.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/support"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/appium/appium.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/test-support"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",


### PR DESCRIPTION
I think npm uses this to link to the correct path of the package in a monorepo.
