### PR TITLE
fix(eslint-config-appium): revert prettier-related change

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "build:loose": "run-s -c build:distfiles build:types || true",
     "build:types": "tsc -b",
     "clean": "run-s clean:artifacts clean:packages clean:monorepo",
-    "clean:artifacts": "run-s clean:distfiles clean:types && npx rimraf \"packages/*/build\"",
     "clean:distfiles": "npx rimraf \"packages/*/build/**/*.js\"",
     "clean:monorepo": "npx rimraf node_modules package-lock.json",
     "clean:packages": "lerna clean -y && npx rimraf \"packages/*/package-lock.json\"",
     "clean:types": "tsc -b --clean",
+    "clean:artifacts": "run-s clean:distfiles clean:types && npx rimraf \"packages/*/build\"",
     "dev": "run-p dev:*",
     "dev:distfiles": "lerna run --parallel --prefix --concurrency=8 dev",
     "dev:types": "tsc -b --watch",
@@ -70,14 +70,7 @@
     "precommit-lint"
   ],
   "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "prettier --write"
-    ]
-  },
-  "prettier": {
-    "bracketSpacing": false,
-    "singleQuote": true
+    "*.js": "eslint --fix"
   },
   "dependencies": {
     "@appium/base-driver": "file:packages/base-driver",
@@ -85,7 +78,6 @@
     "@appium/doctor": "file:packages/doctor",
     "@appium/docutils": "file:packages/docutils",
     "@appium/eslint-config-appium": "file:packages/eslint-config-appium",
-    "@appium/execute-driver-plugin": "file:packages/execute-driver-plugin",
     "@appium/fake-driver": "file:packages/fake-driver",
     "@appium/fake-plugin": "file:packages/fake-plugin",
     "@appium/gulp-plugins": "file:packages/gulp-plugins",
@@ -97,6 +89,7 @@
     "@appium/test-support": "file:packages/test-support",
     "@appium/types": "file:packages/types",
     "@appium/universal-xml-plugin": "file:packages/universal-xml-plugin",
+    "@appium/execute-driver-plugin": "file:packages/execute-driver-plugin",
     "appium": "file:packages/appium"
   },
   "devDependencies": {
@@ -149,7 +142,6 @@
     "chai-as-promised": "7.1.1",
     "chai-webdriverio-async": "2.7.0",
     "eslint": "7.32.0",
-    "eslint-config-prettier": "8.5.0",
     "eslint-find-rules": "4.1.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-mocha": "9.0.0",
@@ -167,7 +159,6 @@
     "mocha": "9.2.2",
     "npm-run-all": "4.1.5",
     "pre-commit": "1.2.2",
-    "prettier": "2.6.2",
     "rewiremock": "3.14.3",
     "rimraf": "3.0.2",
     "serve-static": "1.15.0",

--- a/packages/eslint-config-appium/index.js
+++ b/packages/eslint-config-appium/index.js
@@ -6,18 +6,22 @@ module.exports = {
     sourceType: 'module',
     ecmaFeatures: {
       impliedStrict: true,
-      experimentalObjectRestSpread: true,
-    },
+      experimentalObjectRestSpread: true
+    }
   },
   env: {
     node: true,
     mocha: true,
     es6: true,
   },
-  plugins: ['import', 'mocha', 'promise'],
+  plugins: [
+    'import',
+    'mocha',
+    'promise'
+  ],
   globals: {
     chai: true,
-    should: true,
+    should: true
   },
   rules: {
     'no-console': 2,
@@ -25,13 +29,23 @@ module.exports = {
     radix: [2, 'always'],
     'dot-notation': 2,
     eqeqeq: [2, 'smart'],
-    'brace-style': [
-      2,
-      '1tbs',
-      {
-        allowSingleLine: true,
+    'brace-style': [2, '1tbs', {
+      allowSingleLine: true,
+    }],
+    indent: [2, 2, {
+      VariableDeclarator: {
+        var: 2,
+        let: 2,
+        const: 3,
       },
-    ],
+      ImportDeclaration: 'first',
+      CallExpression: {
+        arguments: 'off',
+      },
+      MemberExpression: 'off',
+      ObjectExpression: 'first',
+      SwitchCase: 1,
+    }],
     'comma-dangle': 0,
     'no-empty': 0,
     'object-shorthand': 2,
@@ -55,43 +69,31 @@ module.exports = {
     // enforce spacing
     'arrow-spacing': 2,
     'keyword-spacing': 2,
-    'comma-spacing': [
-      2,
-      {
-        before: false,
-        after: true,
-      },
-    ],
+    'comma-spacing': [2, {
+      before: false,
+      after: true
+    }],
     'array-bracket-spacing': 2,
     'no-trailing-spaces': 2,
     'no-whitespace-before-property': 2,
     'space-in-parens': [2, 'never'],
     'space-before-blocks': [2, 'always'],
-    'space-unary-ops': [
-      2,
-      {
-        words: true,
-        nonwords: false,
-      },
-    ],
+    'space-before-function-paren': [2, 'always'],
+    'space-unary-ops': [2, {
+      words: true,
+      nonwords: false,
+    }],
     'space-infix-ops': 2,
-    'key-spacing': [
-      2,
-      {
-        mode: 'strict',
-        beforeColon: false,
-        afterColon: true,
-      },
-    ],
+    'key-spacing': [2, {
+      mode: 'strict',
+      beforeColon: false,
+      afterColon: true,
+    }],
     'no-multi-spaces': 2,
-    quotes: [
-      2,
-      'single',
-      {
-        avoidEscape: true,
-        allowTemplateLiterals: true,
-      },
-    ],
+    quotes: [2, 'single', {
+      avoidEscape: true,
+      allowTemplateLiterals: true,
+    }],
     'no-buffer-constructor': 1,
     'require-atomic-updates': 0,
     'no-prototype-builtins': 1,
@@ -111,5 +113,7 @@ module.exports = {
       },
     ],
   },
-  extends: ['eslint:recommended', 'prettier'],
+  extends: [
+    'eslint:recommended',
+  ],
 };

--- a/packages/eslint-config-appium/package.json
+++ b/packages/eslint-config-appium/package.json
@@ -8,14 +8,13 @@
     "appium",
     "es2015"
   ],
-  "homepage": "https://appium.io",
-  "bugs": {
-    "url": "https://github.com/appium/appium/issues"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/appium/appium.git",
     "directory": "packages/eslint-config-appium"
+  },
+  "bugs": {
+    "url": "https://github.com/appium/appium/issues"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
@@ -34,17 +33,17 @@
     "@babel/core": "7.17.10",
     "@babel/eslint-parser": "7.17.0",
     "eslint": "7.32.0",
-    "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-mocha": "9.0.0",
     "eslint-plugin-promise": "6.0.0"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://appium.io",
   "engines": {
     "node": ">=12",
     "npm": ">=6"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }


### PR DESCRIPTION
This reverts commits https://github.com/appium/appium/commit/b34b75a80e4b5d7037a5c93fef1b68fcb6d159ee,  https://github.com/appium/appium/commit/88a6655253a4879041478d64254471efebe4cbfe and https://github.com/appium/appium/commit/d89203f96c7d45e8cda5e447c808d1485449c284 which, as a whole, was breaking.

This will fix the publish of v5.1.0, which should have been a major release.

After v5.1.1 has been released, this PR should be reverted in prep for v6.

Closes #16890 