### PR TITLE
chore(appium): increase build timeout of e2e tests

### DIFF
--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -44,7 +44,7 @@
     "postinstall": "node ./scripts/postinstall.js",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "test": "npm run test:unit",
-    "test:e2e": "mocha --require ../../test/setup-babel.js --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
+    "test:e2e": "mocha --require ../../test/setup-babel.js --timeout 30s --slow 15s \"./test/e2e/**/*.spec.js\"",
     "test:unit": "mocha --require ../../test/setup-babel.js \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {


### PR DESCRIPTION
these are consistently failing at 20s, probably due to heavy load on GHA
