### PR TITLE
fix: Logs format

### DIFF
--- a/packages/support/lib/zip.js
+++ b/packages/support/lib/zip.js
@@ -538,7 +538,7 @@ const getExecutablePath = _.memoize(
    */
   async function getExecutablePath(binaryName) {
     const fullPath = await fs.which(binaryName);
-    log.debug(`Found '%s' at '%s'`, binaryName, fullPath);
+    log.debug(`Found '${binaryName}' at '${fullPath}'`);
     return fullPath;
   }
 );


### PR DESCRIPTION
Our logger does not support format placeholders, so this line actually looks like
```
[debug] [Support] Found '%s' at '%s'
[debug] [Support] unzip
[debug] [Support] /usr/bin/unzip
```

in server logs.