### PR TITLE
feat(eslint-config-appium): adds a warning if code attempts to assign to object prototype

### DIFF
--- a/packages/eslint-config-appium/index.js
+++ b/packages/eslint-config-appium/index.js
@@ -98,6 +98,17 @@ module.exports = {
     'require-atomic-updates': 0,
     'no-prototype-builtins': 1,
     'no-redeclare': 1,
+    'no-restricted-syntax': [
+      'warn',
+      {
+        selector: 'AssignmentExpression[left.object.property.name="prototype"]',
+        message: 'Avoid assignment to prototype; use class fields, methods or mixins instead.',
+      },
+      {
+        selector: 'CallExpression[callee.object.name="Object"][callee.property.name="assign"][arguments.0.property.name="prototype"]',
+        message: 'Avoid assignment to prototype; use class fields, methods or mixins instead.'
+      }
+    ]
   },
   extends: [
     'eslint:recommended',


### PR DESCRIPTION
See #16829

When using ES6 `class` syntax, direct assignment to `prototype` can be a source of bugs.  Class properties seem to exacerbate the issue.  While in many cases this code will work fine, there is not always a straightforward workaround, which is why the rule just emits a warning.

The new syntax rule considers assignment to the `prototype` of any object, as well as using `Object.assign()` to do the same.
