### PR TITLE
feat(fake-driver): use peer deps

### DIFF
--- a/packages/fake-driver/lib/commands/alert.js
+++ b/packages/fake-driver/lib/commands/alert.js
@@ -1,4 +1,4 @@
-import {errors} from '@appium/base-driver';
+import {errors} from 'appium/driver';
 
 let commands = {},
   helpers = {},

--- a/packages/fake-driver/lib/commands/contexts.js
+++ b/packages/fake-driver/lib/commands/contexts.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {errors} from '@appium/base-driver';
+import {errors} from 'appium/driver';
 
 let commands = {},
   helpers = {},

--- a/packages/fake-driver/lib/commands/element.js
+++ b/packages/fake-driver/lib/commands/element.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {errors} from '@appium/base-driver';
+import {errors} from 'appium/driver';
 
 let commands = {},
   helpers = {},

--- a/packages/fake-driver/lib/commands/find.js
+++ b/packages/fake-driver/lib/commands/find.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {errors} from '@appium/base-driver';
+import {errors} from 'appium/driver';
 import {FakeElement} from '../fake-element';
 
 let commands = {},

--- a/packages/fake-driver/lib/commands/general.js
+++ b/packages/fake-driver/lib/commands/general.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {errors} from '@appium/base-driver';
+import {errors} from 'appium/driver';
 
 let commands = {},
   helpers = {},

--- a/packages/fake-driver/lib/driver.js
+++ b/packages/fake-driver/lib/driver.js
@@ -1,6 +1,6 @@
 import B from 'bluebird';
 import _ from 'lodash';
-import {BaseDriver, errors} from '@appium/base-driver';
+import {BaseDriver, errors} from 'appium/driver';
 import {FakeApp} from './fake-app';
 import commands from './commands';
 

--- a/packages/fake-driver/lib/fake-app.js
+++ b/packages/fake-driver/lib/fake-app.js
@@ -1,4 +1,4 @@
-import {fs} from '@appium/support';
+import {fs} from 'appium/support';
 import {readFileSync} from 'fs';
 import path from 'path';
 import XMLDom from '@xmldom/xmldom';

--- a/packages/fake-driver/lib/logger.js
+++ b/packages/fake-driver/lib/logger.js
@@ -1,4 +1,4 @@
-import {logger} from '@appium/support';
+import {logger} from 'appium/support';
 
 const log = logger.getLogger('FakeDriver');
 

--- a/packages/fake-driver/lib/server.js
+++ b/packages/fake-driver/lib/server.js
@@ -1,5 +1,5 @@
 import log from './logger';
-import {server as baseServer, routeConfiguringFunction} from '@appium/base-driver';
+import {server as baseServer, routeConfiguringFunction} from 'appium/driver';
 import {FakeDriver} from './driver';
 
 async function startServer(port, hostname) {

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -46,8 +46,6 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "@appium/base-driver": "file:../base-driver",
-    "@appium/support": "file:../support",
     "@babel/runtime": "7.17.9",
     "@xmldom/xmldom": "0.8.2",
     "asyncbox": "2.9.2",
@@ -55,6 +53,9 @@
     "lodash": "4.17.21",
     "source-map-support": "0.5.21",
     "xpath": "0.0.32"
+  },
+  "peerDependencies": {
+    "appium": "file:../appium"
   },
   "engines": {
     "node": ">=12",


### PR DESCRIPTION
BREAKING CHANGE:

`@appium/fake-driver` now expects to be installed alongside `appium`.
