### PR TITLE
fix(types): add method for elementShadowRoot

### DIFF
--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -241,7 +241,6 @@ const METHOD_MAP = {
     GET: {command: 'getSize'}
   },
   '/session/:sessionId/element/:elementId/shadow': {
-    // @ts-expect-error -- this method is not defined in ExternalDriver
     GET: {command: 'elementShadowRoot'}
   },
   '/session/:sessionId/element/:elementId/css/:propertyName': {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -245,6 +245,7 @@ export interface ExternalDriver extends Driver {
   getLocation?(elementId: string): Promise<Position>;
   getLocationInView?(elementId: string): Promise<Position>;
   getSize?(elementId: string): Promise<Size>;
+  elementShadowRoot?(elementId: string): Promise<Element>;
   equalsElement?(elementId: string, otherElementId: string): Promise<boolean>;
   submit?(elementId: string): Promise<void>;
   keys?(value: string[]): Promise<void>;


### PR DESCRIPTION
This adds a type for the `elementShadowRoot` method that an external driver may implement.

I don't know if `Element` is correct, but that's my best guess.

@mykola-mokhnach Looks like you recently (?) added the route for `elementShadowRoot`.  Is `Element` correct, here?

In the future, when we add new routes, TypeScript will report an error if the route is unexpected (the value of `command` must match a method in `ExternalDriver`).