### PR TITLE
chore(appium,support): cache result of check for local appium

### DIFF
--- a/packages/appium/lib/extension/index.js
+++ b/packages/appium/lib/extension/index.js
@@ -15,10 +15,11 @@ import B from 'bluebird';
  *
  * If `appiumHome` is needed, use `resolveAppiumHome` from the `env` module in `@appium/support`.
  * @param {string} appiumHome
+ * @param {boolean} [hasAppiumDependency]
  * @returns {Promise<ExtensionConfigs>}
  */
-export async function loadExtensions(appiumHome) {
-  const manifest = Manifest.getInstance(appiumHome);
+export async function loadExtensions(appiumHome, hasAppiumDependency) {
+  const manifest = Manifest.getInstance(appiumHome, hasAppiumDependency);
   await manifest.read();
   const driverConfig = DriverConfig.getInstance(manifest) ?? DriverConfig.create(manifest);
   const pluginConfig = PluginConfig.getInstance(manifest) ?? PluginConfig.create(manifest);

--- a/packages/appium/lib/extension/manifest.js
+++ b/packages/appium/lib/extension/manifest.js
@@ -152,15 +152,25 @@ export class Manifest {
   _reading;
 
   /**
+   * If this is `true`, then `<APPIUM_HOME>/package.json` is _not_ managed by Appium.
+   *
+   * This is set upon read and is cached to avoid extra overhead.
+   * @type {boolean|undefined}
+   */
+  hasAppiumDependency;
+
+  /**
    * Sets internal data to a fresh clone of {@link INITIAL_MANIFEST_DATA}
    *
    * Use {@link Manifest.getInstance} instead.
    * @param {string} appiumHome
+   * @param {boolean} [hasAppiumDependency]
    * @private
    */
-  constructor(appiumHome) {
+  constructor(appiumHome, hasAppiumDependency) {
     this._appiumHome = appiumHome;
     this._data = _.cloneDeep(INITIAL_MANIFEST_DATA);
+    this.hasAppiumDependency = hasAppiumDependency;
   }
 
   /**
@@ -168,10 +178,11 @@ export class Manifest {
    *
    * Maintains one instance per value of `appiumHome`.
    * @param {string} appiumHome - Path to `APPIUM_HOME`
+   * @param {boolean} [hasAppiumDependency]
    * @returns {Manifest}
    */
-  static getInstance = _.memoize(function _getInstance(appiumHome) {
-    return new Manifest(appiumHome);
+  static getInstance = _.memoize(function _getInstance(appiumHome, hasAppiumDependency) {
+    return new Manifest(appiumHome, hasAppiumDependency);
   });
 
   /**
@@ -356,10 +367,7 @@ export class Manifest {
 
       this._data = data;
       let installedExtensionsChanged = false;
-      if (
-        (await env.hasAppiumDependency(this.appiumHome)) &&
-        (await packageDidChange(this.appiumHome))
-      ) {
+      if (this.hasAppiumDependency && (await packageDidChange(this.appiumHome))) {
         installedExtensionsChanged = await this.syncWithInstalledExtensions();
       }
 

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -4,7 +4,7 @@ import {init as logsinkInit} from './logsink'; // this import needs to come firs
 import logger from './logger'; // logger needs to remain second
 // @ts-ignore
 import {routeConfiguringFunction as makeRouter, server as baseServer} from '@appium/base-driver';
-import {logger as logFactory, util, env} from '@appium/support';
+import {logger as logFactory, util, env, fs} from '@appium/support';
 import {asyncify} from 'asyncbox';
 import _ from 'lodash';
 import {AppiumDriver} from './appium';
@@ -26,8 +26,6 @@ import {DRIVER_TYPE, PLUGIN_TYPE, SERVER_SUBCOMMAND} from './constants';
 import registerNode from './grid-register';
 import {getDefaultsForSchema, validate} from './schema/schema';
 import {inspect} from './utils';
-
-const {resolveAppiumHome} = env;
 
 /**
  *
@@ -168,9 +166,10 @@ function areServerCommandArgs(args) {
  * const schema = getSchema(); // entire config schema including plugins and drivers
  */
 async function init(args) {
-  const appiumHome = args?.appiumHome ?? (await resolveAppiumHome());
+  const appiumHome = args?.appiumHome ?? (await env.resolveAppiumHome());
+  const hasAppiumDependency = await env.hasAppiumDependency(fs.findRoot(process.cwd()));
 
-  const {driverConfig, pluginConfig} = await loadExtensions(appiumHome);
+  const {driverConfig, pluginConfig} = await loadExtensions(appiumHome, hasAppiumDependency);
 
   const parser = getParser();
   let throwInsteadOfExit = false;
@@ -381,7 +380,9 @@ if (require.main === module) {
 // everything below here is intended to be a public API.
 export {readConfigFile} from './config-file';
 export {finalizeSchema, getSchema, validate} from './schema/schema';
-export {main, init, resolveAppiumHome};
+export {main, init};
+
+export const {resolveAppiumHome} = env;
 
 /**
  * @typedef {import('@appium/types').DriverType} DriverType


### PR DESCRIPTION
This is just a perf improvement.  Anecdotally, this shaves 1-to-5 seconds off of an `appium driver` or `appium plugin` command, depending on system resources (lower end being CI VM's).

While poking around looking for a solution to #16916, I noticed that `npm.list()` in `@appium/support` was getting called twice.  Each call is not fast; an `npm` child process must be forked.  It ended up being two separate calls to `hasAppiumDependency()`.  First, we need to resolve the Appium home dir, so we look for `appium` in `npm ls` output in the directory containing the closest `package.json`.  Second, Appium's `Manifest` class needs to know this information, so it also calls `hasAppiumDependency()` which results in another `npm ls`.  However, that is called with the value of Appium home--not necessarily the same directory as the first call.

It could be argued that the call in `Manifest` is actually a bug, since it shouldn't look at Appium home--it should look at the dir of the closest `package.json`. However, if the result of `hasAppiumDependency(appiumHome)` is `true` then this _is_ the same directory.  But semantically, it's incorrect.  Anyway, it was weird.  To avoid all this nonsense, I decided to just determine the answer earlier so we only need to do it _once_, and hand the result to the `Manifest` factory when loading extensions.  If it's called again for whatever reason, the result will now be memoized (as will the call to find the closest `package.json`).
