### PR TITLE
refactor image-handling code

### DIFF
--- a/packages/base-driver/lib/protocol/errors.js
+++ b/packages/base-driver/lib/protocol/errors.js
@@ -8,8 +8,17 @@ const w3cLog = logger.getLogger('W3C');
 
 const W3C_UNKNOWN_ERROR = 'unknown error';
 
-// base error class for all of our errors
+/**
+ * Base error class for all of our errors
+ */
 export class ProtocolError extends ES6Error {
+  /**
+   *
+   * @param {string} [msg]
+   * @param {*} [jsonwpCode]
+   * @param {*} [w3cStatus]
+   * @param {*} [error]
+   */
   constructor(msg, jsonwpCode, w3cStatus, error) {
     super(msg);
     this.jsonwpCode = jsonwpCode;
@@ -45,6 +54,7 @@ export class NoSuchDriverError extends ProtocolError {
   static error() {
     return 'invalid session id';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'A session is either terminated or not started',
@@ -65,6 +75,7 @@ export class NoSuchElementError extends ProtocolError {
   static error() {
     return 'no such element';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'An element could not be located on the page using the given ' + 'search parameters.',
@@ -85,6 +96,7 @@ export class NoSuchFrameError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.NOT_FOUND;
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err ||
@@ -107,6 +119,7 @@ export class UnknownCommandError extends ProtocolError {
   static error() {
     return 'unknown command';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err ||
@@ -130,6 +143,9 @@ export class StaleElementReferenceError extends ProtocolError {
   static error() {
     return 'stale element reference';
   }
+  /**
+   * @param {string} [err] - the error message
+   */
   constructor(err) {
     super(
       err ||
@@ -152,6 +168,7 @@ export class ElementNotVisibleError extends ProtocolError {
   static error() {
     return 'element not visible';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err ||
@@ -174,6 +191,7 @@ export class InvalidElementStateError extends ProtocolError {
   static error() {
     return 'invalid element state';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err ||
@@ -196,9 +214,10 @@ export class UnknownError extends ProtocolError {
   static error() {
     return W3C_UNKNOWN_ERROR;
   }
+  /** @param {string|Error} [errorOrMessage] */
   constructor(errorOrMessage) {
-    const origMessage = _.isString((errorOrMessage || {}).message)
-      ? errorOrMessage.message
+    const origMessage = _.isString(/** @type {Error} */ ((errorOrMessage) || {}).message)
+      ? /** @type {Error} */ (errorOrMessage).message
       : errorOrMessage;
     const message =
       'An unknown server-side error occurred while processing the command.' +
@@ -217,6 +236,7 @@ export class UnknownMethodError extends ProtocolError {
   static error() {
     return 'unknown method';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'The requested command matched a known URL but did not match an method for that URL',
@@ -237,6 +257,7 @@ export class UnsupportedOperationError extends ProtocolError {
   static error() {
     return 'unsupported operation';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'A server-side error occurred. Command cannot be supported.',
@@ -257,6 +278,7 @@ export class ElementIsNotSelectableError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.BAD_REQUEST;
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'An attempt was made to select an element that cannot be selected.',
@@ -299,6 +321,7 @@ export class ElementNotInteractableError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.BAD_REQUEST;
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err ||
@@ -314,6 +337,7 @@ export class InsecureCertificateError extends ProtocolError {
   static error() {
     return 'insecure certificate';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err ||
@@ -335,6 +359,7 @@ export class JavaScriptError extends ProtocolError {
   static error() {
     return 'javascript error';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'An error occurred while executing user supplied JavaScript.',
@@ -355,6 +380,7 @@ export class XPathLookupError extends ProtocolError {
   static error() {
     return 'invalid selector';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'An error occurred while searching for an element by XPath.',
@@ -375,6 +401,7 @@ export class TimeoutError extends ProtocolError {
   static error() {
     return 'timeout';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'An operation did not complete before its timeout expired.',
@@ -395,6 +422,7 @@ export class NoSuchWindowError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.NOT_FOUND;
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err ||
@@ -417,6 +445,7 @@ export class InvalidArgumentError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.BAD_REQUEST;
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'The arguments passed to the command are either invalid or malformed',
@@ -437,6 +466,7 @@ export class InvalidCookieDomainError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.BAD_REQUEST;
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err ||
@@ -459,6 +489,7 @@ export class NoSuchCookieError extends ProtocolError {
   static error() {
     return 'no such cookie';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err ||
@@ -480,6 +511,7 @@ export class UnableToSetCookieError extends ProtocolError {
   static error() {
     return 'unable to set cookie';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || "A request to set a cookie's value could not be satisfied.",
@@ -500,6 +532,7 @@ export class UnexpectedAlertOpenError extends ProtocolError {
   static error() {
     return 'unexpected alert open';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'A modal dialog was open, blocking this operation',
@@ -520,6 +553,7 @@ export class NoAlertOpenError extends ProtocolError {
   static error() {
     return 'no such alert';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'An attempt was made to operate on a modal dialog when one ' + 'was not open.',
@@ -542,6 +576,7 @@ export class ScriptTimeoutError extends ProtocolError {
   static error() {
     return 'script timeout';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'A script did not complete before its timeout expired.',
@@ -562,6 +597,7 @@ export class InvalidElementCoordinatesError extends ProtocolError {
   static error() {
     return 'invalid coordinates';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'The coordinates provided to an interactions operation are invalid.',
@@ -584,6 +620,7 @@ export class IMENotAvailableError extends ProtocolError {
   static error() {
     return 'unsupported operation';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'IME was not available.',
@@ -624,6 +661,7 @@ export class InvalidSelectorError extends ProtocolError {
   static error() {
     return 'invalid selector';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'Argument was an invalid selector (e.g. XPath/CSS).',
@@ -644,6 +682,7 @@ export class SessionNotCreatedError extends ProtocolError {
   static error() {
     return 'session not created';
   }
+  /** @param {string} [details] */
   constructor(details) {
     let message = 'A new session could not be created.';
     if (details) {
@@ -669,6 +708,7 @@ export class MoveTargetOutOfBoundsError extends ProtocolError {
   static error() {
     return 'move target out of bounds';
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'Target provided for a move action is out of bounds.',
@@ -683,6 +723,7 @@ export class NoSuchContextError extends ProtocolError {
   static code() {
     return 35;
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(err || 'No such context found.', NoSuchContextError.code());
   }
@@ -692,6 +733,7 @@ export class InvalidContextError extends ProtocolError {
   static code() {
     return 36;
   }
+  /** @param {string} [err] */
   constructor(err) {
     super(
       err || 'That command could not be executed in the current context.',
@@ -702,11 +744,13 @@ export class InvalidContextError extends ProtocolError {
 
 // These are aliases for UnknownMethodError
 export class NotYetImplementedError extends UnknownMethodError {
+  /** @param {string} [err] */
   constructor(err) {
     super(err || 'Method has not yet been implemented');
   }
 }
 export class NotImplementedError extends UnknownMethodError {
+  /** @param {string} [err] */
   constructor(err) {
     super(err || 'Method is not implemented');
   }

--- a/packages/base-driver/lib/protocol/errors.js
+++ b/packages/base-driver/lib/protocol/errors.js
@@ -15,9 +15,9 @@ export class ProtocolError extends ES6Error {
   /**
    *
    * @param {string} [msg]
-   * @param {*} [jsonwpCode]
-   * @param {*} [w3cStatus]
-   * @param {*} [error]
+   * @param {number} [jsonwpCode]
+   * @param {number} [w3cStatus]
+   * @param {string} [error]
    */
   constructor(msg, jsonwpCode, w3cStatus, error) {
     super(msg);
@@ -216,7 +216,7 @@ export class UnknownError extends ProtocolError {
   }
   /** @param {string|Error} [errorOrMessage] */
   constructor(errorOrMessage) {
-    const origMessage = _.isString(/** @type {Error} */ ((errorOrMessage) || {}).message)
+    const origMessage = _.isString(/** @type {Error} */ (errorOrMessage || {}).message)
       ? /** @type {Error} */ (errorOrMessage).message
       : errorOrMessage;
     const message =

--- a/packages/images-plugin/lib/compare.js
+++ b/packages/images-plugin/lib/compare.js
@@ -9,75 +9,92 @@ const MATCH_TEMPLATE_MODE = 'matchTemplate';
 const DEFAULT_MATCH_THRESHOLD = 0.4;
 
 /**
+ * @param {CompareMode} value
+ * @returns {value is MatchFeaturesMode}
+ */
+function isMatchFeaturesMode(value) {
+  return _.toLower(value) === MATCH_FEATURES_MODE.toLowerCase();
+}
+
+/**
+ * @param {CompareMode} value
+ * @returns {value is GetSimilarityMode}
+ */
+function isGetSimilarityMode(value) {
+  return _.toLower(value) === GET_SIMILARITY_MODE.toLowerCase();
+}
+
+/**
+ * @param {CompareMode} value
+ * @returns {value is MatchTemplateMode}
+ */
+function isMatchTemplateMode(value) {
+  return _.toLower(value) === MATCH_TEMPLATE_MODE.toLowerCase();
+}
+
+/**
  * Performs images comparison using OpenCV framework features.
  * It is expected that both OpenCV framework and opencv4nodejs
  * module are installed on the machine where Appium server is running.
  *
- * @param {string} mode - One of possible comparison modes:
+ * @template {CompareMode} Mode
+ * @template {boolean} Multiple
+ * @param {Mode} mode - One of possible comparison modes:
  * matchFeatures, getSimilarity, matchTemplate
  * @param {string} firstImage - Base64-encoded image file.
  * All image formats, that OpenCV library itself accepts, are supported.
  * @param {string} secondImage - Base64-encoded image file.
  * All image formats, that OpenCV library itself accepts, are supported.
- * @param {object} [options] - The content of this dictionary depends
+ * @param {CompareImagesOptions<Mode,Multiple>} [options] - The content of this dictionary depends
  * on the actual `mode` value. See the documentation on `@appium/support`
  * module for more details.
- * @returns {Promise<object|object[]>} The content of the resulting dictionary depends
+ * @returns {Promise<CompareImagesResult<Mode,Multiple>>} The content of the resulting dictionary depends
  * on the actual `mode` and `options` values. See the documentation on
  * `@appium/support` module for more details.
  * @throws {Error} If required OpenCV modules are not installed or
  * if `mode` value is incorrect or if there was an unexpected issue while
  * matching the images.
  */
-async function compareImages(mode, firstImage, secondImage, options = {}) {
+async function compareImages(
+  mode,
+  firstImage,
+  secondImage,
+  options = /** @type {CompareImagesOptions<Mode,Multiple>} */ ({})
+) {
   const img1 = Buffer.from(firstImage, 'base64');
   const img2 = Buffer.from(secondImage, 'base64');
-  let result = null;
-  switch (_.toLower(mode)) {
-    case MATCH_FEATURES_MODE.toLowerCase():
-      try {
-        result = await getImagesMatches(img1, img2, options);
-      } catch (err) {
-        // might throw if no matches
-        result = {count: 0};
-      }
-      break;
-    case GET_SIMILARITY_MODE.toLowerCase():
-      result = await getImagesSimilarity(img1, img2, options);
-      break;
-    case MATCH_TEMPLATE_MODE.toLowerCase():
-      // firstImage/img1 is the full image and secondImage/img2 is the partial one
-      result = await getImageOccurrence(img1, img2, options);
-      if (options.multiple) {
-        return result.multiple.map(convertVisualizationToBase64);
-      }
-      break;
-    default:
-      throw new errors.InvalidArgumentError(
-        `'${mode}' images comparison mode is unknown. ` +
-          `Only ${JSON.stringify([
-            MATCH_FEATURES_MODE,
-            GET_SIMILARITY_MODE,
-            MATCH_TEMPLATE_MODE,
-          ])} modes are supported.`
-      );
-  }
-  return convertVisualizationToBase64(result);
-}
 
-/**
- * base64 encodes the visualization part of the result
- * (if necessary)
- *
- * @param {OccurrenceResult} element - occurrence result
- *
- **/
-function convertVisualizationToBase64(element) {
-  if (!_.isEmpty(element.visualization)) {
-    element.visualization = element.visualization.toString('base64');
+  if (isMatchFeaturesMode(mode)) {
+    const opts = /** @type {MatchingOptions} */ (options);
+    /** @type {MatchingResult} */
+    let result;
+    try {
+      result = await getImagesMatches(img1, img2, opts);
+    } catch (err) {
+      // might throw if no matches
+      result = {count: 0};
+    }
+    return /** @type {CompareImagesResult<Mode,Multiple>} */ (result);
   }
 
-  return element;
+  if (isGetSimilarityMode(mode)) {
+    const opts = /** @type {SimilarityOptions} */ (options);
+    return /** @type {CompareImagesResult<Mode,Multiple>} */ (
+      await getImagesSimilarity(img1, img2, opts)
+    );
+  }
+
+  if (isMatchTemplateMode(mode)) {
+    const opts = /** @type {OccurrenceOptions<Multiple>} */ (options);
+    const result = await getImageOccurrence(img1, img2, opts);
+    return /** @type {CompareImagesResult<Mode,Multiple>} */ (
+      opts.multiple ? result.multiple : result
+    );
+  }
+
+  throw new errors.InvalidArgumentError(
+    `Image comparison mode "${mode}" is invalid. Valid modes: ${MATCH_FEATURES_MODE}, ${GET_SIMILARITY_MODE}, ${MATCH_TEMPLATE_MODE}`
+  );
 }
 
 export {
@@ -90,4 +107,33 @@ export {
 
 /**
  * @typedef {import('@appium/opencv').OccurrenceResult} OccurrenceResult
+ * @typedef {import('@appium/opencv').SimilarityOptions} SimilarityOptions
+ * @typedef {import('@appium/opencv').MatchingOptions} MatchingOptions
+ * @typedef {import('@appium/opencv').SimilarityResult} SimilarityResult
+ * @typedef {import('@appium/opencv').MatchingResult} MatchingResult
+ */
+
+/**
+ * @template {boolean} Multiple
+ * @typedef {import('@appium/opencv').OccurrenceOptions<Multiple>} OccurrenceOptions
+
+ */
+
+/**
+ * @typedef {typeof GET_SIMILARITY_MODE} GetSimilarityMode
+ * @typedef {typeof MATCH_FEATURES_MODE} MatchFeaturesMode
+ * @typedef {typeof MATCH_TEMPLATE_MODE} MatchTemplateMode
+ * @typedef {GetSimilarityMode|MatchFeaturesMode|MatchTemplateMode} CompareMode
+ */
+
+/**
+ * @template {CompareMode} Mode
+ * @template {boolean} Multiple
+ * @typedef {Mode extends GetSimilarityMode ? SimilarityOptions : Mode extends MatchFeaturesMode ? MatchingOptions : Mode extends MatchTemplateMode ? OccurrenceOptions<Multiple> : never} CompareImagesOptions
+ */
+
+/**
+ * @template {CompareMode} Mode
+ * @template {boolean} Multiple
+ * @typedef {Mode extends GetSimilarityMode ? SimilarityResult : Mode extends MatchFeaturesMode ? MatchingResult : Mode extends MatchTemplateMode ? (Multiple extends true ? OccurrenceResult[] : OccurrenceResult) : never} CompareImagesResult
  */

--- a/packages/images-plugin/lib/compare.js
+++ b/packages/images-plugin/lib/compare.js
@@ -116,7 +116,6 @@ export {
 /**
  * @template {boolean} Multiple
  * @typedef {import('@appium/opencv').OccurrenceOptions<Multiple>} OccurrenceOptions
-
  */
 
 /**

--- a/packages/images-plugin/lib/finder.js
+++ b/packages/images-plugin/lib/finder.js
@@ -108,7 +108,7 @@ export class ImageElementFinder {
   registerImageElement(imgEl) {
     this.imgElCache.set(imgEl.id, imgEl);
     if (!this.driver) {
-      throw new ReferenceError('No driver set!');
+      throw new ReferenceError('Please call setDriver() before registerImageElement()');
     }
     return imgEl.asElement();
   }
@@ -220,7 +220,7 @@ export class ImageElementFinder {
     }
 
     if (_.isEmpty(results)) {
-      if (multiple === true) {
+      if (multiple) {
         return /** @type {FindByImageResult<Multiple,CheckStaleness>} */ (
           /** @type {Element[]} */ ([])
         );
@@ -287,7 +287,10 @@ export class ImageElementFinder {
    * @returns {Promise<Screenshot & {scale?: ScreenshotScale}>} base64-encoded screenshot and ScreenshotScale
    */
   async getScreenshotForImageFind(screenWidth, screenHeight) {
-    if (!this.driver?.getScreenshot) {
+    if (!this.driver) {
+      throw new Error('Please call setDriver() before calling getScreenshotForImageFind()');
+    }
+    if (!this.driver.getScreenshot) {
       throw new Error("This driver does not support the required 'getScreenshot' command");
     }
     const settings = {...DEFAULT_SETTINGS, ...this.driver.settings.getSettings()};

--- a/packages/images-plugin/test/unit/finder.spec.js
+++ b/packages/images-plugin/test/unit/finder.spec.js
@@ -2,8 +2,8 @@ import _ from 'lodash';
 import {imageUtil} from 'appium/support';
 import {BaseDriver} from 'appium/driver';
 import {ImageElementPlugin, IMAGE_STRATEGY} from '../../lib/plugin';
-import ImageElementFinder from '../../lib/finder';
-import ImageElement from '../../lib/image-element';
+import {ImageElementFinder, W3C_ELEMENT_KEY} from '../../lib/finder';
+import {ImageElement} from '../../lib/image-element';
 import sinon from 'sinon';
 import {TINY_PNG, TINY_PNG_DIMS} from '../fixtures';
 
@@ -71,8 +71,14 @@ describe('finding elements by image', function () {
       return {sizeStub, screenStub};
     }
 
+    /**
+     *
+     * @param {Element} imgElProto
+     * @param {ImageElementFinder} finder
+     * @returns
+     */
     function basicImgElVerify(imgElProto, finder) {
-      const imgElId = imgElProto.ELEMENT;
+      const imgElId = imgElProto[W3C_ELEMENT_KEY];
       finder.imgElCache.has(imgElId).should.be.true;
       const imgEl = finder.imgElCache.get(imgElId);
       (imgEl instanceof ImageElement).should.be.true;
@@ -164,6 +170,7 @@ describe('finding elements by image', function () {
 
   describe('fixImageTemplateScale', function () {
     let d;
+    /** @type {ImageElementFinder} */
     let f;
     const basicTemplate = 'iVBORbaz';
 
@@ -291,6 +298,7 @@ describe('finding elements by image', function () {
 
   describe('getScreenshotForImageFind', function () {
     let d;
+    /** @type {ImageElementFinder} */
     let f;
 
     beforeEach(function () {

--- a/packages/images-plugin/test/unit/finder.spec.js
+++ b/packages/images-plugin/test/unit/finder.spec.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
-import {imageUtil} from 'appium/support';
+import {imageUtil, util} from 'appium/support';
 import {BaseDriver} from 'appium/driver';
 import {ImageElementPlugin, IMAGE_STRATEGY} from '../../lib/plugin';
-import {ImageElementFinder, W3C_ELEMENT_KEY} from '../../lib/finder';
+import {ImageElementFinder} from '../../lib/finder';
 import {ImageElement} from '../../lib/image-element';
 import sinon from 'sinon';
 import {TINY_PNG, TINY_PNG_DIMS} from '../fixtures';
@@ -10,6 +10,8 @@ import {TINY_PNG, TINY_PNG_DIMS} from '../fixtures';
 const compareModule = require('../../lib/compare');
 
 const plugin = new ImageElementPlugin();
+
+const {W3C_ELEMENT_IDENTIFIER} = util;
 
 class PluginDriver extends BaseDriver {
   async getWindowSize() {}
@@ -78,7 +80,7 @@ describe('finding elements by image', function () {
      * @returns
      */
     function basicImgElVerify(imgElProto, finder) {
-      const imgElId = imgElProto[W3C_ELEMENT_KEY];
+      const imgElId = imgElProto[W3C_ELEMENT_IDENTIFIER];
       finder.imgElCache.has(imgElId).should.be.true;
       const imgEl = finder.imgElCache.get(imgElId);
       (imgEl instanceof ImageElement).should.be.true;

--- a/packages/images-plugin/test/unit/image-element.spec.js
+++ b/packages/images-plugin/test/unit/image-element.spec.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import BaseDriver from 'appium/driver';
-import ImageElementFinder from '../../lib/finder';
+import {ImageElementFinder, W3C_ELEMENT_KEY} from '../../lib/finder';
 import {getImgElFromArgs} from '../../lib/plugin';
-import ImageElement, {IMAGE_ELEMENT_PREFIX} from '../../lib/image-element';
+import {ImageElement, IMAGE_ELEMENT_PREFIX} from '../../lib/image-element';
 import sinon from 'sinon';
 
 const defRect = {x: 100, y: 110, width: 50, height: 25};
@@ -48,7 +48,7 @@ describe('ImageElement', function () {
   describe('.asElement', function () {
     it('should get the webdriver object representation of the element', function () {
       const el = new ImageElement(defTemplate, defRect);
-      el.asElement('ELEMENT').ELEMENT.should.match(/^appium-image-el/);
+      el.asElement()[W3C_ELEMENT_KEY].should.match(/^appium-image-el/);
     });
   });
 
@@ -226,7 +226,7 @@ describe('ImageElement', function () {
         imgElement,
         'getAttribute',
         'visual'
-      ).should.eventually.eql(null);
+      ).should.eventually.equal(null);
     });
     it('should not get other attribute', async function () {
       await ImageElement.execute(
@@ -234,7 +234,7 @@ describe('ImageElement', function () {
         imgEl,
         'getAttribute',
         'content-desc'
-      ).should.eventually.rejectedWith('Method has not yet been implemented');
+      ).should.be.rejectedWith('Method has not yet been implemented');
     });
     it('should click element', async function () {
       await ImageElement.execute(driver, imgEl, 'click').should.eventually.be.true;

--- a/packages/images-plugin/test/unit/plugin.spec.js
+++ b/packages/images-plugin/test/unit/plugin.spec.js
@@ -48,7 +48,7 @@ describe('ImageElementPlugin#handle', function () {
     it('should throw an error if comparison mode is not supported', async function () {
       await p
         .compareImages(next, driver, 'some mode', '', '')
-        .should.eventually.be.rejectedWith(/comparison mode is unknown/);
+        .should.be.rejectedWith(/Image comparison mode "some mode" is invalid/i);
     });
   });
 
@@ -148,7 +148,7 @@ describe('ImageElementPlugin#handle', function () {
     it('should not allow any other attrs', async function () {
       await p
         .handle(next, driver, 'getAttribute', 'rando', elId)
-        .should.eventually.be.rejectedWith(/not yet/i);
+        .should.be.rejectedWith(/not yet/i);
     });
   });
 });

--- a/packages/images-plugin/tsconfig.json
+++ b/packages/images-plugin/tsconfig.json
@@ -4,7 +4,8 @@
     "paths": {
       "@appium/opencv": ["../opencv"],
       "appium": ["../appium"]
-    }
+    },
+    "checkJs": true
   },
   "extends": "../../config/tsconfig.base.json",
   "include": ["lib"],

--- a/packages/opencv/lib/index.js
+++ b/packages/opencv/lib/index.js
@@ -6,28 +6,6 @@ import B from 'bluebird';
 /** @type {any} */
 let cv;
 
-/**
- * @typedef Region
- * @property {number} left - The offset from the left side
- * @property {number} top - The offset from the top
- * @property {number} width - The width
- * @property {number} height - The height
- */
-
-/**
- * @typedef Point
- * @property {number} x - The x coordinate
- * @property {number} y - The y coordinate
- */
-
-/**
- * @typedef Rect
- * @property {number} x - The top left coordinate
- * @property {number} y - The bottom right coordinate
- * @property {number} width - The width
- * @property {number} height - The height
- */
-
 const DEFAULT_MATCH_THRESHOLD = 0.5;
 const MATCH_NEIGHBOUR_THRESHOLD = 10;
 
@@ -124,7 +102,7 @@ function detectAndCompute(img, detector) {
 /**
  * Calculated the bounding rect coordinates for the array of matching points
  *
- * @param {Array<Point>} matchedPoints Array of matching points
+ * @param {Point[]} matchedPoints Array of matching points
  * @returns {Rect} The matching bounding rect or a zero rect if no match
  * can be found.
  */
@@ -139,11 +117,14 @@ function calculateMatchedRect(matchedPoints) {
   }
 
   const pointsSortedByDistance = matchedPoints
-    .map((point) => [Math.sqrt(point.x * point.x + point.y * point.y), point])
-    .sort((pair1, pair2) => pair1[0] >= pair2[0])
+    .map(
+      (point) =>
+        /** @type {[number, point]} */ ([Math.sqrt(point.x * point.x + point.y * point.y), point])
+    )
+    .sort((pair1, pair2) => Number(pair1[0] >= pair2[0]))
     .map((pair) => pair[1]);
-  const firstPoint = _.head(pointsSortedByDistance);
-  const lastPoint = _.last(pointsSortedByDistance);
+  const firstPoint = /** @type {Point} */ (_.head(pointsSortedByDistance));
+  const lastPoint = /** @type {Point} */ (_.last(pointsSortedByDistance));
   const topLeftPoint = {
     x: firstPoint.x <= lastPoint.x ? firstPoint.x : lastPoint.x,
     y: firstPoint.y <= lastPoint.y ? firstPoint.y : lastPoint.y,
@@ -163,10 +144,10 @@ function calculateMatchedRect(matchedPoints) {
 /**
  * Draws a rectanngle on the given image matrix
  *
- * @param {cv.Mat} mat The source image
+ * @param {OpenCVBindings['Mat']} mat The source image
  * @param {Rect} region The region to highlight
  *
- * @returns {cv.Mat} The same image with the rectangle on it
+ * @returns {OpenCVBindings['Mat']} The same image with the rectangle on it
  */
 function highlightRegion(mat, region) {
   if (region.width <= 0 || region.height <= 0) {
@@ -183,49 +164,14 @@ function highlightRegion(mat, region) {
 }
 
 /**
- * @typedef MatchingOptions
- * @property {?string} detectorName ['ORB'] One of possible OpenCV feature detector names
- * from keys of the `AVAILABLE_DETECTORS` object.
- * Some of these methods (FAST, AGAST, GFTT, FAST, SIFT and MSER) are not available
- * in the default OpenCV installation and have to be enabled manually before
- * library compilation.
- * @property {?string} matchFunc ['BruteForce'] The name of the matching function.
- * Should be one of the keys of the `AVAILABLE_MATCHING_FUNCTIONS` object.
- * @property {?number|Function} goodMatchesFactor The maximum count of "good" matches
- * (e. g. with minimal distances) or a function, which accepts 3 arguments: the current distance,
- * minimal distance, maximum distance and returns true or false to include or exclude the match.
- * @property {?boolean} visualize [false] Whether to return the resulting visalization
- * as an image (useful for debugging purposes)
- */
-
-/**
- * @typedef MatchingResult
- * @property {number} count The count of matched edges on both images.
- * The more matching edges there are no both images the more similar they are.
- * @property {number} totalCount The total count of matched edges on both images.
- * It is equal to `count` if `goodMatchesFactor` does not limit the matches,
- * otherwise it contains the total count of matches before `goodMatchesFactor` is
- * applied.
- * @property {?Buffer} visualization The visualization of the matching result
- * represented as PNG image buffer. This visualization looks like
- * https://user-images.githubusercontent.com/31125521/29702731-c79e3142-8972-11e7-947e-db109d415469.jpg
- * @property {Array<Point>} points1 The array of matching points on the first image
- * @property {Rect} rect1 The bounding rect for the `matchedPoints1` set or a zero rect
- * if not enough matching points are found
- * @property {Array<Point>} points2 The array of matching points on the second image
- * @property {Rect} rect2 The bounding rect for the `matchedPoints2` set or a zero rect
- * if not enough matching points are found
- */
-
-/**
  * Calculates the count of common edges between two images.
  * The images might be rotated or resized relatively to each other.
  *
  * @param {Buffer} img1Data The data of the first image packed into a NodeJS buffer
  * @param {Buffer} img2Data The data of the second image packed into a NodeJS buffer
- * @param {?MatchingOptions} options [{}] Set of matching options
+ * @param {MatchingOptions} [options] Set of matching options
  *
- * @returns {MatchingResult} Maching result
+ * @returns {Promise<MatchingResult>} Maching result
  * @throws {Error} If `detectorName` value is unknown.
  */
 async function getImagesMatches(img1Data, img2Data, options = {}) {
@@ -304,6 +250,7 @@ async function getImagesMatches(img1Data, img2Data, options = {}) {
     const points2 = matches.map(extractPoint(result2.keyPoints, 'trainIdx'));
     const rect2 = calculateMatchedRect(points2);
 
+    /** @type {MatchingResult} */
     const result = {
       points1,
       rect1,
@@ -335,7 +282,10 @@ async function getImagesMatches(img1Data, img2Data, options = {}) {
         width: rect2.width,
         height: rect2.height,
       });
-      result.visualization = await jimpImgFromCvMat(visualization).getBufferAsync(Jimp.MIME_PNG);
+      result.visualization = base64Encode(
+        await jimpImgFromCvMat(visualization).getBufferAsync(Jimp.MIME_PNG)
+      );
+      return result;
     }
 
     return result;
@@ -344,10 +294,10 @@ async function getImagesMatches(img1Data, img2Data, options = {}) {
       img1.delete();
       img2.delete();
       detector.delete();
-      result1.keyPoints.delete();
-      result1.descriptor.delete();
-      result2.keyPoints.delete();
-      result2.descriptor.delete();
+      result1?.keyPoints.delete();
+      result1?.descriptor.delete();
+      result2?.keyPoints.delete();
+      result2?.descriptor.delete();
       matcher.delete();
       matchesVec.delete();
     } catch (ign) {}
@@ -355,29 +305,12 @@ async function getImagesMatches(img1Data, img2Data, options = {}) {
 }
 
 /**
- * @typedef SimilarityOptions
- * @property {?boolean} visualize [false] Whether to return the resulting visalization
- * as an image (useful for debugging purposes)
- * @property {string} method [TM_CCOEFF_NORMED] The name of the template matching method.
- * Acceptable values are:
- * - TM_CCOEFF
- * - TM_CCOEFF_NORMED (default)
- * - TM_CCORR
- * - TM_CCORR_NORMED
- * - TM_SQDIFF
- * - TM_SQDIFF_NORMED
- * Read https://docs.opencv.org/3.0-beta/doc/py_tutorials/py_imgproc/py_template_matching/py_template_matching.html
- * for more details.
+ * @param {Buffer} buf
+ * @returns {string}
  */
-
-/**
- * @typedef SimilarityResult
- * @property {number} score The similarity score as a float number in range [0.0, 1.0].
- * 1.0 is the highest score (means both images are totally equal).
- * @property {?Buffer} visualization The visualization of the matching result
- * represented as PNG image buffer. This image includes both input pictures where
- * difference regions are highlighted with rectangles.
- */
+function base64Encode(buf) {
+  return buf.toString('base64');
+}
 
 /**
  * Calculates the similarity score between two images.
@@ -385,15 +318,17 @@ async function getImagesMatches(img1Data, img2Data, options = {}) {
  *
  * @param {Buffer} img1Data The data of the first image packed into a NodeJS buffer
  * @param {Buffer} img2Data The data of the second image packed into a NodeJS buffer
- * @param {?SimilarityOptions} options [{}] Set of similarity calculation options
+ * @param {SimilarityOptions} [options] Set of similarity calculation options
  *
- * @returns {SimilarityResult} The calculation result
+ * @returns {Promise<SimilarityResult>} The calculation result
  * @throws {Error} If the given images have different resolution.
  */
-async function getImagesSimilarity(img1Data, img2Data, options = {}) {
+async function getImagesSimilarity(
+  img1Data,
+  img2Data,
+  {method = DEFAULT_MATCHING_METHOD, visualize = false} = {}
+) {
   await initOpenCv();
-
-  const {method = DEFAULT_MATCHING_METHOD, visualize = false} = options;
 
   let template, reference, matched;
   try {
@@ -453,6 +388,9 @@ async function getImagesSimilarity(img1Data, img2Data, options = {}) {
         } catch (ign) {}
       }
     }
+    if (!_.isEmpty(result.visualization)) {
+      result.visualization = result.visualization.toString('base64');
+    }
     return result;
   } finally {
     try {
@@ -464,53 +402,15 @@ async function getImagesSimilarity(img1Data, img2Data, options = {}) {
 }
 
 /**
- * @typedef OccurrenceOptions
- * @property {boolean} [visualize=false] Whether to return the resulting visalization
- * as an image (useful for debugging purposes)
- * @property {number} [threshold=0.5] At what normalized threshold to reject
- * a match
- * @property {number|boolean} [multiple=false] find multiple matches in the image
- * @property {number} [matchNeighbourThreshold=10] The pixel distance between matches we consider
- * to be part of the same template match
- */
-
-/**
- * @typedef {'TM_CCOEFF'|'TM_CCOEFF_NORMED|'TM_CCORR'|'TM_CCORR_NORMED'|'TM_SQDIFF'|'TMSQDIFF_NORMED'} OccurrenceResultMethod
- */
-
-/**
- * @typedef OccurrenceResult
- * @property {import('@appium/types').Rect} rect The region of the partial image occurence
- * on the full image
- * @property {Buffer} visualization The visualization of the matching result
- * represented as PNG image buffer. On this image the matching
- * region is highlighted with a rectangle. If the multiple option is passed,
- * all results are highlighted here.
- * @property {number} score The similarity score as a float number in range [0.0, 1.0].
- * 1.0 is the highest score (means both images are totally equal).
- * @property {OccurrenceResult[]} multiple The array of matching OccurenceResults
- * - only when multiple option is passed
- * @property {OccurrenceResultMethod} [method='TM_CCOEFF_NORMED'] The name of the template matching method.
- * Acceptable values are:
- * - TM_CCOEFF
- * - TM_CCOEFF_NORMED (default)
- * - TM_CCORR
- * - TM_CCORR_NORMED
- * - TM_SQDIFF
- * - TM_SQDIFF_NORMED
- * Read https://docs.opencv.org/3.0-beta/doc/py_tutorials/py_imgproc/py_template_matching/py_template_matching.html
- * for more details.
- */
-
-/**
  * Calculates the occurrence position of a partial image in the full
  * image.
  *
+ * @template {boolean} [Multiple=false]
  * @param {Buffer} fullImgData The data of the full image packed into a NodeJS buffer
  * @param {Buffer} partialImgData The data of the partial image packed into a NodeJS buffer
- * @param {OccurrenceOptions?} [options] Set of occurrence calculation options
+ * @param {OccurrenceOptions<Multiple>} [options] Set of occurrence calculation options
  *
- * @returns {OccurrenceResult}
+ * @returns {Promise<OccurrenceResult>}
  * @throws {Error} If no occurrences of the partial image can be found in the full image
  */
 async function getImageOccurrence(fullImgData, partialImgData, options = {}) {
@@ -532,14 +432,16 @@ async function getImageOccurrence(fullImgData, partialImgData, options = {}) {
       cvMatFromImage(partialImgData),
     ]);
     matched = new cv.Mat();
+    /** @type {OccurrenceResult[]} */
     const results = [];
-    let visualization = null;
+    let visualization;
 
     try {
       cv.matchTemplate(fullImg, partialImg, matched, toMatchingMethod(method));
       const minMax = cv.minMaxLoc(matched);
 
       if (multiple) {
+        /** @type {(Point & {score: number})[]} */
         const matches = [];
         for (let row = 0; row < matched.rows; row++) {
           for (let col = 0; col < matched.cols; col++) {
@@ -598,11 +500,13 @@ async function getImageOccurrence(fullImgData, partialImgData, options = {}) {
 
         highlightRegion(singleHighlightedImage, result.rect);
         highlightRegion(fullHighlightedImage, result.rect);
-        result.visualization = await jimpImgFromCvMat(singleHighlightedImage).getBufferAsync(
-          Jimp.MIME_PNG
+        result.visualization = base64Encode(
+          await jimpImgFromCvMat(singleHighlightedImage).getBufferAsync(Jimp.MIME_PNG)
         );
       }
-      visualization = await jimpImgFromCvMat(fullHighlightedImage).getBufferAsync(Jimp.MIME_PNG);
+      visualization = base64Encode(
+        await jimpImgFromCvMat(fullHighlightedImage).getBufferAsync(Jimp.MIME_PNG)
+      );
     }
     return {
       rect: results[0].rect,
@@ -622,7 +526,7 @@ async function getImageOccurrence(fullImgData, partialImgData, options = {}) {
 /**
  * Convert an opencv image matrix into a Jimp image object
  *
- * @param {cv.Mat} mat the image matrix
+ * @param {OpenCVBindings['Mat']} mat the image matrix
  * @return {Jimp} the Jimp image
  */
 function jimpImgFromCvMat(mat) {
@@ -637,7 +541,7 @@ function jimpImgFromCvMat(mat) {
  * Take a binary image buffer and return a cv.Mat
  *
  * @param {Buffer} img the image data buffer
- * @return {cv.Mat} the opencv matrix
+ * @return {Promise<OpenCVBindings['Mat']>} the opencv matrix
  */
 async function cvMatFromImage(img) {
   const jimpImg = await Jimp.read(img);
@@ -647,10 +551,11 @@ async function cvMatFromImage(img) {
 /**
  * Filter out match results which have a matched neighbour
  *
- * @param {Array<Point>} nonZeroMatchResults matrix of image match results
+ * @template {Point} PointLike
+ * @param {PointLike[]} nonZeroMatchResults matrix of image match results
  * @param {number} matchNeighbourThreshold The pixel distance within which we
  * consider an element being a neighbour of an existing match
- * @return {Array<Point>} the filtered array of matched points
+ * @return {PointLike[]} the filtered array of matched points
  */
 function filterNearMatches(nonZeroMatchResults, matchNeighbourThreshold) {
   return nonZeroMatchResults.reduce((acc, element) => {
@@ -658,7 +563,7 @@ function filterNearMatches(nonZeroMatchResults, matchNeighbourThreshold) {
       acc.push(element);
     }
     return acc;
-  }, []);
+  }, /** @type {PointLike[]} */ ([]));
 }
 
 /**
@@ -681,4 +586,131 @@ export {getImagesMatches, getImagesSimilarity, getImageOccurrence, initOpenCv};
  * @property {any} Mat
  * @property {any} KeyPointVector
  * @property {any} FeatureDetector
+ */
+
+/**
+ * @typedef SimilarityOptions
+ * @property {boolean} [visualize=false] Whether to return the resulting visalization
+ * as an image (useful for debugging purposes)
+ * @property {string} [method=TM_CCOEFF_NORMED] The name of the template matching method.
+ * Acceptable values are:
+ * - `TM_CCOEFF`
+ * - `TM_CCOEFF_NORMED` (default)
+ * - `TM_CCORR`
+ * - `TM_CCORR_NORMED`
+ * - `TM_SQDIFF`
+ * - `TM_SQDIFF_NORMED`
+ * Read https://docs.opencv.org/3.0-beta/doc/py_tutorials/py_imgproc/py_template_matching/py_template_matching.html
+ * for more details.
+ */
+
+/**
+ * @typedef SimilarityResult
+ * @property {number} score The similarity score as a float number in range [0.0, 1.0].
+ * 1.0 is the highest score (means both images are totally equal).
+ * @property {Buffer} [visualization] The visualization of the matching result
+ * represented as PNG image buffer. This image includes both input pictures where
+ * difference regions are highlighted with rectangles.
+ */
+
+/**
+ * @callback GoodMatchFunction
+ * @param {number} current
+ * @param {number} minimal
+ * @param {number} maximum
+ * @returns {boolean}
+ */
+
+/**
+ * @typedef MatchingOptions
+ * @property {string} [detectorName='ORB'] One of possible OpenCV feature detector names
+ * from keys of the `AVAILABLE_DETECTORS` object.
+ * Some of these methods (FAST, AGAST, GFTT, FAST, SIFT and MSER) are not available
+ * in the default OpenCV installation and have to be enabled manually before
+ * library compilation.
+ * @property {string} [matchFunc='BruteForce'] The name of the matching function.
+ * Should be one of the keys of the `AVAILABLE_MATCHING_FUNCTIONS` object.
+ * @property {number|GoodMatchFunction} [goodMatchesFactor] The maximum count of "good" matches
+ * (e. g. with minimal distances) or a function, which accepts 3 arguments: the current distance,
+ * minimal distance, maximum distance and returns true or false to include or exclude the match.
+ * @property {boolean} [visualize=false] Whether to return the resulting visalization
+ * as an image (useful for debugging purposes)
+ */
+
+/**
+ * @typedef MatchingResult
+ * @property {number} count The count of matched edges on both images.
+ * The more matching edges there are no both images the more similar they are.
+ * @property {number} [totalCount] The total count of matched edges on both images.
+ * It is equal to `count` if `goodMatchesFactor` does not limit the matches,
+ * otherwise it contains the total count of matches before `goodMatchesFactor` is
+ * applied.
+ * @property {string} [visualization] The visualization of the matching result
+ * represented as PNG image buffer. This visualization looks like
+ * https://user-images.githubusercontent.com/31125521/29702731-c79e3142-8972-11e7-947e-db109d415469.jpg
+ * @property {Point[]} [points1] The array of matching points on the first image
+ * @property {Rect} [rect1] The bounding rect for the `matchedPoints1` set or a zero rect
+ * if not enough matching points are found
+ * @property {Point[]} [points2] The array of matching points on the second image
+ * @property {Rect} [rect2] The bounding rect for the `matchedPoints2` set or a zero rect
+ * if not enough matching points are found
+ */
+
+/**
+ * @typedef {import('@appium/types').Rect} Rect
+ */
+
+/**
+ * @template {boolean} Multiple
+ * @typedef OccurrenceOptions
+ * @property {boolean} [visualize=false] Whether to return the resulting visalization
+ * as an image (useful for debugging purposes)
+ * @property {number} [threshold=0.5] At what normalized threshold to reject
+ * a match
+ * @property {Multiple} [multiple=false] find multiple matches in the image
+ * @property {number} [matchNeighbourThreshold=10] The pixel distance between matches we consider
+ * to be part of the same template match
+ * @property {OccurrenceResultMethod} [method='TM_CCOEFF_NORMED']
+ */
+
+/**
+ * @typedef {'TM_CCOEFF'|'TM_CCOEFF_NORMED'|'TM_CCORR'|'TM_CCORR_NORMED'|'TM_SQDIFF'|'TMSQDIFF_NORMED'} OccurrenceResultMethod
+ */
+
+/**
+ * @typedef OccurrenceResult
+ * @property {Rect} rect The region of the partial image occurence
+ * on the full image
+ * @property {string} [visualization] The visualization of the matching result
+ * represented as PNG image buffer. On this image the matching
+ * region is highlighted with a rectangle. If the multiple option is passed,
+ * all results are highlighted here.
+ * @property {number} score The similarity score as a float number in range [0.0, 1.0].
+ * 1.0 is the highest score (means both images are totally equal).
+ * @property {OccurrenceResult[]} [multiple] The array of matching OccurenceResults
+ * - only when multiple option is passed
+ * @property {OccurrenceResultMethod} [method='TM_CCOEFF_NORMED'] The name of the template matching method.
+ * Acceptable values are:
+ * - TM_CCOEFF
+ * - TM_CCOEFF_NORMED (default)
+ * - TM_CCORR
+ * - TM_CCORR_NORMED
+ * - TM_SQDIFF
+ * - TM_SQDIFF_NORMED
+ * Read https://docs.opencv.org/3.0-beta/doc/py_tutorials/py_imgproc/py_template_matching/py_template_matching.html
+ * for more details.
+ */
+
+/**
+ * @typedef Region
+ * @property {number} left - The offset from the left side
+ * @property {number} top - The offset from the top
+ * @property {number} width - The width
+ * @property {number} height - The height
+ */
+
+/**
+ * @typedef Point
+ * @property {number} x - The x coordinate
+ * @property {number} y - The y coordinate
  */

--- a/packages/opencv/tsconfig.json
+++ b/packages/opencv/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "build"
+    "outDir": "build",
+    "checkJs": true
   },
   "include": ["lib"]
 }

--- a/packages/support/lib/mjpeg.js
+++ b/packages/support/lib/mjpeg.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import log from './logger';
 import B from 'bluebird';
-import {getJimpImage, MIME_PNG} from './image-util';
+import {AppiumImage, MIME_PNG} from './image-util';
 import {Writable} from 'stream';
 import {requirePackage} from './node';
 import axios from 'axios';
@@ -77,7 +77,7 @@ class MJpegStream extends Writable {
     }
 
     try {
-      const jpg = await getJimpImage(lastChunk);
+      const jpg = await AppiumImage.from(lastChunk);
       return await jpg.getBuffer(MIME_PNG);
     } catch (e) {
       return null;

--- a/packages/support/test/unit/image-util.spec.js
+++ b/packages/support/test/unit/image-util.spec.js
@@ -1,0 +1,133 @@
+/* eslint-disable promise/prefer-await-to-callbacks */
+/* eslint-disable require-await */
+import {createSandbox} from 'sinon';
+import rewiremock from 'rewiremock/node';
+
+const {expect} = chai;
+
+const PHONY_BUFFER = Buffer.from('cheeseburgers');
+
+/** @type {import('@jimp/core/types').Bitmap} */
+const PHONY_BITMAP = {
+  data: PHONY_BUFFER,
+  width: 100,
+  height: 100,
+};
+
+describe('AppiumImage', function () {
+  /** @type {import('sinon').SinonSandbox} */
+  let sandbox;
+
+  /** @type {typeof import('../../lib/image-util').AppiumImage} */
+  let AppiumImage;
+
+  let mockJimp;
+
+  beforeEach(function () {
+    sandbox = createSandbox();
+    mockJimp = {
+      getBufferAsync: sandbox.stub().resolves(PHONY_BUFFER),
+      writeAsync: sandbox.stub().resolves(),
+      resize: sandbox.stub().returnsThis(),
+      scaleToFit: sandbox.stub().returnsThis(),
+    };
+
+    const jimpStub = sandbox.stub().callsFake((buf, cb) => {
+      mockJimp.bitmap = PHONY_BITMAP;
+      setImmediate(() => cb(null, mockJimp));
+      return mockJimp;
+    });
+    jimpStub.MIME_JPEG = 'image/jpeg';
+    jimpStub.MIME_PNG = 'image/png';
+    jimpStub.MIME_BMP = 'image/bmp';
+
+    ({AppiumImage} = rewiremock.proxy(() => require('../../lib/image-util'), {
+      jimp: jimpStub,
+    }));
+  });
+
+  afterEach(function () {
+    sandbox.restore();
+  });
+
+  describe('constructor', function () {
+    it('should instantiate an AppiumImage', function () {
+      expect(new AppiumImage(mockJimp)).to.be.an.instanceof(AppiumImage);
+    });
+  });
+
+  describe('static method', function () {
+    describe('from()', function () {});
+    describe('fromString()', function () {});
+    describe('fromBuffer()', function () {});
+  });
+
+  describe('instance method', function () {
+    /** @type {AppiumImage} */
+    let img;
+
+    beforeEach(async function () {
+      img = await AppiumImage.fromBuffer(PHONY_BUFFER);
+    });
+
+    describe('getBuffer()', function () {
+      it('should resolve to a Buffer', async function () {
+        await expect(img.getBuffer('image/jpeg')).to.eventually.equal(PHONY_BUFFER);
+      });
+
+      it('should call thru to Jimp', function () {
+        img.getBuffer('image/jpeg');
+        expect(mockJimp.getBufferAsync).to.have.been.calledOnce;
+      });
+    });
+
+    describe('resize()', function () {
+      it('should return an AppiumImage', function () {
+        expect(img.resize(100, 100)).to.equal(img);
+      });
+
+      it('should call thru to Jimp', function () {
+        img.resize(100, 100);
+        expect(mockJimp.resize).to.have.been.calledWith(100, 100);
+      });
+    });
+
+    describe('scaleToFit()', function () {
+      it('should return an AppiumImage', function () {
+        expect(img.scaleToFit(100, 100)).to.equal(img);
+      });
+
+      it('should call thru to Jimp', function () {
+        img.scaleToFit(100, 100);
+        expect(mockJimp.scaleToFit).to.have.been.calledWith(100, 100);
+      });
+    });
+
+    describe('write()', function () {
+      it('should resolve with an AppiumImage', async function () {
+        mockJimp.write = sandbox.stub().resolves(img);
+        await expect(img.write('/some/path')).to.eventually.be.an.instanceof(AppiumImage);
+      });
+    });
+  });
+
+  describe('property', function () {
+    /** @type {AppiumImage} */
+    let img;
+
+    beforeEach(async function () {
+      img = await AppiumImage.fromBuffer(PHONY_BUFFER);
+    });
+
+    describe('bitmap', function () {
+      it('should return the value of the `bitmap` property of the internal Jimp image', function () {
+        expect(img.bitmap).to.exist;
+        expect(img.bitmap).to.equal(mockJimp.bitmap);
+      });
+    });
+  });
+});
+
+/**
+ * @typedef {import('../../lib/image-util').AppiumImage} AppiumImage
+ */


### PR DESCRIPTION
This PR contains improvements as follows:

- Both `@appium/images-plugin` and `@appium/opencv` are now type-error-free. They aren't "fully typechecked" because not everything that needs annotating is annotated. But what _is_ there passes `tsc` without throwing errors.
- `@appium/support` exposes an `AppiumImage` class which wraps a `Jimp` instance. Given that a) we currently monkeypatch a `Jimp` instance because we want to use Jimp's `Promise`-returning methods _by default_ instead of referring specifically to `*Async` methods (the non-`*Async` versions being callback-based), and b) much of Jimp's API is of the "chainable" variety (it's rather haphazard), it is impossible to guarantee the consistency of the return type (is it a `Jimp` or is it a _monkeypatched_ `Jimp`? What does `getBuffer()` return?) when calling chainable methods without some extra work. This PR represents that extra work.
- `getJimpImage()` in `@appium/support`'s `image-util` is now considered deprecated, as `AppiumImage` is superior. It should be eventually removed.

However...

Various drivers may depend on methods in the `Jimp` instance as returned by `getJimpImage()`. If any are missing (e.g., `Jimp#setPixelColor()`, `Jimp#scan()`, etc.), they will need to be explicitly added to `AppiumImage` if drivers are to move away from `getJimpImage()`. Drivers currently assume they are working with a monkeypatched `Jimp` instace; `AppiumImage` does not wrap `Jimp` _in its entirety_.

Further, `@appium/opencv` may benefit from using `AppiumImage`, but this has not been changed.

Other notes:

- I ended up _not_ changing the return value of `ImageElementFinder#findByImage()` because it was a rabbit hole. I don't think external code interacts with `ImageElementFinder` directly, so this is more of a nice-to-have.
- There are some other methods (e.g., `cropImage()`, `imageToBase64()`) in the `image-util` module which seem to operate directly on `Buffer`s instead of `Jimp` instances. I'm unsure why this is, since presumably `Jimp` can crop images. Anyway, some drivers use this code, but it isn't used anywhere else in this codebase.
