### PR TITLE
chore(ci): add Node v18 to matrix; remove Node v17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
- Node.js v18 is now current
- Node.js v17 is EOL

