### PR TITLE
chore: "lerna link convert"; replace siblings with relative "file:" links

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,9 @@ jobs:
       - name: Install latest npm
         run: npm install -g npm
       - name: Install dependencies
-        run: npm install
+        run: |
+          npm install
+          npm run install-mjpeg-consumer
       - name: Run all tests
         run: npm run test:ci
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "generate-docs": "lerna run --scope=appium generate-docs",
     "postinstall": "npm run build:loose",
     "install-fake-driver": "npm start -- driver install --source=local ./packages/fake-driver",
+    "install-mjpeg-consumer": "npm install mjpeg-consumer --no-save",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "precommit-lint": "lint-staged",
@@ -75,7 +76,9 @@
     "@appium/base-driver": "file:packages/base-driver",
     "@appium/base-plugin": "file:packages/base-plugin",
     "@appium/doctor": "file:packages/doctor",
+    "@appium/docutils": "file:packages/docutils",
     "@appium/eslint-config-appium": "file:packages/eslint-config-appium",
+    "@appium/execute-driver-plugin": "file:packages/execute-driver-plugin",
     "@appium/fake-driver": "file:packages/fake-driver",
     "@appium/fake-plugin": "file:packages/fake-plugin",
     "@appium/gulp-plugins": "file:packages/gulp-plugins",
@@ -87,7 +90,6 @@
     "@appium/test-support": "file:packages/test-support",
     "@appium/types": "file:packages/types",
     "@appium/universal-xml-plugin": "file:packages/universal-xml-plugin",
-    "@appium/execute-driver-plugin": "file:packages/execute-driver-plugin",
     "appium": "file:packages/appium"
   },
   "devDependencies": {
@@ -168,6 +170,7 @@
     "typescript": "4.6.3",
     "validate.js": "0.13.1",
     "webdriverio": "7.19.5",
+    "ws": "8.5.0",
     "yaml-js": "0.3.1"
   },
   "engines": {

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -53,11 +53,11 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/base-driver": "^8.5.2",
-    "@appium/base-plugin": "^1.8.4",
-    "@appium/docutils": "^0.0.3",
-    "@appium/schema": "^0.0.5",
-    "@appium/support": "^2.57.4",
+    "@appium/base-driver": "file:../base-driver",
+    "@appium/base-plugin": "file:../base-plugin",
+    "@appium/docutils": "file:../docutils",
+    "@appium/schema": "file:../schema",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.17.9",
     "@sidvind/better-ajv-errors": "1.1.1",
     "ajv": "8.11.0",

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -48,7 +48,7 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/support": "^2.57.4",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.17.9",
     "@colors/colors": "1.5.0",
     "async-lock": "1.3.1",
@@ -66,9 +66,6 @@
     "serve-favicon": "2.5.0",
     "source-map-support": "0.5.21",
     "validate.js": "0.13.1"
-  },
-  "devDependencies": {
-    "ws": "8.5.0"
   },
   "engines": {
     "node": ">=12",

--- a/packages/base-plugin/package.json
+++ b/packages/base-plugin/package.json
@@ -31,7 +31,7 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/support": "^2.57.4"
+    "@appium/support": "file:../support"
   },
   "engines": {
     "node": ">=12",

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -45,7 +45,7 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/support": "^2.57.4",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.17.9",
     "@colors/colors": "1.5.0",
     "appium-adb": "9.2.1",

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -38,7 +38,7 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/support": "^2.57.4",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.17.9",
     "docdash": "1.2.0",
     "jsdoc": "3.6.10",

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -28,8 +28,8 @@
     "index.js"
   ],
   "dependencies": {
-    "@appium/base-plugin": "^1.8.4",
-    "@appium/support": "^2.57.4",
+    "@appium/base-plugin": "file:../base-plugin",
+    "@appium/support": "file:../support",
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
     "vm2": "3.9.9",

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -45,8 +45,8 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/base-driver": "^8.5.2",
-    "@appium/support": "^2.57.4",
+    "@appium/base-driver": "file:../base-driver",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.17.9",
     "@xmldom/xmldom": "0.8.2",
     "asyncbox": "2.9.2",

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -36,8 +36,8 @@
     "build"
   ],
   "dependencies": {
-    "@appium/base-plugin": "^1.8.4",
-    "@appium/support": "^2.57.4",
+    "@appium/base-plugin": "file:../base-plugin",
+    "@appium/support": "file:../support",
     "bluebird": "3.7.2",
     "lodash": "4.17.21"
   },

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -41,7 +41,7 @@
     "test:e2e": "gulp e2e-test:run"
   },
   "dependencies": {
-    "@appium/eslint-config-appium": "^5.0.6",
+    "@appium/eslint-config-appium": "file:../eslint-config-appium",
     "@babel/core": "7.17.9",
     "@babel/eslint-parser": "7.17.0",
     "@babel/plugin-transform-runtime": "7.17.0",

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -35,10 +35,10 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/base-driver": "^8.5.2",
-    "@appium/base-plugin": "^1.8.4",
-    "@appium/opencv": "^1.0.7",
-    "@appium/support": "^2.57.4",
+    "@appium/base-driver": "file:../base-driver",
+    "@appium/base-plugin": "file:../base-plugin",
+    "@appium/opencv": "file:../opencv",
+    "@appium/support": "file:../support",
     "lru-cache": "6.0.0"
   },
   "appium": {

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -32,7 +32,7 @@
     "build"
   ],
   "dependencies": {
-    "@appium/base-plugin": "^1.8.4",
+    "@appium/base-plugin": "file:../base-plugin",
     "lodash": "4.17.21"
   },
   "scripts": {

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -85,11 +85,5 @@
     "access": "public"
   },
   "types": "./build/lib/index.d.ts",
-  "devDependencies": {
-    "type-fest": "2.12.2"
-  },
-  "overrides": {
-    "type-fest": "$type-fest"
-  },
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -45,7 +45,7 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/support": "^2.57.4",
+    "@appium/support": "file:../support",
     "@babel/runtime": "7.17.9",
     "bluebird": "3.7.2",
     "lodash": "4.17.21",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -38,6 +38,6 @@
   },
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
   "dependencies": {
-    "@appium/schema": "^0.0.5"
+    "@appium/schema": "file:../schema"
   }
 }

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -32,8 +32,8 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/base-driver": "^8.5.2",
-    "@appium/base-plugin": "^1.8.4",
+    "@appium/base-driver": "file:../base-driver",
+    "@appium/base-plugin": "file:../base-plugin",
     "fast-xml-parser": "3.21.1",
     "xmldom": "0.6.0",
     "xpath": "0.0.32"


### PR DESCRIPTION
not sure what went wrong with the last round of publishes, but this reverts the change.

during publish, lerna replaces these relative `file:..` dependencies with actual version numbers using a temp file.  I imagine if something breaks, that does not get restored properly.

the command to run is `lerna link convert` or `npm exec lerna link convert`