### PR TITLE
fix: Update the way build info is fetched from GitHub

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -108,10 +108,13 @@ class AppiumDriver extends DriverCore {
 
     // allow this to happen in the background, so no `await`
     // catch this to avoid an unhandled rejection
-    // eslint-disable-next-line promise/prefer-await-to-then,promise/prefer-await-to-callbacks
-    updateBuildInfo().catch((err) => {
-      this.log.debug(err);
-    });
+    (async () => {
+      try {
+        await updateBuildInfo();
+      } catch (e) {
+        this.log.debug(`Appium build into cannot be updated: ${e.message}`);
+      }
+    })();
   }
 
   /**

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -107,11 +107,11 @@ class AppiumDriver extends DriverCore {
     this.args = {...opts};
 
     // allow this to happen in the background, so no `await`
-    // catch this to avoid an unhandled rejection
     (async () => {
       try {
         await updateBuildInfo();
       } catch (e) {
+        // make sure we catch any possible errors to avoid unhandled rejections
         this.log.debug(`Cannot fetch Appium build info: ${e.message}`);
       }
     })();

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -112,7 +112,7 @@ class AppiumDriver extends DriverCore {
       try {
         await updateBuildInfo();
       } catch (e) {
-        this.log.debug(`Appium build into cannot be updated: ${e.message}`);
+        this.log.debug(`Cannot fetch Appium build info: ${e.message}`);
       }
     })();
   }

--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -37,9 +37,9 @@ async function updateBuildInfo(useGithubApiFallback = false) {
     return;
   }
   BUILD_INFO['git-sha'] = sha;
-  const builtTimestamp = await getGitTimestamp(sha, useGithubApiFallback);
-  if (builtTimestamp) {
-    BUILD_INFO.built = builtTimestamp;
+  const buildTimestamp = await getGitTimestamp(sha, useGithubApiFallback);
+  if (buildTimestamp) {
+    BUILD_INFO.built = buildTimestamp;
   }
 }
 

--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -28,15 +28,18 @@ function getNodeVersion() {
   return /** @type {import('semver').SemVer} */ (semver.coerce(process.version));
 }
 
+/**
+ * @param {boolean} [useGithubApiFallback]
+ */
 async function updateBuildInfo(useGithubApiFallback = false) {
   const sha = await getGitRev(useGithubApiFallback);
   if (!sha) {
     return;
   }
   BUILD_INFO['git-sha'] = sha;
-  const built = await getGitTimestamp(sha, useGithubApiFallback);
-  if (built) {
-    BUILD_INFO.built = built;
+  const builtTimestamp = await getGitTimestamp(sha, useGithubApiFallback);
+  if (builtTimestamp) {
+    BUILD_INFO.built = builtTimestamp;
   }
 }
 
@@ -51,6 +54,10 @@ async function findGitRoot() {
   return await findUp(GIT_META_ROOT, {cwd: rootDir, type: 'directory'});
 }
 
+/**
+ * @param {boolean} [useGithubApiFallback]
+ * @returns {Promise<string?>}
+ */
 async function getGitRev(useGithubApiFallback = false) {
   const gitRoot = await findGitRoot();
   if (gitRoot) {
@@ -66,21 +73,16 @@ async function getGitRev(useGithubApiFallback = false) {
     return null;
   }
 
+  // If the package folder is not a valid git repository
+  // then fetch the corresponding tag info from GitHub
   try {
-    const resBodyObj = (
-      await axios.get(`${GITHUB_API}/tags`, {
+    return (
+      await axios.get(`${GITHUB_API}/git/refs/tags/appium@${APPIUM_VER}`, {
         headers: {
           'User-Agent': `Appium ${APPIUM_VER}`,
         },
       })
-    ).data;
-    if (_.isArray(resBodyObj)) {
-      for (const {name, commit} of resBodyObj) {
-        if (name === `v${APPIUM_VER}` && commit && commit.sha) {
-          return commit.sha;
-        }
-      }
-    }
+    ).data?.object?.sha;
   } catch (ign) {}
   return null;
 }
@@ -106,21 +108,13 @@ async function getGitTimestamp(commitSha, useGithubApiFallback = false) {
   }
 
   try {
-    const resBodyObj = (
-      await axios.get(`${GITHUB_API}/commits/${commitSha}`, {
+    return (
+      await axios.get(`${GITHUB_API}/git/tags/${commitSha}`, {
         headers: {
           'User-Agent': `Appium ${APPIUM_VER}`,
         },
       })
-    ).data;
-    if (resBodyObj && resBodyObj.commit) {
-      if (resBodyObj.commit.committer && resBodyObj.commit.committer.date) {
-        return resBodyObj.commit.committer.date;
-      }
-      if (resBodyObj.commit.author && resBodyObj.commit.author.date) {
-        return resBodyObj.commit.author.date;
-      }
-    }
+    ).data?.tagger?.date;
   } catch (ign) {}
   return null;
 }

--- a/packages/appium/test/e2e/config.e2e.spec.js
+++ b/packages/appium/test/e2e/config.e2e.spec.js
@@ -54,7 +54,7 @@ describe('Config', function () {
         data: {
           ref: `refs/tags/appium@${APPIUM_VER}`,
           node_id: 'MDM6UmVmNzUzMDU3MDpyZWZzL3RhZ3MvYXBwaXVtQDIuMC4wLWJldGEuNDA=',
-          url: 'https://api.github.com/repos/appium/appium/git/refs/tags/appium@2.0.0-beta.40',
+          url: `https://api.github.com/repos/appium/appium/git/refs/tags/appium@${APPIUM_VER}`,
           object: {
             sha: 'a7404fddd50ee1c6ff1aac3d2f259abab0d3291a',
             type: 'tag',

--- a/packages/appium/test/e2e/config.e2e.spec.js
+++ b/packages/appium/test/e2e/config.e2e.spec.js
@@ -51,64 +51,41 @@ describe('Config', function () {
     });
     it('should get a configuration object if the local git metadata is not present', async function () {
       getStub.onCall(0).returns({
-        data: [
-          {
-            name: `v${APPIUM_VER}`,
-            zipball_url: 'https://api.github.com/repos/appium/appium/zipball/v1.9.0-beta.1',
-            tarball_url: 'https://api.github.com/repos/appium/appium/tarball/v1.9.0-beta.1',
-            commit: {
-              sha: '3c2752f9f9c56000705a4ae15b3ba68a5d2e644c',
-              url: 'https://api.github.com/repos/appium/appium/commits/3c2752f9f9c56000705a4ae15b3ba68a5d2e644c',
-            },
-            node_id: 'MDM6UmVmNzUzMDU3MDp2MS45LjAtYmV0YS4x',
-          },
-          {
-            name: 'v1.8.2-beta',
-            zipball_url: 'https://api.github.com/repos/appium/appium/zipball/v1.8.2-beta',
-            tarball_url: 'https://api.github.com/repos/appium/appium/tarball/v1.8.2-beta',
-            commit: {
-              sha: '5b98b9197e75aa85e7507d21d3126c1a63d1ce8f',
-              url: 'https://api.github.com/repos/appium/appium/commits/5b98b9197e75aa85e7507d21d3126c1a63d1ce8f',
-            },
-            node_id: 'MDM6UmVmNzUzMDU3MDp2MS44LjItYmV0YQ==',
-          },
-        ],
+        data: {
+          ref: `refs/tags/appium@${APPIUM_VER}`,
+          node_id: 'MDM6UmVmNzUzMDU3MDpyZWZzL3RhZ3MvYXBwaXVtQDIuMC4wLWJldGEuNDA=',
+          url: 'https://api.github.com/repos/appium/appium/git/refs/tags/appium@2.0.0-beta.40',
+          object: {
+            sha: 'a7404fddd50ee1c6ff1aac3d2f259abab0d3291a',
+            type: 'tag',
+            url: 'https://api.github.com/repos/appium/appium/git/tags/a7404fddd50ee1c6ff1aac3d2f259abab0d3291a'
+          }
+        }
       });
       getStub.onCall(1).returns({
         data: {
-          sha: '3c2752f9f9c56000705a4ae15b3ba68a5d2e644c',
-          node_id: 'MDY6Q29tbWl0NzUzMDU3MDozYzI3NTJmOWY5YzU2MDAwNzA1YTRhZTE1YjNiYTY4YTVkMmU2NDRj',
-          commit: {
-            author: {
-              name: 'Isaac Murchie',
-              email: 'isaac@saucelabs.com',
-              date: '2018-08-17T19:48:00Z',
-            },
-            committer: {
-              name: 'Isaac Murchie',
-              email: 'isaac@saucelabs.com',
-              date: '2018-08-17T19:48:00Z',
-            },
-            message: 'v1.9.0-beta.1',
-            tree: {
-              sha: '2c0974727470eba419ea0b9951c52f72f8036b18',
-              url: 'https://api.github.com/repos/appium/appium/git/trees/2c0974727470eba419ea0b9951c52f72f8036b18',
-            },
-            url: 'https://api.github.com/repos/appium/appium/git/commits/3c2752f9f9c56000705a4ae15b3ba68a5d2e644c',
-            comment_count: 0,
-            verification: {
-              verified: false,
-              reason: 'unsigned',
-              signature: null,
-              payload: null,
-            },
+          node_id: 'TA_kwDOAHLoStoAKGE3NDA0ZmRkZDUwZWUxYzZmZjFhYWMzZDJmMjU5YWJhYjBkMzI5MWE',
+          sha: 'a7404fddd50ee1c6ff1aac3d2f259abab0d3291a',
+          url: 'https://api.github.com/repos/appium/appium/git/tags/a7404fddd50ee1c6ff1aac3d2f259abab0d3291a',
+          tagger: {
+            name: 'Jonathan Lipps',
+            email: 'jlipps@gmail.com',
+            date: '2022-06-04T02:08:17Z'
           },
-          url: 'https://api.github.com/repos/appium/appium/commits/3c2752f9f9c56000705a4ae15b3ba68a5d2e644c',
-          html_url:
-            'https://github.com/appium/appium/commit/3c2752f9f9c56000705a4ae15b3ba68a5d2e644c',
-          comments_url:
-            'https://api.github.com/repos/appium/appium/commits/3c2752f9f9c56000705a4ae15b3ba68a5d2e644c/comments',
-        },
+          object: {
+            sha: '4cf2cc92d066ed32adda27e0439547290a4b71ce',
+            type: 'commit',
+            url: 'https://api.github.com/repos/appium/appium/git/commits/4cf2cc92d066ed32adda27e0439547290a4b71ce'
+          },
+          tag: `appium@${APPIUM_VER}`,
+          message: `appium@${APPIUM_VER}\n`,
+          verification: {
+            verified: false,
+            reason: 'unsigned',
+            signature: null,
+            payload: null
+          }
+        }
       });
       await verifyBuildInfoUpdate(false);
     });

--- a/packages/appium/test/unit/appiumdriver.spec.js
+++ b/packages/appium/test/unit/appiumdriver.spec.js
@@ -67,7 +67,7 @@ describe('AppiumDriver', function () {
       sandbox.stub(ad._log, 'debug');
       // finally, wait for `updateBuildInfo()` to finish up
       await promise;
-      ad._log.debug.should.have.been.calledOnceWith(err);
+      ad._log.debug.should.have.been.calledOnce;
     });
   });
 


### PR DESCRIPTION
## Proposed changes

We have changed the way our monorepo is tagged and thus it's necessary to update the build info retrieval logic that uses GitHub REST API. Previously the /status call was returning some random stuff

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
