### PR TITLE
chore(appium): simplify type references

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -1,13 +1,19 @@
 /* eslint-disable no-unused-vars */
 import _ from 'lodash';
-import { getBuildInfo, updateBuildInfo, APPIUM_VER } from './config';
-import { BaseDriver, DriverCore, errors, isSessionCommand,
-         CREATE_SESSION_COMMAND, DELETE_SESSION_COMMAND, GET_STATUS_COMMAND
+import {getBuildInfo, updateBuildInfo, APPIUM_VER} from './config';
+import {
+  BaseDriver,
+  DriverCore,
+  errors,
+  isSessionCommand,
+  CREATE_SESSION_COMMAND,
+  DELETE_SESSION_COMMAND,
+  GET_STATUS_COMMAND,
 } from '@appium/base-driver';
 import AsyncLock from 'async-lock';
-import { parseCapsForInnerDriver, pullSettings } from './utils';
-import { util, node, logger } from '@appium/support';
-import { getDefaultsForExtension } from './schema';
+import {parseCapsForInnerDriver, pullSettings} from './utils';
+import {util, node, logger} from '@appium/support';
+import {getDefaultsForExtension} from './schema';
 
 /**
  * Invariant set of base constraints
@@ -70,7 +76,7 @@ class AppiumDriver extends DriverCore {
    * some commands are sessionless, so we need a set of plugins for them
    * @type {InstanceType<PluginClass>[]}
    */
-  sessionlessPlugins = [];;
+  sessionlessPlugins = [];
 
   /** @type {DriverConfig} */
   driverConfig;
@@ -81,7 +87,7 @@ class AppiumDriver extends DriverCore {
   /**
    * @param {DriverOpts} opts
    */
-  constructor (opts) {
+  constructor(opts) {
     // It is necessary to set `--tmp` here since it should be set to
     // process.env.APPIUM_TMP_DIR once at an initial point in the Appium lifecycle.
     // The process argument will be referenced by BaseDriver.
@@ -107,9 +113,11 @@ class AppiumDriver extends DriverCore {
   /**
    * Retrieves logger instance for the current umbrella driver instance
    */
-  get log () {
+  get log() {
     if (!this._log) {
-      const instanceName = `${this.constructor.name}@${node.getObjectId(this).substring(0, 4)}`;
+      const instanceName = `${this.constructor.name}@${node
+        .getObjectId(this)
+        .substring(0, 4)}`;
       this._log = logger.getLogger(instanceName);
     }
     return this._log;
@@ -118,43 +126,50 @@ class AppiumDriver extends DriverCore {
   /**
    * Cancel commands queueing for the umbrella Appium driver
    */
-  get isCommandsQueueEnabled () {
+  get isCommandsQueueEnabled() {
     return false;
   }
 
-  sessionExists (sessionId) {
+  sessionExists(sessionId) {
     const dstSession = this.sessions[sessionId];
     return dstSession && dstSession.sessionId !== null;
   }
 
-  driverForSession (sessionId) {
+  driverForSession(sessionId) {
     return this.sessions[sessionId];
   }
 
-  async getStatus () { // eslint-disable-line require-await
+  // eslint-disable-next-line require-await
+  async getStatus() {
     return {
       build: _.clone(getBuildInfo()),
     };
   }
 
-  async getSessions () { // eslint-disable-line require-await
-    return _.toPairs(this.sessions)
-      .map(([id, driver]) => ({id, capabilities: driver.caps}));
+  // eslint-disable-next-line require-await
+  async getSessions() {
+    return _.toPairs(this.sessions).map(([id, driver]) => ({
+      id,
+      capabilities: driver.caps,
+    }));
   }
 
-  printNewSessionAnnouncement (driverName, driverVersion, driverBaseVersion) {
-    this.log.info(driverVersion
-      ? `Appium v${APPIUM_VER} creating new ${driverName} (v${driverVersion}) session`
-      : `Appium v${APPIUM_VER} creating new ${driverName} session`
+  printNewSessionAnnouncement(driverName, driverVersion, driverBaseVersion) {
+    this.log.info(
+      driverVersion
+        ? `Appium v${APPIUM_VER} creating new ${driverName} (v${driverVersion}) session`
+        : `Appium v${APPIUM_VER} creating new ${driverName} session`
     );
     this.log.info(`Checking BaseDriver versions for Appium and ${driverName}`);
-    this.log.info(AppiumDriver.baseVersion
-      ? `Appium's BaseDriver version is ${AppiumDriver.baseVersion}`
-      : `Could not determine Appium's BaseDriver version`
+    this.log.info(
+      AppiumDriver.baseVersion
+        ? `Appium's BaseDriver version is ${AppiumDriver.baseVersion}`
+        : `Could not determine Appium's BaseDriver version`
     );
-    this.log.info(driverBaseVersion
-      ? `${driverName}'s BaseDriver version is ${driverBaseVersion}`
-      : `Could not determine ${driverName}'s BaseDriver version`
+    this.log.info(
+      driverBaseVersion
+        ? `${driverName}'s BaseDriver version is ${driverBaseVersion}`
+        : `Could not determine ${driverName}'s BaseDriver version`
     );
   }
 
@@ -168,13 +183,17 @@ class AppiumDriver extends DriverCore {
    * @param {string} extName the name of the extension
    * @param {Object} extInstance the driver or plugin instance
    */
-  assignCliArgsToExtension (extType, extName, extInstance) {
-    const allCliArgsForExt = /** @type {Record<string,unknown>|undefined} */(this.args[extType]?.[extName]);
+  assignCliArgsToExtension(extType, extName, extInstance) {
+    const allCliArgsForExt = /** @type {Record<string,unknown>|undefined} */ (
+      this.args[extType]?.[extName]
+    );
     if (!_.isEmpty(allCliArgsForExt)) {
       const defaults = getDefaultsForExtension(extType, extName);
       const cliArgs = _.isEmpty(defaults)
         ? allCliArgsForExt
-        : _.omitBy(allCliArgsForExt, (value, key) => _.isEqual(defaults[key], value));
+        : _.omitBy(allCliArgsForExt, (value, key) =>
+            _.isEqual(defaults[key], value)
+          );
       if (!_.isEmpty(cliArgs)) {
         extInstance.cliArgs = cliArgs;
       }
@@ -188,7 +207,7 @@ class AppiumDriver extends DriverCore {
    * @param {W3CCapabilities} w3cCapabilities W3C capabilities
    * @param {import('@appium/types').DriverData[]} [driverData]
    */
-  async createSession (jsonwpCaps, reqCaps, w3cCapabilities, driverData) {
+  async createSession(jsonwpCaps, reqCaps, w3cCapabilities, driverData) {
     const defaultCapabilities = _.cloneDeep(this.args.defaultCapabilities);
     const defaultSettings = pullSettings(defaultCapabilities);
     jsonwpCaps = _.cloneDeep(jsonwpCaps);
@@ -200,9 +219,9 @@ class AppiumDriver extends DriverCore {
     // JSONWP caps to W3C caps
     const w3cSettings = {
       ...jwpSettings,
-      ...pullSettings((w3cCapabilities ?? {}).alwaysMatch ?? {})
+      ...pullSettings((w3cCapabilities ?? {}).alwaysMatch ?? {}),
     };
-    for (const firstMatchEntry of ((w3cCapabilities ?? {}).firstMatch ?? [])) {
+    for (const firstMatchEntry of (w3cCapabilities ?? {}).firstMatch ?? []) {
       Object.assign(w3cSettings, pullSettings(firstMatchEntry));
     }
 
@@ -217,9 +236,14 @@ class AppiumDriver extends DriverCore {
         defaultCapabilities
       );
 
-      const {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} = /** @type {import('./utils').ParsedDriverCaps} */(parsedCaps);
+      const {
+        desiredCaps,
+        processedJsonwpCapabilities,
+        processedW3CCapabilities,
+      } = /** @type {import('./utils').ParsedDriverCaps} */ (parsedCaps);
       protocol = parsedCaps.protocol;
-      const error = /** @type {import('./utils').InvalidCaps} */(parsedCaps).error;
+      const error = /** @type {import('./utils').InvalidCaps} */ (parsedCaps)
+        .error;
       // If the parsing of the caps produced an error, throw it in here
       if (error) {
         throw error;
@@ -228,9 +252,13 @@ class AppiumDriver extends DriverCore {
       const {
         driver: InnerDriver,
         version: driverVersion,
-        driverName
+        driverName,
       } = this.driverConfig.findMatchingDriver(desiredCaps);
-      this.printNewSessionAnnouncement(InnerDriver.name, driverVersion, InnerDriver.baseVersion);
+      this.printNewSessionAnnouncement(
+        InnerDriver.name,
+        driverVersion,
+        InnerDriver.baseVersion
+      );
 
       if (this.args.sessionOverride) {
         await this.deleteAllSessions();
@@ -252,9 +280,11 @@ class AppiumDriver extends DriverCore {
       // could have been set by a malicious user via capabilities, whereas we
       // want a guarantee the values were set by the appium server admin
       if (this.args.relaxedSecurityEnabled) {
-        this.log.info(`Applying relaxed security to '${InnerDriver.name}' as per ` +
-          `server command line argument. All insecure features will be ` +
-          `enabled unless explicitly disabled by --deny-insecure`);
+        this.log.info(
+          `Applying relaxed security to '${InnerDriver.name}' as per ` +
+            `server command line argument. All insecure features will be ` +
+            `enabled unless explicitly disabled by --deny-insecure`
+        );
         driverInstance.relaxedSecurityEnabled = true;
       }
 
@@ -284,13 +314,17 @@ class AppiumDriver extends DriverCore {
       driverInstance.serverPath = this.args.basePath;
 
       try {
-        runningDriversData = await this.curSessionDataForDriver(InnerDriver) ?? [];
+        runningDriversData =
+          (await this.curSessionDataForDriver(InnerDriver)) ?? [];
       } catch (e) {
         throw new errors.SessionNotCreatedError(e.message);
       }
       await pendingDriversGuard.acquire(AppiumDriver.name, () => {
-        this.pendingDrivers[InnerDriver.name] = this.pendingDrivers[InnerDriver.name] || [];
-        otherPendingDriversData = _.compact(this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData));
+        this.pendingDrivers[InnerDriver.name] =
+          this.pendingDrivers[InnerDriver.name] || [];
+        otherPendingDriversData = _.compact(
+          this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData)
+        );
         this.pendingDrivers[InnerDriver.name].push(driverInstance);
       });
 
@@ -311,20 +345,29 @@ class AppiumDriver extends DriverCore {
 
       this.attachUnexpectedShutdownHandler(driverInstance, innerSessionId);
 
-      this.log.info(`New ${InnerDriver.name} session created successfully, session ` +
-        `${innerSessionId} added to master session list`);
+      this.log.info(
+        `New ${InnerDriver.name} session created successfully, session ` +
+          `${innerSessionId} added to master session list`
+      );
 
       // set the New Command Timeout for the inner driver
       driverInstance.startNewCommandTimeout();
 
       // apply initial values to Appium settings (if provided)
       if (driverInstance.isW3CProtocol() && !_.isEmpty(w3cSettings)) {
-        this.log.info(`Applying the initial values to Appium settings parsed from W3C caps: ` +
-          JSON.stringify(w3cSettings));
+        this.log.info(
+          `Applying the initial values to Appium settings parsed from W3C caps: ` +
+            JSON.stringify(w3cSettings)
+        );
         await driverInstance.updateSettings(w3cSettings);
-      } else if (driverInstance.isMjsonwpProtocol() && !_.isEmpty(jwpSettings)) {
-        this.log.info(`Applying the initial values to Appium settings parsed from MJSONWP caps: ` +
-          JSON.stringify(jwpSettings));
+      } else if (
+        driverInstance.isMjsonwpProtocol() &&
+        !_.isEmpty(jwpSettings)
+      ) {
+        this.log.info(
+          `Applying the initial values to Appium settings parsed from MJSONWP caps: ` +
+            JSON.stringify(jwpSettings)
+        );
         await driverInstance.updateSettings(jwpSettings);
       }
     } catch (error) {
@@ -336,30 +379,38 @@ class AppiumDriver extends DriverCore {
 
     return {
       protocol,
-      value: [innerSessionId, dCaps, protocol]
+      value: [innerSessionId, dCaps, protocol],
     };
   }
 
-  attachUnexpectedShutdownHandler (driver, innerSessionId) {
+  attachUnexpectedShutdownHandler(driver, innerSessionId) {
     const onShutdown = (cause = new Error('Unknown error')) => {
       this.log.warn(`Ending session, cause was '${cause.message}'`);
 
       if (this.sessionPlugins[innerSessionId]) {
         for (const plugin of this.sessionPlugins[innerSessionId]) {
           if (_.isFunction(plugin.onUnexpectedShutdown)) {
-            this.log.debug(`Plugin ${plugin.name} defines an unexpected shutdown handler; calling it now`);
+            this.log.debug(
+              `Plugin ${plugin.name} defines an unexpected shutdown handler; calling it now`
+            );
             try {
               plugin.onUnexpectedShutdown(driver, cause);
             } catch (e) {
-              this.log.warn(`Got an error when running plugin ${plugin.name} shutdown handler: ${e}`);
+              this.log.warn(
+                `Got an error when running plugin ${plugin.name} shutdown handler: ${e}`
+              );
             }
           } else {
-            this.log.debug(`Plugin ${plugin.name} does not define an unexpected shutdown handler`);
+            this.log.debug(
+              `Plugin ${plugin.name} does not define an unexpected shutdown handler`
+            );
           }
         }
       }
 
-      this.log.info(`Removing session '${innerSessionId}' from our master session list`);
+      this.log.info(
+        `Removing session '${innerSessionId}' from our master session list`
+      );
       delete this.sessions[innerSessionId];
       delete this.sessionPlugins[innerSessionId];
     };
@@ -367,24 +418,31 @@ class AppiumDriver extends DriverCore {
     if (_.isFunction(driver.onUnexpectedShutdown)) {
       driver.onUnexpectedShutdown(onShutdown);
     } else {
-      this.log.warn(`Failed to attach the unexpected shutdown listener. ` +
-        `Is 'onUnexpectedShutdown' method available for '${driver.constructor.name}'?`);
+      this.log.warn(
+        `Failed to attach the unexpected shutdown listener. ` +
+          `Is 'onUnexpectedShutdown' method available for '${driver.constructor.name}'?`
+      );
     }
   }
 
   /**
    *
-   * @param {import('../types/extension').DriverClass} InnerDriver
+   * @param {import('appium/types').DriverClass} InnerDriver
    * @returns {Promise<DriverData[]>}}
    */
-  async curSessionDataForDriver (InnerDriver) { // eslint-disable-line require-await
-    const data = _.compact(_.values(this.sessions)
-      .filter((s) => s.constructor.name === InnerDriver.name)
-      .map((s) => s.driverData));
+  // eslint-disable-next-line require-await
+  async curSessionDataForDriver(InnerDriver) {
+    const data = _.compact(
+      _.values(this.sessions)
+        .filter((s) => s.constructor.name === InnerDriver.name)
+        .map((s) => s.driverData)
+    );
     for (const datum of data) {
       if (!datum) {
-        throw new Error(`Problem getting session data for driver type ` +
-          `${InnerDriver.name}; does it implement 'get driverData'?`);
+        throw new Error(
+          `Problem getting session data for driver type ` +
+            `${InnerDriver.name}; does it implement 'get driverData'?`
+        );
       }
     }
     return data;
@@ -393,28 +451,37 @@ class AppiumDriver extends DriverCore {
   /**
    * @param {string} sessionId
    */
-  async deleteSession (sessionId) {
+  async deleteSession(sessionId) {
     let protocol;
     try {
       let otherSessionsData;
-      const dstSession = await sessionsListGuard.acquire(AppiumDriver.name, () => {
-        if (!this.sessions[sessionId]) {
-          return;
+      const dstSession = await sessionsListGuard.acquire(
+        AppiumDriver.name,
+        () => {
+          if (!this.sessions[sessionId]) {
+            return;
+          }
+          const curConstructorName = this.sessions[sessionId].constructor.name;
+          otherSessionsData = _.toPairs(this.sessions)
+            .filter(
+              ([key, value]) =>
+                value.constructor.name === curConstructorName &&
+                key !== sessionId
+            )
+            .map(([, value]) => value.driverData);
+          const dstSession = this.sessions[sessionId];
+          protocol = dstSession.protocol;
+          this.log.info(
+            `Removing session ${sessionId} from our master session list`
+          );
+          // regardless of whether the deleteSession completes successfully or not
+          // make the session unavailable, because who knows what state it might
+          // be in otherwise
+          delete this.sessions[sessionId];
+          delete this.sessionPlugins[sessionId];
+          return dstSession;
         }
-        const curConstructorName = this.sessions[sessionId].constructor.name;
-        otherSessionsData = _.toPairs(this.sessions)
-              .filter(([key, value]) => value.constructor.name === curConstructorName && key !== sessionId)
-              .map(([, value]) => value.driverData);
-        const dstSession = this.sessions[sessionId];
-        protocol = dstSession.protocol;
-        this.log.info(`Removing session ${sessionId} from our master session list`);
-        // regardless of whether the deleteSession completes successfully or not
-        // make the session unavailable, because who knows what state it might
-        // be in otherwise
-        delete this.sessions[sessionId];
-        delete this.sessionPlugins[sessionId];
-        return dstSession;
-      });
+      );
       // this may not be correct, but if `dstSession` was falsy, the call to `deleteSession()` would
       // throw anyway.
       if (!dstSession) {
@@ -433,20 +500,21 @@ class AppiumDriver extends DriverCore {
     }
   }
 
-  async deleteAllSessions (opts = {}) {
+  async deleteAllSessions(opts = {}) {
     const sessionsCount = _.size(this.sessions);
     if (0 === sessionsCount) {
       this.log.debug('There are no active sessions for cleanup');
       return;
     }
 
-    const {
-      force = false,
-      reason,
-    } = opts;
-    this.log.debug(`Cleaning up ${util.pluralize('active session', sessionsCount, true)}`);
+    const {force = false, reason} = opts;
+    this.log.debug(
+      `Cleaning up ${util.pluralize('active session', sessionsCount, true)}`
+    );
     const cleanupPromises = force
-      ? _.values(this.sessions).map((drv) => drv.startUnexpectedShutdown(reason && new Error(reason)))
+      ? _.values(this.sessions).map((drv) =>
+          drv.startUnexpectedShutdown(reason && new Error(reason))
+        )
       : _.keys(this.sessions).map((id) => this.deleteSession(id));
     for (const cleanupPromise of cleanupPromises) {
       try {
@@ -463,7 +531,7 @@ class AppiumDriver extends DriverCore {
    * @param {?string} sessionId - the sessionId (or null) to use to find plugins
    * @returns {Array} - array of plugin instances
    */
-  pluginsForSession (sessionId = null) {
+  pluginsForSession(sessionId = null) {
     if (sessionId) {
       if (!this.sessionPlugins[sessionId]) {
         this.sessionPlugins[sessionId] = this.createPluginInstances();
@@ -487,14 +555,15 @@ class AppiumDriver extends DriverCore {
    * @param {?string} sessionId - the particular session for which to find a plugin, or null if
    * sessionless
    */
-  pluginsToHandleCmd (cmd, sessionId = null) {
+  pluginsToHandleCmd(cmd, sessionId = null) {
     // to handle a given command, a plugin should either implement that command as a plugin
     // instance method or it should implement a generic 'handle' method
-    return this.pluginsForSession(sessionId)
-      .filter((p) => _.isFunction(p[cmd]) || _.isFunction(p.handle));
+    return this.pluginsForSession(sessionId).filter(
+      (p) => _.isFunction(p[cmd]) || _.isFunction(p.handle)
+    );
   }
 
-  createPluginInstances () {
+  createPluginInstances() {
     return this.pluginClasses.map((PluginClass) => {
       const name = PluginClass.pluginName;
       const plugin = new PluginClass(name);
@@ -509,7 +578,7 @@ class AppiumDriver extends DriverCore {
    * @param  {...any} args
    * @returns {Promise<{value: any, error?: Error, protocol: string} | import('type-fest').AsyncReturnType<import('@appium/types').Driver['executeCommand']>>}
    */
-  async executeCommand (cmd, ...args) {
+  async executeCommand(cmd, ...args) {
     // We have basically three cases for how to handle commands:
     // 1. handle getStatus (we do this as a special out of band case so it doesn't get added to an
     //    execution queue, and can be called while e.g. createSession is in progress)
@@ -530,7 +599,6 @@ class AppiumDriver extends DriverCore {
     if (reqForProxy) {
       args.pop();
     }
-
 
     // first do some error checking. If we're requesting a session command execution, then make
     // sure that session actually exists on the session driver, and set the session driver itself
@@ -571,7 +639,10 @@ class AppiumDriver extends DriverCore {
       // if we're running with plugins, make sure we log that the default behavior is actually
       // happening so we can tell when the plugin call chain is unwrapping to the default behavior
       // if that's what happens
-      plugins.length && this.log.info(`Executing default handling behavior for command '${cmd}'`);
+      plugins.length &&
+        this.log.info(
+          `Executing default handling behavior for command '${cmd}'`
+        );
 
       // if we make it here, we know that the default behavior is handled
       cmdHandledBy.default = true;
@@ -584,8 +655,11 @@ class AppiumDriver extends DriverCore {
         if (!dstSession.proxyCommand) {
           throw new NoDriverProxyCommandError();
         }
-        return await dstSession.proxyCommand(reqForProxy.originalUrl, reqForProxy.method,
-          reqForProxy.body);
+        return await dstSession.proxyCommand(
+          reqForProxy.originalUrl,
+          reqForProxy.method,
+          reqForProxy.body
+        );
       }
 
       if (isGetStatus) {
@@ -595,7 +669,11 @@ class AppiumDriver extends DriverCore {
       if (isUmbrellaCmd) {
         // some commands, like deleteSession, we want to make sure to handle on *this* driver,
         // not the platform driver
-        return await BaseDriver.prototype.executeCommand.call(this, cmd, ...args);
+        return await BaseDriver.prototype.executeCommand.call(
+          this,
+          cmd,
+          ...args
+        );
       }
 
       // here we know that we are executing a session command, and have a valid session driver
@@ -604,7 +682,12 @@ class AppiumDriver extends DriverCore {
 
     // now take our default behavior, wrap it with any number of plugin behaviors, and run it
     const wrappedCmd = this.wrapCommandWithPlugins({
-      driver, cmd, args, plugins, cmdHandledBy, next: defaultBehavior
+      driver,
+      cmd,
+      args,
+      plugins,
+      cmdHandledBy,
+      next: defaultBehavior,
     });
     const res = await this.executeWrappedCommand({wrappedCmd, protocol});
 
@@ -615,10 +698,16 @@ class AppiumDriver extends DriverCore {
     // And finally, if the command was createSession, we want to migrate any plugins which were
     // previously sessionless to use the new sessionId, so that plugins can share state between
     // their createSession method and other instance methods
-    if (cmd === CREATE_SESSION_COMMAND && this.sessionlessPlugins.length && !res.error) {
+    if (
+      cmd === CREATE_SESSION_COMMAND &&
+      this.sessionlessPlugins.length &&
+      !res.error
+    ) {
       const sessionId = _.first(res.value);
-      this.log.info(`Promoting ${this.sessionlessPlugins.length} sessionless plugins to be attached ` +
-        `to session ID ${sessionId}`);
+      this.log.info(
+        `Promoting ${this.sessionlessPlugins.length} sessionless plugins to be attached ` +
+          `to session ID ${sessionId}`
+      );
       this.sessionPlugins[sessionId] = this.sessionlessPlugins;
       this.sessionlessPlugins = [];
     }
@@ -626,8 +715,11 @@ class AppiumDriver extends DriverCore {
     return res;
   }
 
-  wrapCommandWithPlugins ({driver, cmd, args, next, cmdHandledBy, plugins}) {
-    plugins.length && this.log.info(`Plugins which can handle cmd '${cmd}': ${plugins.map((p) => p.name)}`);
+  wrapCommandWithPlugins({driver, cmd, args, next, cmdHandledBy, plugins}) {
+    plugins.length &&
+      this.log.info(
+        `Plugins which can handle cmd '${cmd}': ${plugins.map((p) => p.name)}`
+      );
 
     // now we can go through each plugin and wrap `next` around its own handler, passing the *old*
     // next in so that it can call it if it wants to
@@ -651,7 +743,7 @@ class AppiumDriver extends DriverCore {
     return next;
   }
 
-  logPluginHandlerReport (plugins, {cmd, cmdHandledBy}) {
+  logPluginHandlerReport(plugins, {cmd, cmdHandledBy}) {
     if (!plugins.length) {
       return;
     }
@@ -663,16 +755,24 @@ class AppiumDriver extends DriverCore {
     // interact well together, and it would be hard to debug otherwise without this kind of
     // message).
     const didHandle = Object.keys(cmdHandledBy).filter((k) => cmdHandledBy[k]);
-    const didntHandle = Object.keys(cmdHandledBy).filter((k) => !cmdHandledBy[k]);
+    const didntHandle = Object.keys(cmdHandledBy).filter(
+      (k) => !cmdHandledBy[k]
+    );
     if (didntHandle.length > 0) {
-      this.log.info(`Command '${cmd}' was *not* handled by the following behaviours or plugins, even ` +
-        `though they were registered to handle it: ${JSON.stringify(didntHandle)}. The ` +
-        `command *was* handled by these: ${JSON.stringify(didHandle)}.`);
+      this.log.info(
+        `Command '${cmd}' was *not* handled by the following behaviours or plugins, even ` +
+          `though they were registered to handle it: ${JSON.stringify(
+            didntHandle
+          )}. The ` +
+          `command *was* handled by these: ${JSON.stringify(didHandle)}.`
+      );
     }
   }
 
-  async executeWrappedCommand ({wrappedCmd, protocol}) {
-    let cmdRes, cmdErr, res = {};
+  async executeWrappedCommand({wrappedCmd, protocol}) {
+    let cmdRes,
+      cmdErr,
+      res = {};
     try {
       // At this point, `wrappedCmd` defines a whole sequence of plugin handlers, culminating in
       // our default handler. Whatever it returns is what we're going to want to send back to the
@@ -695,17 +795,21 @@ class AppiumDriver extends DriverCore {
     return res;
   }
 
-  proxyActive (sessionId) {
+  proxyActive(sessionId) {
     const dstSession = this.sessions[sessionId];
-    return dstSession && _.isFunction(dstSession.proxyActive) && dstSession.proxyActive(sessionId);
+    return (
+      dstSession &&
+      _.isFunction(dstSession.proxyActive) &&
+      dstSession.proxyActive(sessionId)
+    );
   }
 
-  getProxyAvoidList (sessionId) {
+  getProxyAvoidList(sessionId) {
     const dstSession = this.sessions[sessionId];
     return dstSession ? dstSession.getProxyAvoidList() : [];
   }
 
-  canProxy (sessionId) {
+  canProxy(sessionId) {
     const dstSession = this.sessions[sessionId];
     return dstSession && dstSession.canProxy(sessionId);
   }
@@ -713,7 +817,7 @@ class AppiumDriver extends DriverCore {
 
 // help decide which commands should be proxied to sub-drivers and which
 // should be handled by this, our umbrella driver
-function isAppiumDriverCommand (cmd) {
+function isAppiumDriverCommand(cmd) {
   return !isSessionCommand(cmd) || cmd === DELETE_SESSION_COMMAND;
 }
 
@@ -727,15 +831,17 @@ export class NoDriverProxyCommandError extends Error {
    */
   code = 'APPIUMERR_NO_DRIVER_PROXYCOMMAND';
 
-  constructor () {
-    super(`The default behavior for this command was to proxy, but the driver ` +
-          `did not have the 'proxyCommand' method defined. To fully support ` +
-          `plugins, drivers should have 'proxyCommand' set to a jwpProxy object's ` +
-          `'command()' method, in addition to the normal 'proxyReqRes'`);
+  constructor() {
+    super(
+      `The default behavior for this command was to proxy, but the driver ` +
+        `did not have the 'proxyCommand' method defined. To fully support ` +
+        `plugins, drivers should have 'proxyCommand' set to a jwpProxy object's ` +
+        `'command()' method, in addition to the normal 'proxyReqRes'`
+    );
   }
 }
 
-export { AppiumDriver };
+export {AppiumDriver};
 
 /**
  * @typedef {import('@appium/types').ExternalDriver} ExternalDriver
@@ -744,8 +850,8 @@ export { AppiumDriver };
  * @typedef {import('@appium/types').ServerArgs} DriverOpts
  * @typedef {import('@appium/types').Constraints} Constraints
  * @typedef {import('@appium/types').AppiumServer} AppiumServer
- * @typedef {import('../types').ExtensionType} ExtensionType
- * @typedef {import('../types/extension').PluginClass} PluginClass
+ * @typedef {import('appium/types').ExtensionType} ExtensionType
+ * @typedef {import('appium/types').PluginClass} PluginClass
  * @typedef {import('./extension/driver-config').DriverConfig} DriverConfig
  */
 

--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -1,9 +1,16 @@
-
 // @ts-ignore
 import _ from 'lodash';
-import { DRIVER_TYPE, PLUGIN_TYPE, EXT_SUBCOMMAND_INSTALL, EXT_SUBCOMMAND_LIST, EXT_SUBCOMMAND_RUN, EXT_SUBCOMMAND_UNINSTALL, EXT_SUBCOMMAND_UPDATE } from '../constants';
-import { INSTALL_TYPES } from '../extension/extension-config';
-import { toParserArgs } from '../schema/cli-args';
+import {
+  DRIVER_TYPE,
+  PLUGIN_TYPE,
+  EXT_SUBCOMMAND_INSTALL,
+  EXT_SUBCOMMAND_LIST,
+  EXT_SUBCOMMAND_RUN,
+  EXT_SUBCOMMAND_UNINSTALL,
+  EXT_SUBCOMMAND_UPDATE,
+} from '../constants';
+import {INSTALL_TYPES} from '../extension/extension-config';
+import {toParserArgs} from '../schema/cli-args';
 const DRIVER_EXAMPLE = 'xcuitest';
 const PLUGIN_EXAMPLE = 'find_by_image';
 
@@ -19,19 +26,22 @@ const EXTENSION_TYPES = new Set([DRIVER_TYPE, PLUGIN_TYPE]);
 // this set of args works for both drivers and plugins ('extensions')
 /** @type {ArgumentDefinitions} */
 const globalExtensionArgs = new Map([
-  [['--json'], {
-    required: false,
-    default: false,
-    action: 'store_true',
-    help: 'Use JSON for output format',
-    dest: 'json'
-  }]
+  [
+    ['--json'],
+    {
+      required: false,
+      default: false,
+      action: 'store_true',
+      help: 'Use JSON for output format',
+      dest: 'json',
+    },
+  ],
 ]);
 
 /**
  * Builds a Record of extension types to a Record of subcommands to their argument definitions
  */
-const getExtensionArgs = _.memoize(function getExtensionArgs () {
+const getExtensionArgs = _.memoize(function getExtensionArgs() {
   const extensionArgs = {};
   for (const type of EXTENSION_TYPES) {
     extensionArgs[type] = {
@@ -42,7 +52,9 @@ const getExtensionArgs = _.memoize(function getExtensionArgs () {
       [EXT_SUBCOMMAND_RUN]: makeRunArgs(type),
     };
   }
-  return /** @type {Record<ExtensionType, Record<import('../../types/cli').CliExtensionSubcommand,ArgumentDefinitions>>} */(extensionArgs);
+  return /** @type {Record<ExtensionType, Record<import('appium/types').CliExtensionSubcommand,ArgumentDefinitions>>} */ (
+    extensionArgs
+  );
 });
 
 /**
@@ -50,23 +62,29 @@ const getExtensionArgs = _.memoize(function getExtensionArgs () {
  * @param {ExtensionType} type
  * @returns {ArgumentDefinitions}
  */
-function makeListArgs (type) {
+function makeListArgs(type) {
   return new Map([
     ...globalExtensionArgs,
-    [['--installed'], {
-      required: false,
-      default: false,
-      action: 'store_true',
-      help: `List only installed ${type}s`,
-      dest: 'showInstalled'
-    }],
-    [['--updates'], {
-      required: false,
-      default: false,
-      action: 'store_true',
-      help: 'Show information about newer versions',
-      dest: 'showUpdates'
-    }]
+    [
+      ['--installed'],
+      {
+        required: false,
+        default: false,
+        action: 'store_true',
+        help: `List only installed ${type}s`,
+        dest: 'showInstalled',
+      },
+    ],
+    [
+      ['--updates'],
+      {
+        required: false,
+        default: false,
+        action: 'store_true',
+        help: 'Show information about newer versions',
+        dest: 'showUpdates',
+      },
+    ],
   ]);
 }
 
@@ -75,48 +93,66 @@ function makeListArgs (type) {
  * @param {ExtensionType} type
  * @returns {ArgumentDefinitions}
  */
-function makeInstallArgs (type) {
+function makeInstallArgs(type) {
   return new Map([
     ...globalExtensionArgs,
-    [[type], {
-      type: 'str',
-      help: `Name of the ${type} to install, for example: ` +
-            type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE,
-    }],
-    [['--source'], {
-      required: false,
-      default: null,
-      choices: INSTALL_TYPES_ARRAY,
-      help: `Where to look for the ${type} if it is not one of Appium's verified ` +
-            `${type}s. Possible values: ${INSTALL_TYPES_ARRAY.join(', ')}`,
-      dest: 'installType'
-    }],
-    [['--package'], {
-      required: false,
-      default: null,
-      type: 'str',
-      help: `If installing from Git or GitHub, the package name, as defined in the plugin's ` +
-            `package.json file in the "name" field, cannot be determined automatically, and ` +
-            `should be reported here, otherwise the install will probably fail.`,
-      dest: 'packageName',
-    }],
+    [
+      [type],
+      {
+        type: 'str',
+        help:
+          `Name of the ${type} to install, for example: ` + type === DRIVER_TYPE
+            ? DRIVER_EXAMPLE
+            : PLUGIN_EXAMPLE,
+      },
+    ],
+    [
+      ['--source'],
+      {
+        required: false,
+        default: null,
+        choices: INSTALL_TYPES_ARRAY,
+        help:
+          `Where to look for the ${type} if it is not one of Appium's verified ` +
+          `${type}s. Possible values: ${INSTALL_TYPES_ARRAY.join(', ')}`,
+        dest: 'installType',
+      },
+    ],
+    [
+      ['--package'],
+      {
+        required: false,
+        default: null,
+        type: 'str',
+        help:
+          `If installing from Git or GitHub, the package name, as defined in the plugin's ` +
+          `package.json file in the "name" field, cannot be determined automatically, and ` +
+          `should be reported here, otherwise the install will probably fail.`,
+        dest: 'packageName',
+      },
+    ],
   ]);
 }
-
 
 /**
  * Makes the opts for the `uninstall` subcommand for each extension type
  * @param {ExtensionType} type
  * @returns {ArgumentDefinitions}
  */
-function makeUninstallArgs (type) {
+function makeUninstallArgs(type) {
   return new Map([
     ...globalExtensionArgs,
-    [[type], {
-      type: 'str',
-      help: 'Name of the driver to uninstall, for example: ' +
-            type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE
-    }],
+    [
+      [type],
+      {
+        type: 'str',
+        help:
+          'Name of the driver to uninstall, for example: ' + type ===
+          DRIVER_TYPE
+            ? DRIVER_EXAMPLE
+            : PLUGIN_EXAMPLE,
+      },
+    ],
   ]);
 }
 
@@ -125,22 +161,34 @@ function makeUninstallArgs (type) {
  * @param {ExtensionType} type
  * @returns {ArgumentDefinitions}
  */
-function makeUpdateArgs (type) {
+function makeUpdateArgs(type) {
   return new Map([
     ...globalExtensionArgs,
-    [[type], {
-      type: 'str',
-      help: `Name of the ${type} to update, or the word "installed" to update all installed ` +
+    [
+      [type],
+      {
+        type: 'str',
+        help:
+          `Name of the ${type} to update, or the word "installed" to update all installed ` +
             `${type}s. To see available updates, run "appium ${type} list --installed --updates". ` +
-            'For example: ' + type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE,
-    }],
-    [['--unsafe'], {
-      required: false,
-      default: false,
-      action: 'store_true',
-      help: `Include updates that might have a new major revision, and potentially include ` +
-            `breaking changes`,
-    }],
+            'For example: ' +
+            type ===
+          DRIVER_TYPE
+            ? DRIVER_EXAMPLE
+            : PLUGIN_EXAMPLE,
+      },
+    ],
+    [
+      ['--unsafe'],
+      {
+        required: false,
+        default: false,
+        action: 'store_true',
+        help:
+          `Include updates that might have a new major revision, and potentially include ` +
+          `breaking changes`,
+      },
+    ],
   ]);
 }
 
@@ -149,20 +197,30 @@ function makeUpdateArgs (type) {
  * @param {ExtensionType} type
  * @returns {ArgumentDefinitions}
  */
-function makeRunArgs (type) {
+function makeRunArgs(type) {
   return new Map([
     ...globalExtensionArgs,
-    [[type], {
-      type: 'str',
-      help: `Name of the ${type} to run a script from, for example: ` +
-            type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE,
-    }],
-    [['scriptName'], {
-      default: null,
-      type: 'str',
-      help: `Name of the script to run from the ${type}. The script name must be cached ` +
-            `inside the "scripts" field under "appium" inside the ${type}'s "package.json" file`
-    }],
+    [
+      [type],
+      {
+        type: 'str',
+        help:
+          `Name of the ${type} to run a script from, for example: ` + type ===
+          DRIVER_TYPE
+            ? DRIVER_EXAMPLE
+            : PLUGIN_EXAMPLE,
+      },
+    ],
+    [
+      ['scriptName'],
+      {
+        default: null,
+        type: 'str',
+        help:
+          `Name of the script to run from the ${type}. The script name must be cached ` +
+          `inside the "scripts" field under "appium" inside the ${type}'s "package.json" file`,
+      },
+    ],
   ]);
 }
 
@@ -171,11 +229,8 @@ function makeRunArgs (type) {
  * which are disallowed in the config file.
  * @returns {ArgumentDefinitions}
  */
-function getServerArgs () {
-  return new Map([
-    ...toParserArgs(),
-    ...serverArgsDisallowedInConfig,
-  ]);
+function getServerArgs() {
+  return new Map([...toParserArgs(), ...serverArgsDisallowedInConfig]);
 }
 
 /**
@@ -211,7 +266,7 @@ const serverArgsDisallowedInConfig = new Map([
       const: true,
       required: false,
       help: 'Show the current Appium configuration and exit',
-    }
+    },
   ],
   [
     ['--config'],
@@ -224,10 +279,7 @@ const serverArgsDisallowedInConfig = new Map([
   ],
 ]);
 
-export {
-  getServerArgs,
-  getExtensionArgs
-};
+export {getServerArgs, getExtensionArgs};
 
 /**
  * Alias

--- a/packages/appium/lib/cli/driver-command.js
+++ b/packages/appium/lib/cli/driver-command.js
@@ -15,14 +15,14 @@ const REQ_DRIVER_FIELDS = [
  */
 export default class DriverCommand extends ExtensionCommand {
   /**
-   * @param {DriverCommandOptions} opts
+   * @param {import('./extension-command').ExtensionCommandOptions<DriverType>} opts
    */
-  constructor ({config, json}) {
+  constructor({config, json}) {
     super({config, json});
     this.knownExtensions = KNOWN_DRIVERS;
   }
 
-  async install ({driver, installType, packageName}) {
+  async install({driver, installType, packageName}) {
     return await super._install({
       installSpec: driver,
       installType,
@@ -30,19 +30,19 @@ export default class DriverCommand extends ExtensionCommand {
     });
   }
 
-  async uninstall ({driver}) {
+  async uninstall({driver}) {
     return await super._uninstall({installSpec: driver});
   }
 
-  async update ({driver, unsafe}) {
+  async update({driver, unsafe}) {
     return await super._update({installSpec: driver, unsafe});
   }
 
-  async run ({driver, scriptName}) {
+  async run({driver, scriptName}) {
     return await super._run({installSpec: driver, scriptName});
   }
 
-  getPostInstallText ({extName, extData}) {
+  getPostInstallText({extName, extData}) {
     return (
       `Driver ${extName}@${extData.version} successfully installed\n`.green +
       `- automationName: ${extData.automationName.green}\n` +
@@ -59,7 +59,7 @@ export default class DriverCommand extends ExtensionCommand {
    * @param {import('appium/types').ExtMetadata<DriverType>} driverMetadata
    * @param {string} installSpec
    */
-  validateExtensionFields (driverMetadata, installSpec) {
+  validateExtensionFields(driverMetadata, installSpec) {
     const missingFields = REQ_DRIVER_FIELDS.reduce(
       (acc, field) => (driverMetadata[field] ? acc : [...acc, field]),
       []

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -44,7 +44,7 @@ class ExtensionCommand {
    * Build an ExtensionCommand
    * @param {ExtensionCommandOptions<ExtType>} opts
    */
-  constructor ({config, json}) {
+  constructor({config, json}) {
     this.config = config;
     this.isJsonOutput = json;
   }
@@ -52,7 +52,7 @@ class ExtensionCommand {
   /**
    * `driver` or `plugin`, depending on the `ExtensionConfig`.
    */
-  get type () {
+  get type() {
     return this.config.extensionType;
   }
 
@@ -62,7 +62,7 @@ class ExtensionCommand {
    * @param {object} args - a key/value object with CLI flags and values
    * @return {Promise<object>} the result of the specific command which is executed
    */
-  async execute (args) {
+  async execute(args) {
     const cmd = args[`${this.type}Command`];
     if (!_.isFunction(this[cmd])) {
       throw new Error(`Cannot handle ${this.type} command ${cmd}`);
@@ -83,7 +83,7 @@ class ExtensionCommand {
    * @param {ListOptions} opts
    * @return {Promise<ExtensionListData>} map of extension names to extension data
    */
-  async list ({showInstalled, showUpdates}) {
+  async list({showInstalled, showUpdates}) {
     const lsMsg = `Listing ${showInstalled ? 'installed' : 'available'} ${
       this.type
     }s`;
@@ -195,7 +195,7 @@ class ExtensionCommand {
    * @param {InstallArgs} args
    * @return {Promise<ExtRecord<ExtType>>} map of all installed extension names to extension data
    */
-  async _install ({installSpec, installType, packageName}) {
+  async _install({installSpec, installType, packageName}) {
     /** @type {ExtensionFields<typeof this.type>} */
     let extData;
 
@@ -313,7 +313,7 @@ class ExtensionCommand {
    *
    * @param {InstallViaNpmArgs} args
    */
-  async installViaNpm ({installSpec, pkgName, pkgVer}) {
+  async installViaNpm({installSpec, pkgName, pkgVer}) {
     const npmSpec = `${pkgName}${pkgVer ? '@' + pkgVer : ''}`;
     const specMsg =
       npmSpec === installSpec ? '' : ` using NPM install spec '${npmSpec}'`;
@@ -343,7 +343,7 @@ class ExtensionCommand {
    * @returns {string}
    */
   // eslint-disable-next-line no-unused-vars
-  getPostInstallText (args) {
+  getPostInstallText(args) {
     throw new Error('Must be implemented in final class');
   }
 
@@ -357,7 +357,7 @@ class ExtensionCommand {
    * @param {string} installSpec
    * @returns {ExtensionFields<ExtType>}
    */
-  getExtensionFields (pkgJsonData, installSpec) {
+  getExtensionFields(pkgJsonData, installSpec) {
     if (!pkgJsonData.appium) {
       throw new Error(
         `Installed driver did not have an 'appium' section in its ` +
@@ -384,7 +384,7 @@ class ExtensionCommand {
    * @param {string} installSpec - Extension name/spec
    */
   // eslint-disable-next-line no-unused-vars
-  validateExtensionFields (extMetadata, installSpec) {
+  validateExtensionFields(extMetadata, installSpec) {
     throw new Error('Must be implemented in final class');
   }
 
@@ -394,7 +394,7 @@ class ExtensionCommand {
    * @param {UninstallOpts} opts
    * @return {Promise<ExtRecord<ExtType>>} map of all installed extension names to extension data
    */
-  async _uninstall ({installSpec}) {
+  async _uninstall({installSpec}) {
     if (!this.config.isInstalled(installSpec)) {
       throw new Error(
         `Can't uninstall ${this.type} '${installSpec}'; it is not installed`
@@ -419,7 +419,7 @@ class ExtensionCommand {
    * @param {ExtensionUpdateOpts} updateSpec
    * @return {Promise<ExtensionUpdateResult>}
    */
-  async _update ({installSpec, unsafe}) {
+  async _update({installSpec, unsafe}) {
     const shouldUpdateAll = installSpec === UPDATE_ALL;
     // if we're specifically requesting an update for an extension, make sure it's installed
     if (!shouldUpdateAll && !this.config.isInstalled(installSpec)) {
@@ -519,7 +519,7 @@ class ExtensionCommand {
    * @param {string} ext - name of extension
    * @return {Promise<PossibleUpdates>}
    */
-  async checkForExtensionUpdate (ext) {
+  async checkForExtensionUpdate(ext) {
     // TODO decide how we want to handle beta versions?
     // this is a helper method, 'ext' is assumed to already be installed here, and of the npm
     // install type
@@ -557,7 +557,7 @@ class ExtensionCommand {
    * @param {string} version - version string identifier to update extension to
    * @returns {Promise<void>}
    */
-  async updateExtension (installSpec, version) {
+  async updateExtension(installSpec, version) {
     const {pkgName} = this.config.installedExtensions[installSpec];
     await fs.rimraf(this.config.getInstallPath(installSpec));
     const extData = await this.installViaNpm({
@@ -580,7 +580,7 @@ class ExtensionCommand {
    * @param {RunOptions} opts
    * @return {Promise<RunOutput>}
    */
-  async _run ({installSpec, scriptName}) {
+  async _run({installSpec, scriptName}) {
     if (!_.has(this.config.installedExtensions, installSpec)) {
       throw new Error(`please install the ${this.type} first`);
     }
@@ -658,14 +658,14 @@ export {ExtensionCommand};
  */
 
 /**
- * @typedef {import('../../types').ExtensionType} ExtensionType
- * @typedef {import('../../types').DriverType} DriverType
- * @typedef {import('../../types').PluginType} PluginType
+ * @typedef {import('appium/types').ExtensionType} ExtensionType
+ * @typedef {import('appium/types').DriverType} DriverType
+ * @typedef {import('appium/types').PluginType} PluginType
  */
 
 /**
  * @template {ExtensionType} ExtType
- * @typedef {import('../../types/appium-manifest').ExtRecord<ExtType>} ExtRecord
+ * @typedef {import('appium/types').ExtRecord<ExtType>} ExtRecord
  */
 
 /**
@@ -675,17 +675,17 @@ export {ExtensionCommand};
 
 /**
  * @template {ExtensionType} ExtType
- * @typedef {import('../../types/external-manifest').ExtMetadata<ExtType>} ExtMetadata
+ * @typedef {import('appium/types').ExtMetadata<ExtType>} ExtMetadata
  */
 
 /**
  * @template {ExtensionType} ExtType
- * @typedef {import('../../types/appium-manifest').ExtManifest<ExtType>} ExtManifest
+ * @typedef {import('appium/types').ExtManifest<ExtType>} ExtManifest
  */
 
 /**
  * @template {ExtensionType} ExtType
- * @typedef {import('../../types/external-manifest').ExtPackageJson<ExtType>} ExtPackageJson
+ * @typedef {import('appium/types').ExtPackageJson<ExtType>} ExtPackageJson
  */
 
 /**
@@ -697,7 +697,7 @@ export {ExtensionCommand};
 
 /**
  * Possible return value for {@linkcode ExtensionCommand.list}
- * @typedef {import('../../types/appium-manifest').InternalMetadata & ExtensionMetadata} InstalledExtensionListData
+ * @typedef {import('appium/types').InternalMetadata & ExtensionMetadata} InstalledExtensionListData
  */
 
 /**
@@ -774,7 +774,7 @@ export {ExtensionCommand};
  * Options for {@linkcode ExtensionCommand._install}
  * @typedef InstallArgs
  * @property {string} installSpec - the name or spec of an extension to install
- * @property {import('../../types/appium-manifest').InstallType} installType - how to install this extension. One of the INSTALL_TYPES
+ * @property {import('appium/types').InstallType} installType - how to install this extension. One of the INSTALL_TYPES
  * @property {string} [packageName] - for git/github installs, the extension node package name
  */
 

--- a/packages/appium/lib/cli/extension.js
+++ b/packages/appium/lib/cli/extension.js
@@ -2,13 +2,15 @@
 
 import DriverCommand from './driver-command';
 import PluginCommand from './plugin-command';
-import { DRIVER_TYPE, PLUGIN_TYPE } from '../constants';
-import { errAndQuit, log, JSON_SPACES } from './utils';
+import {DRIVER_TYPE, PLUGIN_TYPE} from '../constants';
+import {errAndQuit, log, JSON_SPACES} from './utils';
 
-const commandClasses = Object.freeze(/** @type {const} */({
-  [DRIVER_TYPE]: DriverCommand,
-  [PLUGIN_TYPE]: PluginCommand
-}));
+const commandClasses = Object.freeze(
+  /** @type {const} */ ({
+    [DRIVER_TYPE]: DriverCommand,
+    [PLUGIN_TYPE]: PluginCommand,
+  })
+);
 
 /**
  * Run a subcommand of the 'appium driver' type. Each subcommand has its own set of arguments which
@@ -19,14 +21,16 @@ const commandClasses = Object.freeze(/** @type {const} */({
  * @template {import('../extension/manifest').ExtensionType} ExtType
  * @param {import('../extension/extension-config').ExtensionConfig<ExtType>} configObject - Extension config object
  */
-async function runExtensionCommand (args, configObject) {
+async function runExtensionCommand(args, configObject) {
   // TODO driver config file should be locked while any of these commands are
   // running to prevent weird situations
   let jsonResult = null;
   const {extensionType: type} = configObject;
   const extCmd = args[`${type}Command`];
   if (!extCmd) {
-    throw new TypeError(`Cannot call ${type} command without a subcommand like 'install'`);
+    throw new TypeError(
+      `Cannot call ${type} command without a subcommand like 'install'`
+    );
   }
   let {json, suppressOutput} = args;
   if (suppressOutput) {
@@ -35,7 +39,9 @@ async function runExtensionCommand (args, configObject) {
   const logFn = (msg) => log(json, msg);
   let config = configObject;
   config.log = logFn;
-  const CommandClass = /** @type {ExtCommand<ExtType>} */(commandClasses[type]);
+  const CommandClass = /** @type {ExtCommand<ExtType>} */ (
+    commandClasses[type]
+  );
   const cmd = new CommandClass({config, json});
   try {
     jsonResult = await cmd.execute(args);
@@ -55,11 +61,9 @@ async function runExtensionCommand (args, configObject) {
   return jsonResult;
 }
 
-export {
-  runExtensionCommand,
-};
+export {runExtensionCommand};
 
 /**
- * @template {import('../../types').ExtensionType} ExtType
- * @typedef {ExtType extends import('../../types').DriverType ? import('@appium/types').Class<DriverCommand> : ExtType extends import('../../types').PluginType ? import('@appium/types').Class<PluginCommand> : never} ExtCommand
+ * @template {import('appium/types').ExtensionType} ExtType
+ * @typedef {ExtType extends import('appium/types').DriverType ? import('@appium/types').Class<DriverCommand> : ExtType extends import('appium/types').PluginType ? import('@appium/types').Class<PluginCommand> : never} ExtCommand
  */

--- a/packages/appium/lib/cli/parser.js
+++ b/packages/appium/lib/cli/parser.js
@@ -1,15 +1,11 @@
-
-import { fs } from '@appium/support';
-import { ArgumentParser } from 'argparse';
+import {fs} from '@appium/support';
+import {ArgumentParser} from 'argparse';
 import _ from 'lodash';
 import path from 'path';
-import { DRIVER_TYPE, PLUGIN_TYPE, SERVER_SUBCOMMAND } from '../constants';
-import { finalizeSchema, getArgSpec, hasArgSpec } from '../schema';
-import { rootDir } from '../config';
-import {
-  getExtensionArgs,
-  getServerArgs
-} from './args';
+import {DRIVER_TYPE, PLUGIN_TYPE, SERVER_SUBCOMMAND} from '../constants';
+import {finalizeSchema, getArgSpec, hasArgSpec} from '../schema';
+import {rootDir} from '../config';
+import {getExtensionArgs, getServerArgs} from './args';
 
 /**
  * If the parsed args do not contain any of these values, then we
@@ -23,7 +19,7 @@ const NON_SERVER_ARGS = Object.freeze(
     '-h',
     '--help',
     '-v',
-    '--version'
+    '--version',
   ])
 );
 
@@ -40,7 +36,7 @@ class ArgParser {
   /**
    * @param {boolean} [debug] - If true, throw instead of exit on error.
    */
-  constructor (debug = false) {
+  constructor(debug = false) {
     const prog = process.argv[1] ? path.basename(process.argv[1]) : 'appium';
     const parser = new ArgumentParser({
       add_help: true,
@@ -99,11 +95,11 @@ class ArgParser {
    * If no subcommand is passed in, this method will inject the `server` subcommand.
    *
    * `ArgParser.prototype.parse_args` is an alias of this method.
-   * @template [T=import('../../types').WithServerSubcommand]
+   * @template [T=import('appium/types').WithServerSubcommand]
    * @param {string[]} [args] - Array of arguments, ostensibly from `process.argv`. Gathers args from `process.argv` if not provided.
-   * @returns {import('../../types').Args<T>} - The parsed arguments
+   * @returns {import('appium/types').Args<T>} - The parsed arguments
    */
-  parseArgs (args = process.argv.slice(2)) {
+  parseArgs(args = process.argv.slice(2)) {
     if (!NON_SERVER_ARGS.has(args[0])) {
       args.unshift(SERVER_SUBCOMMAND);
     }
@@ -137,12 +133,14 @@ class ArgParser {
    * @param {object} args
    * @returns {object}
    */
-  static _transformParsedArgs (args) {
+  static _transformParsedArgs(args) {
     return _.reduce(
       args,
       (unpacked, value, key) => {
         if (!_.isUndefined(value) && hasArgSpec(key)) {
-          const {dest} = /** @type {import('../schema/arg-spec').ArgSpec} */(getArgSpec(key));
+          const {dest} = /** @type {import('../schema/arg-spec').ArgSpec} */ (
+            getArgSpec(key)
+          );
           _.set(unpacked, dest, value);
         } else {
           // this could be anything that _isn't_ a server arg
@@ -150,7 +148,7 @@ class ArgParser {
         }
         return unpacked;
       },
-      {},
+      {}
     );
   }
 
@@ -158,7 +156,7 @@ class ArgParser {
    * Patches the `exit()` method of the parser to throw an error, so we can handle it manually.
    * @param {ArgumentParser} parser
    */
-  static _patchExit (parser) {
+  static _patchExit(parser) {
     parser.exit = (code, msg) => {
       if (code) {
         throw new Error(msg);
@@ -172,7 +170,7 @@ class ArgParser {
    * @param {import('argparse').SubParser} subParser
    * @returns {import('./args').ArgumentDefinitions}
    */
-  static _addServerToParser (subParser) {
+  static _addServerToParser(subParser) {
     const serverParser = subParser.add_parser('server', {
       add_help: true,
       help: 'Run an Appium server',
@@ -194,7 +192,7 @@ class ArgParser {
    * Adds extension sub-sub-commands to `driver`/`plugin` subcommands
    * @param {import('argparse').SubParser} subParsers
    */
-  static _addExtensionCommandsToParser (subParsers) {
+  static _addExtensionCommandsToParser(subParsers) {
     for (const type of [DRIVER_TYPE, PLUGIN_TYPE]) {
       const extParser = subParsers.add_parser(type, {
         add_help: true,
@@ -259,10 +257,10 @@ class ArgParser {
  * @param {boolean} [debug] - If `true`, throw instead of exit upon parsing error
  * @returns {ArgParser}
  */
-function getParser (debug) {
+function getParser(debug) {
   finalizeSchema();
 
   return new ArgParser(debug);
 }
 
-export { getParser, ArgParser };
+export {getParser, ArgParser};

--- a/packages/appium/lib/extension/driver-config.js
+++ b/packages/appium/lib/extension/driver-config.js
@@ -1,14 +1,12 @@
-
 import _ from 'lodash';
-import { DRIVER_TYPE } from '../constants';
+import {DRIVER_TYPE} from '../constants';
 import log from '../logger';
-import { ExtensionConfig } from './extension-config';
+import {ExtensionConfig} from './extension-config';
 
 /**
  * @extends {ExtensionConfig<DriverType>}
  */
 export class DriverConfig extends ExtensionConfig {
-
   /**
    * A set of unique automation names used by drivers.
    * @type {Set<string>}
@@ -25,182 +23,199 @@ export class DriverConfig extends ExtensionConfig {
    * @type {WeakMap<Manifest,DriverConfig>}
    * @private
    */
-   static _instances = new WeakMap();
+  static _instances = new WeakMap();
 
-   /**
+  /**
    * Call {@link DriverConfig.create} instead.
    * @private
    * @param {import('./manifest').Manifest} manifest - Manifest instance
    * @param {DriverConfigOptions} [opts]
    */
-   constructor (manifest, {logFn, extData} = {}) {
-     super(DRIVER_TYPE, manifest, logFn);
+  constructor(manifest, {logFn, extData} = {}) {
+    super(DRIVER_TYPE, manifest, logFn);
 
-     this.knownAutomationNames = new Set();
+    this.knownAutomationNames = new Set();
 
-     if (extData) {
-       this.validate(extData);
-     }
-   }
+    if (extData) {
+      this.validate(extData);
+    }
+  }
 
-   /**
-    * Creates a new {@link DriverConfig} instance for a {@link Manifest} instance.
-    *
-    * @param {Manifest} manifest
-    * @param {DriverConfigOptions} [opts]
-    * @throws If `manifest` already associated with a `DriverConfig`
-    * @returns {DriverConfig}
-    */
-   static create (manifest, {extData, logFn} = {}) {
-     const instance = new DriverConfig(manifest, {logFn, extData});
-     if (DriverConfig.getInstance(manifest)) {
-       throw new Error(`Manifest with APPIUM_HOME ${manifest.appiumHome} already has a DriverConfig; use DriverConfig.getInstance() to retrieve it.`);
-     }
-     DriverConfig._instances.set(manifest, instance);
-     return instance;
-   }
+  /**
+   * Creates a new {@link DriverConfig} instance for a {@link Manifest} instance.
+   *
+   * @param {Manifest} manifest
+   * @param {DriverConfigOptions} [opts]
+   * @throws If `manifest` already associated with a `DriverConfig`
+   * @returns {DriverConfig}
+   */
+  static create(manifest, {extData, logFn} = {}) {
+    const instance = new DriverConfig(manifest, {logFn, extData});
+    if (DriverConfig.getInstance(manifest)) {
+      throw new Error(
+        `Manifest with APPIUM_HOME ${manifest.appiumHome} already has a DriverConfig; use DriverConfig.getInstance() to retrieve it.`
+      );
+    }
+    DriverConfig._instances.set(manifest, instance);
+    return instance;
+  }
 
-   /**
-    * Returns a DriverConfig associated with a Manifest
-    * @param {Manifest} manifest
-    * @returns {DriverConfig|undefined}
-    */
-   static getInstance (manifest) {
-     return DriverConfig._instances.get(manifest);
-   }
+  /**
+   * Returns a DriverConfig associated with a Manifest
+   * @param {Manifest} manifest
+   * @returns {DriverConfig|undefined}
+   */
+  static getInstance(manifest) {
+    return DriverConfig._instances.get(manifest);
+  }
 
-   /**
+  /**
    * Checks extensions for problems
    * @param {ExtRecord<DriverType>} exts
    */
-   validate (exts) {
-     this.knownAutomationNames.clear();
-     return super.validate(exts);
-   }
+  validate(exts) {
+    this.knownAutomationNames.clear();
+    return super.validate(exts);
+  }
 
-   /**
+  /**
    * @param {ExtManifest<DriverType>} extData
    * @returns {import('./extension-config').Problem[]}
    */
-   getConfigProblems (extData) {
-     const problems = [];
-     const {platformNames, automationName} = extData;
+  getConfigProblems(extData) {
+    const problems = [];
+    const {platformNames, automationName} = extData;
 
-     if (!_.isArray(platformNames)) {
-       problems.push({
-         err: 'Missing or incorrect supported platformNames list.',
-         val: platformNames
-       });
-     } else {
-       if (_.isEmpty(platformNames)) {
-         problems.push({
-           err: 'Empty platformNames list.',
-           val: platformNames
-         });
-       } else {
-         for (const pName of platformNames) {
-           if (!_.isString(pName)) {
-             problems.push({err: 'Incorrectly formatted platformName.', val: pName});
-           }
-         }
-       }
-     }
+    if (!_.isArray(platformNames)) {
+      problems.push({
+        err: 'Missing or incorrect supported platformNames list.',
+        val: platformNames,
+      });
+    } else {
+      if (_.isEmpty(platformNames)) {
+        problems.push({
+          err: 'Empty platformNames list.',
+          val: platformNames,
+        });
+      } else {
+        for (const pName of platformNames) {
+          if (!_.isString(pName)) {
+            problems.push({
+              err: 'Incorrectly formatted platformName.',
+              val: pName,
+            });
+          }
+        }
+      }
+    }
 
-     if (!_.isString(automationName)) {
-       problems.push({err: 'Missing or incorrect automationName', val: automationName});
-     }
+    if (!_.isString(automationName)) {
+      problems.push({
+        err: 'Missing or incorrect automationName',
+        val: automationName,
+      });
+    }
 
-     if (this.knownAutomationNames.has(automationName)) {
-       problems.push({
-         err: 'Multiple drivers claim support for the same automationName',
-         val: automationName
-       });
-     }
+    if (this.knownAutomationNames.has(automationName)) {
+      problems.push({
+        err: 'Multiple drivers claim support for the same automationName',
+        val: automationName,
+      });
+    }
 
-     // should we retain the name at the end of this function, once we've checked there are no problems?
-     this.knownAutomationNames.add(automationName);
+    // should we retain the name at the end of this function, once we've checked there are no problems?
+    this.knownAutomationNames.add(automationName);
 
-     return problems;
-   }
+    return problems;
+  }
 
-   /**
+  /**
    * @param {ExtName<DriverType>} driverName
    * @param {ExtManifest<DriverType>} extData
    * @returns {string}
    */
-   extensionDesc (driverName, {version, automationName}) {
-     return `${driverName}@${version} (automationName '${automationName}')`;
-   }
+  extensionDesc(driverName, {version, automationName}) {
+    return `${driverName}@${version} (automationName '${automationName}')`;
+  }
 
-   /**
+  /**
    * Given capabilities, find a matching driver within the config. Load its class and return it along with version and driver name.
    * @param {Capabilities} caps
    * @returns {MatchedDriver}
    */
-   findMatchingDriver ({automationName, platformName}) {
-     if (!_.isString(platformName)) {
-       throw new Error('You must include a platformName capability');
-     }
+  findMatchingDriver({automationName, platformName}) {
+    if (!_.isString(platformName)) {
+      throw new Error('You must include a platformName capability');
+    }
 
-     if (!_.isString(automationName)) {
-       throw new Error('You must include an automationName capability');
-     }
+    if (!_.isString(automationName)) {
+      throw new Error('You must include an automationName capability');
+    }
 
-     log.info(`Attempting to find matching driver for automationName ` +
-             `'${automationName}' and platformName '${platformName}'`);
+    log.info(
+      `Attempting to find matching driver for automationName ` +
+        `'${automationName}' and platformName '${platformName}'`
+    );
 
-     try {
-       const {
-         driverName,
-         mainClass,
-         version,
-       } = this._getDriverBySupport(automationName, platformName);
-       log.info(`The '${driverName}' driver was installed and matched caps.`);
-       log.info(`Will require it at ${this.getInstallPath(driverName)}`);
-       const driver = this.require(driverName);
-       if (!driver) {
-         throw new Error(`Driver '${driverName}' did not export a class with name '${mainClass}'. Contact the author of the driver!`);
-       }
-       return {driver, version, driverName};
-     } catch (err) {
-       const msg = `Could not find a driver for automationName ` +
-                  `'${automationName}' and platformName ${platformName}'. ` +
-                  `Have you installed a driver that supports those ` +
-                  `capabilities? Run 'appium driver list --installed' to see. ` +
-                  `(Lower-level error: ${err.message})`;
-       throw new Error(msg);
-     }
-   }
+    try {
+      const {driverName, mainClass, version} = this._getDriverBySupport(
+        automationName,
+        platformName
+      );
+      log.info(`The '${driverName}' driver was installed and matched caps.`);
+      log.info(`Will require it at ${this.getInstallPath(driverName)}`);
+      const driver = this.require(driverName);
+      if (!driver) {
+        throw new Error(
+          `Driver '${driverName}' did not export a class with name '${mainClass}'. Contact the author of the driver!`
+        );
+      }
+      return {driver, version, driverName};
+    } catch (err) {
+      const msg =
+        `Could not find a driver for automationName ` +
+        `'${automationName}' and platformName ${platformName}'. ` +
+        `Have you installed a driver that supports those ` +
+        `capabilities? Run 'appium driver list --installed' to see. ` +
+        `(Lower-level error: ${err.message})`;
+      throw new Error(msg);
+    }
+  }
 
-   /**
+  /**
    * Given an automation name and platform name, find a suitable driver and return its extension data.
    * @param {string} matchAutomationName
    * @param {string} matchPlatformName
-   * @returns {ExtMetadata<DriverType> & import('../../types/appium-manifest').InternalMetadata & import('../../types/external-manifest').CommonMetadata}
+   * @returns {ExtMetadata<DriverType> & import('appium/types').InternalMetadata & import('appium/types').CommonMetadata}
    */
-   _getDriverBySupport (matchAutomationName, matchPlatformName) {
-     const drivers = this.installedExtensions;
-     for (const [driverName, driverData] of _.toPairs(drivers)) {
-       const {automationName, platformNames} = driverData;
-       const aNameMatches = automationName.toLowerCase() === matchAutomationName.toLowerCase();
-       const pNameMatches = _.includes(platformNames.map(_.toLower),
-                                      matchPlatformName.toLowerCase());
+  _getDriverBySupport(matchAutomationName, matchPlatformName) {
+    const drivers = this.installedExtensions;
+    for (const [driverName, driverData] of _.toPairs(drivers)) {
+      const {automationName, platformNames} = driverData;
+      const aNameMatches =
+        automationName.toLowerCase() === matchAutomationName.toLowerCase();
+      const pNameMatches = _.includes(
+        platformNames.map(_.toLower),
+        matchPlatformName.toLowerCase()
+      );
 
-       if (aNameMatches && pNameMatches) {
-         return {driverName, ...driverData};
-       }
+      if (aNameMatches && pNameMatches) {
+        return {driverName, ...driverData};
+      }
 
-       if (aNameMatches) {
-         throw new Error(`Driver '${driverName}' supports automationName ` +
-                        `'${automationName}', but Appium could not find ` +
-                        `support for platformName '${matchPlatformName}'. Supported ` +
-                        `platformNames are: ` +
-                        JSON.stringify(platformNames));
-       }
-     }
+      if (aNameMatches) {
+        throw new Error(
+          `Driver '${driverName}' supports automationName ` +
+            `'${automationName}', but Appium could not find ` +
+            `support for platformName '${matchPlatformName}'. Supported ` +
+            `platformNames are: ` +
+            JSON.stringify(platformNames)
+        );
+      }
+    }
 
-     throw new Error(`Could not find installed driver to support given caps`);
-   }
+    throw new Error(`Could not find installed driver to support given caps`);
+  }
 }
 
 /**
@@ -211,35 +226,34 @@ export class DriverConfig extends ExtensionConfig {
 
 /**
  * @template T
- * @typedef {import('../../types').ExtMetadata<T>} ExtMetadata
+ * @typedef {import('appium/types').ExtMetadata<T>} ExtMetadata
  */
 
 /**
  * @template T
- * @typedef {import('../../types').ExtManifest<T>} ExtManifest
+ * @typedef {import('appium/types').ExtManifest<T>} ExtManifest
  */
 
 /**
- * @typedef {import('../../types').ManifestData} ManifestData
- * @typedef {import('../../types').DriverType} DriverType
+ * @typedef {import('appium/types').ManifestData} ManifestData
+ * @typedef {import('appium/types').DriverType} DriverType
  * @typedef {import('./manifest').Manifest} Manifest
  */
 
 /**
  * @template T
- * @typedef {import('../../types').ExtRecord<T>} ExtRecord
+ * @typedef {import('appium/types').ExtRecord<T>} ExtRecord
  */
 
 /**
  * @template T
- * @typedef {import('../../types').ExtName<T>} ExtName
+ * @typedef {import('appium/types').ExtName<T>} ExtName
  */
-
 
 /**
  * Return value of {@linkcode DriverConfig.findMatchingDriver}
  * @typedef MatchedDriver
- * @property {import('../../types/extension').DriverClass} driver
+ * @property {import('appium/types').DriverClass} driver
  * @property {string} version
  * @property {string} driverName
  */

--- a/packages/appium/lib/extension/extension-config.js
+++ b/packages/appium/lib/extension/extension-config.js
@@ -1,4 +1,3 @@
-
 import _ from 'lodash';
 import path from 'path';
 import resolveFrom from 'resolve-from';
@@ -50,7 +49,7 @@ export class ExtensionConfig {
    * @param {Manifest} manifest - `Manifest` instance
    * @param {ExtensionLogFn} [logFn]
    */
-  constructor (extensionType, manifest, logFn) {
+  constructor(extensionType, manifest, logFn) {
     const logger = _.isFunction(logFn) ? logFn : log.error.bind(log);
     this.extensionType = extensionType;
     this.configKey = `${extensionType}s`;
@@ -59,11 +58,11 @@ export class ExtensionConfig {
     this.manifest = manifest;
   }
 
-  get manifestPath () {
+  get manifestPath() {
     return this.manifest.manifestPath;
   }
 
-  get appiumHome () {
+  get appiumHome() {
     return this.manifest.appiumHome;
   }
 
@@ -71,15 +70,15 @@ export class ExtensionConfig {
    * Checks extensions for problems
    * @param {ExtRecord<ExtType>} exts - Extension data
    */
-  validate (exts) {
+  validate(exts) {
     const foundProblems =
       /** @type {Record<ExtName<ExtType>,Problem[]>} */ ({});
     for (const [
       extName,
       extData,
     ] of /** @type {[ExtName<ExtType>, ExtManifest<ExtType>][]} */ (
-        _.toPairs(exts)
-      )) {
+      _.toPairs(exts)
+    )) {
       foundProblems[extName] = [
         ...this.getGenericConfigProblems(extData, extName),
         ...this.getConfigProblems(extData),
@@ -96,12 +95,12 @@ export class ExtensionConfig {
       delete exts[extName];
       problemSummaries.push(
         `${this.extensionType} ${extName} had errors and will not ` +
-          `be available. Errors:`,
+          `be available. Errors:`
       );
       for (const problem of problems) {
         problemSummaries.push(
           `  - ${problem.err} (Actual value: ` +
-            `${JSON.stringify(problem.val)})`,
+            `${JSON.stringify(problem.val)})`
         );
       }
     }
@@ -109,7 +108,7 @@ export class ExtensionConfig {
     if (!_.isEmpty(problemSummaries)) {
       this.log(
         `Appium encountered one or more errors while validating ` +
-          `the ${this.configKey} extension file (${this.manifestPath}):`,
+          `the ${this.configKey} extension file (${this.manifestPath}):`
       );
       for (const summary of problemSummaries) {
         this.log(summary);
@@ -124,7 +123,7 @@ export class ExtensionConfig {
    * @param {ExtName<ExtType>} extName
    * @returns {Problem[]}
    */
-  getSchemaProblems (extData, extName) {
+  getSchemaProblems(extData, extName) {
     const problems = [];
     const {schema: argSchemaPath} = extData;
     if (ExtensionConfig.extDataHasSchema(extData)) {
@@ -171,9 +170,8 @@ export class ExtensionConfig {
    * @returns {Problem[]}
    */
   // eslint-disable-next-line no-unused-vars
-  getGenericConfigProblems (extData, extName) {
-    const {version, pkgName, installSpec, installType, mainClass} =
-      extData;
+  getGenericConfigProblems(extData, extName) {
+    const {version, pkgName, installSpec, installType, mainClass} = extData;
     const problems = [];
 
     if (!_.isString(version)) {
@@ -217,7 +215,7 @@ export class ExtensionConfig {
    * @returns {Problem[]}
    */
   // eslint-disable-next-line no-unused-vars
-  getConfigProblems (extData) {
+  getConfigProblems(extData) {
     // shoud override this method if special validation is necessary for this extension type
     return [];
   }
@@ -228,7 +226,7 @@ export class ExtensionConfig {
    * @param {ExtensionConfigMutationOpts} [opts]
    * @returns {Promise<void>}
    */
-  async addExtension (extName, extData, {write = true} = {}) {
+  async addExtension(extName, extData, {write = true} = {}) {
     this.manifest.addExtension(this.extensionType, extName, extData);
     if (write) {
       await this.manifest.write();
@@ -241,7 +239,7 @@ export class ExtensionConfig {
    * @param {ExtensionConfigMutationOpts} [opts]
    * @returns {Promise<void>}
    */
-  async updateExtension (extName, extData, {write = true} = {}) {
+  async updateExtension(extName, extData, {write = true} = {}) {
     this.installedExtensions[extName] = {
       ...this.installedExtensions[extName],
       ...extData,
@@ -256,7 +254,7 @@ export class ExtensionConfig {
    * @param {ExtensionConfigMutationOpts} [opts]
    * @returns {Promise<void>}
    */
-  async removeExtension (extName, {write = true} = {}) {
+  async removeExtension(extName, {write = true} = {}) {
     delete this.installedExtensions[extName];
     if (write) {
       await this.manifest.write();
@@ -268,11 +266,11 @@ export class ExtensionConfig {
    * @returns {void}
    */
   // eslint-disable-next-line no-unused-vars
-  print (activeNames) {
+  print(activeNames) {
     if (_.isEmpty(this.installedExtensions)) {
       log.info(
         `No ${this.configKey} have been installed in ${this.appiumHome}. Use the "appium ${this.extensionType}" ` +
-          'command to install the one(s) you want to use.',
+          'command to install the one(s) you want to use.'
       );
       return;
     }
@@ -282,8 +280,8 @@ export class ExtensionConfig {
       extName,
       extData,
     ] of /** @type {[string, ExtManifest<ExtType>][]} */ (
-        _.toPairs(this.installedExtensions)
-      )) {
+      _.toPairs(this.installedExtensions)
+    )) {
       log.info(`  - ${this.extensionDesc(extName, extData)}`);
     }
   }
@@ -296,7 +294,7 @@ export class ExtensionConfig {
    * @abstract
    */
   // eslint-disable-next-line no-unused-vars
-  extensionDesc (extName, extData) {
+  extensionDesc(extName, extData) {
     throw new Error('This must be implemented in a subclass');
   }
 
@@ -304,8 +302,12 @@ export class ExtensionConfig {
    * @param {string} extName
    * @returns {string}
    */
-  getInstallPath (extName) {
-    return path.join(this.appiumHome, 'node_modules', this.installedExtensions[extName].pkgName);
+  getInstallPath(extName) {
+    return path.join(
+      this.appiumHome,
+      'node_modules',
+      this.installedExtensions[extName].pkgName
+    );
   }
 
   /**
@@ -313,7 +315,7 @@ export class ExtensionConfig {
    * @param {ExtName<ExtType>} extName
    * @returns {ExtClass<ExtType>}
    */
-  require (extName) {
+  require(extName) {
     const {mainClass} = this.installedExtensions[extName];
     const reqPath = this.getInstallPath(extName);
     const reqResolved = require.resolve(reqPath);
@@ -330,7 +332,7 @@ export class ExtensionConfig {
    * @param {string} extName
    * @returns {boolean}
    */
-  isInstalled (extName) {
+  isInstalled(extName) {
     return _.includes(Object.keys(this.installedExtensions), extName);
   }
 
@@ -344,16 +346,19 @@ export class ExtensionConfig {
    * @param {ExtManifestWithSchema<ExtType>} extData - Extension config
    * @returns {import('ajv').SchemaObject|undefined}
    */
-  static _readExtensionSchema (appiumHome, extType, extName, extData) {
+  static _readExtensionSchema(appiumHome, extType, extName, extData) {
     const {pkgName, schema: argSchemaPath} = extData;
     if (!argSchemaPath) {
       throw new TypeError(
-        `No \`schema\` property found in config for ${extType} ${pkgName} -- why is this function being called?`,
+        `No \`schema\` property found in config for ${extType} ${pkgName} -- why is this function being called?`
       );
     }
     let moduleObject;
     if (_.isString(argSchemaPath)) {
-      const schemaPath = resolveFrom(appiumHome, path.join(pkgName, argSchemaPath));
+      const schemaPath = resolveFrom(
+        appiumHome,
+        path.join(pkgName, argSchemaPath)
+      );
       moduleObject = require(schemaPath);
     } else {
       moduleObject = argSchemaPath;
@@ -373,7 +378,7 @@ export class ExtensionConfig {
    * @param {ExtManifest<ExtType>} extData
    * @returns {extData is ExtManifestWithSchema<ExtType>}
    */
-  static extDataHasSchema (extData) {
+  static extDataHasSchema(extData) {
     return _.isString(extData?.schema) || _.isObject(extData?.schema);
   }
 
@@ -384,12 +389,12 @@ export class ExtensionConfig {
    * @param {ExtManifestWithSchema<ExtType>} extData - Extension data
    * @returns {import('ajv').SchemaObject|undefined}
    */
-  readExtensionSchema (extName, extData) {
+  readExtensionSchema(extName, extData) {
     return ExtensionConfig._readExtensionSchema(
       this.appiumHome,
       this.extensionType,
       extName,
-      extData,
+      extData
     );
   }
 }
@@ -417,33 +422,33 @@ export {
  */
 
 /**
- * @typedef {import('../../types').ExtensionType} ExtensionType
+ * @typedef {import('appium/types').ExtensionType} ExtensionType
  * @typedef {import('./manifest').Manifest} Manifest
  */
 
 /**
  * @template T
- * @typedef {import('../../types/appium-manifest').ExtManifest<T>} ExtManifest
+ * @typedef {import('appium/types').ExtManifest<T>} ExtManifest
  */
 
 /**
  * @template T
- * @typedef {import('../../types/appium-manifest').ExtManifestWithSchema<T>} ExtManifestWithSchema
+ * @typedef {import('appium/types').ExtManifestWithSchema<T>} ExtManifestWithSchema
  */
 
 /**
  * @template T
- * @typedef {import('../../types/appium-manifest').ExtName<T>} ExtName
+ * @typedef {import('appium/types').ExtName<T>} ExtName
  */
 
 /**
  * @template T
- * @typedef {import('../../types/extension').ExtClass<T>} ExtClass
+ * @typedef {import('appium/types').ExtClass<T>} ExtClass
  */
 
 /**
  * @template T
- * @typedef {import('../../types/appium-manifest').ExtRecord<T>} ExtRecord
+ * @typedef {import('appium/types').ExtRecord<T>} ExtRecord
  */
 
 /**

--- a/packages/appium/lib/extension/index.js
+++ b/packages/appium/lib/extension/index.js
@@ -1,10 +1,9 @@
-
 import _ from 'lodash';
-import { USE_ALL_PLUGINS } from '../constants';
+import {USE_ALL_PLUGINS} from '../constants';
 import log from '../logger';
-import { DriverConfig } from './driver-config';
-import { Manifest } from './manifest';
-import { PluginConfig } from './plugin-config';
+import {DriverConfig} from './driver-config';
+import {Manifest} from './manifest';
+import {PluginConfig} from './plugin-config';
 
 /**
  * Loads extensions and creates `ExtensionConfig` instances.
@@ -17,7 +16,7 @@ import { PluginConfig } from './plugin-config';
  * @param {string} appiumHome
  * @returns {Promise<ExtensionConfigs>}
  */
-export async function loadExtensions (appiumHome) {
+export async function loadExtensions(appiumHome) {
   const manifest = Manifest.getInstance(appiumHome);
   const {drivers, plugins} = await manifest.read();
   const driverConfig =
@@ -37,15 +36,15 @@ export async function loadExtensions (appiumHome) {
  *
  * @param {import('./plugin-config').PluginConfig} pluginConfig - a plugin extension config
  * @param {string[]} usePlugins
- * @returns {import('../../types').PluginClass[]}
+ * @returns {import('appium/types').PluginClass[]}
  */
-export function getActivePlugins (pluginConfig, usePlugins = []) {
+export function getActivePlugins(pluginConfig, usePlugins = []) {
   return _.compact(
     Object.keys(pluginConfig.installedExtensions)
       .filter(
         (pluginName) =>
           _.includes(usePlugins, pluginName) ||
-          (usePlugins.length === 1 && usePlugins[0] === USE_ALL_PLUGINS),
+          (usePlugins.length === 1 && usePlugins[0] === USE_ALL_PLUGINS)
       )
       .map((pluginName) => {
         try {
@@ -57,11 +56,11 @@ export function getActivePlugins (pluginConfig, usePlugins = []) {
         } catch (err) {
           log.error(
             `Could not load plugin '${pluginName}', so it will not be available. Error ` +
-              `in loading the plugin was: ${err.message}`,
+              `in loading the plugin was: ${err.message}`
           );
           log.debug(err.stack);
         }
-      }),
+      })
   );
 }
 
@@ -73,12 +72,12 @@ export function getActivePlugins (pluginConfig, usePlugins = []) {
  * @param {import('./driver-config').DriverConfig} driverConfig - a driver extension config
  * @param {string[]} [useDrivers] - optional list of drivers to load
  */
-export function getActiveDrivers (driverConfig, useDrivers = []) {
+export function getActiveDrivers(driverConfig, useDrivers = []) {
   return _.compact(
     Object.keys(driverConfig.installedExtensions)
       .filter(
         (driverName) =>
-          _.includes(useDrivers, driverName) || useDrivers.length === 0,
+          _.includes(useDrivers, driverName) || useDrivers.length === 0
       )
       .map((driverName) => {
         try {
@@ -87,11 +86,11 @@ export function getActiveDrivers (driverConfig, useDrivers = []) {
         } catch (err) {
           log.error(
             `Could not load driver '${driverName}', so it will not be available. Error ` +
-              `in loading the driver was: ${err.message}`,
+              `in loading the driver was: ${err.message}`
           );
           log.debug(err.stack);
         }
-      }),
+      })
   );
 }
 

--- a/packages/appium/lib/extension/manifest.js
+++ b/packages/appium/lib/extension/manifest.js
@@ -2,14 +2,14 @@
  * Module containing {@link Manifest} which handles reading & writing of extension config files.
  */
 
-import { env, fs } from '@appium/support';
+import {env, fs} from '@appium/support';
 import _ from 'lodash';
 import path from 'path';
 import YAML from 'yaml';
-import { DRIVER_TYPE, PLUGIN_TYPE } from '../constants';
+import {DRIVER_TYPE, PLUGIN_TYPE} from '../constants';
 import log from '../logger';
-import { INSTALL_TYPE_NPM } from './extension-config';
-import { packageDidChange } from './package-changed';
+import {INSTALL_TYPE_NPM} from './extension-config';
+import {packageDidChange} from './package-changed';
 
 /**
  * Default depth to search in directory tree for whatever it is we're looking for.
@@ -61,7 +61,7 @@ const INITIAL_MANIFEST_DATA = Object.freeze({
  * @param {any} value
  * @returns {value is ExtPackageJson<ExtensionType>}
  */
-function isExtension (value) {
+function isExtension(value) {
   return (
     _.isPlainObject(value) &&
     _.isPlainObject(value.appium) &&
@@ -77,7 +77,7 @@ function isExtension (value) {
  * @param {any} value - Value to test
  * @returns {value is ExtPackageJson<DriverType>}
  */
-function isDriver (value) {
+function isDriver(value) {
   return (
     isExtension(value) &&
     _.isString(_.get(value, 'appium.driverName')) &&
@@ -93,7 +93,7 @@ function isDriver (value) {
  * @param {any} value - Value to test
  * @returns {value is ExtPackageJson<PluginType>}
  */
-function isPlugin (value) {
+function isPlugin(value) {
   return isExtension(value) && _.isString(_.get(value, 'appium.pluginName'));
 }
 
@@ -157,7 +157,7 @@ export class Manifest {
    * @param {string} appiumHome
    * @private
    */
-  constructor (appiumHome) {
+  constructor(appiumHome) {
     this._appiumHome = appiumHome;
     this._data = _.cloneDeep(INITIAL_MANIFEST_DATA);
   }
@@ -169,9 +169,7 @@ export class Manifest {
    * @param {string} appiumHome - Path to `APPIUM_HOME`
    * @returns {Manifest}
    */
-  static getInstance = _.memoize(function _getInstance (
-    appiumHome,
-  ) {
+  static getInstance = _.memoize(function _getInstance(appiumHome) {
     return new Manifest(appiumHome);
   });
 
@@ -180,13 +178,13 @@ export class Manifest {
    * @param {SyncWithInstalledExtensionsOpts} opts
    * @returns {Promise<boolean>} `true` if any extensions were added, `false` otherwise.
    */
-  async syncWithInstalledExtensions ({depthLimit = DEFAULT_SEARCH_DEPTH} = {}) {
+  async syncWithInstalledExtensions({depthLimit = DEFAULT_SEARCH_DEPTH} = {}) {
     const walkOpts = _.defaults({depthLimit}, DEFAULT_FIND_EXTENSIONS_OPTS);
     // this could be parallelized, but we can't use fs.walk as an async iterator
     let didChange = false;
     for await (const {stats, path: filepath} of fs.walk(
       this._appiumHome,
-      walkOpts,
+      walkOpts
     )) {
       if (filepath !== this._appiumHome && stats.isDirectory()) {
         try {
@@ -196,7 +194,7 @@ export class Manifest {
             // so only update `didChange` if it's new.
             const added = this.addExtensionFromPackage(
               pkg,
-              path.join(filepath, 'package.json'),
+              path.join(filepath, 'package.json')
             );
             didChange = didChange || added;
           }
@@ -211,7 +209,7 @@ export class Manifest {
    * @param {string} name - Driver name
    * @returns {boolean}
    */
-  hasDriver (name) {
+  hasDriver(name) {
     return Boolean(this._data.drivers[name]);
   }
 
@@ -220,7 +218,7 @@ export class Manifest {
    * @param {string} name - Plugin name
    * @returns {boolean}
    */
-  hasPlugin (name) {
+  hasPlugin(name) {
     return Boolean(this._data.plugins[name]);
   }
 
@@ -233,7 +231,7 @@ export class Manifest {
    * @param {string} pkgPath
    * @returns {boolean} - `true` upon success, `false` if the extension is already registered.
    */
-  addExtensionFromPackage (pkgJson, pkgPath) {
+  addExtensionFromPackage(pkgJson, pkgPath) {
     /**
      * @type {InternalMetadata}
      */
@@ -248,7 +246,7 @@ export class Manifest {
       if (!this.hasDriver(pkgJson.appium.driverName)) {
         this.addExtension(DRIVER_TYPE, pkgJson.appium.driverName, {
           ..._.omit(pkgJson.appium, 'driverName'),
-          ...internal
+          ...internal,
         });
         return true;
       }
@@ -265,8 +263,8 @@ export class Manifest {
     } else {
       throw new TypeError(
         `The extension in ${path.dirname(
-          pkgPath,
-        )} is neither a valid driver nor a valid plugin.`,
+          pkgPath
+        )} is neither a valid driver nor a valid plugin.`
       );
     }
   }
@@ -282,21 +280,21 @@ export class Manifest {
    * @param {ExtManifest<ExtType>} extData - Extension metadata
    * @returns {void}
    */
-  addExtension (extType, extName, extData) {
+  addExtension(extType, extName, extData) {
     this._data[`${extType}s`][extName] = extData;
   }
 
   /**
    * Returns the APPIUM_HOME path
    */
-  get appiumHome () {
+  get appiumHome() {
     return this._appiumHome;
   }
 
   /**
    * Returns the path to the manifest file
    */
-  get manifestPath () {
+  get manifestPath() {
     return this._manifestPath;
   }
 
@@ -307,7 +305,7 @@ export class Manifest {
    * @param {ExtType} extType
    * @returns {ExtRecord<ExtType>}
    */
-  getExtensionData (extType) {
+  getExtensionData(extType) {
     return this._data[/** @type {string} */ (`${extType}s`)];
   }
 
@@ -321,7 +319,7 @@ export class Manifest {
    * Only one read operation should happen at a time.  This is controlled via the {@link Manifest._reading} property.
    * @returns {Promise<ManifestData>} The data
    */
-  async read () {
+  async read() {
     if (this._reading) {
       await this._reading;
       return this._data;
@@ -344,11 +342,11 @@ export class Manifest {
           if (this._manifestPath) {
             throw new Error(
               `Appium had trouble loading the extension installation ` +
-                `cache file (${this._manifestPath}). It may be invalid YAML. Specific error: ${err.message}`,
+                `cache file (${this._manifestPath}). It may be invalid YAML. Specific error: ${err.message}`
             );
           } else {
             throw new Error(
-              `Appium encountered an unknown problem. Specific error: ${err.message}`,
+              `Appium encountered an unknown problem. Specific error: ${err.message}`
             );
           }
         }
@@ -357,7 +355,7 @@ export class Manifest {
       this._data = data;
       let installedExtensionsChanged = false;
       if (
-        await env.hasAppiumDependency(this.appiumHome) &&
+        (await env.hasAppiumDependency(this.appiumHome)) &&
         (await packageDidChange(this.appiumHome))
       ) {
         installedExtensionsChanged = await this.syncWithInstalledExtensions();
@@ -382,14 +380,14 @@ export class Manifest {
    * @private
    * @returns {Promise<string>}
    */
-  async _setManifestPath () {
+  async _setManifestPath() {
     if (!this._manifestPath) {
       this._manifestPath = await env.resolveManifestPath(this._appiumHome);
 
       /* istanbul ignore if */
       if (path.relative(this._appiumHome, this._manifestPath).startsWith('.')) {
         throw new Error(
-          `Mismatch between location of APPIUM_HOME and manifest file. APPIUM_HOME: ${this.appiumHome}, manifest file: ${this._manifestPath}`,
+          `Mismatch between location of APPIUM_HOME and manifest file. APPIUM_HOME: ${this.appiumHome}, manifest file: ${this._manifestPath}`
         );
       }
     }
@@ -405,7 +403,7 @@ export class Manifest {
    * @todo If this becomes too much of a bottleneck, throttle it.
    * @returns {Promise<boolean>} Whether the data was written
    */
-  async write () {
+  async write() {
     if (this._writing) {
       return this._writing;
     }
@@ -416,21 +414,21 @@ export class Manifest {
       } catch (err) {
         throw new Error(
           `Appium could not create the directory for the manifest file: ${path.dirname(
-            this._manifestPath,
-          )}. Original error: ${err.message}`,
+            this._manifestPath
+          )}. Original error: ${err.message}`
         );
       }
       try {
         await fs.writeFile(
           this._manifestPath,
           YAML.stringify(this._data),
-          'utf8',
+          'utf8'
         );
         return true;
       } catch (err) {
         throw new Error(
           `Appium could not write to manifest at ${this._manifestPath} using APPIUM_HOME ${this._appiumHome}. ` +
-            `Please ensure it is writable. Original error: ${err.message}`,
+            `Please ensure it is writable. Original error: ${err.message}`
         );
       }
     })();
@@ -444,12 +442,12 @@ export class Manifest {
 
 /**
  * Type of the string referring to a driver (typically as a key or type string)
- * @typedef {import('../../types').DriverType} DriverType
+ * @typedef {import('appium/types').DriverType} DriverType
  */
 
 /**
  * Type of the string referring to a plugin (typically as a key or type string)
- * @typedef {import('../../types').PluginType} PluginType
+ * @typedef {import('appium/types').PluginType} PluginType
  */
 
 /**
@@ -458,27 +456,26 @@ export class Manifest {
  */
 
 /**
- * @typedef {import('../../types/appium-manifest').ManifestData} ManifestData
- * @typedef {import('../../types/appium-manifest').InternalMetadata} InternalMetadata
+ * @typedef {import('appium/types').ManifestData} ManifestData
+ * @typedef {import('appium/types').InternalMetadata} InternalMetadata
  */
 
 /**
  * @template T
- * @typedef {import('../../types/external-manifest').ExtPackageJson<T>} ExtPackageJson
+ * @typedef {import('appium/types').ExtPackageJson<T>} ExtPackageJson
  */
 
 /**
  * @template T
- * @typedef {import('../../types/appium-manifest').ExtManifest<T>} ExtManifest
+ * @typedef {import('appium/types').ExtManifest<T>} ExtManifest
  */
 
 /**
  * @template T
- * @typedef {import('../../types/appium-manifest').ExtRecord<T>} ExtRecord
+ * @typedef {import('appium/types').ExtRecord<T>} ExtRecord
  */
 
 /**
  * Either `driver` or `plugin` rn
- * @typedef {import('../../types').ExtensionType} ExtensionType
+ * @typedef {import('appium/types').ExtensionType} ExtensionType
  */
-

--- a/packages/appium/lib/extension/plugin-config.js
+++ b/packages/appium/lib/extension/plugin-config.js
@@ -1,4 +1,3 @@
-
 import _ from 'lodash';
 import {ExtensionConfig} from './extension-config';
 import log from '../logger';
@@ -8,7 +7,6 @@ import {PLUGIN_TYPE} from '../constants';
  * @extends {ExtensionConfig<PluginType>}
  */
 export class PluginConfig extends ExtensionConfig {
-
   /**
    * A mapping of {@link Manifest} instances to {@link PluginConfig} instances.
    *
@@ -19,9 +17,9 @@ export class PluginConfig extends ExtensionConfig {
    * @type {WeakMap<Manifest,PluginConfig>}
    * @private
    */
-   static _instances = new WeakMap();
+  static _instances = new WeakMap();
 
-   /**
+  /**
    * Call {@link PluginConfig.create} instead.
    *
    * Just calls the superclass' constructor with the correct extension type
@@ -29,85 +27,92 @@ export class PluginConfig extends ExtensionConfig {
    * @param {Manifest} manifest - IO object
    * @param {PluginConfigOptions} [opts]
    */
-   constructor (manifest, {extData, logFn} = {}) {
-     super(PLUGIN_TYPE, manifest, logFn);
+  constructor(manifest, {extData, logFn} = {}) {
+    super(PLUGIN_TYPE, manifest, logFn);
 
-     if (extData) {
-       this.validate(extData);
-     }
-   }
+    if (extData) {
+      this.validate(extData);
+    }
+  }
 
-   /**
-    * Creates a new {@link PluginConfig} instance for a {@link Manifest} instance.
-    *
-    * @param {Manifest} manifest
-    * @param {PluginConfigOptions} [opts]
-    * @throws If `manifest` already associated with a `PluginConfig`
-    * @returns {PluginConfig}
-    */
-   static create (manifest, {extData, logFn} = {}) {
-     const instance = new PluginConfig(manifest, {logFn, extData});
-     if (PluginConfig.getInstance(manifest)) {
-       throw new Error(`Manifest with APPIUM_HOME ${manifest.appiumHome} already has a PluginConfig; use PluginConfig.getInstance() to retrieve it.`);
-     }
-     PluginConfig._instances.set(manifest, instance);
-     return instance;
-   }
+  /**
+   * Creates a new {@link PluginConfig} instance for a {@link Manifest} instance.
+   *
+   * @param {Manifest} manifest
+   * @param {PluginConfigOptions} [opts]
+   * @throws If `manifest` already associated with a `PluginConfig`
+   * @returns {PluginConfig}
+   */
+  static create(manifest, {extData, logFn} = {}) {
+    const instance = new PluginConfig(manifest, {logFn, extData});
+    if (PluginConfig.getInstance(manifest)) {
+      throw new Error(
+        `Manifest with APPIUM_HOME ${manifest.appiumHome} already has a PluginConfig; use PluginConfig.getInstance() to retrieve it.`
+      );
+    }
+    PluginConfig._instances.set(manifest, instance);
+    return instance;
+  }
 
-   /**
-     * Returns a PluginConfig associated with a Manifest
-     * @param {Manifest} manifest
-     * @returns {PluginConfig|undefined}
-     */
-   static getInstance (manifest) {
-     return PluginConfig._instances.get(manifest);
-   }
+  /**
+   * Returns a PluginConfig associated with a Manifest
+   * @param {Manifest} manifest
+   * @returns {PluginConfig|undefined}
+   */
+  static getInstance(manifest) {
+    return PluginConfig._instances.get(manifest);
+  }
 
-   /**
+  /**
    * @param {string} pluginName
-   * @param {import('../../types/appium-manifest').ExtManifest<PluginType>} pluginData
+   * @param {import('appium/types').ExtManifest<PluginType>} pluginData
    * @returns {string}
    */
-   extensionDesc (pluginName, {version}) {
-     return `${pluginName}@${version}`;
-   }
+  extensionDesc(pluginName, {version}) {
+    return `${pluginName}@${version}`;
+  }
 
-   /**
+  /**
    *
    * @param {(keyof PluginRecord)[]} activeNames
    * @returns {void}
    */
-   print (activeNames) {
-     const pluginNames = Object.keys(this.installedExtensions);
+  print(activeNames) {
+    const pluginNames = Object.keys(this.installedExtensions);
 
-     if (_.isEmpty(pluginNames)) {
-       log.info(`No plugins have been installed. Use the "appium plugin" ` +
-               'command to install the one(s) you want to use.');
-       return;
-     }
+    if (_.isEmpty(pluginNames)) {
+      log.info(
+        `No plugins have been installed. Use the "appium plugin" ` +
+          'command to install the one(s) you want to use.'
+      );
+      return;
+    }
 
-     log.info(`Available plugins:`);
-     for (const [pluginName, pluginData] of _.toPairs(this.installedExtensions)) {
-       const activeTxt = _.includes(activeNames, pluginName) ? ' (ACTIVE)' : '';
-       log.info(`  - ${this.extensionDesc(pluginName, pluginData)}${activeTxt}`);
-     }
+    log.info(`Available plugins:`);
+    for (const [pluginName, pluginData] of _.toPairs(
+      this.installedExtensions
+    )) {
+      const activeTxt = _.includes(activeNames, pluginName) ? ' (ACTIVE)' : '';
+      log.info(`  - ${this.extensionDesc(pluginName, pluginData)}${activeTxt}`);
+    }
 
-     if (_.isEmpty(activeNames)) {
-       log.info('No plugins activated. Use the --use-plugins flag with names of plugins to activate');
-     }
-   }
+    if (_.isEmpty(activeNames)) {
+      log.info(
+        'No plugins activated. Use the --use-plugins flag with names of plugins to activate'
+      );
+    }
+  }
 }
 
 /**
  * @typedef PluginConfigOptions
  * @property {import('./extension-config').ExtensionLogFn} [logFn] - Optional logging function
- * @property {import('../../types/appium-manifest').PluginRecord} [extData] - Extension data
+ * @property {import('appium/types').PluginRecord} [extData] - Extension data
  */
 
-
 /**
- * @typedef {import('../../types/appium-manifest').PluginRecord} PluginRecord
- * @typedef {import('../../types').PluginType} PluginType
- * @typedef {import('../../types/external-manifest').ExtMetadata<PluginType>} PluginMetadata
+ * @typedef {import('appium/types').PluginRecord} PluginRecord
+ * @typedef {import('appium/types').PluginType} PluginType
+ * @typedef {import('appium/types').ExtMetadata<PluginType>} PluginMetadata
  * @typedef {import('./manifest').Manifest} Manifest
  */

--- a/packages/appium/test/e2e/cli.e2e.spec.js
+++ b/packages/appium/test/e2e/cli.e2e.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { npm, env, fs, tempDir, util } from '@appium/support';
+import {npm, env, fs, tempDir, util} from '@appium/support';
 import B from 'bluebird';
 import path from 'path';
 import resolveFrom from 'resolve-from';
@@ -13,10 +13,17 @@ import {
   EXT_SUBCOMMAND_UNINSTALL as UNINSTALL,
   PKG_HASHFILE_RELATIVE_PATH,
   KNOWN_DRIVERS,
-  PLUGIN_TYPE
+  PLUGIN_TYPE,
 } from '../../lib/constants';
-import { FAKE_DRIVER_DIR, resolveFixture } from '../helpers';
-import { installLocalExtension, runAppium, runAppiumJson, runAppiumRaw, readAppiumArgErrorFixture, formatAppiumArgErrorOutput } from './e2e-helpers';
+import {FAKE_DRIVER_DIR, resolveFixture} from '../helpers';
+import {
+  installLocalExtension,
+  runAppium,
+  runAppiumJson,
+  runAppiumRaw,
+  readAppiumArgErrorFixture,
+  formatAppiumArgErrorOutput,
+} from './e2e-helpers';
 
 const {MANIFEST_RELATIVE_PATH} = env;
 const {expect} = chai;
@@ -27,7 +34,9 @@ describe('CLI behavior', function () {
    */
   let appiumHome;
 
-  const testDriverPath = path.dirname(resolveFixture('test-driver/package.json'));
+  const testDriverPath = path.dirname(
+    resolveFixture('test-driver/package.json')
+  );
 
   beforeEach(function () {
     this.timeout(30000);
@@ -45,7 +54,7 @@ describe('CLI behavior', function () {
      * Helper fn
      * @returns {Promise<ManifestData>}
      */
-    async function readManifest () {
+    async function readManifest() {
       const manifest = await fs.readFile(manifestPath, 'utf8');
       return YAML.parse(manifest);
     }
@@ -54,7 +63,7 @@ describe('CLI behavior', function () {
      * Helper fn
      * @returns {Promise<string>}
      */
-    async function readHash () {
+    async function readHash() {
       return await fs.readFile(hashPath, 'utf8');
     }
 
@@ -73,7 +82,7 @@ describe('CLI behavior', function () {
       // an example package.json referencing appium dependency
       await fs.copyFile(
         resolveFixture('cli/appium-dependency.package.json'),
-        appiumHomePkgPath,
+        appiumHomePkgPath
       );
     });
 
@@ -88,7 +97,7 @@ describe('CLI behavior', function () {
         );
         res.should.satisfy(
           /** @param {typeof res} value */ (value) =>
-            Object.values(value).every(({installed}) => !installed),
+            Object.values(value).every(({installed}) => !installed)
         );
       });
     });
@@ -109,7 +118,7 @@ describe('CLI behavior', function () {
         (() =>
           resolveFrom(
             appiumHome,
-            '@appium/fake-driver/package.json',
+            '@appium/fake-driver/package.json'
           )).should.not.throw();
       });
     });
@@ -159,7 +168,9 @@ describe('CLI behavior', function () {
         });
 
         it('should update package.json', async function () {
-          const newPkg = JSON.parse(await fs.readFile(appiumHomePkgPath, 'utf8'));
+          const newPkg = JSON.parse(
+            await fs.readFile(appiumHomePkgPath, 'utf8')
+          );
           expect(newPkg).to.have.nested.property('devDependencies.test-driver');
         });
 
@@ -177,7 +188,8 @@ describe('CLI behavior', function () {
         });
 
         it('should actually install both drivers', function () {
-          expect(() => resolveFrom(appiumHome, '@appium/fake-driver')).not.to.throw;
+          expect(() => resolveFrom(appiumHome, '@appium/fake-driver')).not.to
+            .throw;
           expect(() => resolveFrom(appiumHome, 'test-driver')).not.to.throw;
         });
       });
@@ -203,7 +215,7 @@ describe('CLI behavior', function () {
       await fs.rimraf(appiumHome);
     });
 
-    async function clear () {
+    async function clear() {
       await fs.rimraf(appiumHome);
       await fs.mkdirp(appiumHome);
     }
@@ -268,16 +280,23 @@ describe('CLI behavior', function () {
             '--source',
             'npm',
           ]);
-          const {fake} = /** @type {Record<string,import('../../lib/cli/extension-command').InstalledExtensionListData>} */(await runList(['--updates']));
+          const {fake} =
+            /** @type {Record<string,import('appium/lib/cli/extension-command').InstalledExtensionListData>} */ (
+              await runList(['--updates'])
+            );
           util.compareVersions(
             fake.updateVersion,
             '>',
-            penultimateFakeDriverVersionAsOfRightNow,
+            penultimateFakeDriverVersionAsOfRightNow
           ).should.be.true;
           // TODO: this could probably be replaced by looking at updateVersion in the JSON
-          const stdout = await runAppium(appiumHome, [DRIVER_TYPE, LIST, '--updates']);
+          const stdout = await runAppium(appiumHome, [
+            DRIVER_TYPE,
+            LIST,
+            '--updates',
+          ]);
           stdout.should.match(
-            new RegExp(`fake.+[${fake.updateVersion} available]`),
+            new RegExp(`fake.+[${fake.updateVersion} available]`)
           );
         });
       });
@@ -310,33 +329,31 @@ describe('CLI behavior', function () {
 
         it('should install a driver from npm and a local driver', async function () {
           await clear();
-          await runInstall([
-            '@appium/fake-driver',
-            '--source',
-            'npm',
-          ]);
+          await runInstall(['@appium/fake-driver', '--source', 'npm']);
           await installLocalExtension(appiumHome, DRIVER_TYPE, testDriverPath);
           const list = await runList(['--installed']);
           expect(list.fake).to.exist;
           expect(list.test).to.exist;
-          expect(() => resolveFrom(appiumHome, '@appium/fake-driver')).not.to.throw;
+          expect(() =>
+            resolveFrom(appiumHome, '@appium/fake-driver')
+          ).not.to.throw;
           expect(() => resolveFrom(appiumHome, 'test-driver')).not.to.throw;
         });
 
         it('should install _two_ drivers from npm', async function () {
           this.timeout('40s');
           await clear();
-          await runInstall([
-            '@appium/fake-driver',
-            '--source',
-            'npm',
-          ]);
+          await runInstall(['@appium/fake-driver', '--source', 'npm']);
           await runInstall(['appium-uiautomator2-driver', '--source', 'npm']);
           const list = await runList(['--installed']);
           expect(list.fake).to.exist;
           expect(list.uiautomator2).to.exist;
-          expect(() => resolveFrom(appiumHome, '@appium/fake-driver')).not.to.throw;
-          expect(() => resolveFrom(appiumHome, 'appium-uiautomator2-driver')).not.to.throw;
+          expect(() =>
+            resolveFrom(appiumHome, '@appium/fake-driver')
+          ).not.to.throw;
+          expect(() =>
+            resolveFrom(appiumHome, 'appium-uiautomator2-driver')
+          ).not.to.throw;
         });
 
         it('should install a driver from npm with a specific version/tag', async function () {
@@ -395,7 +412,7 @@ describe('CLI behavior', function () {
           ret.fake.pkgName.should.eql('appium-fake-driver');
           ret.fake.installType.should.eql('git');
           ret.fake.installSpec.should.eql(
-            'git+https://github.com/appium/appium-fake-driver',
+            'git+https://github.com/appium/appium-fake-driver'
           );
           const list = await runList(['--installed']);
           delete list.fake.installed;
@@ -405,7 +422,11 @@ describe('CLI behavior', function () {
           await clear();
           // take advantage of the fact that we know we have fake driver installed as a dependency in
           // this module, so we know its local path on disk
-          const ret = await installLocalExtension(appiumHome, DRIVER_TYPE, FAKE_DRIVER_DIR);
+          const ret = await installLocalExtension(
+            appiumHome,
+            DRIVER_TYPE,
+            FAKE_DRIVER_DIR
+          );
           ret.fake.pkgName.should.eql('@appium/fake-driver');
           ret.fake.installType.should.eql('local');
           ret.fake.installSpec.should.eql(FAKE_DRIVER_DIR);
@@ -415,7 +436,9 @@ describe('CLI behavior', function () {
 
           // it should be a link!  this may be npm-version dependent, but it's worked
           // this way for quite awhile
-          const stat = await fs.lstat(path.join(appiumHome, 'node_modules', '@appium', 'fake-driver'));
+          const stat = await fs.lstat(
+            path.join(appiumHome, 'node_modules', '@appium', 'fake-driver')
+          );
           expect(stat.isSymbolicLink()).to.be.true;
         });
       });
@@ -456,20 +479,22 @@ describe('CLI behavior', function () {
         });
         it('should take a valid driver, invalid script, and throw an error', async function () {
           const driverName = 'fake';
-          await expect(runRun([driverName, 'foo']))
-            .to.eventually.be.rejectedWith(Error);
+          await expect(
+            runRun([driverName, 'foo'])
+          ).to.eventually.be.rejectedWith(Error);
         });
         it('should take an invalid driver, invalid script, and throw an error', async function () {
           const driverName = 'foo';
-          await expect(runRun([driverName, 'bar']))
-            .to.eventually.be.rejectedWith(Error);
+          await expect(
+            runRun([driverName, 'bar'])
+          ).to.eventually.be.rejectedWith(Error);
         });
       });
     });
 
     describe('Plugin CLI', function () {
       const FAKE_PLUGIN_DIR = path.dirname(
-        require.resolve('@appium/fake-plugin/package.json'),
+        require.resolve('@appium/fake-plugin/package.json')
       );
 
       before(function () {
@@ -502,12 +527,14 @@ describe('CLI behavior', function () {
         });
         it('should take a valid plugin, invalid script, and throw an error', async function () {
           const pluginName = 'fake';
-          await expect(runRun([pluginName, 'foo', '--json']))
-            .to.eventually.be.rejectedWith(Error);
+          await expect(
+            runRun([pluginName, 'foo', '--json'])
+          ).to.eventually.be.rejectedWith(Error);
         });
         it('should take an invalid plugin, invalid script, and throw an error', async function () {
-          await expect(runRun(['foo', 'bar', '--json']))
-            .to.eventually.be.rejectedWith(Error);
+          await expect(
+            runRun(['foo', 'bar', '--json'])
+          ).to.eventually.be.rejectedWith(Error);
         });
       });
     });
@@ -518,8 +545,10 @@ describe('CLI behavior', function () {
       describe('when color output is supported', function () {
         it('should output a fancy error message', async function () {
           const [{stderr: actual}, expected] = await B.all([
-            runAppiumRaw(appiumHome, ['--port=sheep'], {env: {FORCE_COLOR: '1'}}),
-            readAppiumArgErrorFixture('cli/cli-error-output-color.txt')
+            runAppiumRaw(appiumHome, ['--port=sheep'], {
+              env: {FORCE_COLOR: '1'},
+            }),
+            readAppiumArgErrorFixture('cli/cli-error-output-color.txt'),
           ]);
           expect(formatAppiumArgErrorOutput(actual)).to.equal(expected);
         });
@@ -529,7 +558,7 @@ describe('CLI behavior', function () {
         it('should output a colorless yet fancy error message', async function () {
           const [{stderr: actual}, expected] = await B.all([
             runAppiumRaw(appiumHome, ['--port=sheep'], {}),
-            readAppiumArgErrorFixture('cli/cli-error-output.txt')
+            readAppiumArgErrorFixture('cli/cli-error-output.txt'),
           ]);
           expect(formatAppiumArgErrorOutput(actual)).to.equal(expected);
         });
@@ -540,7 +569,7 @@ describe('CLI behavior', function () {
       it('should output a basic error message', async function () {
         const [{stderr: actual}, expected] = await B.all([
           runAppiumRaw(appiumHome, ['--relaxed-security=sheep'], {}),
-          readAppiumArgErrorFixture('cli/cli-error-output-boolean.txt')
+          readAppiumArgErrorFixture('cli/cli-error-output-boolean.txt'),
         ]);
         expect(formatAppiumArgErrorOutput(actual)).to.equal(expected);
       });
@@ -550,7 +579,7 @@ describe('CLI behavior', function () {
       it('should output a basic error message', async function () {
         const [{stderr: actual}, expected] = await B.all([
           runAppiumRaw(appiumHome, ['--pigs=sheep'], {}),
-          readAppiumArgErrorFixture('cli/cli-error-output-unknown.txt')
+          readAppiumArgErrorFixture('cli/cli-error-output-unknown.txt'),
         ]);
         expect(formatAppiumArgErrorOutput(actual)).to.equal(expected);
       });
@@ -559,13 +588,13 @@ describe('CLI behavior', function () {
 });
 
 /**
- * @typedef {import('../../lib/extension/manifest').ExtensionType} ExtensionType
- * @typedef {import('../../lib/extension/manifest').ManifestData} ManifestData
- * @typedef {import('../../lib/extension/manifest').DriverType} DriverType
- * @typedef {import('../../lib/extension/manifest').PluginType} PluginType
- * @typedef {import('../../lib/cli/extension-command').ExtensionListData} ExtensionListData
+ * @typedef {import('appium/types').ExtensionType} ExtensionType
+ * @typedef {import('appium/types').ManifestData} ManifestData
+ * @typedef {import('appium/types').DriverType} DriverType
+ * @typedef {import('appium/types').PluginType} PluginType
+ * @typedef {import('appium/lib/cli/extension-command').ExtensionListData} ExtensionListData
  * @typedef {import('./e2e-helpers').CliArgs} CliArgs
- * @typedef {import('../../types/cli').CliExtensionSubcommand} CliExtensionSubcommand
+ * @typedef {import('appium/types').CliExtensionSubcommand} CliExtensionSubcommand
  */
 
 /**
@@ -575,5 +604,5 @@ describe('CLI behavior', function () {
 
 /**
  * @template T
- * @typedef {import('../../lib/extension/manifest').ExtRecord<T>} ExtRecord
+ * @typedef {import('appium/types').ExtRecord<T>} ExtRecord
  */

--- a/packages/appium/test/e2e/config-file.e2e.spec.js
+++ b/packages/appium/test/e2e/config-file.e2e.spec.js
@@ -1,41 +1,45 @@
 // @ts-check
 
-import { DRIVER_TYPE } from '../../lib/constants';
-import { readConfigFile, normalizeConfig } from '../../lib/config-file';
-import { finalizeSchema, registerSchema, resetSchema } from '../../lib/schema/schema';
+import {DRIVER_TYPE} from '../../lib/constants';
+import {readConfigFile, normalizeConfig} from '../../lib/config-file';
+import {
+  finalizeSchema,
+  registerSchema,
+  resetSchema,
+} from '../../lib/schema/schema';
 import extSchema from '../fixtures/driver.schema.js';
-import { resolveFixture } from '../helpers';
+import {resolveFixture} from '../helpers';
 
 describe('config file behavior', function () {
   const GOOD_FILEPATH = resolveFixture('config', 'appium.config.good.json');
   const BAD_NODECONFIG_FILEPATH = resolveFixture(
     'config',
-    'appium.config.bad-nodeconfig.json',
+    'appium.config.bad-nodeconfig.json'
   );
   const BAD_FILEPATH = resolveFixture('config', 'appium.config.bad.json');
   const INVALID_JSON_FILEPATH = resolveFixture(
     'config',
-    'appium.config.invalid.json',
+    'appium.config.invalid.json'
   );
   const SECURITY_ARRAY_FILEPATH = resolveFixture(
     'config',
-    'appium.config.security-array.json',
+    'appium.config.security-array.json'
   );
   const SECURITY_DELIMITED_FILEPATH = resolveFixture(
     'config',
-    'appium.config.security-delimited.json',
+    'appium.config.security-delimited.json'
   );
   const SECURITY_PATH_FILEPATH = resolveFixture(
     'config',
-    'appium.config.security-path.json',
+    'appium.config.security-path.json'
   );
   const UNKNOWN_PROPS_FILEPATH = resolveFixture(
     'config',
-    'appium.config.ext-unknown-props.json',
+    'appium.config.ext-unknown-props.json'
   );
   const EXT_PROPS_FILEPATH = resolveFixture(
     'config',
-    'appium.config.ext-good.json',
+    'appium.config.ext-good.json'
   );
 
   beforeEach(function () {
@@ -45,7 +49,6 @@ describe('config file behavior', function () {
   afterEach(function () {
     resetSchema();
   });
-
 
   describe('when provided a path to a config file', function () {
     describe('when the config file is valid per the schema', function () {
@@ -64,7 +67,7 @@ describe('config file behavior', function () {
             const result = await readConfigFile(BAD_NODECONFIG_FILEPATH);
             result.should.have.nested.property(
               'errors[0].instancePath',
-              '/server/nodeconfig',
+              '/server/nodeconfig'
             );
           });
         });
@@ -83,7 +86,7 @@ describe('config file behavior', function () {
             const result = await readConfigFile(SECURITY_PATH_FILEPATH);
             result.should.have.nested.property(
               'errors[0].instancePath',
-              '/server/allow-insecure',
+              '/server/allow-insecure'
             );
           });
         });
@@ -93,7 +96,7 @@ describe('config file behavior', function () {
             const result = await readConfigFile(SECURITY_DELIMITED_FILEPATH);
             result.should.have.nested.property(
               'errors[0].instancePath',
-              '/server/allow-insecure',
+              '/server/allow-insecure'
             );
           });
         });
@@ -115,104 +118,111 @@ describe('config file behavior', function () {
       describe('without extensions', function () {
         it('should return an object containing errors', async function () {
           const result = await readConfigFile(BAD_FILEPATH);
-          result.should.have.deep.property('config', normalizeConfig(require(BAD_FILEPATH)));
+          result.should.have.deep.property(
+            'config',
+            normalizeConfig(require(BAD_FILEPATH))
+          );
           result.should.have.property('filepath', BAD_FILEPATH);
-          result.should.have.deep.property('errors').that.contains.members([
-            {
-              instancePath: '',
-              schemaPath: '#/additionalProperties',
-              keyword: 'additionalProperties',
-              params: {
-                additionalProperty: 'appium-home',
+          result.should.have.deep
+            .property('errors')
+            .that.contains.members([
+              {
+                instancePath: '',
+                schemaPath: '#/additionalProperties',
+                keyword: 'additionalProperties',
+                params: {
+                  additionalProperty: 'appium-home',
+                },
+                message: 'must NOT have additional properties',
+                isIdentifierLocation: true,
               },
-              message: 'must NOT have additional properties',
-              isIdentifierLocation: true,
-            },
-            {
-              instancePath: '/server/allow-cors',
-              schemaPath: '#/properties/server/properties/allow-cors/type',
-              keyword: 'type',
-              params: {
-                type: 'boolean',
+              {
+                instancePath: '/server/allow-cors',
+                schemaPath: '#/properties/server/properties/allow-cors/type',
+                keyword: 'type',
+                params: {
+                  type: 'boolean',
+                },
+                message: 'must be boolean',
               },
-              message: 'must be boolean',
-            },
-            {
-              instancePath: '/server/allow-insecure',
-              schemaPath: '#/properties/server/properties/allow-insecure/type',
-              keyword: 'type',
-              params: {
-                type: 'array'
+              {
+                instancePath: '/server/allow-insecure',
+                schemaPath:
+                  '#/properties/server/properties/allow-insecure/type',
+                keyword: 'type',
+                params: {
+                  type: 'array',
+                },
+                message: 'must be array',
               },
-              message: 'must be array',
-            },
-            {
-              instancePath: '/server/callback-port',
-              schemaPath:
-                '#/properties/server/properties/callback-port/maximum',
-              keyword: 'maximum',
-              params: {
-                comparison: '<=',
-                limit: 65535,
+              {
+                instancePath: '/server/callback-port',
+                schemaPath:
+                  '#/properties/server/properties/callback-port/maximum',
+                keyword: 'maximum',
+                params: {
+                  comparison: '<=',
+                  limit: 65535,
+                },
+                message: 'must be <= 65535',
               },
-              message: 'must be <= 65535',
-            },
-            {
-              instancePath: '/server/log-level',
-              schemaPath: '#/properties/server/properties/log-level/enum',
-              keyword: 'enum',
-              params: {
-                allowedValues: [
-                  'info',
-                  'info:debug',
-                  'info:info',
-                  'info:warn',
-                  'info:error',
-                  'warn',
-                  'warn:debug',
-                  'warn:info',
-                  'warn:warn',
-                  'warn:error',
-                  'error',
-                  'error:debug',
-                  'error:info',
-                  'error:warn',
-                  'error:error',
-                  'debug',
-                  'debug:debug',
-                  'debug:info',
-                  'debug:warn',
-                  'debug:error',
-                ],
+              {
+                instancePath: '/server/log-level',
+                schemaPath: '#/properties/server/properties/log-level/enum',
+                keyword: 'enum',
+                params: {
+                  allowedValues: [
+                    'info',
+                    'info:debug',
+                    'info:info',
+                    'info:warn',
+                    'info:error',
+                    'warn',
+                    'warn:debug',
+                    'warn:info',
+                    'warn:warn',
+                    'warn:error',
+                    'error',
+                    'error:debug',
+                    'error:info',
+                    'error:warn',
+                    'error:error',
+                    'debug',
+                    'debug:debug',
+                    'debug:info',
+                    'debug:warn',
+                    'debug:error',
+                  ],
+                },
+                message: 'must be equal to one of the allowed values',
               },
-              message: 'must be equal to one of the allowed values',
-            },
-            {
-              instancePath: '/server/log-no-colors',
-              schemaPath: '#/properties/server/properties/log-no-colors/type',
-              keyword: 'type',
-              params: {
-                type: 'boolean',
+              {
+                instancePath: '/server/log-no-colors',
+                schemaPath: '#/properties/server/properties/log-no-colors/type',
+                keyword: 'type',
+                params: {
+                  type: 'boolean',
+                },
+                message: 'must be boolean',
               },
-              message: 'must be boolean',
-            },
-            {
-              instancePath: '/server/port',
-              schemaPath: '#/properties/server/properties/port/type',
-              keyword: 'type',
-              params: {
-                type: 'integer',
+              {
+                instancePath: '/server/port',
+                schemaPath: '#/properties/server/properties/port/type',
+                keyword: 'type',
+                params: {
+                  type: 'integer',
+                },
+                message: 'must be integer',
               },
-              message: 'must be integer',
-            },
-          ]).and.lengthOf(7);
+            ])
+            .and.lengthOf(7);
 
           result.should.have.property('reason').that.is.a.string;
         });
       });
 
       describe('with extensions', function () {
-        /** @type {import('../../lib/config-file').ReadConfigFileResult} */
+        /** @type {import('appium/lib/config-file').ReadConfigFileResult} */
         let result;
 
         beforeEach(function () {
@@ -229,8 +239,7 @@ describe('config file behavior', function () {
             result.should.have.deep.property('errors', [
               {
                 instancePath: '/server/driver/fake',
-                schemaPath:
-                  'driver-fake.json/additionalProperties',
+                schemaPath: 'driver-fake.json/additionalProperties',
                 keyword: 'additionalProperties',
                 params: {additionalProperty: 'bubb'},
                 message: 'must NOT have additional properties',
@@ -254,7 +263,7 @@ describe('config file behavior', function () {
     describe('when the config file is invalid JSON', function () {
       it('should reject with a user-friendly error message', async function () {
         await readConfigFile(INVALID_JSON_FILEPATH).should.be.rejectedWith(
-          new RegExp(`${INVALID_JSON_FILEPATH} is invalid`),
+          new RegExp(`${INVALID_JSON_FILEPATH} is invalid`)
         );
       });
     });

--- a/packages/appium/test/e2e/e2e-helpers.js
+++ b/packages/appium/test/e2e/e2e-helpers.js
@@ -24,13 +24,13 @@ const log = logger.getLogger('appium-e2e-helpers');
  * Runs the `appium` executable with the given args.
  *
  * If the process exits with a nonzero code, the error will be a {@link AppiumRunError}.
- * @template {import('../../types/cli').CliExtensionSubcommand} ExtSubcommand
+ * @template {import('appium/types').CliExtensionSubcommand} ExtSubcommand
  * @param {string} appiumHome - Path to `APPIUM_HOME`
  * @param {CliExtArgs<ExtSubcommand> | CliArgs} args - Args, including commands
  * @param {import('teen_process').ExecOptions} [opts] - Options for `teen_process`
  * @returns {Promise<import('teen_process').ExecResult<string>>}
  */
-async function run (appiumHome, args, opts = {}) {
+async function run(appiumHome, args, opts = {}) {
   const cwd = PACKAGE_ROOT;
   const env = {
     APPIUM_HOME: appiumHome,
@@ -64,7 +64,7 @@ async function run (appiumHome, args, opts = {}) {
  * See {@link runAppium}.
  * @type {AppiumRunner<string>}
  */
-async function _runAppium (appiumHome, args) {
+async function _runAppium(appiumHome, args) {
   const {stdout} = await run(appiumHome, args);
   return stdout;
 }
@@ -81,7 +81,7 @@ export const runAppium = _.curry(_runAppium);
  * See {@link runAppiumRaw}.
  * @type {AppiumOptsRunner<import('teen_process').ExecResult>}
  */
-async function _runAppiumRaw (appiumHome, args, opts) {
+async function _runAppiumRaw(appiumHome, args, opts) {
   try {
     return await run(appiumHome, args, opts);
   } catch (err) {
@@ -101,7 +101,7 @@ export const runAppiumRaw = _.curry(_runAppiumRaw);
  * See {@link runAppiumJson}.
  * @type {AppiumRunner<unknown>}
  */
-async function _runAppiumJson (appiumHome, args) {
+async function _runAppiumJson(appiumHome, args) {
   if (!args.includes('--json')) {
     args.push('--json');
   }
@@ -122,7 +122,7 @@ async function _runAppiumJson (appiumHome, args) {
  * i.e., add `@type {MyType}` tag.
  */
 export const runAppiumJson = /**
- * @template {import('../../types/cli').CliExtensionSubcommand} ExtSubcommand
+ * @template {import('appium/types').CliExtensionSubcommand} ExtSubcommand
  * @type {import('lodash').CurriedFunction2<string, CliExtArgs<ExtSubcommand>|CliArgs, Promise<unknown>>}
  */ (_.curry(_runAppiumJson));
 
@@ -133,8 +133,8 @@ export const runAppiumJson = /**
  * @param {ExtType} type
  * @param {string} pathToExtension
  */
-export async function installLocalExtension (appiumHome, type, pathToExtension) {
-  return /** @type {import('../../lib/extension/manifest').ExtRecord<ExtType>} */ (
+export async function installLocalExtension(appiumHome, type, pathToExtension) {
+  return /** @type {import('appium/types').ExtRecord<ExtType>} */ (
     /** @type {unknown} */ (
       await runAppiumJson(appiumHome, [
         type,
@@ -154,7 +154,7 @@ export async function installLocalExtension (appiumHome, type, pathToExtension) 
  * @param {string} name - Name of a fixture
  * @returns {Promise<string>} - Contents of file, normalized
  */
-export async function readAppiumArgErrorFixture (name) {
+export async function readAppiumArgErrorFixture(name) {
   const filepath = resolveFixture(name);
   const body = await fs.readFile(filepath, 'utf8');
   return formatAppiumArgErrorOutput(body);
@@ -165,7 +165,7 @@ export async function readAppiumArgErrorFixture (name) {
  * @param {string} stderr
  * @returns {string}
  */
-export function formatAppiumArgErrorOutput (stderr) {
+export function formatAppiumArgErrorOutput(stderr) {
   return stderr.replace(/^[\s\S]+\n\n([\s\S]+)/, '$1').trim() + '\n';
 }
 
@@ -182,9 +182,9 @@ export function formatAppiumArgErrorOutput (stderr) {
  */
 
 /**
- * @typedef {import('../../lib/extension/manifest').ExtensionType} ExtensionType
+ * @typedef {import('appium/types').ExtensionType} ExtensionType
  * @typedef {import('@appium/support/lib/npm').TeenProcessExecError} TeenProcessExecError
- * @typedef {import('../../lib/cli/extension-command').ExtensionListData} ExtensionListData
+ * @typedef {import('appium/lib/cli/extension-command').ExtensionListData} ExtensionListData
  */
 
 /**
@@ -198,12 +198,12 @@ export function formatAppiumArgErrorOutput (stderr) {
 
 /**
  * @template T
- * @typedef {import('../../lib/extension/manifest').ExtRecord<T>} ExtRecord
+ * @typedef {import('appium/types').ExtRecord<T>} ExtRecord
  */
 
 /**
  * @template ExtSubCommand
- * @typedef {[import('../../types/cli').CliSubcommand, ExtSubCommand, ...string[]]} CliExtArgs
+ * @typedef {[import('appium/types').CliSubcommand, ExtSubCommand, ...string[]]} CliExtArgs
  */
 
 /**
@@ -212,7 +212,7 @@ export function formatAppiumArgErrorOutput (stderr) {
 
 /**
  * @template [Result=unknown]
- * @template {import('../../types/cli').CliSubcommand} [ExtSubcommand=never]
+ * @template {import('appium/types').CliSubcommand} [ExtSubcommand=never]
  * @callback AppiumRunner
  * @param {string} appiumHome
  * @param {CliExtArgs<ExtSubcommand>|CliArgs} args
@@ -221,7 +221,7 @@ export function formatAppiumArgErrorOutput (stderr) {
 
 /**
  * @template [Result=unknown]
- * @template {import('../../types/cli').CliExtensionSubcommand} [ExtSubcommand=never]
+ * @template {import('appium/types').CliExtensionSubcommand} [ExtSubcommand=never]
  * @callback AppiumOptsRunner
  * @param {string} appiumHome
  * @param {CliExtArgs<ExtSubcommand>|CliArgs} args

--- a/packages/appium/test/e2e/plugin.e2e.spec.js
+++ b/packages/appium/test/e2e/plugin.e2e.spec.js
@@ -3,14 +3,19 @@
 import _ from 'lodash';
 import path from 'path';
 import B from 'bluebird';
-import { remote as wdio } from 'webdriverio';
+import {remote as wdio} from 'webdriverio';
 import axios from 'axios';
-import { main as appiumServer } from '../../lib/main';
-import { INSTALL_TYPE_LOCAL } from '../../lib/extension/extension-config';
-import { W3C_PREFIXED_CAPS, TEST_HOST, getTestPort, PROJECT_ROOT } from '../helpers';
-import { runExtensionCommand } from '../../lib/cli/extension';
-import { tempDir, fs } from '@appium/support';
-import { loadExtensions } from '../../lib/extension';
+import {main as appiumServer} from '../../lib/main';
+import {INSTALL_TYPE_LOCAL} from '../../lib/extension/extension-config';
+import {
+  W3C_PREFIXED_CAPS,
+  TEST_HOST,
+  getTestPort,
+  PROJECT_ROOT,
+} from '../helpers';
+import {runExtensionCommand} from '../../lib/cli/extension';
+import {tempDir, fs} from '@appium/support';
+import {loadExtensions} from '../../lib/extension';
 
 const FAKE_ARGS = {sillyWebServerPort: 1234, host: 'hey'};
 const FAKE_PLUGIN_ARGS = {fake: FAKE_ARGS};
@@ -24,12 +29,17 @@ const wdOpts = {
   capabilities: W3C_PREFIXED_CAPS,
 };
 const FAKE_DRIVER_DIR = path.join(PROJECT_ROOT, 'packages', 'fake-driver');
-const FAKE_PLUGIN_DIR = path.join(PROJECT_ROOT, 'node_modules', '@appium', 'fake-plugin');
+const FAKE_PLUGIN_DIR = path.join(
+  PROJECT_ROOT,
+  'node_modules',
+  '@appium',
+  'fake-plugin'
+);
 
 describe('FakePlugin', function () {
   /** @type {string} */
   let appiumHome;
-  /** @type {Partial<import('../../types/cli').ParsedArgs>} */
+  /** @type {Partial<import('appium/types').ParsedArgs>} */
   let baseArgs;
   /** @type {string} */
   let testServerBaseUrl;
@@ -45,37 +55,47 @@ describe('FakePlugin', function () {
     testServerBaseSessionUrl = `${testServerBaseUrl}/session`;
     const {driverConfig, pluginConfig} = await loadExtensions(appiumHome);
     // first ensure we have fakedriver installed
-    const driverList = await runExtensionCommand({
-      driverCommand: 'list',
-      showInstalled: true,
-    }, driverConfig
+    const driverList = await runExtensionCommand(
+      {
+        driverCommand: 'list',
+        showInstalled: true,
+      },
+      driverConfig
     );
     if (!_.has(driverList, 'fake')) {
-      await runExtensionCommand({
-        driverCommand: 'install',
-        driver: FAKE_DRIVER_DIR,
-        installType: INSTALL_TYPE_LOCAL,
-      }, driverConfig
+      await runExtensionCommand(
+        {
+          driverCommand: 'install',
+          driver: FAKE_DRIVER_DIR,
+          installType: INSTALL_TYPE_LOCAL,
+        },
+        driverConfig
       );
     }
 
-    const pluginList = await runExtensionCommand({
-      pluginCommand: 'list',
-      showInstalled: true,
-    }, pluginConfig);
+    const pluginList = await runExtensionCommand(
+      {
+        pluginCommand: 'list',
+        showInstalled: true,
+      },
+      pluginConfig
+    );
     if (!_.has(pluginList, 'fake')) {
-      await runExtensionCommand({
-        pluginCommand: 'install',
-        plugin: FAKE_PLUGIN_DIR,
-        installType: INSTALL_TYPE_LOCAL,
-      }, pluginConfig);
+      await runExtensionCommand(
+        {
+          pluginCommand: 'install',
+          plugin: FAKE_PLUGIN_DIR,
+          installType: INSTALL_TYPE_LOCAL,
+        },
+        pluginConfig
+      );
     }
     baseArgs = {
       appiumHome,
       port,
       address: TEST_HOST,
       usePlugins: ['fake'],
-      useDrivers: ['fake']
+      useDrivers: ['fake'],
     };
   });
 
@@ -88,8 +108,13 @@ describe('FakePlugin', function () {
     let server;
 
     before(async function () {
-      const args = {appiumHome, port, address: TEST_HOST, usePlugins: ['other1', 'other2']};
-      server = /** @type {typeof server} */(
+      const args = {
+        appiumHome,
+        port,
+        address: TEST_HOST,
+        usePlugins: ['other1', 'other2'],
+      };
+      server = /** @type {typeof server} */ (
         // @ts-expect-error
         await appiumServer(args)
       );
@@ -102,13 +127,19 @@ describe('FakePlugin', function () {
     });
 
     it('should not update the server if plugin is not activated', async function () {
-      await axios.post(`http://${TEST_HOST}:${port}/fake`).should.eventually.be.rejectedWith(/404/);
+      await axios
+        .post(`http://${TEST_HOST}:${port}/fake`)
+        .should.eventually.be.rejectedWith(/404/);
     });
     it('should not update method map if plugin is not activated', async function () {
       const driver = await wdio(wdOpts);
       const {sessionId} = driver;
       try {
-        await axios.post(`${testServerBaseSessionUrl}/${sessionId}/fake_data`, {data: {fake: 'data'}}).should.eventually.be.rejectedWith(/404/);
+        await axios
+          .post(`${testServerBaseSessionUrl}/${sessionId}/fake_data`, {
+            data: {fake: 'data'},
+          })
+          .should.eventually.be.rejectedWith(/404/);
       } finally {
         await driver.deleteSession();
       }
@@ -117,7 +148,12 @@ describe('FakePlugin', function () {
       const driver = await wdio(wdOpts);
       const {sessionId} = driver;
       try {
-        const el = (await axios.post(`${testServerBaseSessionUrl}/${sessionId}/element`, {using: 'xpath', value: '//MockWebView'})).data.value;
+        const el = (
+          await axios.post(`${testServerBaseSessionUrl}/${sessionId}/element`, {
+            using: 'xpath',
+            value: '//MockWebView',
+          })
+        ).data.value;
         el.should.not.have.property('fake');
       } finally {
         await driver.deleteSession();
@@ -131,9 +167,16 @@ describe('FakePlugin', function () {
       let server;
       before(async function () {
         // then start server if we need to
-        const usePlugins = registrationType === 'explicit' ? ['fake', 'p2', 'p3'] : ['all'];
-        const args = {appiumHome, port, address: TEST_HOST, usePlugins, useDrivers: ['fake']};
-        server = /** @type {typeof server} */(
+        const usePlugins =
+          registrationType === 'explicit' ? ['fake', 'p2', 'p3'] : ['all'];
+        const args = {
+          appiumHome,
+          port,
+          address: TEST_HOST,
+          usePlugins,
+          useDrivers: ['fake'],
+        };
+        server = /** @type {typeof server} */ (
           // @ts-expect-error
           await appiumServer(args)
         );
@@ -145,15 +188,24 @@ describe('FakePlugin', function () {
       });
       it('should update the server', async function () {
         const res = {fake: 'fakeResponse'};
-        (await axios.post(`http://${TEST_HOST}:${port}/fake`)).data.should.eql(res);
+        (await axios.post(`http://${TEST_HOST}:${port}/fake`)).data.should.eql(
+          res
+        );
       });
 
       it('should modify the method map with new commands', async function () {
         const driver = await wdio(wdOpts);
         const {sessionId} = driver;
         try {
-          await axios.post(`${testServerBaseSessionUrl}/${sessionId}/fake_data`, {data: {fake: 'data'}});
-          (await axios.get(`${testServerBaseSessionUrl}/${sessionId}/fake_data`)).data.value.should.eql({fake: 'data'});
+          await axios.post(
+            `${testServerBaseSessionUrl}/${sessionId}/fake_data`,
+            {data: {fake: 'data'}}
+          );
+          (
+            await axios.get(
+              `${testServerBaseSessionUrl}/${sessionId}/fake_data`
+            )
+          ).data.value.should.eql({fake: 'data'});
         } finally {
           await driver.deleteSession();
         }
@@ -163,7 +215,11 @@ describe('FakePlugin', function () {
         const driver = await wdio(wdOpts);
         const {sessionId} = driver;
         try {
-          await driver.getPageSource().should.eventually.eql(`<Fake>${JSON.stringify([sessionId])}</Fake>`);
+          await driver
+            .getPageSource()
+            .should.eventually.eql(
+              `<Fake>${JSON.stringify([sessionId])}</Fake>`
+            );
         } finally {
           await driver.deleteSession();
         }
@@ -173,7 +229,12 @@ describe('FakePlugin', function () {
         const driver = await wdio(wdOpts);
         const {sessionId} = driver;
         try {
-          const el = (await axios.post(`${testServerBaseSessionUrl}/${sessionId}/element`, {using: 'xpath', value: '//MockWebView'})).data.value;
+          const el = (
+            await axios.post(
+              `${testServerBaseSessionUrl}/${sessionId}/element`,
+              {using: 'xpath', value: '//MockWebView'}
+            )
+          ).data.value;
           el.should.have.property('fake');
         } finally {
           await driver.deleteSession();
@@ -184,11 +245,19 @@ describe('FakePlugin', function () {
         const driver = await wdio(wdOpts);
         const {sessionId} = driver;
         try {
-          await axios.post(`${testServerBaseSessionUrl}/${sessionId}/context`, {name: 'PROXY'});
-          const handle = (await axios.get(`${testServerBaseSessionUrl}/${sessionId}/window/handle`)).data.value;
+          await axios.post(`${testServerBaseSessionUrl}/${sessionId}/context`, {
+            name: 'PROXY',
+          });
+          const handle = (
+            await axios.get(
+              `${testServerBaseSessionUrl}/${sessionId}/window/handle`
+            )
+          ).data.value;
           handle.should.eql('<<proxied via proxyCommand>>');
         } finally {
-          await axios.post(`${testServerBaseSessionUrl}/${sessionId}/context`, {name: 'NATIVE_APP'});
+          await axios.post(`${testServerBaseSessionUrl}/${sessionId}/context`, {
+            name: 'NATIVE_APP',
+          });
           await driver.deleteSession();
         }
       });
@@ -196,7 +265,10 @@ describe('FakePlugin', function () {
       it('should handle unexpected driver shutdown', async function () {
         /** @type {WebdriverIO.RemoteOptions} */
         const newOpts = {...wdOpts};
-        newOpts.capabilities = {...newOpts.capabilities ?? {}, 'appium:newCommandTimeout': 1};
+        newOpts.capabilities = {
+          ...(newOpts.capabilities ?? {}),
+          'appium:newCommandTimeout': 1,
+        };
         const driver = await wdio(newOpts);
         let shutdownErr;
         try {
@@ -220,7 +292,7 @@ describe('FakePlugin', function () {
     before(async function () {
       // then start server if we need to
       const args = {...baseArgs, plugin: FAKE_PLUGIN_ARGS};
-      server = /** @type {typeof server} */(
+      server = /** @type {typeof server} */ (
         // @ts-expect-error
         await appiumServer(args)
       );
@@ -235,7 +307,9 @@ describe('FakePlugin', function () {
       const driver = await wdio(wdOpts);
       const {sessionId} = driver;
       try {
-        const {data} = await axios.get(`${testServerBaseSessionUrl}/${sessionId}/fakepluginargs`);
+        const {data} = await axios.get(
+          `${testServerBaseSessionUrl}/${sessionId}/fakepluginargs`
+        );
         data.value.should.eql(FAKE_ARGS);
       } finally {
         await driver.deleteSession();
@@ -260,7 +334,9 @@ describe('FakePlugin', function () {
       const driver = await wdio(wdOpts);
       const {sessionId} = driver;
       try {
-        const {data} = await axios.get(`${testServerBaseSessionUrl}/${sessionId}/fakepluginargs`);
+        const {data} = await axios.get(
+          `${testServerBaseSessionUrl}/${sessionId}/fakepluginargs`
+        );
         should.not.exist(data.value);
       } finally {
         await driver.deleteSession();

--- a/packages/appium/test/unit/cli/schema-args.spec.js
+++ b/packages/appium/test/unit/cli/schema-args.spec.js
@@ -1,11 +1,15 @@
-import { createSandbox } from 'sinon';
-import { finalizeSchema, resetSchema, SchemaFinalizationError } from '../../../lib/schema/schema';
-import { rewiremock } from '../../helpers';
+import {createSandbox} from 'sinon';
+import {
+  finalizeSchema,
+  resetSchema,
+  SchemaFinalizationError,
+} from '../../../lib/schema/schema';
+import {rewiremock} from '../../helpers';
 
 const expect = chai.expect;
 
 describe('cli/schema-args', function () {
-  /** @type {import('../../../lib/schema/cli-args').toParserArgs} */
+  /** @type {import('appium/lib/schema/cli-args').toParserArgs} */
   let toParserArgs;
 
   /**
@@ -15,7 +19,9 @@ describe('cli/schema-args', function () {
 
   beforeEach(function () {
     sandbox = createSandbox();
-    ({toParserArgs} = rewiremock.proxy(() => require('../../../lib/schema/cli-args')));
+    ({toParserArgs} = rewiremock.proxy(() =>
+      require('../../../lib/schema/cli-args')
+    ));
   });
 
   afterEach(function () {
@@ -29,7 +35,10 @@ describe('cli/schema-args', function () {
       afterEach(resetSchema);
 
       it('should return a Map', function () {
-        expect(toParserArgs()).to.be.an.instanceof(Map).and.have.property('size').that.is.above(0);
+        expect(toParserArgs())
+          .to.be.an.instanceof(Map)
+          .and.have.property('size')
+          .that.is.above(0);
       });
 
       it('should generate metavars in SCREAMING_SNAKE_CASE', function () {
@@ -38,7 +47,7 @@ describe('cli/schema-args', function () {
         expect(argDefsWithMetavar).not.to.be.empty;
         // is there a more idiomatic way to do this?
         expect(
-          argDefsWithMetavar.every((arg) => /[A-Z_]+/.test(arg[1].metavar)),
+          argDefsWithMetavar.every((arg) => /[A-Z_]+/.test(arg[1].metavar))
         ).to.be.true;
       });
     });
@@ -46,9 +55,7 @@ describe('cli/schema-args', function () {
     describe('when schema has not yet been compiled', function () {
       it('should throw', function () {
         resetSchema();
-        expect(() => toParserArgs()).to.throw(
-          SchemaFinalizationError
-        );
+        expect(() => toParserArgs()).to.throw(SchemaFinalizationError);
       });
     });
   });

--- a/packages/appium/test/unit/config-file.spec.js
+++ b/packages/appium/test/unit/config-file.spec.js
@@ -1,30 +1,33 @@
 // @ts-check
 
 import fs from 'fs';
-import { createSandbox } from 'sinon';
+import {createSandbox} from 'sinon';
 import YAML from 'yaml';
 import * as schema from '../../lib/schema/schema';
-import { resolveFixture, rewiremock } from '../helpers';
+import {resolveFixture, rewiremock} from '../helpers';
 
 const expect = chai.expect;
 
 describe('config-file', function () {
   const GOOD_YAML_CONFIG_FILEPATH = resolveFixture(
     'config',
-    'appium.config.good.yaml',
+    'appium.config.good.yaml'
   );
   const GOOD_JSON_CONFIG_FILEPATH = resolveFixture(
     'config',
-    'appium.config.good.json',
+    'appium.config.good.json'
   );
-  const GOOD_JS_CONFIG_FILEPATH = resolveFixture('config', 'appium.config.good.js');
+  const GOOD_JS_CONFIG_FILEPATH = resolveFixture(
+    'config',
+    'appium.config.good.js'
+  );
   const GOOD_YAML_CONFIG = YAML.parse(
-    fs.readFileSync(GOOD_YAML_CONFIG_FILEPATH, 'utf8'),
+    fs.readFileSync(GOOD_YAML_CONFIG_FILEPATH, 'utf8')
   );
   const GOOD_JSON_CONFIG = require(GOOD_JSON_CONFIG_FILEPATH);
   const BAD_JSON_CONFIG_FILEPATH = resolveFixture(
     'config',
-    'appium.config.bad.json',
+    'appium.config.bad.json'
   );
   const BAD_JSON_CONFIG = require(BAD_JSON_CONFIG_FILEPATH);
 
@@ -35,12 +38,12 @@ describe('config-file', function () {
 
   /**
    * `readConfigFile()` from an isolated `config-file` module
-   * @type {import('../../lib/config-file').readConfigFile}
+   * @type {import('appium/lib/config-file').readConfigFile}
    */
   let readConfigFile;
 
   /**
-   * @type {import('../../lib/config-file').formatErrors}
+   * @type {import('appium/lib/config-file').formatErrors}
    */
   let formatErrors;
 
@@ -104,7 +107,10 @@ describe('config-file', function () {
     // loads the `config-file` module using the lilconfig mock.
     // we only mock lilconfig because it'd otherwise be a pain in the rear to test
     // searching for config files, and it increases the likelihood that we'd load the wrong file.
-    ({readConfigFile, formatErrors} = rewiremock.proxy(() => require('../../lib/config-file'), mocks));
+    ({readConfigFile, formatErrors} = rewiremock.proxy(
+      () => require('../../lib/config-file'),
+      mocks
+    ));
 
     // just want to be extra-sure `validate()` happens
     sandbox.spy(schema, 'validate');
@@ -116,7 +122,7 @@ describe('config-file', function () {
 
   describe('readConfigFile()', function () {
     /**
-     * @type {import('../../lib/config-file').ReadConfigFileResult}
+     * @type {import('appium/lib/config-file').ReadConfigFileResult}
      */
     let result;
 
@@ -155,7 +161,9 @@ describe('config-file', function () {
       describe('when no config file is found', function () {
         beforeEach(async function () {
           lc.search.resolves();
-          /** @type {sinon.SinonSpiedMember<typeof schema.validate>} */(schema.validate).resetHistory();
+          /** @type {sinon.SinonSpiedMember<typeof schema.validate>} */ (
+            schema.validate
+          ).resetHistory();
           result = await readConfigFile();
         });
 
@@ -185,7 +193,7 @@ describe('config-file', function () {
         describe('when the config file is not empty', function () {
           it('should validate the config against a schema', function () {
             expect(schema.validate).to.have.been.calledOnceWith(
-              GOOD_JSON_CONFIG,
+              GOOD_JSON_CONFIG
             );
           });
 
@@ -243,7 +251,7 @@ describe('config-file', function () {
 
         it('should reject with user-friendly message', async function () {
           await expect(readConfigFile('appium.json')).to.be.rejectedWith(
-            /not found at user-provided path/,
+            /not found at user-provided path/
           );
         });
       });
@@ -255,7 +263,7 @@ describe('config-file', function () {
 
         it('should reject with user-friendly message', async function () {
           await expect(readConfigFile('appium.json')).to.be.rejectedWith(
-            /Config file at user-provided path appium.json is invalid/,
+            /Config file at user-provided path appium.json is invalid/
           );
         });
       });
@@ -267,7 +275,7 @@ describe('config-file', function () {
 
         it('should pass error through', async function () {
           await expect(readConfigFile('appium.json')).to.be.rejectedWith(
-            /guru meditation/,
+            /guru meditation/
           );
         });
       });
@@ -291,7 +299,7 @@ describe('config-file', function () {
         describe('when the config file is not empty', function () {
           it('should validate the config against a schema', function () {
             expect(schema.validate).to.have.been.calledOnceWith(
-              GOOD_JSON_CONFIG,
+              GOOD_JSON_CONFIG
             );
           });
 
@@ -328,7 +336,7 @@ describe('config-file', function () {
       it('should throw', function () {
         expect(() => formatErrors([])).to.throw(
           TypeError,
-          'Array of errors must be non-empty',
+          'Array of errors must be non-empty'
         );
       });
     });
@@ -337,7 +345,7 @@ describe('config-file', function () {
       it('should throw', function () {
         expect(() => formatErrors()).to.throw(
           TypeError,
-          'Array of errors must be non-empty',
+          'Array of errors must be non-empty'
         );
       });
     });
@@ -357,7 +365,7 @@ describe('config-file', function () {
           schema.getSchema(),
           {},
           [{}],
-          {format: 'cli', json: '{"foo": "bar"}'},
+          {format: 'cli', json: '{"foo": "bar"}'}
         );
       });
     });

--- a/packages/appium/test/unit/extension/driver-config.spec.js
+++ b/packages/appium/test/unit/extension/driver-config.spec.js
@@ -1,10 +1,10 @@
 // @ts-check
 
-import { promises as fs } from 'fs';
-import { Manifest } from '../../../lib/extension/manifest';
-import { resetSchema } from '../../../lib/schema';
-import { resolveFixture, rewiremock } from '../../helpers';
-import { initMocks } from './mocks';
+import {promises as fs} from 'fs';
+import {Manifest} from '../../../lib/extension/manifest';
+import {resetSchema} from '../../../lib/schema';
+import {resolveFixture, rewiremock} from '../../helpers';
+import {initMocks} from './mocks';
 
 const {expect} = chai;
 
@@ -27,8 +27,8 @@ describe('DriverConfig', function () {
   let MockResolveFrom;
 
   /**
-   * @type {typeof import('../../../lib/extension/driver-config').DriverConfig}
-    */
+   * @type {typeof import('appium/lib/extension/driver-config').DriverConfig}
+   */
   let DriverConfig;
 
   before(async function () {
@@ -39,14 +39,11 @@ describe('DriverConfig', function () {
     manifest = Manifest.getInstance('/somewhere/');
     /** @type {import('./mocks').Overrides} */
     let overrides;
-    ({MockAppiumSupport,
-      MockResolveFrom,
-      overrides,
-      sandbox} = initMocks());
+    ({MockAppiumSupport, MockResolveFrom, overrides, sandbox} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({DriverConfig} = rewiremock.proxy(
       () => require('../../../lib/extension/driver-config'),
-      overrides,
+      overrides
     ));
     resetSchema();
   });
@@ -79,8 +76,8 @@ describe('DriverConfig', function () {
             Error,
             new RegExp(
               `Manifest with APPIUM_HOME ${manifest.appiumHome} already has a DriverConfig`,
-              'i',
-            ),
+              'i'
+            )
           );
         });
       });
@@ -114,7 +111,7 @@ describe('DriverConfig', function () {
         const config = DriverConfig.create(manifest);
         expect(
           // @ts-expect-error
-          config.extensionDesc('foo', {version: '1.0', automationName: 'bar'}),
+          config.extensionDesc('foo', {version: '1.0', automationName: 'bar'})
         ).to.equal(`foo@1.0 (automationName 'bar')`);
       });
     });
@@ -152,7 +149,7 @@ describe('DriverConfig', function () {
             expect(
               driverConfig
                 // @ts-expect-error
-                .getConfigProblems({platformNames: []}),
+                .getConfigProblems({platformNames: []})
             ).to.deep.include({
               err: 'Empty platformNames list.',
               val: [],
@@ -165,7 +162,7 @@ describe('DriverConfig', function () {
             expect(
               driverConfig
                 // @ts-expect-error
-                .getConfigProblems({platformNames: 'foo'}),
+                .getConfigProblems({platformNames: 'foo'})
             ).to.deep.include({
               err: 'Missing or incorrect supported platformNames list.',
               val: 'foo',
@@ -178,7 +175,7 @@ describe('DriverConfig', function () {
             expect(
               driverConfig
                 // @ts-expect-error
-                .getConfigProblems({platformNames: ['a', 1]}),
+                .getConfigProblems({platformNames: ['a', 1]})
             ).to.deep.include({
               err: 'Incorrectly formatted platformName.',
               val: 1,
@@ -204,7 +201,7 @@ describe('DriverConfig', function () {
             expect(
               driverConfig
                 // @ts-expect-error
-                .getConfigProblems({automationName: 'foo'}),
+                .getConfigProblems({automationName: 'foo'})
             ).to.deep.include({
               err: 'Multiple drivers claim support for the same automationName',
               val: 'foo',
@@ -229,7 +226,7 @@ describe('DriverConfig', function () {
           expect(
             driverConfig
               // @ts-expect-error
-              .getSchemaProblems({schema: []}),
+              .getSchemaProblems({schema: []})
           ).to.deep.include({
             err: 'Incorrectly formatted schema field; must be a path to a schema file or a schema object.',
             val: [],
@@ -243,7 +240,7 @@ describe('DriverConfig', function () {
             expect(
               driverConfig
                 // @ts-expect-error
-                .getSchemaProblems({schema: 'selenium.java'}),
+                .getSchemaProblems({schema: 'selenium.java'})
             ).to.deep.include({
               err: 'Schema file has unsupported extension. Allowed: .json, .js, .cjs',
               val: 'selenium.java',
@@ -261,8 +258,8 @@ describe('DriverConfig', function () {
                     pkgName: 'doop',
                     schema: 'herp.json',
                   },
-                  'foo',
-                ),
+                  'foo'
+                )
               )
                 .with.nested.property('[0].err')
                 .to.match(/Unable to register schema at path herp\.json/i);
@@ -282,8 +279,8 @@ describe('DriverConfig', function () {
                     pkgName: 'whatever',
                     schema: 'driver.schema.js',
                   },
-                  'foo',
-                ),
+                  'foo'
+                )
               ).to.be.empty;
             });
           });
@@ -297,7 +294,7 @@ describe('DriverConfig', function () {
        */
       let driverConfig;
 
-      /** @type {ExtDataWithSchema<DriverType>} */
+      /** @type {ExtManifestWithSchema<DriverType>} */
       let extData;
 
       const extName = 'stuff';
@@ -319,10 +316,9 @@ describe('DriverConfig', function () {
 
       describe('when the extension data is missing `schema`', function () {
         it('should throw', function () {
-          // @ts-expect-error
           delete extData.schema;
           expect(() =>
-            driverConfig.readExtensionSchema(extName, extData),
+            driverConfig.readExtensionSchema(extName, extData)
           ).to.throw(TypeError, /why is this function being called/i);
         });
       });
@@ -331,7 +327,7 @@ describe('DriverConfig', function () {
         it('should not throw', function () {
           driverConfig.readExtensionSchema(extName, extData);
           expect(() =>
-            driverConfig.readExtensionSchema(extName, extData),
+            driverConfig.readExtensionSchema(extName, extData)
           ).not.to.throw();
         });
       });
@@ -349,11 +345,16 @@ describe('DriverConfig', function () {
 });
 
 /**
- * @typedef {import('../../../lib/extension/manifest').DriverType} DriverType
- * @typedef {import('../../../lib/extension/driver-config').DriverConfig} DriverConfig
+ * @typedef {import('appium/types').DriverType} DriverType
+ * @typedef {import('appium/lib/extension/driver-config').DriverConfig} DriverConfig
  */
 
 /**
- * @template {import('../../../lib/extension/manifest').ExtensionType} ExtType
- * @typedef {import('../../../lib/extension/manifest').ExtDataWithSchema<ExtType>} ExtDataWithSchema
+ * @template {import('appium/types').ExtensionType} ExtType
+ * @typedef {import('appium/types').ExtManifestWithSchema<ExtType>} ExtManifestWithSchema
+ */
+
+/**
+ * @template {import('appium/types').ExtensionType} ExtType
+ * @typedef {import('appium/types').ExtManifest<ExtType>} ExtManifest
  */

--- a/packages/appium/test/unit/extension/manifest.spec.js
+++ b/packages/appium/test/unit/extension/manifest.spec.js
@@ -1,9 +1,9 @@
 // @ts-check
 import B from 'bluebird';
-import { promises as fs } from 'fs';
-import { DRIVER_TYPE, PLUGIN_TYPE } from '../../../lib/constants';
-import { resolveFixture, rewiremock } from '../../helpers';
-import { initMocks } from './mocks';
+import {promises as fs} from 'fs';
+import {DRIVER_TYPE, PLUGIN_TYPE} from '../../../lib/constants';
+import {resolveFixture, rewiremock} from '../../helpers';
+import {initMocks} from './mocks';
 
 const {expect} = chai;
 
@@ -27,7 +27,7 @@ describe('Manifest', function () {
   });
 
   /**
-   * @type {typeof import('../../../lib/extension/manifest').Manifest}
+   * @type {typeof import('appium/lib/extension/manifest').Manifest}
    */
   let Manifest;
 
@@ -38,7 +38,7 @@ describe('Manifest', function () {
 
     ({Manifest} = rewiremock.proxy(
       () => require('../../../lib/extension/manifest'),
-      overrides,
+      overrides
     ));
 
     Manifest.getInstance.cache = new Map();
@@ -72,7 +72,7 @@ describe('Manifest', function () {
     describe('appiumHome', function () {
       it('should return the `appiumHome` path', function () {
         expect(Manifest.getInstance('/some/path').appiumHome).to.equal(
-          '/some/path',
+          '/some/path'
         );
       });
 
@@ -103,7 +103,7 @@ describe('Manifest', function () {
         it('should return the manifest file path', function () {
           // this path is not the actual path; it's mocked in `MockAppiumSupport.env.resolveManifestPath`.
           expect(Manifest.getInstance('/some/path').manifestPath).to.equal(
-            '/some/path/extensions.yaml',
+            '/some/path/extensions.yaml'
           );
         });
       });
@@ -119,7 +119,7 @@ describe('Manifest', function () {
   });
 
   describe('instance method', function () {
-    /** @type {import('../../../lib/extension/manifest').Manifest} */
+    /** @type {import('appium/lib/extension/manifest').Manifest} */
     let manifest;
 
     beforeEach(function () {
@@ -153,7 +153,7 @@ describe('Manifest', function () {
         it('should reject', async function () {
           await expect(manifest.read()).to.be.rejectedWith(
             Error,
-            /trouble loading the extension installation cache file/i,
+            /trouble loading the extension installation cache file/i
           );
         });
       });
@@ -161,14 +161,14 @@ describe('Manifest', function () {
       describe('when the manifest path cannot be determined', function () {
         beforeEach(function () {
           MockAppiumSupport.env.resolveManifestPath.rejects(
-            new Error('Could not determine manifest path'),
+            new Error('Could not determine manifest path')
           );
         });
 
         it('should reject', async function () {
           await expect(manifest.read()).to.be.rejectedWith(
             Error,
-            /could not determine manifest path/i,
+            /could not determine manifest path/i
           );
         });
       });
@@ -180,7 +180,7 @@ describe('Manifest', function () {
         it('should not read the file twice', function () {
           expect(MockAppiumSupport.fs.readFile).to.have.been.calledOnceWith(
             '/some/path/extensions.yaml',
-            'utf8',
+            'utf8'
           );
         });
       });
@@ -194,7 +194,7 @@ describe('Manifest', function () {
         it('should attempt to read the file at `filepath`', function () {
           expect(MockAppiumSupport.fs.readFile).to.have.been.calledOnceWith(
             '/some/path/extensions.yaml',
-            'utf8',
+            'utf8'
           );
         });
 
@@ -234,10 +234,10 @@ describe('Manifest', function () {
       });
 
       describe('when called after `read()`', function () {
-        /** @type {import('../../../lib/extension/manifest').ManifestData} */
+        /** @type {ManifestData} */
         let data;
 
-        /** @type {ExtData<DriverType>} */
+        /** @type {ExtManifest<DriverType>} */
         const extData = {
           version: '1.0.0',
           automationName: 'Derp',
@@ -274,7 +274,7 @@ describe('Manifest', function () {
           it('should reject', async function () {
             await expect(manifest.write()).to.be.rejectedWith(
               Error,
-              /Appium could not write to manifest/i,
+              /Appium could not write to manifest/i
             );
           });
         });
@@ -287,7 +287,7 @@ describe('Manifest', function () {
           it('should reject', async function () {
             await expect(manifest.write()).to.be.rejectedWith(
               Error,
-              /could not create the directory for the manifest file/i,
+              /could not create the directory for the manifest file/i
             );
           });
         });
@@ -295,7 +295,7 @@ describe('Manifest', function () {
     });
 
     describe('addExtension()', function () {
-      /** @type {ExtData<DriverType>} */
+      /** @type {ExtManifest<DriverType>} */
       const extData = {
         automationName: 'derp',
         version: '1.0.0',
@@ -312,7 +312,7 @@ describe('Manifest', function () {
       });
 
       describe('when existing extension added', function () {
-        /** @type {ExtData<DriverType>} */
+        /** @type {ExtManifest<DriverType>} */
 
         beforeEach(function () {
           manifest.addExtension(DRIVER_TYPE, 'foo', extData);
@@ -331,7 +331,7 @@ describe('Manifest', function () {
 
     describe('addExtensionFromPackage()', function () {
       describe('when provided a valid package.json for a driver and its path', function () {
-        /** @type {ExtensionPackageJson<DriverType>} */
+        /** @type {ExtPackageJson<DriverType>} */
         let packageJson;
 
         beforeEach(function () {
@@ -350,7 +350,7 @@ describe('Manifest', function () {
         it('should add an extension to the internal data', function () {
           manifest.addExtensionFromPackage(
             packageJson,
-            '/some/path/to/package.json',
+            '/some/path/to/package.json'
           );
           expect(manifest.getExtensionData('driver')).to.deep.equal({
             myDriver: {
@@ -369,8 +369,8 @@ describe('Manifest', function () {
           expect(
             manifest.addExtensionFromPackage(
               packageJson,
-              '/some/path/to/package.json',
-            ),
+              '/some/path/to/package.json'
+            )
           ).to.be.true;
         });
 
@@ -378,7 +378,7 @@ describe('Manifest', function () {
           beforeEach(function () {
             manifest.addExtensionFromPackage(
               packageJson,
-              '/some/path/to/package.json',
+              '/some/path/to/package.json'
             );
           });
 
@@ -386,15 +386,15 @@ describe('Manifest', function () {
             expect(
               manifest.addExtensionFromPackage(
                 packageJson,
-                '/some/path/to/package.json',
-              ),
+                '/some/path/to/package.json'
+              )
             ).to.be.false;
           });
         });
       });
 
       describe('when provided a valid package.json for a plugin and its path', function () {
-        /** @type {ExtensionPackageJson<PluginType>} */
+        /** @type {ExtPackageJson<PluginType>} */
         let packageJson;
         beforeEach(function () {
           packageJson = {
@@ -410,7 +410,7 @@ describe('Manifest', function () {
         it('should add an extension to the internal data', function () {
           manifest.addExtensionFromPackage(
             packageJson,
-            '/some/path/to/package.json',
+            '/some/path/to/package.json'
           );
           expect(manifest.getExtensionData(PLUGIN_TYPE)).to.deep.equal({
             myPlugin: {
@@ -427,8 +427,8 @@ describe('Manifest', function () {
           expect(
             manifest.addExtensionFromPackage(
               packageJson,
-              '/some/path/to/package.json',
-            ),
+              '/some/path/to/package.json'
+            )
           ).to.be.true;
         });
 
@@ -436,7 +436,7 @@ describe('Manifest', function () {
           beforeEach(function () {
             manifest.addExtensionFromPackage(
               packageJson,
-              '/some/path/to/package.json',
+              '/some/path/to/package.json'
             );
           });
 
@@ -444,8 +444,8 @@ describe('Manifest', function () {
             expect(
               manifest.addExtensionFromPackage(
                 packageJson,
-                '/some/path/to/package.json',
-              ),
+                '/some/path/to/package.json'
+              )
             ).to.be.false;
           });
         });
@@ -457,8 +457,8 @@ describe('Manifest', function () {
             manifest.addExtensionFromPackage(
               // @ts-expect-error
               {herp: 'derp'},
-              '/some/path/to/package.json',
-            ),
+              '/some/path/to/package.json'
+            )
           ).to.throw(/neither a valid driver nor a valid plugin/);
         });
       });
@@ -485,7 +485,7 @@ describe('Manifest', function () {
                 next,
               }),
             })
-          ),
+          )
         );
         MockAppiumSupport.env.readPackageInDir.resolves({
           name: 'foo',
@@ -505,7 +505,7 @@ describe('Manifest', function () {
       it('should add a found extension', async function () {
         await manifest.syncWithInstalledExtensions();
         expect(manifest.getExtensionData(DRIVER_TYPE)).to.have.property(
-          'myDriver',
+          'myDriver'
         );
       });
     });
@@ -552,15 +552,16 @@ describe('Manifest', function () {
 
 /**
  * @template T
- * @typedef {import('../../../lib/extension/manifest').ExtData<T>} ExtData
+ * @typedef {import('appium/types').ExtManifest<T>} ExtManifest
  */
 
 /**
  * @template T
- * @typedef {import('../../../lib/extension/manifest').ExtensionPackageJson<T>} ExtensionPackageJson
+ * @typedef {import('appium/types').ExtPackageJson<T>} ExtPackageJson
  */
 
 /**
- * @typedef {import('../../../lib/extension/manifest').DriverType} DriverType
- * @typedef {import('../../../lib/extension/manifest').PluginType} PluginType
+ * @typedef {import('appium/types').DriverType} DriverType
+ * @typedef {import('appium/types').PluginType} PluginType
+ * @typedef {import('appium/types').ManifestData} ManifestData
  */

--- a/packages/appium/test/unit/extension/package-changed.spec.js
+++ b/packages/appium/test/unit/extension/package-changed.spec.js
@@ -1,13 +1,13 @@
 // @ts-check
 import path from 'path';
-import { PKG_HASHFILE_RELATIVE_PATH } from '../../../lib/constants';
-import { rewiremock } from '../../helpers';
-import { initMocks } from './mocks';
+import {PKG_HASHFILE_RELATIVE_PATH} from '../../../lib/constants';
+import {rewiremock} from '../../helpers';
+import {initMocks} from './mocks';
 
 const {expect} = chai;
 
 describe('package-changed', function () {
-  /** @type {typeof import('../../../lib/extension/package-changed').packageDidChange} */
+  /** @type {typeof import('appium/lib/extension/package-changed').packageDidChange} */
   let packageDidChange;
 
   /** @type {sinon.SinonSandbox} */
@@ -26,7 +26,7 @@ describe('package-changed', function () {
       {
         'package-changed': MockPackageChanged,
         '@appium/support': MockAppiumSupport,
-      },
+      }
     ));
   });
 
@@ -47,7 +47,7 @@ describe('package-changed', function () {
     it('it should attempt to create the parent dir for the hash file', async function () {
       await packageDidChange('/some/path');
       expect(MockAppiumSupport.fs.mkdirp).to.have.been.calledWith(
-        path.dirname(path.join('/some/path', PKG_HASHFILE_RELATIVE_PATH)),
+        path.dirname(path.join('/some/path', PKG_HASHFILE_RELATIVE_PATH))
       );
     });
 
@@ -64,7 +64,7 @@ describe('package-changed', function () {
         MockAppiumSupport.fs.mkdirp.rejects(new Error('some error'));
         await expect(packageDidChange('/some/path')).to.be.rejectedWith(
           Error,
-          /could not create the directory/i,
+          /could not create the directory/i
         );
       });
     });
@@ -106,7 +106,7 @@ describe('package-changed', function () {
         it('should reject', async function () {
           await expect(packageDidChange('/some/where')).to.be.rejectedWith(
             Error,
-            /could not write hash file/i,
+            /could not write hash file/i
           );
         });
       });

--- a/packages/appium/test/unit/extension/plugin-config.spec.js
+++ b/packages/appium/test/unit/extension/plugin-config.spec.js
@@ -1,10 +1,10 @@
 // @ts-check
 
-import { promises as fs } from 'fs';
-import { Manifest } from '../../../lib/extension/manifest';
-import { resetSchema } from '../../../lib/schema';
-import { resolveFixture, rewiremock } from '../../helpers';
-import { initMocks } from './mocks';
+import {promises as fs} from 'fs';
+import {Manifest} from '../../../lib/extension/manifest';
+import {resetSchema} from '../../../lib/schema';
+import {resolveFixture, rewiremock} from '../../helpers';
+import {initMocks} from './mocks';
 
 const {expect} = chai;
 
@@ -27,7 +27,7 @@ describe('PluginConfig', function () {
   let MockResolveFrom;
 
   /**
-   * @type {typeof import('../../../lib/extension/plugin-config').PluginConfig}
+   * @type {typeof import('appium/lib/extension/plugin-config').PluginConfig}
    */
   let PluginConfig;
 
@@ -43,7 +43,7 @@ describe('PluginConfig', function () {
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({PluginConfig} = rewiremock.proxy(
       () => require('../../../lib/extension/plugin-config'),
-      overrides,
+      overrides
     ));
     resetSchema();
   });
@@ -76,8 +76,8 @@ describe('PluginConfig', function () {
             Error,
             new RegExp(
               `Manifest with APPIUM_HOME ${manifest.appiumHome} already has a PluginConfig`,
-              'i',
-            ),
+              'i'
+            )
           );
         });
       });
@@ -115,7 +115,7 @@ describe('PluginConfig', function () {
             pkgName: 'herrbbbff',
             installType: 'npm',
             installSpec: 'herrbbbff',
-          }),
+          })
         ).to.equal(`foo@1.0`);
       });
     });
@@ -159,8 +159,8 @@ describe('PluginConfig', function () {
                 pkgName: 'yodel',
                 version: '-1',
               },
-              'foo',
-            ),
+              'foo'
+            )
           ).to.deep.include({
             err: 'Incorrectly formatted schema field; must be a path to a schema file or a schema object.',
             val: [],
@@ -181,8 +181,8 @@ describe('PluginConfig', function () {
                   installType: 'npm',
                   installSpec: 'yodel',
                 },
-                'foo',
-              ),
+                'foo'
+              )
             ).to.deep.include({
               err: 'Schema file has unsupported extension. Allowed: .json, .js, .cjs',
               val: 'selenium.java',
@@ -202,8 +202,8 @@ describe('PluginConfig', function () {
                     mainClass: 'Yankovic',
                     version: '1.0.0',
                   },
-                  'foo',
-                ),
+                  'foo'
+                )
               )
                 .with.nested.property('[0].err')
                 .to.match(/Unable to register schema at path herp\.json/i);
@@ -225,8 +225,8 @@ describe('PluginConfig', function () {
                     mainClass: 'Yankovic',
                     version: '1.0.0',
                   },
-                  'foo',
-                ),
+                  'foo'
+                )
               ).to.be.empty;
             });
           });
@@ -310,7 +310,7 @@ describe('PluginConfig', function () {
           // @ts-expect-error
           delete extData.schema;
           expect(() =>
-            pluginConfig.readExtensionSchema(extName, extData),
+            pluginConfig.readExtensionSchema(extName, extData)
           ).to.throw(TypeError, /why is this function being called/i);
         });
       });
@@ -320,7 +320,7 @@ describe('PluginConfig', function () {
           it('should not throw', function () {
             pluginConfig.readExtensionSchema(extName, extData);
             expect(() =>
-              pluginConfig.readExtensionSchema(extName, extData),
+              pluginConfig.readExtensionSchema(extName, extData)
             ).not.to.throw();
           });
         });
@@ -330,7 +330,7 @@ describe('PluginConfig', function () {
             pluginConfig.readExtensionSchema(extName, extData);
             MockResolveFrom.returns(resolveFixture('driver.schema.js'));
             expect(() =>
-              pluginConfig.readExtensionSchema(extName, extData),
+              pluginConfig.readExtensionSchema(extName, extData)
             ).to.throw(/conflicts with an existing schema/i);
           });
         });
@@ -347,11 +347,11 @@ describe('PluginConfig', function () {
 });
 
 /**
- * @typedef {import('../../../lib/extension/manifest').PluginType} PluginType
- * @typedef {import('../../../lib/extension/plugin-config').PluginConfig} PluginConfig
+ * @typedef {import('appium/lib/extension/manifest').PluginType} PluginType
+ * @typedef {import('appium/lib/extension/plugin-config').PluginConfig} PluginConfig
  */
 
 /**
- * @template {import('../../../lib/extension/manifest').ExtensionType} ExtType
- * @typedef {import('../../../lib/extension/manifest').ExtDataWithSchema<ExtType>} ExtDataWithSchema
+ * @template {import('appium/lib/extension/manifest').ExtensionType} ExtType
+ * @typedef {import('appium/lib/extension/manifest').ExtDataWithSchema<ExtType>} ExtDataWithSchema
  */

--- a/packages/appium/test/unit/grid-register.spec.js
+++ b/packages/appium/test/unit/grid-register.spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 
-import { createSandbox } from 'sinon';
-import { rewiremock } from '../helpers';
+import {createSandbox} from 'sinon';
+import {rewiremock} from '../helpers';
 
 describe('grid-register', function () {
   let sandbox;
@@ -15,7 +15,7 @@ describe('grid-register', function () {
   });
 
   describe('registerNode()', function () {
-    /** @type {import('../../lib/grid-register').default} */
+    /** @type {import('appium/lib/grid-register').default} */
     let registerNode;
     let mocks;
 
@@ -26,15 +26,15 @@ describe('grid-register', function () {
             readFile: sandbox.stub().resolves('{}'),
           },
           logger: {
-            getLogger: sandbox.stub().returns(console)
-          }
+            getLogger: sandbox.stub().returns(console),
+          },
         },
         axios: sandbox.stub().resolves({data: '', status: 200}),
       };
 
       ({default: registerNode} = rewiremock.proxy(
         () => require('../../lib/grid-register'),
-        mocks,
+        mocks
       ));
     });
 
@@ -43,7 +43,7 @@ describe('grid-register', function () {
         await registerNode('/path/to/config-file.json');
         mocks['@appium/support'].fs.readFile.should.have.been.calledOnceWith(
           '/path/to/config-file.json',
-          'utf-8',
+          'utf-8'
         );
       });
 
@@ -51,7 +51,7 @@ describe('grid-register', function () {
         sandbox.spy(JSON, 'parse');
         await registerNode('/path/to/config-file.json');
         JSON.parse.should.have.been.calledOnceWith(
-          await mocks['@appium/support'].fs.readFile.firstCall.returnValue,
+          await mocks['@appium/support'].fs.readFile.firstCall.returnValue
         );
       });
 

--- a/packages/appium/test/unit/schema/schema.spec.js
+++ b/packages/appium/test/unit/schema/schema.spec.js
@@ -1,14 +1,14 @@
 // @ts-check
 
 import _ from 'lodash';
-import { createSandbox } from 'sinon';
-import { DRIVER_TYPE, PLUGIN_TYPE } from '../../../lib/constants';
-import { AppiumConfigJsonSchema } from '@appium/schema';
-import { APPIUM_CONFIG_SCHEMA_ID } from '../../../lib/schema/arg-spec';
+import {createSandbox} from 'sinon';
+import {DRIVER_TYPE, PLUGIN_TYPE} from '../../../lib/constants';
+import {AppiumConfigJsonSchema} from '@appium/schema';
+import {APPIUM_CONFIG_SCHEMA_ID} from '../../../lib/schema/arg-spec';
 import defaultArgsFixture from '../../fixtures/default-args';
 import DRIVER_SCHEMA_FIXTURE from '../../fixtures/driver.schema';
 import flattenedSchemaFixture from '../../fixtures/flattened-schema';
-import { rewiremock } from '../../helpers';
+import {rewiremock} from '../../helpers';
 
 const {expect} = chai;
 
@@ -17,64 +17,64 @@ describe('schema', function () {
   let sandbox;
 
   /**
-   * @type {import('@appium/types').Class<import('../../../lib/schema/schema').SchemaFinalizationError>}
+   * @type {import('@appium/types').Class<import('appium/lib/schema/schema').SchemaFinalizationError>}
    */
   let SchemaFinalizationError;
 
   /**
-   * @type {import('@appium/types').Class<import('../../../lib/schema/schema').SchemaUnknownSchemaError>}
+   * @type {import('@appium/types').Class<import('appium/lib/schema/schema').SchemaUnknownSchemaError>}
    */
   let SchemaUnknownSchemaError;
 
   /**
-   * @type {import('@appium/types').Class<import('../../../lib/schema/schema').SchemaUnsupportedSchemaError>}
+   * @type {import('@appium/types').Class<import('appium/lib/schema/schema').SchemaUnsupportedSchemaError>}
    */
   let SchemaUnsupportedSchemaError;
 
   /**
-   * @type {import('../../../lib/schema/schema').resetSchema}
+   * @type {import('appium/lib/schema/schema').resetSchema}
    */
   let resetSchema;
 
   /**
-   * @type {import('../../../lib/schema/schema').registerSchema}
+   * @type {import('appium/lib/schema/schema').registerSchema}
    */
   let registerSchema;
 
   /**
-   * @type {import('../../../lib/schema/schema').getSchema}
+   * @type {import('appium/lib/schema/schema').getSchema}
    */
   let getSchema;
 
   /**
-   * @type {import('../../../lib/schema/schema').finalizeSchema}
+   * @type {import('appium/lib/schema/schema').finalizeSchema}
    */
   let finalizeSchema;
 
   /**
-   * @type {import('../../../lib/schema/schema').getDefaultsForSchema}
+   * @type {import('appium/lib/schema/schema').getDefaultsForSchema}
    */
   let getDefaultsForSchema;
 
   /**
-   * @type {import('../../../lib/schema/schema').flattenSchema}
+   * @type {import('appium/lib/schema/schema').flattenSchema}
    */
   let flattenSchema;
 
   /**
-   * @type {import('../../../lib/schema/schema').isFinalized}
+   * @type {import('appium/lib/schema/schema').isFinalized}
    */
   let isFinalized;
 
   /**
-   * @type {import('../../../lib/schema/schema').validate}
+   * @type {import('appium/lib/schema/schema').validate}
    */
   let validate;
 
   let mocks;
 
   /**
-   * @type {import('@appium/types').Class<import('../../../lib/schema/schema').RoachHotelMap>}
+   * @type {import('@appium/types').Class<import('appium/lib/schema/schema').RoachHotelMap>}
    */
   let RoachHotelMap;
 
@@ -99,7 +99,7 @@ describe('schema', function () {
       finalizeSchema,
       getDefaultsForSchema,
       flattenSchema,
-      validate
+      validate,
     } = rewiremock.proxy(() => require('../../../lib/schema/schema'), mocks));
     resetSchema();
   });
@@ -123,7 +123,7 @@ describe('schema', function () {
         it('should throw a TypeError', function () {
           expect(() =>
             // @ts-expect-error
-            registerSchema(DRIVER_TYPE, 'whoopeee'),
+            registerSchema(DRIVER_TYPE, 'whoopeee')
           ).to.throw(TypeError, /expected extension type/i);
         });
       });
@@ -133,7 +133,7 @@ describe('schema', function () {
           expect(() =>
             registerSchema(DRIVER_TYPE, undefined, {
               title: 'whoopeee',
-            }),
+            })
           ).to.throw(TypeError, /expected extension type/i);
         });
       });
@@ -146,7 +146,7 @@ describe('schema', function () {
               registerSchema(DRIVER_TYPE, 'whoopeee', [45]);
             }).to.throw(
               SchemaUnsupportedSchemaError,
-              /must be a plain object/i,
+              /must be a plain object/i
             );
           });
         });
@@ -158,7 +158,7 @@ describe('schema', function () {
               registerSchema(DRIVER_TYPE, 'whoopee', {$async: true});
             }).to.throw(
               SchemaUnsupportedSchemaError,
-              /cannot be an async schema/i,
+              /cannot be an async schema/i
             );
           });
         });
@@ -179,7 +179,7 @@ describe('schema', function () {
             const schemaObject = {title: 'whoopee'};
             registerSchema(DRIVER_TYPE, 'whoopee', schemaObject);
             expect(() =>
-              registerSchema(DRIVER_TYPE, 'whoopee', schemaObject),
+              registerSchema(DRIVER_TYPE, 'whoopee', schemaObject)
             ).not.to.throw();
           });
         });
@@ -191,7 +191,7 @@ describe('schema', function () {
             expect(() =>
               registerSchema(DRIVER_TYPE, 'whoopee', {
                 title: 'cushion?',
-              }),
+              })
             ).to.throw(Error, /conflicts with an existing schema/);
           });
         });
@@ -202,7 +202,7 @@ describe('schema', function () {
       it('should register the schema', function () {
         const schemaObject = {title: 'whoopee'};
         expect(() =>
-          registerSchema(DRIVER_TYPE, 'whoopee', schemaObject),
+          registerSchema(DRIVER_TYPE, 'whoopee', schemaObject)
         ).not.to.throw();
       });
 
@@ -212,7 +212,7 @@ describe('schema', function () {
           const schema2 = {title: 'anti-skub'};
           registerSchema(DRIVER_TYPE, 'skub', schema1);
           expect(() =>
-            registerSchema(PLUGIN_TYPE, 'skub', schema2),
+            registerSchema(PLUGIN_TYPE, 'skub', schema2)
           ).not.to.throw();
         });
       });
@@ -244,7 +244,7 @@ describe('schema', function () {
       describe('when schema ID is the base schema ID', function () {
         it('should return the base schema', function () {
           expect(getSchema(APPIUM_CONFIG_SCHEMA_ID)).to.eql(
-            AppiumConfigJsonSchema,
+            AppiumConfigJsonSchema
           );
         });
       });
@@ -253,10 +253,10 @@ describe('schema', function () {
         it('should return the schema for the reference', function () {
           expect(
             getSchema(
-              `${APPIUM_CONFIG_SCHEMA_ID}#/properties/server/properties/address`,
-            ),
+              `${APPIUM_CONFIG_SCHEMA_ID}#/properties/server/properties/address`
+            )
           ).to.exist.and.to.eql(
-            AppiumConfigJsonSchema.properties.server.properties.address,
+            AppiumConfigJsonSchema.properties.server.properties.address
           );
         });
       });
@@ -264,7 +264,7 @@ describe('schema', function () {
       describe('when schema ID is invalid', function () {
         it('should throw', function () {
           expect(() => getSchema('schema-the-clown')).to.throw(
-            SchemaUnknownSchemaError,
+            SchemaUnknownSchemaError
           );
         });
       });
@@ -277,9 +277,7 @@ describe('schema', function () {
       });
 
       it('should return the extension schema', function () {
-        expect(getSchema('driver-stuff.json')).to.eql(
-          DRIVER_SCHEMA_FIXTURE,
-        );
+        expect(getSchema('driver-stuff.json')).to.eql(DRIVER_SCHEMA_FIXTURE);
       });
     });
   });
@@ -287,9 +285,7 @@ describe('schema', function () {
   describe('getDefaultsForSchema()', function () {
     describe('when schema not yet compiled', function () {
       it('should throw', function () {
-        expect(() => getDefaultsForSchema()).to.throw(
-          SchemaFinalizationError,
-        );
+        expect(() => getDefaultsForSchema()).to.throw(SchemaFinalizationError);
       });
     });
 
@@ -339,7 +335,7 @@ describe('schema', function () {
           'fake',
           // TS complains about this require()
           // @ts-ignore
-          require('@appium/fake-driver/build/lib/fake-driver-schema').default,
+          require('@appium/fake-driver/build/lib/fake-driver-schema').default
         );
         finalizeSchema();
 
@@ -447,7 +443,7 @@ describe('schema', function () {
       describe('when provided an invalid schema ID ref', function () {
         it('should throw', function () {
           expect(() => validate('foo', 'bar')).to.throw(
-            SchemaUnknownSchemaError,
+            SchemaUnknownSchemaError
           );
         });
       });
@@ -455,16 +451,14 @@ describe('schema', function () {
       describe('when not provided a schema ID ref', function () {
         describe('when provided a valid value', function () {
           it('should return an empty array of no errors', function () {
-            expect(validate({server: {address: '127.0.0.1'}})).to.eql(
-              [],
-            );
+            expect(validate({server: {address: '127.0.0.1'}})).to.eql([]);
           });
         });
 
         describe('when provided an invalid value', function () {
           it('should return an array containing errors', function () {
-            expect(validate({address: '127.0.0.1'})).to.be.an('array')
-              .and.to.not.be.empty;
+            expect(validate({address: '127.0.0.1'})).to.be.an('array').and.to
+              .not.be.empty;
           });
         });
       });
@@ -475,8 +469,8 @@ describe('schema', function () {
             expect(
               validate(
                 '127.0.0.1',
-                'appium.json#/properties/server/properties/address',
-              ),
+                'appium.json#/properties/server/properties/address'
+              )
             ).to.eql([]);
           });
         });
@@ -486,8 +480,8 @@ describe('schema', function () {
             expect(
               validate(
                 '127.0.0.1',
-                'appium.json#/properties/server/properties/port',
-              ),
+                'appium.json#/properties/server/properties/port'
+              )
             ).to.be.an('array').and.to.not.be.empty;
           });
         });
@@ -503,7 +497,7 @@ describe('schema', function () {
       describe('when provided an invalid schema ID ref', function () {
         it('should throw', function () {
           expect(() => validate('foo', 'bar')).to.throw(
-            SchemaUnknownSchemaError,
+            SchemaUnknownSchemaError
           );
         });
       });
@@ -511,16 +505,16 @@ describe('schema', function () {
       describe('when not provided a schema ID ref', function () {
         describe('when provided a valid value', function () {
           it('should return an empty array of no errors', function () {
-            expect(
-              validate({server: {driver: {stuff: {answer: 99}}}}),
-            ).to.eql([]);
+            expect(validate({server: {driver: {stuff: {answer: 99}}}})).to.eql(
+              []
+            );
           });
         });
 
         describe('when provided an invalid value', function () {
           it('should return an array containing errors', function () {
             expect(
-              validate({server: {driver: {stuff: {answer: 101}}}}),
+              validate({server: {driver: {stuff: {answer: 101}}}})
             ).to.be.an('array').and.to.not.be.empty;
           });
         });
@@ -529,16 +523,16 @@ describe('schema', function () {
       describe('when provided a schema ID ref', function () {
         describe('when provided a valid value', function () {
           it('should return an empty array of no errors', function () {
-            expect(
-              validate(99, 'driver-stuff.json#/properties/answer'),
-            ).to.eql([]);
+            expect(validate(99, 'driver-stuff.json#/properties/answer')).to.eql(
+              []
+            );
           });
         });
 
         describe('when provided an invalid value', function () {
           it('should return an array containing errors', function () {
             expect(
-              validate(101, 'driver-stuff.json#/properties/answer'),
+              validate(101, 'driver-stuff.json#/properties/answer')
             ).to.be.an('array').and.to.not.be.empty;
           });
         });

--- a/packages/appium/tsconfig.json
+++ b/packages/appium/tsconfig.json
@@ -7,7 +7,8 @@
       "@appium/support": ["../support"],
       "@appium/base-driver": ["../base-driver"],
       "@appium/types": ["../types"],
-      "@appium/schema": ["../schema"]
+      "@appium/schema": ["../schema"],
+      "appium": ["."]
     },
     "checkJs": true
   },

--- a/packages/appium/types/appium-manifest.ts
+++ b/packages/appium/types/appium-manifest.ts
@@ -4,8 +4,21 @@ import { ExtensionType, DriverType, PluginType } from '.';
 export type InstallType = 'npm' | 'git' | 'local' | 'github';
 
 export interface InternalMetadata {
+  /**
+   * Package name of extension
+   * 
+   * `name` from its `package.json`
+   */
   pkgName: string;
+  /**
+   * Version of extension
+   * 
+   * `version` from its `package.json`
+   */
   version: string;
+  /**
+   * The method in which the user installed the extension (the `source` CLI arg)
+   */
   installType: InstallType;
   /**
    * Whatever the user typed as the extension to install. May be derived from `package.json`


### PR DESCRIPTION
`import` in jsdoc types previously using relative paths to reference the `types` folder can now be referenced via `appium/types`; e.g., `import('../types').Foo`, `import('./types').Foo`, `import('../../../types/bar').Foo` are now just `import('appium/types').Foo`

Also add some missing descriptions