### PR TITLE
chore: do not use @babel/register w/ wallaby

### DIFF
--- a/.wallaby.js
+++ b/.wallaby.js
@@ -19,8 +19,6 @@ module.exports = (wallaby) => {
       '!./packages/*/gulpfile.js',
       '!./packages/*/scripts/**',
       './packages/*/test/**/fixtures/**/*',
-      './packages/*/test/**/mocks.js',
-      './packages/*/test/helpers.js',
       './babel.config.json',
       // below this are fixtures
       {
@@ -35,34 +33,29 @@ module.exports = (wallaby) => {
         instrument: false,
         pattern: './packages/base-driver/static/**/*',
       },
-      {
-        instrument: false,
-        pattern: './packages/gulp-plugins/build/**/*',
-      },
-      // this setup file is special
-      {
-        instrument: false,
-        pattern: './test/setup.js'
-      },
-      '!**/local_appium_home/**'
+      '!**/local_appium_home/**',
     ],
     testFramework: 'mocha',
-    tests: [
-      './packages/*/test/**/*-specs.js',
-      './packages/*/test/unit/**/*.spec.js',
-      '!./packages/*/test/**/*-e2e-specs.js',
-      '!./packages/*/test/e2e/**/*',
-      '!./packages/*/node_modules/**',
-      // this is more of an E2E test and it's tedious to run
-      '!./packages/gulp-plugins/test/transpile-specs.js',
-      '!**/local_appium_home/**'
-    ],
+    tests: ['./packages/*/test/unit/**/*.spec.js'],
     workers: {
       restart: true,
     },
     setup() {
-      require('./test/setup');
+      // This copied out of `./test/setup.js`, which uses `@babel/register`.
+      // Wallaby doesn't need `@babel/register` (and it probably makes Wallaby slow),
+      // but we need the other stuff, so here it is.
+
+      const chai = require('chai');
+      const chaiAsPromised = require('chai-as-promised');
+      const sinonChai = require('sinon-chai');
+
+      // The `chai` global is set if a test needs something special.
+      // Most tests won't need this.
+      global.chai = chai.use(chaiAsPromised).use(sinonChai);
+
+      // `should()` is only necessary when working with some `null` or `undefined` values.
+      global.should = chai.should();
     },
-    runMode: 'onsave'
+    runMode: 'onsave',
   };
 };


### PR DESCRIPTION
I realize nobody except me cares about this, but anyway: Wallaby has its own way of running Babel, so we don't need `@babel/register`. Worst case, running it will mess things up--but most likely it just makes things slightly slower.
