### PR TITLE
chore(ci): run smoke test in all packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           script: test:smoke
           workspaces: true
+          quiet: true
       - name: Run unit & E2E tests
         run: npm run test:ci
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   test:
-    name: Test
+    name: Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,7 +27,12 @@ jobs:
         run: |
           npm install
           npm run install-mjpeg-consumer
-      - name: Run all tests
+      - name: Run smoke tests
+        uses: boneskull/nodejs-production-test-action@v1
+        with:
+          script: test:smoke
+          workspaces: true
+      - name: Run unit & E2E tests
         run: npm run test:ci
 
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ appium.zip
 packages/*/LICENSE
 local_appium_home
 jsdoc-out
+*.tgz

--- a/package.json
+++ b/package.json
@@ -192,5 +192,8 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -56,6 +56,7 @@
     "publish:docs": "APPIUM_DOCS_PUBLISH=1 npm run build:docs",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 75s --slow 30s \"./test/e2e/**/*.spec.js\"",
+    "test:smoke": "node ./index.js --show-build-info",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/appium/test/e2e/e2e-helpers.js
+++ b/packages/appium/test/e2e/e2e-helpers.js
@@ -37,7 +37,7 @@ async function run(appiumHome, args, opts = {}) {
   opts.env = _.defaults(opts.env, {APPIUM_HOME: appiumHome, PATH: process.env.PATH});
   try {
     args = [...process.execArgv, '--', EXECUTABLE, ...args];
-    log.debug('APPIUM_HOME: %s', opts.env.appiumHome);
+    log.debug('APPIUM_HOME: %s', opts.env.APPIUM_HOME);
     log.debug(`Running: ${process.execPath} ${args.join(' ')}`);
     const retval = await exec(process.execPath, args, {
       ...opts,

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -46,6 +46,7 @@
     "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/base-plugin/package.json
+++ b/packages/base-plugin/package.json
@@ -29,6 +29,7 @@
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "prepare": "npm run build",
     "test": "npm run test:unit",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -43,6 +43,7 @@
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "prepare": "npm run build",
     "test": "npm run test:unit",
+    "test:smoke": "node ./build/lib/index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -37,8 +37,10 @@
     "build"
   ],
   "scripts": {
-    "build": "babel lib --root-mode=upward --out-dir=build/lib",
-    "dev": "npm run build -- --watch",
+    "build:lib": "babel lib --root-mode=upward --out-dir=build/lib",
+    "build:bin": "babel bin --root-mode=upward --out-dir=build/bin",
+    "build": "run-s build:*",
+    "dev": "run-p \"build:lib -- --watch\" \"build:bin -- --watch\"",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "prepare": "npm run build",

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -37,6 +37,7 @@
     "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "echo \"No e2e tests for this package\"",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/eslint-config-appium/package.json
+++ b/packages/eslint-config-appium/package.json
@@ -28,7 +28,8 @@
     "eslint:find:current-rules": "eslint-find-rules -c",
     "eslint:find:plugin-rules": "eslint-find-rules -p",
     "eslint:find:unused-rules": "eslint-find-rules -u -n",
-    "lint": "eslint index.js"
+    "lint": "eslint index.js",
+    "test:smoke": "node ./index.js"
   },
   "peerDependencies": {
     "@babel/core": "7.18.2",

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -31,6 +31,7 @@
     "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha -t 160s --slow 20s \"./test/e2e/**/*.spec.js\"",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -43,6 +43,7 @@
     "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
+    "test:smoke": "node ./build/lib/index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/fake-plugin/lib/scripts/fake-error.js
+++ b/packages/fake-plugin/lib/scripts/fake-error.js
@@ -1,0 +1,1 @@
+throw Error('Unsuccessfully ran the script');

--- a/packages/fake-plugin/lib/scripts/fake-success.js
+++ b/packages/fake-plugin/lib/scripts/fake-success.js
@@ -1,0 +1,3 @@
+import log from '../logger';
+
+log.info('Successfully ran the script');

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -18,6 +18,7 @@
     "lib": "./lib"
   },
   "files": [
+    "index.js",
     "lib",
     "build"
   ],

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -2,6 +2,7 @@
   "name": "@appium/fake-plugin",
   "version": "2.0.3",
   "description": "A fake Appium 2.0 plugin",
+  "homepage": "https://appium.io",
   "bugs": {
     "url": "https://github.com/appium/appium/issues"
   },
@@ -27,6 +28,7 @@
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "prepare": "npm run build",
     "test": "npm run test:unit",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
@@ -55,6 +57,5 @@
   "gitHead": "5c7af8ee73078018e4ec52fccf19fe3f77249d72",
   "tags": [
     "appium"
-  ],
-  "homepage": "https://appium.io"
+  ]
 }

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -39,7 +39,8 @@
     "build": "gulp transpile",
     "prepare": "npm run build",
     "test": "gulp unit-test:run",
-    "test:e2e": "gulp e2e-test:run"
+    "test:e2e": "gulp e2e-test:run",
+    "test:smoke": "node ./index.js"
   },
   "dependencies": {
     "@appium/eslint-config-appium": "^6.0.2",

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -33,6 +33,7 @@
     "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 40s --slow 20s \"./test/e2e/**/*.spec.js\"",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -40,6 +40,7 @@
     "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -27,6 +27,7 @@
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "prepare": "npm run build",
     "test": "npm run test:unit",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -36,7 +36,8 @@
     "dev": "npm run build:distfiles -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test:smoke": "node ./index.js"
   },
   "engines": {
     "node": ">=14",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -40,6 +40,7 @@
     "prepare": "npm run build",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -43,6 +43,7 @@
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "prepare": "npm run build",
     "test": "npm run test:unit",
+    "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -28,7 +28,8 @@
     "dev": "npm run build -- --watch",
     "fix": "npm run lint -- --fix",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "test:smoke": "echo 'No smoke test for this package'"
   },
   "dependencies": {
     "@appium/schema": "^0.0.7"

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "prepare": "npm run build",
     "test": "npm run test:unit",
+    "test:smoke": "node ./build/lib/index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {


### PR DESCRIPTION
This uses the [boneskull/nodejs-production-test-action](https://github.com/boneskull/nodejs-production-test-action) GH action to run a smoke test across all packages.

The action does the following:

1. Runs `npm pack` on each package, writing the tarball to a temp dir. This tarball contains the package as a user would `npm install` it.
2. Changes into the temp dir and runs `npm install <tarball>` on each
3. Runs a specified script (in our case, `test:smoke`) in each installed package's dir in `<tmp_dir>/node_modules`

Because `devDependencies` will not be present, this should avoid a class of issues where production deps are miscategorized as dev deps.

The action should probably use a separate temp dir for each--in the case of a dependency being present but only because some other package depends on it--but it's not smart enough to figure out peer dependencies yet.