### PR TITLE
chore(ci): only build on PRs and pushes to 2.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,11 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Appium Build
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - '2.0'
 
 jobs:
   test:


### PR DESCRIPTION
For every push to a PR, when the PR branch exists on `appium/appium`, a "push" build happens and a "pr" build happens.  The "push" build tests the code in isolation, and the "pr" build tests it as it would be merged into the base branch.  mostly this is just extra work, as the latter type is much more important.  however, the `2.0` branch should be tested every time code is merged into it.

What do we think of this (assuming it works)?