### PR TITLE
test(docutils): run mike test against sources

### DIFF
--- a/packages/docutils/test/unit/mike.spec.js
+++ b/packages/docutils/test/unit/mike.spec.js
@@ -1,4 +1,4 @@
-import { Mike } from '../..';
+import { Mike } from '../../lib';
 import { expect } from 'chai';
 
 describe('Mike', function () {


### PR DESCRIPTION
referencing the project root pulls the root `index.js`, which requires `build/lib`, which is not what we want.

I wonder if `eslint-plugin-import` would allow us to avoid this... hm.