### PR TITLE
chore: add prettier

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "build:loose": "run-s -c build:distfiles build:types || true",
     "build:types": "tsc -b",
     "clean": "run-s clean:artifacts clean:packages clean:monorepo",
+    "clean:artifacts": "run-s clean:distfiles clean:types && npx rimraf \"packages/*/build\"",
     "clean:distfiles": "npx rimraf \"packages/*/build/**/*.js\"",
     "clean:monorepo": "npx rimraf node_modules package-lock.json",
     "clean:packages": "lerna clean -y && npx rimraf \"packages/*/package-lock.json\"",
     "clean:types": "tsc -b --clean",
-    "clean:artifacts": "run-s clean:distfiles clean:types && npx rimraf \"packages/*/build\"",
     "dev": "run-p dev:*",
     "dev:distfiles": "lerna run --parallel --prefix --concurrency=8 dev",
     "dev:types": "tsc -b --watch",
@@ -69,13 +69,21 @@
     "precommit-lint"
   ],
   "lint-staged": {
-    "*.js": "eslint --fix"
+    "*.js": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  },
+  "prettier": {
+    "bracketSpacing": false,
+    "singleQuote": true
   },
   "dependencies": {
     "@appium/base-driver": "file:packages/base-driver",
     "@appium/base-plugin": "file:packages/base-plugin",
     "@appium/doctor": "file:packages/doctor",
     "@appium/eslint-config-appium": "file:packages/eslint-config-appium",
+    "@appium/execute-driver-plugin": "file:packages/execute-driver-plugin",
     "@appium/fake-driver": "file:packages/fake-driver",
     "@appium/fake-plugin": "file:packages/fake-plugin",
     "@appium/gulp-plugins": "file:packages/gulp-plugins",
@@ -87,7 +95,6 @@
     "@appium/test-support": "file:packages/test-support",
     "@appium/types": "file:packages/types",
     "@appium/universal-xml-plugin": "file:packages/universal-xml-plugin",
-    "@appium/execute-driver-plugin": "file:packages/execute-driver-plugin",
     "appium": "file:packages/appium"
   },
   "devDependencies": {
@@ -140,6 +147,7 @@
     "chai-as-promised": "7.1.1",
     "chai-webdriverio-async": "2.6.0",
     "eslint": "7.32.0",
+    "eslint-config-prettier": "8.5.0",
     "eslint-find-rules": "4.1.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-mocha": "9.0.0",
@@ -157,6 +165,7 @@
     "mocha": "9.2.2",
     "npm-run-all": "4.1.5",
     "pre-commit": "1.2.2",
+    "prettier": "2.6.2",
     "rewiremock": "3.14.3",
     "rimraf": "3.0.2",
     "serve-static": "1.15.0",

--- a/packages/eslint-config-appium/index.js
+++ b/packages/eslint-config-appium/index.js
@@ -6,22 +6,18 @@ module.exports = {
     sourceType: 'module',
     ecmaFeatures: {
       impliedStrict: true,
-      experimentalObjectRestSpread: true
-    }
+      experimentalObjectRestSpread: true,
+    },
   },
   env: {
     node: true,
     mocha: true,
     es6: true,
   },
-  plugins: [
-    'import',
-    'mocha',
-    'promise'
-  ],
+  plugins: ['import', 'mocha', 'promise'],
   globals: {
     chai: true,
-    should: true
+    should: true,
   },
   rules: {
     'no-console': 2,
@@ -29,23 +25,31 @@ module.exports = {
     radix: [2, 'always'],
     'dot-notation': 2,
     eqeqeq: [2, 'smart'],
-    'brace-style': [2, '1tbs', {
-      allowSingleLine: true,
-    }],
-    indent: [2, 2, {
-      VariableDeclarator: {
-        var: 2,
-        let: 2,
-        const: 3,
+    'brace-style': [
+      2,
+      '1tbs',
+      {
+        allowSingleLine: true,
       },
-      ImportDeclaration: 'first',
-      CallExpression: {
-        arguments: 'off',
+    ],
+    indent: [
+      2,
+      2,
+      {
+        VariableDeclarator: {
+          var: 2,
+          let: 2,
+          const: 3,
+        },
+        ImportDeclaration: 'first',
+        CallExpression: {
+          arguments: 'off',
+        },
+        MemberExpression: 'off',
+        ObjectExpression: 'first',
+        SwitchCase: 1,
       },
-      MemberExpression: 'off',
-      ObjectExpression: 'first',
-      SwitchCase: 1,
-    }],
+    ],
     'comma-dangle': 0,
     'no-empty': 0,
     'object-shorthand': 2,
@@ -69,31 +73,44 @@ module.exports = {
     // enforce spacing
     'arrow-spacing': 2,
     'keyword-spacing': 2,
-    'comma-spacing': [2, {
-      before: false,
-      after: true
-    }],
+    'comma-spacing': [
+      2,
+      {
+        before: false,
+        after: true,
+      },
+    ],
     'array-bracket-spacing': 2,
     'no-trailing-spaces': 2,
     'no-whitespace-before-property': 2,
     'space-in-parens': [2, 'never'],
     'space-before-blocks': [2, 'always'],
     'space-before-function-paren': [2, 'always'],
-    'space-unary-ops': [2, {
-      words: true,
-      nonwords: false,
-    }],
+    'space-unary-ops': [
+      2,
+      {
+        words: true,
+        nonwords: false,
+      },
+    ],
     'space-infix-ops': 2,
-    'key-spacing': [2, {
-      mode: 'strict',
-      beforeColon: false,
-      afterColon: true,
-    }],
+    'key-spacing': [
+      2,
+      {
+        mode: 'strict',
+        beforeColon: false,
+        afterColon: true,
+      },
+    ],
     'no-multi-spaces': 2,
-    quotes: [2, 'single', {
-      avoidEscape: true,
-      allowTemplateLiterals: true,
-    }],
+    quotes: [
+      2,
+      'single',
+      {
+        avoidEscape: true,
+        allowTemplateLiterals: true,
+      },
+    ],
     'no-buffer-constructor': 1,
     'require-atomic-updates': 0,
     'no-prototype-builtins': 1,
@@ -110,7 +127,5 @@ module.exports = {
       }
     ]
   },
-  extends: [
-    'eslint:recommended',
-  ],
+  extends: ['eslint:recommended', 'prettier'],
 };

--- a/packages/eslint-config-appium/package.json
+++ b/packages/eslint-config-appium/package.json
@@ -8,13 +8,14 @@
     "appium",
     "es2015"
   ],
+  "homepage": "https://appium.io",
+  "bugs": {
+    "url": "https://github.com/appium/appium/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/appium/appium.git",
     "directory": "packages/eslint-config-appium"
-  },
-  "bugs": {
-    "url": "https://github.com/appium/appium/issues"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
@@ -33,17 +34,17 @@
     "@babel/core": "7.17.9",
     "@babel/eslint-parser": "7.17.0",
     "eslint": "7.32.0",
+    "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-mocha": "9.0.0",
     "eslint-plugin-promise": "6.0.0"
   },
-  "publishConfig": {
-    "access": "public"
-  },
-  "homepage": "https://appium.io",
   "engines": {
     "node": ">=12",
     "npm": ">=6"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }


### PR DESCRIPTION
- As a pre-commit hook, `.js` files will be run thru `eslint --fix` and rewritten using `prettier`.
- Added `eslint-config-prettier` to disable rules incompatible with `prettier`.
- Added a `.gitattributes` to enforce `lf` line endings.

Files will not be formatted with `prettier` _unless_ they have been added to the stage; nothing is going to go reformat the whole codebase.

* * *

The idea with Prettier, of course, is to automatically format code.

You made not like some of the choices it makes.  Heck, I don't like some of the choices it makes.  But the point is twofold:

1. Consistent formatting across codebase
2. Avoiding the inevitable discussion about formatting in pull requests

Prettier has relatively few options.  There's a lot of minutiae that it simply won't let you control.  That said, I have set a few options which it _does_ have:

1. `bracketSpacing: false` - we don't use bracket spacing in general, but we _do_ use it in `import` statements.  It's all-or-nothing.
2. `singleQuote: true` - use single quotes for formatting strings, unless we'd end up with too many escapes. does not affect template literals


