### PR TITLE
fix installation of multiple extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "clean:distfiles": "npx rimraf \"packages/*/build\"",
     "clean:monorepo": "npx rimraf node_modules package-lock.json",
     "clean:packages": "lerna clean -y && npx rimraf \"packages/*/package-lock.json\"",
-    "clean:distfiles": "npx rimraf \"packages/*/build\"",
     "clean:types": "tsc -b --clean",
     "dev": "lerna run --parallel --prefix --concurrency=8 dev",
     "dev:types": "tsc -b --watch",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "@types/shell-quote": "1.7.1",
     "@types/sinon": "10.0.11",
     "@types/sinon-chai": "3.2.8",
+    "@types/teen_process": "1.16.0",
     "@types/through2": "2.0.36",
     "@types/uuid": "8.3.4",
     "@wdio/types": "7.19.1",

--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -86,7 +86,7 @@ async function getGitRev (useGithubApiFallback = false) {
 /**
  * @param {string} commitSha
  * @param {boolean} [useGithubApiFallback]
- * @returns {Promise<number?>}
+ * @returns {Promise<string?>}
  */
 async function getGitTimestamp (commitSha, useGithubApiFallback = false) {
   const gitRoot = await findGitRoot();

--- a/packages/appium/test/e2e/driver.e2e.spec.js
+++ b/packages/appium/test/e2e/driver.e2e.spec.js
@@ -44,7 +44,7 @@ describe('FakeDriver - via HTTP', function () {
   let appiumHome;
   // since we update the FakeDriver.prototype below, make sure we update the FakeDriver which is
   // actually going to be required by Appium
-  /** @type {import('../../lib/extension/manifest').DriverClass} */
+  /** @type {import('../../types/extension').DriverClass} */
   let FakeDriver;
   /** @type {string} */
   let testServerBaseSessionUrl;
@@ -85,7 +85,7 @@ describe('FakeDriver - via HTTP', function () {
   /**
    *
    * @param {number} port
-   * @param {Partial<import('../../types/types').ParsedArgs>} [args]
+   * @param {Partial<import('../../types/cli').ParsedArgs>} [args]
    */
   async function serverStart (port, args = {}) {
     args = {...args, port, address: TEST_HOST};

--- a/packages/appium/test/e2e/e2e-helpers.js
+++ b/packages/appium/test/e2e/e2e-helpers.js
@@ -21,11 +21,11 @@ export const EXECUTABLE = path.join(PACKAGE_ROOT, 'build', 'lib', 'main.js');
  * Runs the `appium` executable with the given args.
  *
  * If the process exits with a nonzero code, the error will be a {@link AppiumRunError}.
- * @template {import('../../types/types').CliExtensionSubcommand} ExtSubcommand
+ * @template {import('../../types/cli').CliExtensionSubcommand} ExtSubcommand
  * @param {string} appiumHome - Path to `APPIUM_HOME`
  * @param {CliExtArgs<ExtSubcommand> | CliArgs} args - Args, including commands
- * @param {import('@appium/support/lib/npm').TeenProcessExecOpts} [opts] - Options for `teen_process`
- * @returns {Promise<TeenProcessExecResult>}
+ * @param {import('teen_process').ExecOptions} [opts] - Options for `teen_process`
+ * @returns {Promise<import('teen_process').ExecResult<string>>}
  */
 async function run (appiumHome, args, opts = {}) {
   const cwd = PACKAGE_ROOT;
@@ -35,9 +35,6 @@ async function run (appiumHome, args, opts = {}) {
   };
   try {
     args = [...process.execArgv, '--', EXECUTABLE, ...args];
-    /**
-     * @type {TeenProcessExecResult}
-     */
     return await exec(process.execPath, args, {
       cwd,
       env,
@@ -78,7 +75,7 @@ export const runAppium = _.curry(_runAppium);
 
 /**
  * See {@link runAppiumRaw}.
- * @type {AppiumOptsRunner<TeenProcessExecResult>}
+ * @type {AppiumOptsRunner<import('teen_process').ExecResult>}
  */
 async function _runAppiumRaw (appiumHome, args, opts) {
   try {
@@ -90,7 +87,7 @@ async function _runAppiumRaw (appiumHome, args, opts) {
 
 /**
  * Runs the `appium` executable with the given args and returns the entire
- * {@link TeenProcessExecResult} object.
+ * `ExecResult` object.
  *
  * **The third parameter is required**.  Pass empty object if you don't need it.
  **/
@@ -121,7 +118,7 @@ async function _runAppiumJson (appiumHome, args) {
  * i.e., add `@type {MyType}` tag.
  */
 export const runAppiumJson = /**
- * @template {import('../../types/types').CliExtensionSubcommand} ExtSubcommand
+ * @template {import('../../types/cli').CliExtensionSubcommand} ExtSubcommand
  * @type {import('lodash').CurriedFunction2<string, CliExtArgs<ExtSubcommand>|CliArgs, Promise<unknown>>}
  */ (_.curry(_runAppiumJson));
 
@@ -181,13 +178,8 @@ export function formatAppiumArgErrorOutput (stderr) {
  */
 
 /**
- * @typedef {import('@appium/support/lib/npm').TeenProcessExecResult} TeenProcessExecResult
- */
-
-/**
- * @typedef {import('@appium/support/lib/npm').TeenProcessExecError} TeenProcessExecError
- * @typedef {import('@appium/support/lib/npm').TeenProcessExecOpts} TeenProcessExecOpts
  * @typedef {import('../../lib/extension/manifest').ExtensionType} ExtensionType
+ * @typedef {import('@appium/support/lib/npm').TeenProcessExecError} TeenProcessExecError
  * @typedef {import('../../lib/cli/extension-command').ExtensionListData} ExtensionListData
  */
 
@@ -207,7 +199,7 @@ export function formatAppiumArgErrorOutput (stderr) {
 
 /**
  * @template ExtSubCommand
- * @typedef {[import('../../types/types').CliSubcommand, ExtSubCommand, ...string[]]} CliExtArgs
+ * @typedef {[import('../../types/cli').CliSubcommand, ExtSubCommand, ...string[]]} CliExtArgs
  */
 
 /**
@@ -216,7 +208,7 @@ export function formatAppiumArgErrorOutput (stderr) {
 
 /**
  * @template [Result=unknown]
- * @template {import('../../types/types').CliExtensionSubcommand} [ExtSubcommand=never]
+ * @template {import('../../types/cli').CliSubcommand} [ExtSubcommand=never]
  * @callback AppiumRunner
  * @param {string} appiumHome
  * @param {CliExtArgs<ExtSubcommand>|CliArgs} args
@@ -226,10 +218,10 @@ export function formatAppiumArgErrorOutput (stderr) {
 
 /**
  * @template [Result=unknown]
- * @template {import('../../types/types').CliExtensionSubcommand} [ExtSubcommand=never]
+ * @template {import('../../types/cli').CliExtensionSubcommand} [ExtSubcommand=never]
  * @callback AppiumOptsRunner
  * @param {string} appiumHome
  * @param {CliExtArgs<ExtSubcommand>|CliArgs} args
- * @param {import('@appium/support/lib/npm').TeenProcessExecOpts} opts
+ * @param {import('teen_process').ExecOptions} opts
  * @returns {Promise<Result>}
  */

--- a/packages/appium/test/e2e/plugin.e2e.spec.js
+++ b/packages/appium/test/e2e/plugin.e2e.spec.js
@@ -29,7 +29,7 @@ const FAKE_PLUGIN_DIR = path.join(PROJECT_ROOT, 'node_modules', '@appium', 'fake
 describe('FakePlugin', function () {
   /** @type {string} */
   let appiumHome;
-  /** @type {Partial<import('../../types/types').ParsedArgs>} */
+  /** @type {Partial<import('../../types/cli').ParsedArgs>} */
   let baseArgs;
   /** @type {string} */
   let testServerBaseUrl;

--- a/packages/appium/test/fixtures/cli/appium-dependency.package.json
+++ b/packages/appium/test/fixtures/cli/appium-dependency.package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-project",
-  "dependencies": {
+  "devDependencies": {
     "appium": "next"
   }
 }

--- a/packages/appium/types/cli.d.ts
+++ b/packages/appium/types/cli.d.ts
@@ -130,5 +130,5 @@ export type ParsedArgs = DriverOpts &
 export type BuildInfo = {
   version: string;
   'git-sha'?: string;
-  built?: number;
+  built?: string;
 };

--- a/packages/support/lib/util.js
+++ b/packages/support/lib/util.js
@@ -454,9 +454,10 @@ async function toInMemoryBase64 (srcPath, opts = {}) {
  * longer present on the system. This allows for preventing concurrent behavior across processes
  * using a known lockfile path.
  *
+ * @template T
  * @param {string} lockFile The full path to the file used for the lock
  * @param {LockFileOptions} opts
- * @returns {(behavior: () => Promise<void>) => Promise<void>} async function that takes another async function defining the locked
+ * @returns async function that takes another async function defining the locked
  * behavior
  */
 function getLockFileGuard (lockFile, opts = {}) {
@@ -469,6 +470,10 @@ function getLockFileGuard (lockFile, opts = {}) {
   const check = B.promisify(_lockfile.check);
   const unlock = B.promisify(_lockfile.unlock);
 
+  /**
+   * @param {(...args: any[]) => T} behavior
+   * @returns {Promise<T>}
+   */
   const guard = async (behavior) => {
     let triedRecovery = false;
     do {


### PR DESCRIPTION
Closes #16674

the problem here was the existence of the empty `package.json`.  it should exist, because if it doesn't, then `npm` may end up using a `package.json` in a parent directory.  but it can't be _empty_, because subsequent `npm install`s will essentially remove any package that it's currently not installing!  `npm` likes to "fix" `node_modules`, which is undesirable here.

to avoid this, the behavior has changed to persisting the dependency version to `package.json`.  behavior differs if we're using a local `APPIUM_HOME` or the default one.  with the default, we have more control, and choose to use `--save-dev --save-exact --no-package-lock --global-style` which gives us what we need.  if `APPIUM_HOME` is a local package, all we can do is `--save-dev` (since it's _likely_ that an extension will be a dev dependency).  in the future, we may choose to actually determine _what kind_ of dependency `appium` is and tell `npm` to use the same one.  not sure if that's needed, though.

further, in the case of a local appium dep (local `APPIUM_HOME`), updating `package.json` should cause the package hash (used by the thing that syncs `extensions.yaml` with installed packages) to update as well, so we're doing that.

modified the logic in `ExtensionCommand` to treat `--source=local` to pass the `installSpec` thru ~~verbatim~~ as an absolute path

also fixed `BuildInfo` type to reflect reality and use `@types/teen_process`.  fixed some other broken types in `test` (files in `test` are not checked by typescript yet; we'll need a separate `tsconfig.json` for this, since we do not want to emit declarations)

* * *

@jlipps I'm unclear on the intent of avoiding writing to the "dummy" `package.json` (the presence of `--no-save` in the `npm install` command, which I needed to remove).  If we have to keep that behavior, then I need to go back to the drawing board.  Unfortunately, the result will be more complex than it already is, as I'll need to revert "do not create an empty directory for each extension", and keep that behavior separate from how it behaves when run in a dir with an `appium` dep.  I am not sure how to tell `npm` "do not look for a parent `package.json` above `cwd`", or if that's even possible.
