### PR TITLE
fix(base): address zip/unzip in the docstring of configureApp

### DIFF
--- a/packages/base-driver/lib/basedriver/helpers.js
+++ b/packages/base-driver/lib/basedriver/helpers.js
@@ -193,6 +193,8 @@ async function isAppIntegrityOk (currentPath, expectedIntegrity = {}) {
 /**
  * Prepares an app to be used in an automated test. The app gets cached automatically
  * if it is an archive or if it is downloaded from an URL.
+ * If the downloaded app has `.zip` extension, this method will unzip it.
+ * The unzip does not work when `onPostProcess` is provided.
  *
  * @param {string} app Either a full path to the app or a remote URL
  * @param {string|string[]|ConfigureAppOptions} options
@@ -332,7 +334,7 @@ async function configureApp (app, options = {}) {
       packageHash = await calculateFileIntegrity(newApp);
     }
 
-    if (isPackageAFile && shouldUnzipApp) {
+    if (isPackageAFile && shouldUnzipApp && !_.isFunction(onPostProcess)) {
       const archivePath = newApp;
       if (packageHash === cachedAppInfo?.packageHash) {
         const {fullPath} = cachedAppInfo;

--- a/packages/base-driver/lib/basedriver/helpers.js
+++ b/packages/base-driver/lib/basedriver/helpers.js
@@ -332,7 +332,7 @@ async function configureApp (app, options = {}) {
       packageHash = await calculateFileIntegrity(newApp);
     }
 
-    if (isPackageAFile && shouldUnzipApp && !_.isFunction(onPostProcess)) {
+    if (isPackageAFile && shouldUnzipApp) {
       const archivePath = newApp;
       if (packageHash === cachedAppInfo?.packageHash) {
         const {fullPath} = cachedAppInfo;


### PR DESCRIPTION
## Proposed changes

`appPath` in https://github.com/appium/appium-espresso-driver/pull/750/files#diff-ed3c013edbc896bd87ef62539626fcdc8930a31f3cee7ecb37438e172af2c8e0R236 is still `.zip`.
It results https://github.com/appium/appium-espresso-driver/pull/750/files#diff-ed3c013edbc896bd87ef62539626fcdc8930a31f3cee7ecb37438e172af2c8e0R247 is always `false`. It caused https://github.com/appium/ruby_lib_core/issues/370

At least this change allows appium to unzip `.zip` file first before calling `onPostProcess`. Then, the `appPath` is after unzipped one.

I haven't dug deeply yet, so this might cause another issue...

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
