### PR TITLE
chore(base-driver): Update the deprecated 'del' method name

### DIFF
--- a/packages/base-driver/lib/basedriver/helpers.js
+++ b/packages/base-driver/lib/basedriver/helpers.js
@@ -262,7 +262,7 @@ async function configureApp (app, options = {}) {
         }
         logger.info(`The application at '${cachedPath}' does not exist anymore ` +
           `or its integrity has been damaged. Deleting it from the internal cache`);
-        APPLICATIONS_CACHE.del(app);
+        APPLICATIONS_CACHE.delete(app);
       }
 
       let fileName = null;
@@ -347,7 +347,7 @@ async function configureApp (app, options = {}) {
         }
         logger.info(`The application at '${fullPath}' does not exist anymore ` +
           `or its integrity has been damaged. Deleting it from the cache`);
-        APPLICATIONS_CACHE.del(app);
+        APPLICATIONS_CACHE.delete(app);
       }
       const tmpRoot = await tempDir.openDir();
       try {

--- a/packages/base-driver/lib/express/idempotency.js
+++ b/packages/base-driver/lib/express/idempotency.js
@@ -78,14 +78,14 @@ function cacheResponse (key, req, res) {
     }
     if (writeError) {
       log.info(`Could not cache the response identified by '${key}': ${writeError.message}`);
-      IDEMPOTENT_RESPONSES.del(key);
+      IDEMPOTENT_RESPONSES.delete(key);
       return responseStateListener.emit('ready', null);
     }
     if (!isResponseFullySent) {
       log.info(`Could not cache the response identified by '${key}', ` +
         `because it has not been completed`);
       log.info('Does the client terminate connections too early?');
-      IDEMPOTENT_RESPONSES.del(key);
+      IDEMPOTENT_RESPONSES.delete(key);
       return responseStateListener.emit('ready', null);
     }
 
@@ -125,7 +125,7 @@ async function handleIdempotency (req, res, next) {
 
   const rerouteCachedResponse = async (cachedResPath) => {
     if (!await fs.exists(cachedResPath)) {
-      IDEMPOTENT_RESPONSES.del(key);
+      IDEMPOTENT_RESPONSES.delete(key);
       log.warn(`Could not read the cached response identified by key '${key}'`);
       log.warn('The temporary storage is not accessible anymore');
       return next();


### PR DESCRIPTION
## Proposed changes

> (node:58940) [LRU_CACHE_METHOD_del] DeprecationWarning: The del method is deprecated. Please use cache.delete() instead.
> (Use `node --trace-deprecation ...` to show where the warning was created)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
