### PR TITLE
feat(eslint-config-appium,gulp-plugins): add prettier BREAKING CHANGE

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "build:loose": "run-s -c build:distfiles build:types || true",
     "build:types": "tsc -b",
     "clean": "run-s clean:artifacts clean:packages clean:monorepo",
+    "clean:artifacts": "run-s clean:distfiles clean:types && npx rimraf \"packages/*/build\"",
     "clean:distfiles": "npx rimraf \"packages/*/build/**/*.js\"",
     "clean:monorepo": "npx rimraf node_modules package-lock.json",
     "clean:packages": "lerna clean -y && npx rimraf \"packages/*/package-lock.json\"",
     "clean:types": "tsc -b --clean",
-    "clean:artifacts": "run-s clean:distfiles clean:types && npx rimraf \"packages/*/build\"",
     "dev": "run-p dev:*",
     "dev:distfiles": "lerna run --parallel --prefix --concurrency=8 dev",
     "dev:types": "tsc -b --watch",
@@ -70,7 +70,14 @@
     "precommit-lint"
   ],
   "lint-staged": {
-    "*.js": "eslint --fix"
+    "*.js": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  },
+  "prettier": {
+    "bracketSpacing": false,
+    "singleQuote": true
   },
   "dependencies": {
     "@appium/base-driver": "file:packages/base-driver",
@@ -78,6 +85,7 @@
     "@appium/doctor": "file:packages/doctor",
     "@appium/docutils": "file:packages/docutils",
     "@appium/eslint-config-appium": "file:packages/eslint-config-appium",
+    "@appium/execute-driver-plugin": "file:packages/execute-driver-plugin",
     "@appium/fake-driver": "file:packages/fake-driver",
     "@appium/fake-plugin": "file:packages/fake-plugin",
     "@appium/gulp-plugins": "file:packages/gulp-plugins",
@@ -89,7 +97,6 @@
     "@appium/test-support": "file:packages/test-support",
     "@appium/types": "file:packages/types",
     "@appium/universal-xml-plugin": "file:packages/universal-xml-plugin",
-    "@appium/execute-driver-plugin": "file:packages/execute-driver-plugin",
     "appium": "file:packages/appium"
   },
   "devDependencies": {
@@ -142,6 +149,7 @@
     "chai-as-promised": "7.1.1",
     "chai-webdriverio-async": "2.7.0",
     "eslint": "7.32.0",
+    "eslint-config-prettier": "8.5.0",
     "eslint-find-rules": "4.1.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-mocha": "9.0.0",
@@ -159,6 +167,7 @@
     "mocha": "10.0.0",
     "npm-run-all": "4.1.5",
     "pre-commit": "1.2.2",
+    "prettier": "2.6.2",
     "rewiremock": "3.14.3",
     "rimraf": "3.0.2",
     "serve-static": "1.15.0",

--- a/packages/eslint-config-appium/index.js
+++ b/packages/eslint-config-appium/index.js
@@ -6,22 +6,18 @@ module.exports = {
     sourceType: 'module',
     ecmaFeatures: {
       impliedStrict: true,
-      experimentalObjectRestSpread: true
-    }
+      experimentalObjectRestSpread: true,
+    },
   },
   env: {
     node: true,
     mocha: true,
     es6: true,
   },
-  plugins: [
-    'import',
-    'mocha',
-    'promise'
-  ],
+  plugins: ['import', 'mocha', 'promise'],
   globals: {
     chai: true,
-    should: true
+    should: true,
   },
   rules: {
     'no-console': 2,
@@ -29,23 +25,13 @@ module.exports = {
     radix: [2, 'always'],
     'dot-notation': 2,
     eqeqeq: [2, 'smart'],
-    'brace-style': [2, '1tbs', {
+    'brace-style': [
+      2,
+      '1tbs',
+      {
       allowSingleLine: true,
-    }],
-    indent: [2, 2, {
-      VariableDeclarator: {
-        var: 2,
-        let: 2,
-        const: 3,
       },
-      ImportDeclaration: 'first',
-      CallExpression: {
-        arguments: 'off',
-      },
-      MemberExpression: 'off',
-      ObjectExpression: 'first',
-      SwitchCase: 1,
-    }],
+    ],
     'comma-dangle': 0,
     'no-empty': 0,
     'object-shorthand': 2,
@@ -69,31 +55,43 @@ module.exports = {
     // enforce spacing
     'arrow-spacing': 2,
     'keyword-spacing': 2,
-    'comma-spacing': [2, {
+    'comma-spacing': [
+      2,
+      {
       before: false,
-      after: true
-    }],
+        after: true,
+      },
+    ],
     'array-bracket-spacing': 2,
     'no-trailing-spaces': 2,
     'no-whitespace-before-property': 2,
     'space-in-parens': [2, 'never'],
     'space-before-blocks': [2, 'always'],
-    'space-before-function-paren': [2, 'always'],
-    'space-unary-ops': [2, {
+    'space-unary-ops': [
+      2,
+      {
       words: true,
       nonwords: false,
-    }],
+      },
+    ],
     'space-infix-ops': 2,
-    'key-spacing': [2, {
+    'key-spacing': [
+      2,
+      {
       mode: 'strict',
       beforeColon: false,
       afterColon: true,
-    }],
+      },
+    ],
     'no-multi-spaces': 2,
-    quotes: [2, 'single', {
+    quotes: [
+      2,
+      'single',
+      {
       avoidEscape: true,
       allowTemplateLiterals: true,
-    }],
+      },
+    ],
     'no-buffer-constructor': 1,
     'require-atomic-updates': 0,
     'no-prototype-builtins': 1,
@@ -113,7 +111,5 @@ module.exports = {
       },
     ],
   },
-  extends: [
-    'eslint:recommended',
-  ],
+  extends: ['eslint:recommended', 'prettier'],
 };

--- a/packages/eslint-config-appium/package.json
+++ b/packages/eslint-config-appium/package.json
@@ -8,13 +8,14 @@
     "appium",
     "es2015"
   ],
+  "homepage": "https://appium.io",
+  "bugs": {
+    "url": "https://github.com/appium/appium/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/appium/appium.git",
     "directory": "packages/eslint-config-appium"
-  },
-  "bugs": {
-    "url": "https://github.com/appium/appium/issues"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
@@ -33,17 +34,17 @@
     "@babel/core": "7.17.10",
     "@babel/eslint-parser": "7.17.0",
     "eslint": "7.32.0",
+    "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-mocha": "9.0.0",
     "eslint-plugin-promise": "6.0.0"
   },
-  "publishConfig": {
-    "access": "public"
-  },
-  "homepage": "https://appium.io",
   "engines": {
     "node": ">=12",
     "npm": ">=6"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -58,6 +58,7 @@
     "bluebird": "3.7.2",
     "del": "6.0.0",
     "eslint": "7.32.0",
+    "eslint-config-prettier": "8.5.0",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-mocha": "9.0.0",
     "eslint-plugin-promise": "6.0.0",


### PR DESCRIPTION
BREAKING CHANGE

`@appium/eslint-config-appium` now requires peer dependency `eslint-config-prettier`. Because `@appium/gulp-plugins` always uses the latest development version of `@appium/eslint-config-appium`, the dependency needs to be added there, too.

In addition, this disables some rules, so _may_ cause code which previously passed lint checks _not_ to pass lint checks.

(This is basically just d89203f96c7d45e8cda5e447c808d1485449c284, b34b75a80e4b5d7037a5c93fef1b68fcb6d159ee, and 88a6655253a4879041478d64254471efebe4cbfe squashed together, plus the addition of the req'd peer dependency in `@appium/gulp-plugins`.)