### PR TITLE
fix: ensure babel runtime and source map support are present in plugins

### DIFF
--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -55,7 +55,7 @@
     "prepare": "npm run build",
     "publish:docs": "APPIUM_DOCS_PUBLISH=1 npm run build:docs",
     "test": "npm run test:unit",
-    "test:e2e": "mocha --timeout 50s --slow 30s \"./test/e2e/**/*.spec.js\"",
+    "test:e2e": "mocha --timeout 75s --slow 30s \"./test/e2e/**/*.spec.js\"",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -34,8 +34,10 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
+    "@babel/runtime": "7.18.3",
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
+    "source-map-support": "0.5.21",
     "vm2": "3.9.9",
     "webdriverio": "7.19.7"
   },

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -32,8 +32,10 @@
   "dependencies": {
     "@appium/base-plugin": "^1.9.1",
     "@appium/support": "^2.59.1",
+    "@babel/runtime": "7.18.3",
     "bluebird": "3.7.2",
-    "lodash": "4.17.21"
+    "lodash": "4.17.21",
+    "source-map-support": "0.5.21"
   },
   "peerDependencies": {
     "appium": "^2.0.0-beta.35"

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -37,7 +37,9 @@
   },
   "dependencies": {
     "@appium/opencv": "^1.0.9",
-    "lru-cache": "7.10.1"
+    "@babel/runtime": "7.18.3",
+    "lru-cache": "7.10.1",
+    "source-map-support": "0.5.21"
   },
   "peerDependencies": {
     "appium": "^2.0.0-beta.35"

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -30,7 +30,9 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "lodash": "4.17.21"
+    "@babel/runtime": "7.18.3",
+    "lodash": "4.17.21",
+    "source-map-support": "0.5.21"
   },
   "peerDependencies": {
     "appium": "^2.0.0-beta.35"

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -34,7 +34,9 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
+    "@babel/runtime": "7.18.3",
     "fast-xml-parser": "3.21.1",
+    "source-map-support": "0.5.21",
     "xmldom": "0.6.0",
     "xpath": "0.0.32"
   },


### PR DESCRIPTION
It looks like this was not done when they were migrated. The plugins worked in the repo because of extraneous deps, and it sometimes worked in Appium Home depending on what other things were installed. But this is necessary.

cc @boneskull 