### PR TITLE
fix(appium): fix extension autoinstall postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,8 +97,7 @@
     "@appium/test-support": "file:packages/test-support",
     "@appium/types": "file:packages/types",
     "@appium/universal-xml-plugin": "file:packages/universal-xml-plugin",
-    "appium": "file:packages/appium",
-    "lru-cache": "7.9.0"
+    "appium": "file:packages/appium"
   },
   "devDependencies": {
     "@appium/fake-plugin": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "scripts": {
     "build": "run-s build:distfiles build:types",
     "build:distfiles": "lerna run --parallel --prefix --concurrency=8 build",
-    "build:loose": "run-s -c build:distfiles build:types || true",
     "build:types": "tsc -b",
     "clean": "run-s clean:artifacts clean:packages clean:monorepo",
     "clean:artifacts": "run-s clean:distfiles clean:types && npx rimraf \"packages/*/build\"",
@@ -39,7 +38,7 @@
     "dev:types": "tsc -b --watch",
     "doctor": "node ./packages/doctor",
     "generate-docs": "lerna run --scope=appium generate-docs",
-    "postinstall": "npm run build:loose",
+    "prepare": "npm run build:types || true",
     "install-fake-driver": "npm start -- driver install --source=local ./packages/fake-driver",
     "install-mjpeg-consumer": "npm install mjpeg-consumer --no-save",
     "lint": "eslint .",
@@ -77,8 +76,8 @@
   },
   "prettier": {
     "bracketSpacing": false,
-    "singleQuote": true,
-    "printWidth": 100
+    "printWidth": 100,
+    "singleQuote": true
   },
   "dependencies": {
     "@appium/base-driver": "file:packages/base-driver",
@@ -98,7 +97,8 @@
     "@appium/test-support": "file:packages/test-support",
     "@appium/types": "file:packages/types",
     "@appium/universal-xml-plugin": "file:packages/universal-xml-plugin",
-    "appium": "file:packages/appium"
+    "appium": "file:packages/appium",
+    "lru-cache": "7.9.0"
   },
   "devDependencies": {
     "@appium/fake-plugin": "1.3.1",

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -23,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
+  "types": "./build/lib/main.d.ts",
   "bin": {
     "appium": "index.js"
   },
@@ -42,16 +43,17 @@
   ],
   "scripts": {
     "build": "babel lib --root-mode=upward --out-dir=build/lib",
-    "dev": "npm run build -- --watch",
-    "fix": "npm run lint -- --fix",
     "build:docs": "node docs/scripts/build-docs.js",
     "build:docs:assets": "node docs/scripts/copy-assets.js",
+    "dev": "npm run build -- --watch",
     "dev:docs": "npm run build:docs:assets && npm run dev:docs:en",
     "dev:docs:en": "mkdocs serve -f ./docs/mkdocs-en.yml",
     "dev:docs:ja": "mkdocs serve -f ./docs/mkdocs-ja.yml",
-    "publish:docs": "APPIUM_DOCS_PUBLISH=1 npm run build:docs",
+    "fix": "npm run lint -- --fix",
     "postinstall": "node ./scripts/postinstall.js",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
+    "publish:docs": "APPIUM_DOCS_PUBLISH=1 npm run build:docs",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 30s --slow 15s \"./test/e2e/**/*.spec.js\"",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
@@ -95,6 +97,5 @@
     "access": "public",
     "tag": "next"
   },
-  "types": "./build/lib/main.d.ts",
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -38,7 +38,7 @@
     "support.*",
     "plugin.*",
     "test.*",
-    "scripts/postinstall.js",
+    "scripts/autoinstall-extensions.js",
     "types"
   ],
   "scripts": {
@@ -50,7 +50,7 @@
     "dev:docs:en": "mkdocs serve -f ./docs/mkdocs-en.yml",
     "dev:docs:ja": "mkdocs serve -f ./docs/mkdocs-ja.yml",
     "fix": "npm run lint -- --fix",
-    "postinstall": "node ./scripts/postinstall.js",
+    "postinstall": "node ./scripts/autoinstall-extensions.js",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "prepare": "npm run build",
     "publish:docs": "APPIUM_DOCS_PUBLISH=1 npm run build:docs",

--- a/packages/appium/scripts/autoinstall-extensions.js
+++ b/packages/appium/scripts/autoinstall-extensions.js
@@ -2,6 +2,22 @@
 
 /* eslint-disable no-console, promise/prefer-await-to-then */
 
+/**
+ * This script is intended to be run as a `postinstall` lifecycle script,
+ * and will automatically install extensions if requested by the user.
+ *
+ * If the current working directory is within a project which has `appium`
+ * as a dependency, this script does nothing; extensions must be managed
+ * via `npm` or another package manager.
+ *
+ * If `CI=1` is in the environment, this script will exit with a non-zero
+ * code upon failure (which will typically break a build).  Otherwise, it
+ * will always exit with code 0, even if errors occur.
+ *
+ * @example
+ * `npm install -g appium --drivers=uiautomator2,xcuitest --plugins=images`
+ */
+
 /** @type {import('../lib/cli/extension').runExtensionCommand} */
 let runExtensionCommand;
 /** @type {import('../lib/constants').DRIVER_TYPE} */

--- a/packages/appium/scripts/postinstall.js
+++ b/packages/appium/scripts/postinstall.js
@@ -1,51 +1,127 @@
 #!/usr/bin/env node
+
 /* eslint-disable no-console, promise/prefer-await-to-then */
 
-async function main() {
-  const driverEnv = process.env.npm_config_drivers;
-  const pluginEnv = process.env.npm_config_plugins;
+/** @type {import('../lib/cli/extension').runExtensionCommand} */
+let runExtensionCommand;
+/** @type {import('../lib/constants').DRIVER_TYPE} */
+let DRIVER_TYPE;
+/** @type {import('../lib/constants').PLUGIN_TYPE} */
+let PLUGIN_TYPE;
+/** @type {import('../lib/extension').loadExtensions} */
+let loadExtensions;
 
-  if (!driverEnv && !pluginEnv) {
-    console.log('Not auto-installing any drivers or plugins');
+const {env, util, logger} = require('@appium/support');
+
+const ora = require('ora');
+
+const log = (message) => {
+  console.error(`[Appium] ${message}`);
+};
+
+const spinner = ora({
+  text: 'Checking Appium installation...',
+  prefixText: '[Appium]',
+}).start();
+
+try {
+  ({runExtensionCommand} = require('../build/lib/cli/extension'));
+  ({DRIVER_TYPE, PLUGIN_TYPE} = require('../build/lib/constants'));
+  ({loadExtensions} = require('../build/lib/extension'));
+  spinner.succeed('Appium installation OK');
+  // suppress logs from Appium, which mess up the script output
+  logger.getLogger('Appium').level = 'error';
+} catch (e) {
+  spinner.fail(`Could not load required module(s); has Appium been built? (${e.message})`);
+  if (process.env.CI) {
+    console.error('Detected CI environment, exiting with code 1');
+    process.exitCode = 1;
+  } else {
+    process.exitCode = 0;
+  }
+  process.exit();
+}
+
+async function main() {
+  if (await env.hasAppiumDependency()) {
+    log(`Found local Appium installation; skipping automatic installation of extensions.`);
     return;
   }
 
-  let extension;
-  try {
-    extension = require('../build/lib/cli/extension');
-  } catch (e) {
-    throw new Error(
-      `Could not load extension CLI file; has the project been transpiled? ` + `(${e.message})`
+  const driverEnv = process.env.npm_config_drivers;
+  const pluginEnv = process.env.npm_config_plugins;
+
+  const spinner = ora({
+    text: 'Looking for extensions to automatically install...',
+    prefixText: '[Appium]',
+  }).start();
+
+  if (!driverEnv && !pluginEnv) {
+    spinner.succeed(
+      'No drivers or plugins to automatically install. If desired, provide arguments with comma-separated values "--drivers=<known_driver>[,known_driver...]" and/or "--plugins=<known_plugin>[,known_plugin...]" to the "npm install appium" command. The specified extensions will be installed automatically with Appium.  Note: to see the list of known extensions, run "appium <driver|plugin> list".'
     );
+    return;
   }
 
-  const {DEFAULT_APPIUM_HOME, DRIVER_TYPE, PLUGIN_TYPE} = require('./build/lib/extension-config');
-  const {runExtensionCommand} = extension;
-  const appiumHome = process.env.npm_config_appium_home || DEFAULT_APPIUM_HOME;
   const specs = [
     [DRIVER_TYPE, driverEnv],
     [PLUGIN_TYPE, pluginEnv],
   ];
 
+  spinner.start('Resolving Appium home directory...');
+  const appiumHome = await env.resolveAppiumHome();
+  spinner.succeed(`Found Appium home: ${appiumHome}`);
+
+  spinner.start(`Loading extension data...`);
+  const {driverConfig, pluginConfig} = await loadExtensions(appiumHome);
+  spinner.succeed(`Loaded extension data.`);
+
+  const installedStats = {[DRIVER_TYPE]: 0, [PLUGIN_TYPE]: 0};
   for (const [type, extEnv] of specs) {
     if (extEnv) {
-      for (const ext of extEnv.split(',')) {
+      for await (let ext of extEnv.split(',')) {
+        ext = ext.trim();
         try {
           await checkAndInstallExtension({
             runExtensionCommand,
             appiumHome,
             type,
             ext,
+            driverConfig,
+            pluginConfig,
+            spinner,
           });
+          installedStats[type]++;
         } catch (e) {
-          console.log(`There was an error checking and installing ${type} ${ext}: ${e.message}`);
+          spinner.fail(`Could not install ${type} "${ext}": ${e.message}`);
+          if (process.env.CI) {
+            process.exitCode = 1;
+          }
+          return;
         }
       }
     }
   }
+  spinner.succeed(
+    `Done. ${installedStats[DRIVER_TYPE]} ${util.pluralize(
+      'driver',
+      installedStats[DRIVER_TYPE]
+    )} and ${installedStats[PLUGIN_TYPE]} ${util.pluralize(
+      'plugin',
+      installedStats[PLUGIN_TYPE]
+    )} are installed.`
+  );
 }
 
-async function checkAndInstallExtension({runExtensionCommand, appiumHome, type, ext}) {
+async function checkAndInstallExtension({
+  runExtensionCommand,
+  appiumHome,
+  type,
+  ext,
+  driverConfig,
+  pluginConfig,
+  spinner,
+}) {
   const extList = await runExtensionCommand(
     {
       appiumHome,
@@ -53,31 +129,33 @@ async function checkAndInstallExtension({runExtensionCommand, appiumHome, type, 
       showInstalled: true,
       suppressOutput: true,
     },
-    type
+    type === DRIVER_TYPE ? driverConfig : pluginConfig
   );
   if (extList[ext]) {
-    console.log(`The ${type} ${ext} was already installed, skipping...`);
+    spinner.info(`The ${type} "${ext}" is already installed.`);
     return;
   }
-  console.log(`Installing the ${type} ${ext}...`);
+  spinner.start(`Installing ${type} "${ext}"...`);
   await runExtensionCommand(
     {
       appiumHome,
       [`${type}Command`]: 'install',
-      [type]: ext,
       suppressOutput: true,
+      [type]: ext,
     },
-    type
+    type === DRIVER_TYPE ? driverConfig : pluginConfig
   );
+  spinner.succeed(`Installed ${type} "${ext}".`);
 }
 
 if (require.main === module) {
-  main()
-    .then(() => {
-      process.exit(0);
-    })
-    .catch((e) => {
-      console.error(e);
-      process.exit(1);
-    });
+  main().catch((e) => {
+    log(e);
+    if (process.env.CI) {
+      log('Detected CI environment, exiting with code 1');
+      process.exitCode = 1;
+    }
+  });
 }
+
+module.exports = main;

--- a/packages/appium/test/e2e/cli.e2e.spec.js
+++ b/packages/appium/test/e2e/cli.e2e.spec.js
@@ -37,7 +37,7 @@ describe('CLI behavior', function () {
   const testDriverPath = path.dirname(resolveFixture('test-driver/package.json'));
 
   beforeEach(function () {
-    this.timeout(30000);
+    this.timeout(40000);
   });
 
   describe('when appium is a dependency of the project in the current working directory', function () {

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -43,6 +43,7 @@
     "dev": "run-p \"build:distfiles -- --watch\" \"build:test -- --watch\"",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""

--- a/packages/base-plugin/package.json
+++ b/packages/base-plugin/package.json
@@ -27,6 +27,7 @@
     "dev": "run-p \"build:distfiles -- --watch\" \"build:test -- --watch\"",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -41,6 +41,7 @@
     "dev": "npm run build -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -17,6 +17,7 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
+  "types": "./build/lib/index.d.ts",
   "directories": {
     "lib": "lib"
   },
@@ -33,6 +34,7 @@
     "dev": "npm run build:sources -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "echo \"No e2e tests for this package\"",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
@@ -53,6 +55,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "types": "./build/lib/index.d.ts",
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -2,31 +2,37 @@
   "name": "@appium/execute-driver-plugin",
   "version": "1.0.5",
   "description": "Plugin for batching and executing driver commands with Appiums",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/appium/appium.git",
-    "directory": "packages/execute-driver-plugin"
-  },
-  "appium": {
-    "pluginName": "execute-driver",
-    "mainClass": "ExecuteDriverPlugin"
-  },
   "keywords": [
     "appium",
     "automation",
     "webdriver"
   ],
-  "author": "Appium <maintainers@appium.io>",
-  "license": "Apache-2.0",
+  "homepage": "https://github.com/appium/appium#readme",
   "bugs": {
     "url": "https://github.com/appium/appium/issues"
   },
-  "homepage": "https://github.com/appium/appium#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/execute-driver-plugin"
+  },
+  "license": "Apache-2.0",
+  "author": "Appium <maintainers@appium.io>",
   "files": [
     "build",
     "lib",
     "index.js"
   ],
+  "scripts": {
+    "build": "babel lib --root-mode=upward --out-dir=build/lib",
+    "dev": "npm run build -- --watch",
+    "fix": "npm run lint -- --fix",
+    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
+    "test": "npm run test:unit",
+    "test:e2e": "mocha -t 160s --slow 20s \"./test/e2e/**/*.spec.js\"",
+    "test:unit": "mocha \"./test/unit/**/*.spec.js\""
+  },
   "dependencies": {
     "@appium/base-plugin": "file:../base-plugin",
     "@appium/support": "file:../support",
@@ -35,17 +41,12 @@
     "vm2": "3.9.9",
     "webdriverio": "7.19.7"
   },
-  "scripts": {
-    "build": "babel lib --root-mode=upward --out-dir=build/lib",
-    "dev": "npm run build -- --watch",
-    "fix": "npm run lint -- --fix",
-    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
-    "test": "npm run test:unit",
-    "test:unit": "mocha \"./test/unit/**/*.spec.js\"",
-    "test:e2e": "mocha -t 160s --slow 20s \"./test/e2e/**/*.spec.js\""
-  },
   "publishConfig": {
     "access": "public"
+  },
+  "appium": {
+    "pluginName": "execute-driver",
+    "mainClass": "ExecuteDriverPlugin"
   },
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -40,6 +40,7 @@
     "dev": "npm run build -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -1,19 +1,39 @@
 {
   "name": "@appium/fake-plugin",
-  "description": "A fake Appium 2.0 plugin",
-  "tags": [
-    "appium"
-  ],
   "version": "1.3.4",
-  "author": "Appium <maintainers@appium.io>",
-  "license": "Apache-2.0",
+  "description": "A fake Appium 2.0 plugin",
+  "bugs": {
+    "url": "https://github.com/appium/appium/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/appium/appium.git",
     "directory": "packages/fake-plugin"
   },
-  "bugs": {
-    "url": "https://github.com/appium/appium/issues"
+  "license": "Apache-2.0",
+  "author": "Appium <maintainers@appium.io>",
+  "main": "./build/index.js",
+  "directories": {
+    "lib": "./lib"
+  },
+  "files": [
+    "lib",
+    "build"
+  ],
+  "scripts": {
+    "build": "babel lib --root-mode=upward --out-dir=build/lib",
+    "dev": "npm run build -- --watch",
+    "fix": "npm run lint -- --fix",
+    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
+    "test": "npm run test:unit",
+    "test:unit": "mocha \"./test/unit/**/*.spec.js\""
+  },
+  "dependencies": {
+    "@appium/base-plugin": "file:../base-plugin",
+    "@appium/support": "file:../support",
+    "bluebird": "3.7.2",
+    "lodash": "4.17.21"
   },
   "engines": {
     "node": ">=12",
@@ -27,27 +47,8 @@
       "fake-success": "./build/lib/scripts/fake-success.js"
     }
   },
-  "main": "./build/index.js",
-  "directories": {
-    "lib": "./lib"
-  },
-  "files": [
-    "lib",
-    "build"
-  ],
-  "dependencies": {
-    "@appium/base-plugin": "file:../base-plugin",
-    "@appium/support": "file:../support",
-    "bluebird": "3.7.2",
-    "lodash": "4.17.21"
-  },
-  "scripts": {
-    "build": "babel lib --root-mode=upward --out-dir=build/lib",
-    "dev": "npm run build -- --watch",
-    "fix": "npm run lint -- --fix",
-    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
-    "test": "npm run test:unit",
-    "test:unit": "mocha \"./test/unit/**/*.spec.js\""
-  },
-  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
+  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
+  "tags": [
+    "appium"
+  ]
 }

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "dev": "gulp dev --no-notif",
     "build": "gulp transpile",
+    "prepare": "npm run build",
     "test": "gulp unit-test:run",
     "test:e2e": "gulp e2e-test:run"
   },

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -30,6 +30,7 @@
     "dev": "npm run build -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 40s --slow 20s \"./test/e2e/**/*.spec.js\"",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -23,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
+  "types": "./build/lib/index.d.ts",
   "directories": {
     "lib": "lib"
   },
@@ -36,6 +37,7 @@
     "dev": "npm run build -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
@@ -48,7 +50,6 @@
     "opencv-bindings": "4.5.5",
     "source-map-support": "0.5.21"
   },
-  "types": "./build/lib/index.d.ts",
   "engines": {
     "node": ">=12",
     "npm": ">=6"

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -1,19 +1,37 @@
 {
   "name": "@appium/relaxed-caps-plugin",
-  "description": "An Appium 2.0 plugin that loosens requirements for vendor prefixes on caps",
-  "tags": [
-    "appium"
-  ],
   "version": "1.0.0-beta.6",
-  "author": "Appium <maintainers@appium.io>",
-  "license": "Apache-2.0",
+  "description": "An Appium 2.0 plugin that loosens requirements for vendor prefixes on caps",
+  "bugs": {
+    "url": "https://github.com/appium/appium/issues"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/appium/appium.git",
     "directory": "packages/relaxed-caps-plugin"
   },
-  "bugs": {
-    "url": "https://github.com/appium/appium/issues"
+  "license": "Apache-2.0",
+  "author": "Appium <maintainers@appium.io>",
+  "directories": {
+    "lib": "./lib"
+  },
+  "files": [
+    "index.js",
+    "lib",
+    "build"
+  ],
+  "scripts": {
+    "build": "babel lib --root-mode=upward --out-dir=build/lib",
+    "dev": "npm run build -- --watch",
+    "fix": "npm run lint -- --fix",
+    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
+    "test": "npm run test:unit",
+    "test:unit": "mocha \"./test/unit/**/*.spec.js\""
+  },
+  "dependencies": {
+    "@appium/base-plugin": "file:../base-plugin",
+    "lodash": "4.17.21"
   },
   "engines": {
     "node": ">=12",
@@ -23,25 +41,8 @@
     "pluginName": "relaxed-caps",
     "mainClass": "RelaxedCapsPlugin"
   },
-  "directories": {
-    "lib": "./lib"
-  },
-  "files": [
-    "index.js",
-    "lib",
-    "build"
-  ],
-  "dependencies": {
-    "@appium/base-plugin": "file:../base-plugin",
-    "lodash": "4.17.21"
-  },
-  "scripts": {
-    "build": "babel lib --root-mode=upward --out-dir=build/lib",
-    "dev": "npm run build -- --watch",
-    "fix": "npm run lint -- --fix",
-    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
-    "test": "npm run test:unit",
-    "test:unit": "mocha \"./test/unit/**/*.spec.js\""
-  },
-  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
+  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
+  "tags": [
+    "appium"
+  ]
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -35,7 +35,8 @@
     "build:schema-json": "node ./scripts/generate-schema-json.js",
     "dev": "npm run build:distfiles -- --watch",
     "fix": "npm run lint -- --fix",
-    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore ."
+    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build"
   },
   "engines": {
     "node": ">=12",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -23,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
+  "types": "./build/lib/index.d.ts",
   "directories": {
     "lib": "lib"
   },
@@ -36,6 +37,7 @@
     "dev": "npm run build -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
@@ -84,6 +86,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "types": "./build/lib/index.d.ts",
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -41,6 +41,7 @@
     "dev": "npm run build -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
+  "types": "./build/index.d.ts",
   "files": [
     "build",
     "lib"
@@ -26,18 +27,18 @@
     "build": "node ./scripts/generate-schema-types.js",
     "dev": "npm run build -- --watch",
     "fix": "npm run lint -- --fix",
-    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore ."
+    "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build"
+  },
+  "dependencies": {
+    "@appium/schema": "file:../schema"
   },
   "engines": {
     "node": ">=12",
     "npm": ">=6"
   },
-  "types": "./build/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
-  "dependencies": {
-    "@appium/schema": "file:../schema"
-  }
+  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "author": "Appium <maintainers@appium.io>",
+  "types": "./build/lib/plugin.d.ts",
   "files": [
     "index.js",
     "build",
@@ -28,6 +29,7 @@
     "dev": "npm run build -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
+    "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
@@ -42,6 +44,5 @@
     "pluginName": "universal-xml",
     "mainClass": "UniversalXMLPlugin"
   },
-  "types": "./build/lib/plugin.d.ts",
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
 }


### PR DESCRIPTION
Resolves #16924

* * *

- This is a little more involved than I would have liked.  Maybe it'd make more sense to just spawn e.g., `appium driver install` child processes?
- Since this script exits with a non-zero code, it can prevent installation of Appium altogether, which seems undesirable.