### PR TITLE
chore(renovate): add supports-color to major version exclusion list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
         "log-symbols",
         "read-pkg",
         "strip-ansi",
+        "supports-color",
         "term-size",
         "wrap-ansi",
         "write-pkg"


### PR DESCRIPTION
newer versions of `supports-color` are ESM-only.