### PR TITLE
fix(appium): postinstall: never assume local appium if it is being installed globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@types/teen_process": "1.16.0",
     "@types/through2": "2.0.36",
     "@types/uuid": "8.3.4",
+    "@types/wrap-ansi": "3.0.0",
     "@types/ws": "8.5.3",
     "@types/xmldom": "0.1.31",
     "@wdio/types": "7.20.0",

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -87,7 +87,7 @@
     "supports-color": "8.1.1",
     "teen_process": "1.16.0",
     "winston": "3.7.2",
-    "word-wrap": "1.2.3",
+    "wrap-ansi": "7.0.0",
     "yaml": "2.1.1"
   },
   "engines": {

--- a/packages/appium/scripts/autoinstall-extensions.js
+++ b/packages/appium/scripts/autoinstall-extensions.js
@@ -28,11 +28,17 @@ let PLUGIN_TYPE;
 let loadExtensions;
 
 const {env, util, logger} = require('@appium/support');
+const _ = require('lodash');
+const wrap = _.partial(
+  require('wrap-ansi'),
+  _,
+  process.stderr.columns ?? process.stdout.columns ?? 25
+);
 
 const ora = require('ora');
 
 const log = (message) => {
-  console.error(`[Appium] ${message}`);
+  console.error(wrap(`[Appium] ${message}`));
 };
 
 const spinner = ora({
@@ -59,7 +65,8 @@ try {
 }
 
 async function main() {
-  if (await env.hasAppiumDependency()) {
+  // if we're doing `npm install -g appium` then we will assume we don't have a local appium.
+  if (!process.env.npm_config_global && (await env.hasAppiumDependency())) {
     log(`Found local Appium installation; skipping automatic installation of extensions.`);
     return;
   }
@@ -74,7 +81,8 @@ async function main() {
 
   if (!driverEnv && !pluginEnv) {
     spinner.succeed(
-      'No drivers or plugins to automatically install. If desired, provide arguments with comma-separated values "--drivers=<known_driver>[,known_driver...]" and/or "--plugins=<known_plugin>[,known_plugin...]" to the "npm install appium" command. The specified extensions will be installed automatically with Appium.  Note: to see the list of known extensions, run "appium <driver|plugin> list".'
+      wrap(`No drivers or plugins to automatically install. 
+      If desired, provide arguments with comma-separated values "--drivers=<known_driver>[,known_driver...]" and/or "--plugins=<known_plugin>[,known_plugin...]" to the "npm install appium" command. The specified extensions will be installed automatically with Appium.  Note: to see the list of known extensions, run "appium <driver|plugin> list".`)
     );
     return;
   }


### PR DESCRIPTION
In addition, wrap the text to the terminal.  `wrap-ansi` is good b/c it
considers colors/emoji/etc.

Removed unused dep `word-wrap`.

Resolves #17054