### PR TITLE
Changed deprecated function

### DIFF
--- a/commands-yml/commands/element/actions/click.yml
+++ b/commands-yml/commands/element/actions/click.yml
@@ -13,8 +13,8 @@ example_usage:
       el.click();
   python:
     |
-      el = self.driver.find_element_by_accessibility_id('SomeId')
-      el.click();
+      el = self.driver.find_element(by=AppiumBy.ACCESSIBILITY_ID, value='SomeId')
+      el.click()
   javascript_wd:
     |
       let element = await driver.elementByAccessibilityId('id', 'SomeId');


### PR DESCRIPTION
## Proposed changes

find_element_by_accessibility_id was deprecated in python. Changed it with by=AppiumBy.ACCESSIBILITY_ID.

## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
