### PR TITLE
fix(appium,support): fix installation problems

### DIFF
--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -4,7 +4,7 @@ import {init as logsinkInit} from './logsink'; // this import needs to come firs
 import logger from './logger'; // logger needs to remain second
 // @ts-ignore
 import {routeConfiguringFunction as makeRouter, server as baseServer} from '@appium/base-driver';
-import {logger as logFactory, util, env} from '@appium/support';
+import {logger as logFactory, util, env, fs} from '@appium/support';
 import {asyncify} from 'asyncbox';
 import _ from 'lodash';
 import {AppiumDriver} from './appium';
@@ -15,6 +15,7 @@ import {
   checkNodeOk,
   getGitRev,
   getNonDefaultServerArgs,
+  rootDir,
   showConfig,
   showBuildInfo,
   validateTmpDir,
@@ -26,8 +27,9 @@ import {DRIVER_TYPE, PLUGIN_TYPE, SERVER_SUBCOMMAND} from './constants';
 import registerNode from './grid-register';
 import {getDefaultsForSchema, validate} from './schema/schema';
 import {inspect} from './utils';
+import path from 'path';
 
-const {resolveAppiumHome} = env;
+const {resolveAppiumHome, hasAppiumDependency} = env;
 
 /**
  *
@@ -169,6 +171,19 @@ function areServerCommandArgs(args) {
  */
 async function init(args) {
   const appiumHome = args?.appiumHome ?? (await resolveAppiumHome());
+
+  // this is here so extensions installed in e.g., `~/.appium` can find the peer dependency
+  // of `appium`, which lives wherever it lives (see `rootDir`).
+  if (!(await hasAppiumDependency(appiumHome))) {
+    try {
+      await fs.mkdirp(path.join(appiumHome, 'node_modules'));
+      await fs.symlink(rootDir, path.join(appiumHome, 'node_modules', 'appium'), 'junction');
+    } catch (err) {
+      if (err.code !== 'EEXIST') {
+        throw new Error(`Unable to create symlink to appium: ${err.message}`);
+      }
+    }
+  }
 
   const {driverConfig, pluginConfig} = await loadExtensions(appiumHome);
 

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -56,7 +56,7 @@
     "prepare": "npm run build",
     "publish:docs": "APPIUM_DOCS_PUBLISH=1 npm run build:docs",
     "test": "npm run test:unit",
-    "test:e2e": "mocha --timeout 75s --slow 30s \"./test/e2e/**/*.spec.js\"",
+    "test:e2e": "mocha --timeout 1m --slow 30s \"./test/e2e/**/*.spec.js\"",
     "test:smoke": "node ./index.js --show-build-info",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },

--- a/packages/support/test/unit/env.spec.js
+++ b/packages/support/test/unit/env.spec.js
@@ -254,8 +254,32 @@ describe('env', function () {
           MockPkgDir.resolves();
         });
 
-        it('should resolve `false``', async function () {
+        it('should resolve `false`', async function () {
           await expect(env.hasAppiumDependency('/somewhere')).to.eventually.equal(false);
+        });
+
+        describe('when it is installed, but extraneous', function () {
+          beforeEach(function () {
+            MockTeenProcess.exec.resolves({
+              stdout: JSON.stringify({
+                version: '0.0.0',
+                name: 'some-pkg',
+                dependencies: {
+                  appium: {
+                    extraneous: true,
+                    version: '2.0.0-beta.25',
+                    resolved: 'https://some/appium-tarball.tgz',
+                  },
+                },
+              }),
+              stderr: '',
+              code: 0,
+            });
+          });
+
+          it('should resolve `false`', async function () {
+            await expect(env.hasAppiumDependency('/somewhere')).to.eventually.equal(false);
+          });
         });
       });
 


### PR DESCRIPTION
Ref: #17073

this change uses `--legacy-peer-deps` for newer versions of npm to
avoid installation of appium when installing extensions in `~/.appium`.  this does not work if the extension contains a shrinkwrap with appium in it, though.
in that case, an extra copy of appium will always be installed.

it creates a symlink, e.g., `~/.appium/node_modules/appium` to the currently-running appium, wherever that is.  could not abuse `NODE_PATH` to do this, as changing it on-the-fly has no effect (it must be set at start of `node` process)

this is rather naive and does not check that the symlink is actually the same as the running appium if it already exists. that might cause some weird problems with multiple installs of appium on the same machine, but if it does, we can fix them as they arise.
