### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@
 name: Appium Build
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
+permissions:
+  contents: read
+
 jobs:
   fossa-check:
     name: Run FOSSA Analysis


### PR DESCRIPTION
Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen [42328488+neilnaveen@users.noreply.github.com](mailto:42328488+neilnaveen@users.noreply.github.com)

based on this PR https://github.com/appium/appium/pull/16842