### PR TITLE
chore(appium): refactor some variable/parameter names for clarity

### DIFF
--- a/packages/appium/lib/cli/driver-command.js
+++ b/packages/appium/lib/cli/driver-command.js
@@ -1,60 +1,85 @@
 import _ from 'lodash';
 import ExtensionCommand from './extension-command';
-import { KNOWN_DRIVERS } from '../constants';
+import {KNOWN_DRIVERS} from '../constants';
 import '@colors/colors';
 
-const REQ_DRIVER_FIELDS = ['driverName', 'automationName', 'platformNames', 'mainClass'];
+const REQ_DRIVER_FIELDS = [
+  'driverName',
+  'automationName',
+  'platformNames',
+  'mainClass',
+];
+
 /**
- * @extends {ExtensionCommand<import('../extension/manifest').DriverType>}
+ * @extends {ExtensionCommand<DriverType>}
  */
 export default class DriverCommand extends ExtensionCommand {
-
   /**
    * @param {DriverCommandOptions} opts
    */
-  constructor ({config, json}) {
+  constructor({config, json}) {
     super({config, json});
     this.knownExtensions = KNOWN_DRIVERS;
   }
 
-  async install ({driver, installType, packageName}) {
-    return await super._install({ext: driver, installType, packageName});
+  async install({driver, installType, packageName}) {
+    return await super._install({
+      installSpec: driver,
+      installType,
+      packageName,
+    });
   }
 
-  async uninstall ({driver}) {
-    return await super._uninstall({ext: driver});
+  async uninstall({driver}) {
+    return await super._uninstall({installSpec: driver});
   }
 
-  async update ({driver, unsafe}) {
-    return await super._update({ext: driver, unsafe});
+  async update({driver, unsafe}) {
+    return await super._update({installSpec: driver, unsafe});
   }
 
-  async run ({driver, scriptName}) {
-    return await super._run({ext: driver, scriptName});
+  async run({driver, scriptName}) {
+    return await super._run({installSpec: driver, scriptName});
   }
 
-  getPostInstallText ({extName, extData}) {
-    return `Driver ${extName}@${extData.version} successfully installed\n`.green +
-           `- automationName: ${extData.automationName.green}\n` +
-           `- platformNames: ${JSON.stringify(extData.platformNames).green}`;
+  getPostInstallText({extName, extData}) {
+    return (
+      `Driver ${extName}@${extData.version} successfully installed\n`.green +
+      `- automationName: ${extData.automationName.green}\n` +
+      `- platformNames: ${JSON.stringify(extData.platformNames).green}`
+    );
   }
 
-  validateExtensionFields (appiumPkgData) {
-    const missingFields = REQ_DRIVER_FIELDS.reduce((acc, field) => (
-      appiumPkgData[field] ? acc : [...acc, field]
-    ), []);
+  /**
+   * Validates fields in `appium` field of `driverMetadata`
+   *
+   * For any `package.json` fields which a driver requires, validate the type of
+   * those fields on the `package.json` data, throwing an error if anything is
+   * amiss.
+   * @param {import('appium/types').ExtMetadata<DriverType>} driverMetadata
+   * @param {string} installSpec
+   */
+  validateExtensionFields(driverMetadata, installSpec) {
+    const missingFields = REQ_DRIVER_FIELDS.reduce(
+      (acc, field) => (driverMetadata[field] ? acc : [...acc, field]),
+      []
+    );
 
     if (!_.isEmpty(missingFields)) {
-      throw new Error(`Installed driver did not expose correct fields for compability ` +
-                      `with Appium. Missing fields: ${JSON.stringify(missingFields)}`);
+      throw new Error(
+        `Driver "${installSpec}" did not expose correct fields for compability ` +
+          `with Appium. Missing fields: ${JSON.stringify(missingFields)}`
+      );
     }
-
   }
-
 }
 
 /**
  * @typedef DriverCommandOptions
- * @property {import('../extension/extension-config').ExtensionConfig<import('../extension/manifest').DriverType>} config
+ * @property {import('../extension/extension-config').ExtensionConfig<DriverType>} config
  * @property {boolean} json
+ */
+
+/**
+ * @typedef {import('appium/types').DriverType} DriverType
  */

--- a/packages/appium/lib/cli/plugin-command.js
+++ b/packages/appium/lib/cli/plugin-command.js
@@ -1,56 +1,71 @@
 import _ from 'lodash';
 import ExtensionCommand from './extension-command';
-import { KNOWN_PLUGINS } from '../constants';
+import {KNOWN_PLUGINS} from '../constants';
 
 const REQ_PLUGIN_FIELDS = ['pluginName', 'mainClass'];
 
+/**
+ * @extends {ExtensionCommand<PluginType>}
+ */
 export default class PluginCommand extends ExtensionCommand {
-
   /**
    *
-   * @param {PluginCommandOptions} opts
+   * @param {import('./extension-command').ExtensionCommandOptions<PluginType>} opts
    */
-  constructor ({config, json}) {
+  constructor({config, json}) {
     super({config, json});
     this.knownExtensions = KNOWN_PLUGINS;
   }
 
-  async install ({plugin, installType, packageName}) {
-    return await super._install({ext: plugin, installType, packageName});
+  async install({plugin, installType, packageName}) {
+    return await super._install({
+      installSpec: plugin,
+      installType,
+      packageName,
+    });
   }
 
-  async uninstall ({plugin}) {
-    return await super._uninstall({ext: plugin});
+  async uninstall({plugin}) {
+    return await super._uninstall({installSpec: plugin});
   }
 
-  async update ({plugin, unsafe}) {
-    return await super._update({ext: plugin, unsafe});
+  async update({plugin, unsafe}) {
+    return await super._update({installSpec: plugin, unsafe});
   }
 
-  async run ({plugin, scriptName}) {
-    return await super._run({ext: plugin, scriptName});
+  async run({plugin, scriptName}) {
+    return await super._run({installSpec: plugin, scriptName});
   }
 
-  getPostInstallText ({extName, extData}) {
+  getPostInstallText({extName, extData}) {
     return `Plugin ${extName}@${extData.version} successfully installed`.green;
   }
 
-  validateExtensionFields (appiumPkgData) {
-    const missingFields = REQ_PLUGIN_FIELDS.reduce((acc, field) => (
-      appiumPkgData[field] ? acc : [...acc, field]
-    ), []);
+  /**
+   * Validates fields in `appium` field of `driverMetadata`
+   *
+   * For any `package.json` fields which a driver requires, validate the type of
+   * those fields on the `package.json` data, throwing an error if anything is
+   * amiss.
+   * @param {import('appium/types').ExtMetadata<PluginType>} pluginMetadata
+   * @param {string} installSpec
+   * @returns {void}
+   */
+  validateExtensionFields(pluginMetadata, installSpec) {
+    const missingFields = REQ_PLUGIN_FIELDS.reduce(
+      (acc, field) => (pluginMetadata[field] ? acc : [...acc, field]),
+      []
+    );
 
     if (!_.isEmpty(missingFields)) {
-      throw new Error(`Installed plugin did not expose correct fields for compability ` +
-                      `with Appium. Missing fields: ${JSON.stringify(missingFields)}`);
+      throw new Error(
+        `Installed plugin "${installSpec}" did not expose correct fields for compability ` +
+          `with Appium. Missing fields: ${JSON.stringify(missingFields)}`
+      );
     }
-
   }
-
 }
 
 /**
- * @typedef PluginCommandOptions
- * @property {import('../extension/extension-config').ExtensionConfig<import('../extension/manifest').PluginType>} config
- * @property {boolean} json
+ * @typedef {import('appium/types').PluginType} PluginType
  */


### PR DESCRIPTION
renamed parameters named `ext` to `installSpec`, since these correspond to the values of `installSpec` in the manifest