### PR TITLE
feat(execute-driver-plugin): use peer deps

### DIFF
--- a/packages/execute-driver-plugin/lib/execute-child.js
+++ b/packages/execute-driver-plugin/lib/execute-child.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import B from 'bluebird';
 import {NodeVM} from 'vm2';
-import {logger, util} from '@appium/support';
+import {logger, util} from 'appium/support';
 import {attach} from 'webdriverio';
 
 const log = logger.getLogger('ExecuteDriver Child');

--- a/packages/execute-driver-plugin/lib/plugin.js
+++ b/packages/execute-driver-plugin/lib/plugin.js
@@ -1,7 +1,7 @@
-import BasePlugin from '@appium/base-plugin';
+import {BasePlugin} from 'appium/plugin';
 import _ from 'lodash';
 import cp from 'child_process';
-import {timing} from '@appium/support';
+import {timing} from 'appium/support';
 import B from 'bluebird';
 
 const FEAT_FLAG = 'execute_driver_script';

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -34,12 +34,13 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/base-plugin": "file:../base-plugin",
-    "@appium/support": "file:../support",
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
     "vm2": "3.9.9",
     "webdriverio": "7.19.7"
+  },
+  "peerDependencies": {
+    "appium": "^2.0.0-beta.35"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.js
+++ b/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.js
@@ -2,10 +2,10 @@
 
 import path from 'path';
 
-import {e2eSetup as _e2eSetup} from '@appium/base-plugin/build/test/helpers';
+import {e2eSetup} from '@appium/base-plugin/build/test/helpers';
 import {remote as wdio} from 'webdriverio';
 import {W3C_ELEMENT_KEY, MJSONWP_ELEMENT_KEY} from '../../lib/execute-child';
-import {fs} from '@appium/support';
+import {fs} from 'appium/support';
 
 const THIS_PLUGIN_DIR = path.join(__dirname, '..', '..');
 const APPIUM_HOME = path.join(THIS_PLUGIN_DIR, 'local_appium_home');
@@ -20,9 +20,6 @@ const TEST_FAKE_APP = path.join(
   'fixtures',
   'app.xml'
 );
-
-// XXX: remove when the test files get a proper TS configuration
-const e2eSetup = /** @type {import('@appium/base-plugin/test/helpers').e2eSetup} */ (_e2eSetup);
 
 const TEST_CAPS = {
   platformName: 'Fake',

--- a/packages/execute-driver-plugin/tsconfig.json
+++ b/packages/execute-driver-plugin/tsconfig.json
@@ -1,24 +1,7 @@
 {
   "compilerOptions": {
-    "outDir": "./build",
-    "paths": {
-      "@appium/base-plugin": ["../base-plugin"],
-      "@appium/support": ["../support"],
-      "appium": ["../appium"]
-    },
-    "types": ["webdriverio/async"]
+    "outDir": "build"
   },
-  "extends": "../../config/tsconfig.base.json",
-  "include": ["lib"],
-  "references": [
-    {
-      "path": "../base-plugin"
-    },
-    {
-      "path": "../support"
-    },
-    {
-      "path": "../appium"
-    }
-  ]
+  "extends": "../../config/tsconfig.plugin.json",
+  "include": ["lib"]
 }


### PR DESCRIPTION
BREAKING CHANGE:

`@appium/execute-driver-plugin` now expects to be installed alongside `appium`.