### PR TITLE
chore(appium,base-plugin,types): plugin name is derived from manifest

### DIFF
--- a/packages/appium/lib/extension/index.js
+++ b/packages/appium/lib/extension/index.js
@@ -35,31 +35,31 @@ export async function loadExtensions(appiumHome) {
  *
  * @param {import('./plugin-config').PluginConfig} pluginConfig - a plugin extension config
  * @param {string[]} usePlugins
- * @returns {import('@appium/types').PluginClass[]}
+ * @returns {PluginNameMap} Mapping of PluginClass to name
  */
 export function getActivePlugins(pluginConfig, usePlugins = []) {
-  return _.compact(
-    Object.keys(pluginConfig.installedExtensions)
-      .filter(
-        (pluginName) =>
-          _.includes(usePlugins, pluginName) ||
-          (usePlugins.length === 1 && usePlugins[0] === USE_ALL_PLUGINS)
-      )
-      .map((pluginName) => {
-        try {
-          log.info(`Attempting to load plugin ${pluginName}...`);
-          const PluginClass = pluginConfig.require(pluginName);
-
-          PluginClass.pluginName = pluginName; // store the plugin name on the class so it can be used later
-          return PluginClass;
-        } catch (err) {
-          log.error(
-            `Could not load plugin '${pluginName}', so it will not be available. Error ` +
-              `in loading the plugin was: ${err.message}`
-          );
-          log.debug(err.stack);
-        }
-      })
+  return new Map(
+    _.compact(
+      Object.keys(pluginConfig.installedExtensions)
+        .filter(
+          (pluginName) =>
+            _.includes(usePlugins, pluginName) ||
+            (usePlugins.length === 1 && usePlugins[0] === USE_ALL_PLUGINS)
+        )
+        .map((pluginName) => {
+          try {
+            log.info(`Attempting to load plugin ${pluginName}...`);
+            const PluginClass = pluginConfig.require(pluginName);
+            return [PluginClass, pluginName];
+          } catch (err) {
+            log.error(
+              `Could not load plugin '${pluginName}', so it will not be available. Error ` +
+                `in loading the plugin was: ${err.message}`
+            );
+            log.debug(err.stack);
+          }
+        })
+    )
   );
 }
 
@@ -70,25 +70,44 @@ export function getActivePlugins(pluginConfig, usePlugins = []) {
  *
  * @param {import('./driver-config').DriverConfig} driverConfig - a driver extension config
  * @param {string[]} [useDrivers] - optional list of drivers to load
+ * @returns {DriverNameMap}
  */
 export function getActiveDrivers(driverConfig, useDrivers = []) {
-  return _.compact(
-    Object.keys(driverConfig.installedExtensions)
-      .filter((driverName) => _.includes(useDrivers, driverName) || useDrivers.length === 0)
-      .map((driverName) => {
-        try {
-          log.info(`Attempting to load driver ${driverName}...`);
-          return driverConfig.require(driverName);
-        } catch (err) {
-          log.error(
-            `Could not load driver '${driverName}', so it will not be available. Error ` +
-              `in loading the driver was: ${err.message}`
-          );
-          log.debug(err.stack);
-        }
-      })
+  return new Map(
+    _.compact(
+      Object.keys(driverConfig.installedExtensions)
+        .filter((driverName) => _.includes(useDrivers, driverName) || useDrivers.length === 0)
+        .map((driverName) => {
+          try {
+            log.info(`Attempting to load driver ${driverName}...`);
+            const DriverClass = driverConfig.require(driverName);
+            return [DriverClass, driverName];
+          } catch (err) {
+            log.error(
+              `Could not load driver '${driverName}', so it will not be available. Error ` +
+                `in loading the driver was: ${err.message}`
+            );
+            log.debug(err.stack);
+          }
+        })
+    )
   );
 }
+
+/**
+ * A mapping of {@linkcode PluginClass} classes to their names.
+ * @typedef {Map<PluginClass,string>} PluginNameMap
+ */
+
+/**
+ * A mapping of {@linkcode DriverClass} classes to their names.
+ * @typedef {Map<DriverClass,string>} DriverNameMap
+ */
+
+/**
+ * @typedef {import('@appium/types').PluginClass} PluginClass
+ * @typedef {import('@appium/types').DriverClass} DriverClass
+ */
 
 /**
  * @typedef ExtensionConfigs

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -118,22 +118,22 @@ function logServerPort(address, port) {
 
 /**
  * Gets a list of `updateServer` functions from all extensions
- * @param {DriverClass[]} driverClasses
- * @param {PluginClass[]} pluginClasses
- * @returns {import('@appium/base-driver/lib/basedriver/driver').UpdateServerCallback[]}
+ * @param {DriverNameMap} driverClasses
+ * @param {PluginNameMap} pluginClasses
+ * @returns {import('@appium/types').UpdateServerCallback[]}
  */
 function getServerUpdaters(driverClasses, pluginClasses) {
-  return _.compact(_.map([...driverClasses, ...pluginClasses], 'updateServer'));
+  return _.compact(_.map([...driverClasses.keys(), ...pluginClasses.keys()], 'updateServer'));
 }
 
 /**
  * Makes a big `MethodMap` from all the little `MethodMap`s in the extensions
- * @param {DriverClass[]} driverClasses
- * @param {PluginClass[]} pluginClasses
+ * @param {DriverNameMap} driverClasses
+ * @param {PluginNameMap} pluginClasses
  * @returns {import('@appium/types').MethodMap}
  */
 function getExtraMethodMap(driverClasses, pluginClasses) {
-  return [...driverClasses, ...pluginClasses].reduce(
+  return [...driverClasses.keys(), ...pluginClasses.keys()].reduce(
     (map, klass) => ({
       ...map,
       ...(klass.newMethodMap ?? {}),
@@ -366,7 +366,7 @@ async function main(args) {
 
   logServerPort(parsedArgs.address, parsedArgs.port);
   driverConfig.print();
-  pluginConfig.print(pluginClasses.map((p) => p.pluginName));
+  pluginConfig.print([...pluginClasses.values()]);
 
   return server;
 }
@@ -389,6 +389,8 @@ export {main, init, resolveAppiumHome};
  * @typedef {import('@appium/types').DriverClass} DriverClass
  * @typedef {import('@appium/types').PluginClass} PluginClass
  * @typedef {import('appium/types').WithServerSubcommand} WithServerSubcommand
+ * @typedef {import('./extension').DriverNameMap} DriverNameMap
+ * @typedef {import('./extension').PluginNameMap} PluginNameMap
  */
 
 /**

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -55,7 +55,7 @@
     "prepare": "npm run build",
     "publish:docs": "APPIUM_DOCS_PUBLISH=1 npm run build:docs",
     "test": "npm run test:unit",
-    "test:e2e": "mocha --timeout 30s --slow 15s \"./test/e2e/**/*.spec.js\"",
+    "test:e2e": "mocha --timeout 40s --slow 20s \"./test/e2e/**/*.spec.js\"",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/appium/test/e2e/plugin.e2e.spec.js
+++ b/packages/appium/test/e2e/plugin.e2e.spec.js
@@ -94,7 +94,7 @@ describe('FakePlugin', function () {
   });
 
   describe('without plugin registered', function () {
-    /** @type {import('http').Server} */
+    /** @type {AppiumServer} */
     let server;
 
     before(async function () {
@@ -104,10 +104,7 @@ describe('FakePlugin', function () {
         address: TEST_HOST,
         usePlugins: ['other1', 'other2'],
       };
-      server = /** @type {typeof server} */ (
-        // @ts-expect-error
-        await appiumServer(args)
-      );
+      server = await appiumServer(args);
     });
 
     after(async function () {
@@ -151,7 +148,7 @@ describe('FakePlugin', function () {
 
   for (const registrationType of ['explicit', 'all']) {
     describe(`with plugin registered via type ${registrationType}`, function () {
-      /** @type {import('http').Server} */
+      /** @type {AppiumServer} */
       let server;
       before(async function () {
         // then start server if we need to
@@ -163,10 +160,7 @@ describe('FakePlugin', function () {
           usePlugins,
           useDrivers: ['fake'],
         };
-        server = /** @type {typeof server} */ (
-          // @ts-expect-error
-          await appiumServer(args)
-        );
+        server = await appiumServer(args);
       });
       after(async function () {
         if (server) {
@@ -264,15 +258,12 @@ describe('FakePlugin', function () {
     });
   }
   describe('cli args handling for plugin args', function () {
-    /** @type {import('http').Server} */
+    /** @type {AppiumServer} */
     let server;
     before(async function () {
       // then start server if we need to
       const args = {...baseArgs, plugin: FAKE_PLUGIN_ARGS};
-      server = /** @type {typeof server} */ (
-        // @ts-expect-error
-        await appiumServer(args)
-      );
+      server = await appiumServer(args);
     });
     after(async function () {
       if (server) {
@@ -292,11 +283,10 @@ describe('FakePlugin', function () {
     });
   });
   describe('cli args handling for empty plugin args', function () {
-    /** @type {import('http').Server} */
+    /** @type {AppiumServer} */
     let server;
     before(async function () {
       // then start server if we need to
-      // @ts-expect-error
       server = await appiumServer(baseArgs);
     });
     after(async function () {
@@ -305,15 +295,21 @@ describe('FakePlugin', function () {
       }
     });
 
-    it('should not receive user cli args for plugin if none were passed in', async function () {
-      const driver = await wdio(wdOpts);
-      const {sessionId} = driver;
-      try {
-        const {data} = await axios.get(`${testServerBaseSessionUrl}/${sessionId}/fakepluginargs`);
-        should.not.exist(data.value);
-      } finally {
-        await driver.deleteSession();
-      }
+    describe('when no cli args provided by user', function () {
+      it('should receive an empty `cliArgs` object', async function () {
+        const driver = await wdio(wdOpts);
+        const {sessionId} = driver;
+        try {
+          const {data} = await axios.get(`${testServerBaseSessionUrl}/${sessionId}/fakepluginargs`);
+          data.value.should.eql({});
+        } finally {
+          await driver.deleteSession();
+        }
+      });
     });
   });
 });
+
+/**
+ * @typedef {import('@appium/types').AppiumServer} AppiumServer
+ */

--- a/packages/base-plugin/lib/plugin.js
+++ b/packages/base-plugin/lib/plugin.js
@@ -15,15 +15,14 @@ class BasePlugin {
    */
   static newMethodMap = {};
 
-  /** @type {Plugin['cliArgs']} */
-  cliArgs;
-
   /**
-   * @param {string} pluginName
+   * @param {string} name
+   * @param {Record<string,any>} [cliArgs]
    */
-  constructor(pluginName) {
-    this.name = pluginName;
-    this.logger = logger.getLogger(`Plugin [${pluginName}]`);
+  constructor(name, cliArgs) {
+    this.name = name;
+    this.cliArgs = cliArgs;
+    this.logger = logger.getLogger(`Plugin [${name}]`);
   }
 }
 

--- a/packages/base-plugin/lib/plugin.js
+++ b/packages/base-plugin/lib/plugin.js
@@ -17,9 +17,9 @@ class BasePlugin {
 
   /**
    * @param {string} name
-   * @param {Record<string,any>} [cliArgs]
+   * @param {Record<string,unknown>} [cliArgs]
    */
-  constructor(name, cliArgs) {
+  constructor(name, cliArgs = {}) {
     this.name = name;
     this.cliArgs = cliArgs;
     this.logger = logger.getLogger(`Plugin [${name}]`);

--- a/packages/fake-plugin/lib/plugin.js
+++ b/packages/fake-plugin/lib/plugin.js
@@ -4,10 +4,6 @@ import BasePlugin from '@appium/base-plugin';
 import B from 'bluebird';
 
 export default class FakePlugin extends BasePlugin {
-  constructor(pluginName, opts = {}) {
-    super(pluginName, opts);
-  }
-
   async getFakePluginArgs() {
     await B.delay(1);
     return this.cliArgs;

--- a/packages/types/lib/plugin.ts
+++ b/packages/types/lib/plugin.ts
@@ -40,7 +40,7 @@ export interface Plugin {
   /**
    * CLI args for this plugin (if any are accepted and provided).
    */
-  cliArgs?: Record<string, any>;
+  cliArgs: Record<string, any>;
   /**
    * Listener for unexpected server shutdown, which allows a plugin to do cleanup or take custom actions.
    */
@@ -89,8 +89,4 @@ export type PluginCommand<TArgs = any> = (
  *
  * The third parameter is the possible constructor signatures for the plugin class.
  */
-export type PluginClass = Class<
-  Plugin,
-  PluginStatic,
-  [string] | [string, Record<string, any> | undefined]
->;
+export type PluginClass = Class<Plugin, PluginStatic, [string, Record<string, unknown>]>;

--- a/packages/types/lib/plugin.ts
+++ b/packages/types/lib/plugin.ts
@@ -30,7 +30,7 @@ export interface PluginStatic<T extends Plugin = Plugin> {
  */
 export interface Plugin {
   /**
-   * Same value as {@linkcode PluginClass['pluginName'] `Plugin.pluginName`}.
+   * Name of the plugin.  Derived from the metadata.
    */
   name: string;
   /**
@@ -86,5 +86,11 @@ export type PluginCommand<TArgs = any> = (
 
 /**
  * Mainly for internal use.
+ *
+ * The third parameter is the possible constructor signatures for the plugin class.
  */
-export type PluginClass = Class<Plugin, PluginStatic & {pluginName: string}, [string]>;
+export type PluginClass = Class<
+  Plugin,
+  PluginStatic,
+  [string] | [string, Record<string, any> | undefined]
+>;


### PR DESCRIPTION
This PR changes the shape of plugin classes as well as how CLI args get assigned.

- The `pluginName` static property has been removed.  `name` is now assigned via the `BasePlugin` constructor, and is derived from the plugin name in the manifest.  This means that an implementor only needs to provide a `pluginName` in the manifest, and the data is not duplicated.  The value in this map (the plugin name) is used to instantiate the plugin, instead of passing static `pluginName` property into the constructor.
- CLI args are now passed in through the constructor instead of assigned to the plugin instance after the fact.

Implementation details:

`getActivePlugins()` and `getActiveDrivers()` now return a `Map` of an extension _class_ to an extension name.  The key is _not_ an instance, and is effectively a singleton, so we are not at risk of a memory leak.

This change does not otherwise affect drivers.

* * *

AFAICT this is not a breaking change.