### PR TITLE
fix(base-driver): supportedLogTypes does not get overwritten

### DIFF
--- a/packages/base-driver/lib/basedriver/commands/log.js
+++ b/packages/base-driver/lib/basedriver/commands/log.js
@@ -13,11 +13,12 @@ export function LogMixin (Base) {
    * @implements {ILogCommands}
    */
   class LogCommands extends Base {
-    /**
-     * XXX: dubious
-     * @type {Record<string,LogType<Driver>>}
-     */
-    supportedLogTypes;
+
+    constructor (...args) {
+      super(...args);
+      /** @type {Record<string, LogType<Driver>>} */
+      this.supportedLogTypes = this.supportedLogTypes ?? {};
+    }
 
     async getLogTypes () {
       this.log.debug('Retrieving supported log types');
@@ -26,19 +27,13 @@ export function LogMixin (Base) {
 
     /**
      * @this {Driver}
+     * @param {string} logType
      */
     async getLog (logType) {
       this.log.debug(`Retrieving '${logType}' logs`);
 
       if (!(await this.getLogTypes()).includes(logType)) {
-        const logsTypesWithDescriptions = _.reduce(
-          this.supportedLogTypes,
-          (acc, value, key) => {
-            acc[key] = value.description;
-            return acc;
-          },
-          {},
-        );
+        const logsTypesWithDescriptions = _.mapValues(this.supportedLogTypes, 'description');
         throw new Error(
           `Unsupported log type '${logType}'. ` +
             `Supported types: ${JSON.stringify(logsTypesWithDescriptions)}`,

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -72,7 +72,7 @@ export interface Driver
   startNewCommandTimeout(): Promise<void>;
   reset(): Promise<void>;
 
-  assignServer(
+  assignServer?(
     server: AppiumServer,
     host: string,
     port: number,
@@ -597,7 +597,14 @@ export interface FindCommands {
 export interface LogCommands {
   supportedLogTypes: Record<string, LogType<Driver>>;
   getLogTypes(): Promise<string[]>;
-  getLog<T>(logType: LogType<T>): Promise<any[]>;
+  /**
+   * Gets logs
+   * 
+   * TODO: `logType` should be a key in `supportedLogTypes`, and the return value of this function
+   * should be the associated `LogType` object's `LogEntry` parameterized type.
+   * @param logType - Name/key of log type as defined in {@linkcode LogCommands.supportedLogTypes}.
+   */
+  getLog(logType: string): Promise<any[]>;
 }
 
 export interface SettingsCommands {


### PR DESCRIPTION
Closes #16738

There's a difference between assigning things to a prototype and public class fields, evidently.

To test this would be best done via interaction between drivers and `base-driver`, but affected drivers do not necessarily run the reusable test suite.  Fundamentally, a unit test for this would be testing Babel.  Unsure of best way to add an E2E test

Once it gets merged, we should publish as soon as possible, since @mykola-mokhnach is blocking on this.