### PR TITLE
test(images-plugin): avoid call to deprecated reset() method

### DIFF
--- a/packages/images-plugin/test/unit/image-element.spec.js
+++ b/packages/images-plugin/test/unit/image-element.spec.js
@@ -179,7 +179,7 @@ describe('ImageElement', function () {
     });
 
     after(function () {
-      f.imgElCache.reset();
+      f.imgElCache.clear();
     });
 
     it('should reject executions for unsupported commands', async function () {


### PR DESCRIPTION
Apparently the `reset()` method in a `LRUCache` object is now deprecated; these tests were calling it.  The deprecation message read:

```
(node:3225) [LRU_CACHE_METHOD_reset] DeprecationWarning: The reset method is deprecated. Please use cache.clear() instead.
```

...so I changed the call to `.clear()`.