### PR TITLE
fix(appium,types): avoid call to assignServer()

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -274,10 +274,14 @@ class AppiumDriver extends DriverCore {
       // the driver so that they cannot be mimicked by a malicious user sending in capabilities
       this.assignCliArgsToExtension('driver', driverName, driverInstance);
 
-
       // This assignment is required for correct web sockets functionality inside the driver
       // Drivers/plugins might also want to know where they are hosted
-      driverInstance.assignServer(this.server, this.args.address, this.args.port, this.args.basePath);
+
+      // XXX: temporary hack to work around #16747
+      driverInstance.server = this.server;
+      driverInstance.serverHost = this.args.address;
+      driverInstance.serverPort = this.args.port;
+      driverInstance.serverPath = this.args.basePath;
 
       try {
         runningDriversData = await this.curSessionDataForDriver(InnerDriver) ?? [];

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -72,7 +72,7 @@ export interface Driver
   startNewCommandTimeout(): Promise<void>;
   reset(): Promise<void>;
 
-  assignServer(
+  assignServer?(
     server: AppiumServer,
     host: string,
     port: number,


### PR DESCRIPTION
Due to the way which drivers currently include `@appium/base-driver`, it's possible for a driver to become out-of-date with respect to `AppiumDriver` and fail to implement the expected interface.  This change partially reverts the addition of `Driver.assignServer()`, which is a new function that old versions of `@appium/base-driver` do not implement.

Ref: #16747 (does not fix)