### PR TITLE
chore(appium,base-driver,base-plugin,doctor,docutils,eslint-config-appium,execute-driver-plugin,fake-driver,fake-plugin,gulp-plugins,images-plugin,opencv,relaxed-caps-plugin,schema,support,test-support,types,universal-xml-plugin): fix engines field 😂

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "yaml-js": "0.3.1"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -91,7 +91,7 @@
     "yaml": "2.1.0"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/appium/test/unit/config.spec.js
+++ b/packages/appium/test/unit/config.spec.js
@@ -129,6 +129,8 @@ describe('Config', function () {
           'v8.0.0',
           'v9.2.3',
           'v10.1.0',
+          'v11.0.0',
+          'v12.0.0',
         ];
         for (const version of unsupportedVersions) {
           it(`should fail if node is ${version}`, function () {
@@ -140,19 +142,19 @@ describe('Config', function () {
       });
 
       describe('supported nodes', function () {
-        it('should succeed if node is 12+', function () {
-          // @ts-expect-error
-          process.version = 'v12.0.1';
-          checkNodeOk.should.not.throw();
-        });
-        it('should succeed if node is 13+', function () {
-          // @ts-expect-error
-          process.version = 'v13.6.0';
-          checkNodeOk.should.not.throw();
-        });
         it('should succeed if node is 14+', function () {
           // @ts-expect-error
           process.version = 'v14.0.0';
+          checkNodeOk.should.not.throw();
+        });
+        it('should succeed if node is 16+', function () {
+          // @ts-expect-error
+          process.version = 'v16.0.0';
+          checkNodeOk.should.not.throw();
+        });
+        it('should succeed if node is 18+', function () {
+          // @ts-expect-error
+          process.version = 'v18.0.0';
           checkNodeOk.should.not.throw();
         });
       });

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -69,7 +69,7 @@
     "validate.js": "0.13.1"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/base-plugin/package.json
+++ b/packages/base-plugin/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/base-plugin"
   },
   "license": "Apache-2.0",
-  "author": "Appium <maintainers@appium.io>",
+  "author": "https://github.com/appium",
   "directories": {
     "lib": "./lib"
   },
@@ -35,12 +35,13 @@
     "@appium/support": "file:../support"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "types": "./build/lib/plugin.d.ts",
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
   "tags": [
     "appium"
-  ]
+  ],
+  "homepage": "https://appium.io"
 }

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -58,7 +58,7 @@
     "yargs": "17.5.1"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -49,7 +49,7 @@
     "teen_process": "1.16.0"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/eslint-config-appium/package.json
+++ b/packages/eslint-config-appium/package.json
@@ -40,7 +40,7 @@
     "eslint-plugin-promise": "6.0.0"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -7,7 +7,7 @@
     "automation",
     "webdriver"
   ],
-  "homepage": "https://github.com/appium/appium#readme",
+  "homepage": "https://appium.io",
   "bugs": {
     "url": "https://github.com/appium/appium/issues"
   },
@@ -17,7 +17,7 @@
     "directory": "packages/execute-driver-plugin"
   },
   "license": "Apache-2.0",
-  "author": "Appium <maintainers@appium.io>",
+  "author": "https://github.com/appium",
   "files": [
     "build",
     "lib",
@@ -49,5 +49,9 @@
     "pluginName": "execute-driver",
     "mainClass": "ExecuteDriverPlugin"
   },
-  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
+  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
+  "engines": {
+    "node": ">=14",
+    "npm": ">=6"
+  }
 }

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -58,7 +58,7 @@
     "appium": "^2.0.0-beta.35"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/fake-plugin"
   },
   "license": "Apache-2.0",
-  "author": "Appium <maintainers@appium.io>",
+  "author": "https://github.com/appium",
   "main": "./build/index.js",
   "directories": {
     "lib": "./lib"
@@ -39,7 +39,7 @@
     "appium": "^2.0.0-beta.35"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "appium": {
@@ -53,5 +53,6 @@
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
   "tags": [
     "appium"
-  ]
+  ],
+  "homepage": "https://appium.io"
 }

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -95,7 +95,7 @@
     "gulp": "^4.0.2"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -18,7 +18,7 @@
     "directory": "packages/images-plugin"
   },
   "license": "Apache-2.0",
-  "author": "Appium <maintainers@appium.io>",
+  "author": "https://github.com/appium",
   "files": [
     "build",
     "docs",
@@ -47,5 +47,10 @@
     "mainClass": "ImageElementPlugin"
   },
   "types": "./build/lib/plugin.d.ts",
-  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
+  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
+  "homepage": "https://appium.io",
+  "engines": {
+    "node": ">=14",
+    "npm": ">=6"
+  }
 }

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -51,7 +51,7 @@
     "source-map-support": "0.5.21"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/relaxed-caps-plugin"
   },
   "license": "Apache-2.0",
-  "author": "Appium <maintainers@appium.io>",
+  "author": "https://github.com/appium",
   "directories": {
     "lib": "./lib"
   },
@@ -36,7 +36,7 @@
     "appium": "^2.0.0-beta.35"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "appium": {
@@ -46,5 +46,6 @@
   "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
   "tags": [
     "appium"
-  ]
+  ],
+  "homepage": "https://appium.io"
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -39,7 +39,7 @@
     "prepare": "npm run build"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -80,7 +80,7 @@
     "yauzl": "2.10.0"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -55,7 +55,7 @@
     "source-map-support": "0.5.21"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -34,7 +34,7 @@
     "@appium/schema": "file:../schema"
   },
   "engines": {
-    "node": ">=12",
+    "node": ">=14",
     "npm": ">=6"
   },
   "publishConfig": {

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -8,16 +8,16 @@
     "xml",
     "webdriver"
   ],
-  "homepage": "https://github.com/appium/appium-plugins#readme",
+  "homepage": "https://appium.io",
   "bugs": {
-    "url": "https://github.com/appium/appium-plugins/issues"
+    "url": "https://github.com/appium/appium/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/appium/appium-plugins.git"
   },
   "license": "Apache-2.0",
-  "author": "Appium <maintainers@appium.io>",
+  "author": "https://github.com/appium",
   "types": "./build/lib/plugin.d.ts",
   "files": [
     "index.js",
@@ -45,5 +45,9 @@
     "pluginName": "universal-xml",
     "mainClass": "UniversalXMLPlugin"
   },
-  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574"
+  "gitHead": "722ae145fb40bf17b0168ea8b025763f120ad574",
+  "engines": {
+    "node": ">=14",
+    "npm": ">=6"
+  }
 }


### PR DESCRIPTION
...we never updated the `engines` fields when we dropped Node.js v12 support.