### PR TITLE
fix(types,base-plugin): fix static prop types for plugins

### DIFF
--- a/config/tsconfig.plugin.json
+++ b/config/tsconfig.plugin.json
@@ -6,5 +6,5 @@
     "types": ["webdriverio/async"]
   },
   "extends": "./tsconfig.base.json",
-  "references": [{"path": "../packages/appium"}]
+  "references": [{"path": "../packages/appium"}, {"path": "../packages/base-plugin"}, {"path": "../packages/types"}]
 }

--- a/packages/base-plugin/lib/plugin.js
+++ b/packages/base-plugin/lib/plugin.js
@@ -4,7 +4,15 @@ import {logger} from '@appium/support';
  * @implements {Plugin}
  */
 class BasePlugin {
-  /** @type {import('@appium/types').PluginStatic['newMethodMap']} */
+  /**
+   * Subclasses should use type `import('@appium/types').MethodMap<SubclassName>`.
+   *
+   * This will verify that the commands in the `newMethodMap` property are
+   * valid.  It is impossible to use a generic type param here; the type of this should really
+   * be something like `MethodMap<T extends BasePlugin>` but that isn't a thing TS does.
+   *
+   * @type {import('@appium/types').MethodMap<any>}
+   */
   static newMethodMap = {};
 
   /** @type {Plugin['cliArgs']} */

--- a/packages/types/lib/plugin.ts
+++ b/packages/types/lib/plugin.ts
@@ -4,7 +4,7 @@ import {Driver, ExternalDriver} from './driver';
 /**
  * The interface describing the constructor and static properties of a Plugin.
  */
-export interface PluginStatic {
+export interface PluginStatic<T extends Plugin = Plugin> {
   /**
    * Allows a plugin to modify the Appium server instance.
    */
@@ -20,7 +20,7 @@ export interface PluginStatic {
    *   }
    * }
    */
-  newMethodMap?: MethodMap<Plugin>;
+  newMethodMap?: MethodMap<T>;
 }
 
 /**


### PR DESCRIPTION
This change modifies the type of `BasePlugin.newMethodMap`, adds a
parameter to the `MethodMap` type, and updates the base plugin TS
config for better incremental builds.