### PR TITLE
chore(renovate): update renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,23 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchDepTypes": ["devDependencies"],
       "automerge": true
+    },
+    {
+      "matchPackageNames": [
+        "find-up",
+        "globby",
+        "log-symbols",
+        "read-pkg",
+        "term-size",
+        "wrap-ansi",
+        "write-pkg",
+        "@types/wrap-ansi",
+        "execa"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "baseBranches": ["2.0"],
@@ -15,5 +31,6 @@
   "semanticCommits": "enabled",
   "semanticCommitScope": "{{parentDir}}",
   "schedule": ["after 10pm and before 5:00am"],
-  "timezone": "America/Vancouver"
+  "timezone": "America/Vancouver",
+  "transitiveRemediation": true
 }


### PR DESCRIPTION
As mentioned in #16553, we want to ensure Renovate doesn't spam us with a ton of stuff. I don't think it will, but I went in here and made some changes in preparation for committing `package-lock.json`.

The changes:

1. Automerging is not actually happening (probably because of no lockfile), but we probably do not want to automerge production dependencies, so restrict to dev deps.
2. Blacklist some package names which we will not upgrade to a new major (we may not be using some of these).  These are packages published as ESM-only.
3. Enable upgrading of transitive dependencies to mitigate seurity issues.

I do not think 1 nor 3 will work without a `package-lock.json`, so these depend on #16553.
