### PR TITLE
test(appium): e2e helpers now log executed child process commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "serve-static": "1.15.0",
     "sinon": "13.0.2",
     "sinon-chai": "3.7.0",
+    "strip-ansi": "6.0.1",
     "sync-monorepo-packages": "0.3.5",
     "through2": "4.0.2",
     "type-fest": "2.12.2",


### PR DESCRIPTION
This is just a tweak to the E2E helpers which run `appium` in a child process. The helpers now dump the entire command string to terminal; this aids in debugging if--for example--child process output gets gobbled.
