### PR TITLE
typecheck the tests

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -7,12 +7,13 @@
     "declaration": true,
     "declarationMap": true,
     "emitDeclarationOnly": true,
-    "module": "es2015",
+    "module": "esnext",
+    "target": "es2015",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "strictNullChecks": true,
     "removeComments": false,
-    "target": "es2015",
-    "types": ["node", "mocha", "chai", "sinon-chai", "chai-as-promised"]
+    "lib": ["dom", "esnext"],
+    "types": ["node", "mocha", "chai", "sinon-chai", "chai-as-promised", "webdriverio/async"]
   }
 }

--- a/config/tsconfig.plugin.json
+++ b/config/tsconfig.plugin.json
@@ -2,11 +2,8 @@
   "compilerOptions": {
     "paths": {
       "appium": ["../packages/appium"]
-    },
-    "types": [
-      "mocha", "chai", "sinon", "sinon-chai", "chai-as-promised", "webdriverio/async"
-    ]
+    }
   },
   "extends": "./tsconfig.base.json",
-  "references": [{"path": "../packages/appium"}, {"path": "../packages/base-plugin"}, {"path": "../packages/types"}]
+  "references": [{"path": "../packages/appium"}, {"path": "../packages/base-plugin"}, {"path": "../packages/types"}, {"path": "../packages/support"}, {"path":"../packages/types"}]
 }

--- a/config/tsconfig.plugin.json
+++ b/config/tsconfig.plugin.json
@@ -3,7 +3,9 @@
     "paths": {
       "appium": ["../packages/appium"]
     },
-    "types": ["webdriverio/async"]
+    "types": [
+      "mocha", "chai", "sinon", "sinon-chai", "chai-as-promised", "webdriverio/async"
+    ]
   },
   "extends": "./tsconfig.base.json",
   "references": [{"path": "../packages/appium"}, {"path": "../packages/base-plugin"}, {"path": "../packages/types"}]

--- a/packages/appium/driver.js
+++ b/packages/appium/driver.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// @ts-check
-
 /**
  * This module is here to re-export `@appium/base-driver` for Appium extensions.
  *

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -178,32 +178,45 @@ function insertAppiumPrefixes(caps) {
       prefixedCaps[`${W3C_APPIUM_PREFIX}:${name}`] = value;
     }
   }
-  return prefixedCaps;
+  // XXX dubious.  It's unclear to me what the type is.  this code accepts
+  // a set of capabilities which could include the standard caps plus any appium-namespaced caps, and
+  // it passes those through verbatim.  everything else is namespaced with appium...even if it's not
+  // an appium capability?
+  return /** @type {AppiumW3CCapabilities} */ (prefixedCaps);
 }
 
 /**
- *
- * @param {AppiumW3CCapabilities} caps
- * @returns {Capabilities}
+ * @template {NamespacedRecord} [T=NamespacedRecord]
+ * @param {AppiumW3CCapabilities<T>} caps
+ * @returns {Capabilities<T>}
  */
 function removeAppiumPrefixes(caps) {
   if (!_.isPlainObject(caps)) {
     return caps;
   }
 
-  /** @type {Capabilities} */
-  const fixedCaps = {};
+  const fixedCaps = /** @type {Capabilities<T>} */ ({});
   for (let [name, value] of _.toPairs(caps)) {
     fixedCaps[removeAppiumPrefix(name)] = value;
   }
   return fixedCaps;
 }
 
+/**
+ *
+ * @param {string} key
+ * @returns {string}
+ */
 function removeAppiumPrefix(key) {
   const prefix = `${W3C_APPIUM_PREFIX}:`;
   return _.startsWith(key, prefix) ? key.substring(prefix.length) : key;
 }
 
+/**
+ *
+ * @param {string} pkgName
+ * @returns {string}
+ */
 function getPackageVersion(pkgName) {
   const pkgInfo = require(`${pkgName}/package.json`) || {};
   return pkgInfo.version;
@@ -264,7 +277,7 @@ export {
 /**
  * @todo protocol is more specific
  * @typedef InvalidCaps
- * @property {Error} error
+ * @property {import('@appium/base-driver').ProtocolError} error
  * @property {string} protocol
  * @property {Capabilities} [desiredCaps]
  * @property {any} [processedJsonwpCapabilities]
@@ -273,6 +286,16 @@ export {
 
 /**
  * @typedef {import('@appium/types').W3CCapabilities} W3CCapabilities
- * @typedef {import('@appium/types').Capabilities} Capabilities
- * @typedef {import('@appium/types').AppiumW3CCapabilities} AppiumW3CCapabilities
+ * @typedef {import('@appium/types').StringRecord} StringRecord
+ * @typedef {import('@appium/types').NamespacedRecord} NamespacedRecord
+ */
+
+/**
+ * @template {NamespacedRecord} [OptionalNamespacedCaps=NamespacedRecord]
+ * @typedef {import('@appium/types').AppiumW3CCapabilities<OptionalNamespacedCaps>} AppiumW3CCapabilities
+ */
+
+/**
+ * @template {StringRecord} [OptionalCaps=StringRecord]
+ * @typedef {import('@appium/types').Capabilities<OptionalCaps>} Capabilities
  */

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -32,7 +32,8 @@
   },
   "files": [
     "lib",
-    "build",
+    "build/lib",
+    "build/types",
     "index.js",
     "driver.*",
     "support.*",

--- a/packages/appium/plugin.js
+++ b/packages/appium/plugin.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// @ts-check
-
 /**
  * This module is here to re-export `@appium/base-plugin` for Appium extensions.
  *

--- a/packages/appium/scripts/parse-yml-commands.js
+++ b/packages/appium/scripts/parse-yml-commands.js
@@ -1,7 +1,5 @@
 #!/usr/bin/env node
 
-// @ts-check
-
 const path = require('path');
 const yaml = require('yaml');
 const {fs, util} = require('@appium/support');

--- a/packages/appium/scripts/write-server-args-docs.js
+++ b/packages/appium/scripts/write-server-args-docs.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-// @ts-check
-
 const {writeFileSync} = require('fs');
 const path = require('path');
 let parser;

--- a/packages/appium/support.js
+++ b/packages/appium/support.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// @ts-check
-
 /**
  * This module is here to re-export `@appium/support` for Appium extensions.
  *

--- a/packages/appium/test.js
+++ b/packages/appium/test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-// @ts-check
-
 /**
  * This module is here to re-export `@appium/test-support` for Appium extensions.
  *

--- a/packages/appium/test/e2e/cli.e2e.spec.js
+++ b/packages/appium/test/e2e/cli.e2e.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {npm, env, fs, tempDir, util} from '@appium/support';
 import B from 'bluebird';
 import path from 'path';
@@ -259,7 +257,7 @@ describe('CLI behavior', function () {
               await runList(['--updates'])
             );
           util.compareVersions(
-            fake.updateVersion,
+            /** @type {string} */ (fake.updateVersion),
             '>',
             penultimateFakeDriverVersionAsOfRightNow
           ).should.be.true;
@@ -280,8 +278,10 @@ describe('CLI behavior', function () {
           ret.uiautomator2.installType.should.eql('npm');
           ret.uiautomator2.installSpec.should.eql('uiautomator2');
           const list = await runList(['--installed']);
-          delete list.uiautomator2.installed;
-          list.should.eql(ret);
+          list.should.eql({
+            ...ret,
+            uiautomator2: {...ret.uiautomator2, installed: list.uiautomator2.installed},
+          });
         });
         it('should install a driver from npm', async function () {
           const ret = await runInstall(['@appium/fake-driver', '--source', 'npm']);
@@ -289,8 +289,10 @@ describe('CLI behavior', function () {
           ret.fake.installType.should.eql('npm');
           ret.fake.installSpec.should.eql('@appium/fake-driver');
           const list = await runList(['--installed']);
-          delete list.fake.installed;
-          list.should.eql(ret);
+          list.should.eql({
+            ...ret,
+            fake: {...ret.fake, installed: list.fake.installed},
+          });
         });
 
         it('should install a driver from npm and a local driver', async function () {
@@ -321,8 +323,10 @@ describe('CLI behavior', function () {
           ret.fake.installType.should.eql('npm');
           ret.fake.installSpec.should.eql(installSpec);
           const list = await runList(['--installed']);
-          delete list.fake.installed;
-          list.should.eql(ret);
+          list.should.eql({
+            ...ret,
+            fake: {...ret.fake, installed: list.fake.installed},
+          });
         });
         it('should install a driver from github', async function () {
           const ret = await runInstall([
@@ -336,8 +340,10 @@ describe('CLI behavior', function () {
           ret.fake.installType.should.eql('github');
           ret.fake.installSpec.should.eql('appium/appium-fake-driver');
           const list = await runList(['--installed']);
-          delete list.fake.installed;
-          list.should.eql(ret);
+          list.should.eql({
+            ...ret,
+            fake: {...ret.fake, installed: list.fake.installed},
+          });
         });
         it('should install a driver from a local git repo', async function () {
           const ret = await runInstall([
@@ -351,8 +357,10 @@ describe('CLI behavior', function () {
           ret.fake.installType.should.eql('git');
           ret.fake.installSpec.should.eql(FAKE_DRIVER_DIR);
           const list = await runList(['--installed', '--json']);
-          delete list.fake.installed;
-          list.should.eql(ret);
+          list.should.eql({
+            ...ret,
+            fake: {...ret.fake, installed: list.fake.installed},
+          });
         });
         it('should install a driver from a remote git repo', async function () {
           const ret = await runInstall([
@@ -366,8 +374,10 @@ describe('CLI behavior', function () {
           ret.fake.installType.should.eql('git');
           ret.fake.installSpec.should.eql('git+https://github.com/appium/appium-fake-driver');
           const list = await runList(['--installed']);
-          delete list.fake.installed;
-          list.should.eql(ret);
+          list.should.eql({
+            ...ret,
+            fake: {...ret.fake, installed: list.fake.installed},
+          });
         });
         it('should install a driver from a local npm module', async function () {
           // take advantage of the fact that we know we have fake driver installed as a dependency in
@@ -377,8 +387,10 @@ describe('CLI behavior', function () {
           ret.fake.installType.should.eql('local');
           ret.fake.installSpec.should.eql(FAKE_DRIVER_DIR);
           const list = await runList(['--installed']);
-          delete list.fake.installed;
-          list.should.eql(ret);
+          list.should.eql({
+            ...ret,
+            fake: {...ret.fake, installed: list.fake.installed},
+          });
 
           // it should be a link!  this may be npm-version dependent, but it's worked
           // this way for quite awhile

--- a/packages/appium/test/e2e/config-file.e2e.spec.js
+++ b/packages/appium/test/e2e/config-file.e2e.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {DRIVER_TYPE} from '../../lib/constants';
 import {readConfigFile, normalizeConfig} from '../../lib/config-file';
 import {finalizeSchema, registerSchema, resetSchema} from '../../lib/schema/schema';

--- a/packages/appium/test/e2e/config.e2e.spec.js
+++ b/packages/appium/test/e2e/config.e2e.spec.js
@@ -3,7 +3,6 @@ import {getGitRev, getBuildInfo, updateBuildInfo, APPIUM_VER} from '../../lib/co
 import axios from 'axios';
 import * as teenProcess from 'teen_process';
 
-
 describe('Config', function () {
   let sandbox;
 
@@ -17,16 +16,22 @@ describe('Config', function () {
 
   describe('getGitRev', function () {
     it('should get a reasonable git revision', async function () {
-      let rev = await getGitRev();
+      let rev = /** @type {string} */ (await getGitRev());
       rev.should.be.a('string');
       rev.length.should.be.equal(40);
-      rev.match(/[0-9a-f]+/i)[0].should.eql(rev);
+      const matches = /** @type {RegExpMatchArray} */ (rev.match(/[0-9a-f]+/i));
+      matches[0].should.eql(rev);
     });
   });
   describe('getBuildInfo', function () {
     const SHA = 'a7404fddd50ee1c6ff1aac3d2f259abab0d3291a';
     const DATE = '2022-06-04T02:08:17Z';
 
+    /**
+     *
+     * @param {boolean} useLocalGit
+     * @param {{sha?: string, built?: string}} [opts]
+     */
     async function verifyBuildInfoUpdate(useLocalGit, {sha, built} = {}) {
       const buildInfo = getBuildInfo();
       if (!useLocalGit) {
@@ -37,12 +42,12 @@ describe('Config', function () {
       await updateBuildInfo(true);
       buildInfo.should.be.an('object');
       if (sha) {
-        buildInfo['git-sha'].should.equal(sha);
+        /** @type {string} */ (/** @type {unknown} */ (buildInfo['git-sha'])).should.equal(sha);
       } else {
         should.exist(buildInfo['git-sha']);
       }
       if (built) {
-        buildInfo.built.should.equal(built);
+        /** @type {string} */ (/** @type {unknown} */ (buildInfo.built)).should.equal(built);
       } else {
         should.exist(buildInfo.built);
       }
@@ -72,9 +77,9 @@ describe('Config', function () {
           object: {
             sha: SHA,
             type: 'tag',
-            url: `https://api.github.com/repos/appium/appium/git/tags/${SHA}`
-          }
-        }
+            url: `https://api.github.com/repos/appium/appium/git/tags/${SHA}`,
+          },
+        },
       });
       getStub.onCall(1).returns({
         data: {
@@ -84,12 +89,12 @@ describe('Config', function () {
           tagger: {
             name: 'Jonathan Lipps',
             email: 'jlipps@gmail.com',
-            date: DATE
+            date: DATE,
           },
           object: {
             sha: '4cf2cc92d066ed32adda27e0439547290a4b71ce',
             type: 'commit',
-            url: 'https://api.github.com/repos/appium/appium/git/commits/4cf2cc92d066ed32adda27e0439547290a4b71ce'
+            url: 'https://api.github.com/repos/appium/appium/git/commits/4cf2cc92d066ed32adda27e0439547290a4b71ce',
           },
           tag: `appium@${APPIUM_VER}`,
           message: `appium@${APPIUM_VER}\n`,
@@ -97,9 +102,9 @@ describe('Config', function () {
             verified: false,
             reason: 'unsigned',
             signature: null,
-            payload: null
-          }
-        }
+            payload: null,
+          },
+        },
       });
       await verifyBuildInfoUpdate(false, {sha: SHA, built: DATE});
     });

--- a/packages/appium/test/e2e/driver.e2e.spec.js
+++ b/packages/appium/test/e2e/driver.e2e.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import _ from 'lodash';
 import path from 'path';
 import B from 'bluebird';
@@ -31,14 +29,14 @@ const shouldStartServer = process.env.USE_RUNNING_SERVER !== '0';
 const caps = W3C_PREFIXED_CAPS;
 const FAKE_DRIVER_DIR = path.join(PROJECT_ROOT, 'packages', 'fake-driver');
 
-/** @type {WebdriverIO.RemoteOptions} */
+/** @type {Partial<import('webdriverio').RemoteOptions>} */
 const wdOpts = {
   hostname: TEST_HOST,
   connectionRetryCount: 0,
 };
 
 describe('FakeDriver - via HTTP', function () {
-  /** @type {import('http').Server} */
+  /** @type {AppiumServer} */
   let server;
   /** @type {string} */
   let appiumHome;
@@ -96,10 +94,7 @@ describe('FakeDriver - via HTTP', function () {
   async function serverStart(port, args = {}) {
     args = {...args, port, address: TEST_HOST};
     if (shouldStartServer) {
-      server = /** @type {typeof server} */ (
-        // @ts-expect-error
-        await appiumServer(args)
-      );
+      server = /** @type {AppiumServer} */ (await appiumServer(args));
     }
   }
 
@@ -399,7 +394,10 @@ describe('FakeDriver - via HTTP', function () {
 // TODO this test only works if the log has not previously been initialized in the same process.
 // there seems to be some global state that is not cleaned up between tests.
 describe.skip('Logsink', function () {
-  let server = null;
+  /**
+   * @type {AppiumServer}
+   */
+  let server;
   let logs = [];
   let logHandler = function (level, message) {
     logs.push([level, message]);
@@ -411,8 +409,7 @@ describe.skip('Logsink', function () {
   };
 
   before(async function () {
-    // @ts-expect-error
-    server = await appiumServer(args);
+    server = /** @type {AppiumServer} */ (await appiumServer(args));
   });
 
   after(async function () {
@@ -426,3 +423,7 @@ describe.skip('Logsink', function () {
     logs[welcomeIndex][1].should.include('Welcome to Appium');
   });
 });
+
+/**
+ * @typedef {import('@appium/types').AppiumServer} AppiumServer
+ */

--- a/packages/appium/test/e2e/e2e-helpers.js
+++ b/packages/appium/test/e2e/e2e-helpers.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 /**
  * This module provides helper functions for E2E tests to spawn an `appium` subprocess.
  */
@@ -49,7 +47,7 @@ async function run(appiumHome, args, opts = {}) {
     }
     return retval;
   } catch (err) {
-    const {stdout, stderr} = /** @type {TeenProcessExecError} */ (err);
+    const {stdout, stderr} = /** @type {import('teen_process').ExecError} */ (err);
     /**
      * @type {AppiumRunError}
      */
@@ -176,12 +174,11 @@ export function formatAppiumArgErrorOutput(stderr) {
 
 /**
  * Error thrown by all of the functions in this file which execute `appium`.
- * @typedef {Error & AppiumRunErrorProps & import('@appium/support/lib/npm').TeenProcessExecErrorProps} AppiumRunError
+ * @typedef {Error & AppiumRunErrorProps & import('teen_process').ExecError} AppiumRunError
  */
 
 /**
  * @typedef {import('@appium/types').ExtensionType} ExtensionType
- * @typedef {import('@appium/support/lib/npm').TeenProcessExecError} TeenProcessExecError
  * @typedef {import('appium/lib/cli/extension-command').ExtensionListData} ExtensionListData
  */
 

--- a/packages/appium/test/e2e/plugin.e2e.spec.js
+++ b/packages/appium/test/e2e/plugin.e2e.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import _ from 'lodash';
 import path from 'path';
 import B from 'bluebird';
@@ -17,7 +15,7 @@ const FAKE_PLUGIN_ARGS = {fake: FAKE_ARGS};
 
 const should = chai.should();
 
-/** @type {WebdriverIO.RemoteOptions} */
+/** @type {import('webdriverio').RemoteOptions} */
 const wdOpts = {
   hostname: TEST_HOST,
   connectionRetryCount: 0,
@@ -104,7 +102,7 @@ describe('FakePlugin', function () {
         address: TEST_HOST,
         usePlugins: ['other1', 'other2'],
       };
-      server = await appiumServer(args);
+      server = /** @type {AppiumServer} */ (await appiumServer(args));
     });
 
     after(async function () {
@@ -160,7 +158,7 @@ describe('FakePlugin', function () {
           usePlugins,
           useDrivers: ['fake'],
         };
-        server = await appiumServer(args);
+        server = /** @type {AppiumServer} */ (await appiumServer(args));
       });
       after(async function () {
         if (server) {
@@ -234,7 +232,7 @@ describe('FakePlugin', function () {
       });
 
       it('should handle unexpected driver shutdown', async function () {
-        /** @type {WebdriverIO.RemoteOptions} */
+        /** @type {import('webdriverio').RemoteOptions} */
         const newOpts = {...wdOpts};
         newOpts.capabilities = {
           ...(newOpts.capabilities ?? {}),
@@ -263,7 +261,7 @@ describe('FakePlugin', function () {
     before(async function () {
       // then start server if we need to
       const args = {...baseArgs, plugin: FAKE_PLUGIN_ARGS};
-      server = await appiumServer(args);
+      server = /** @type {AppiumServer} */ (await appiumServer(args));
     });
     after(async function () {
       if (server) {
@@ -287,7 +285,7 @@ describe('FakePlugin', function () {
     let server;
     before(async function () {
       // then start server if we need to
-      server = await appiumServer(baseArgs);
+      server = /** @type {AppiumServer} */ (await appiumServer(baseArgs));
     });
     after(async function () {
       if (server) {

--- a/packages/appium/test/e2e/schema.e2e.spec.js
+++ b/packages/appium/test/e2e/schema.e2e.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import {fs, tempDir} from '@appium/support';
 import path from 'path';
 import {DRIVER_TYPE} from '../../lib/constants';

--- a/packages/appium/test/fixtures/config/driver-fake.config.json
+++ b/packages/appium/test/fixtures/config/driver-fake.config.json
@@ -1,8 +1,10 @@
 {
-  "driver": {
-    "fake": {
-      "sillyWebServerPort": 1234,
-      "sillyWebServerHost": "hey"
+  "server": {
+    "driver": {
+      "fake": {
+        "sillyWebServerPort": 1234,
+        "sillyWebServerHost": "hey"
+      }
     }
   }
 }

--- a/packages/appium/test/helpers.js
+++ b/packages/appium/test/helpers.js
@@ -1,9 +1,6 @@
-// @ts-check
-
 import getPort from 'get-port';
 import path from 'path';
 import rewiremock, {addPlugin, overrideEntryPoint, plugins} from 'rewiremock';
-import {insertAppiumPrefixes} from '../lib/utils';
 
 const TEST_HOST = '127.0.0.1';
 
@@ -12,14 +9,25 @@ const PROJECT_ROOT = path.join(FAKE_DRIVER_DIR, '..', '..');
 const PACKAGE_ROOT = path.join(PROJECT_ROOT, 'packages', 'appium');
 const TEST_FAKE_APP = path.join(FAKE_DRIVER_DIR, 'test', 'fixtures', 'app.xml');
 
+/** @type {import('@appium/types').Capabilities} */
 const BASE_CAPS = {
   automationName: 'Fake',
   platformName: 'Fake',
   deviceName: 'Fake',
   app: TEST_FAKE_APP,
 };
-const W3C_PREFIXED_CAPS = {...insertAppiumPrefixes(BASE_CAPS)};
-/** @type {import('@appium/types').W3CCapabilities} */
+
+// XXX: Replaced use of `insertAppiumPrefixes()` with this due to TS failures.
+// I am not sure what it is about the `utils` module that's causing the issue,
+// as I cannot reproduce it outside of an Appium context.  Maybe try again
+// in the future??
+const W3C_PREFIXED_CAPS = {
+  'appium:automationName': 'Fake',
+  'appium:platformName': 'Fake',
+  'appium:deviceName': 'Fake',
+  'appium:app': TEST_FAKE_APP,
+};
+
 const W3C_CAPS = {
   alwaysMatch: {...W3C_PREFIXED_CAPS},
   firstMatch: [{}],

--- a/packages/appium/test/unit/appiumdriver.spec.js
+++ b/packages/appium/test/unit/appiumdriver.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {PLUGIN_TYPE} from '../../lib/constants';
 import B from 'bluebird';
 import {BaseDriver} from '@appium/base-driver';
@@ -60,6 +58,7 @@ describe('AppiumDriver', function () {
         });
       });
 
+      // @ts-expect-error
       let ad = new AppiumDriver({});
       // triggers the `log` getter to set `_log`
       ad.log;
@@ -88,6 +87,7 @@ describe('AppiumDriver', function () {
         return fakeDriver;
       };
 
+      // @ts-expect-error
       appium.driverConfig = {
         findMatchingDriver: sandbox.stub().returns({
           driver: mockedDriverReturnerClass,
@@ -117,9 +117,11 @@ describe('AppiumDriver', function () {
           .once()
           .withExactArgs(undefined, null, W3C_CAPS, [])
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS)]);
+        // @ts-expect-error
         await appium.createSession(undefined, null, W3C_CAPS);
         mockFakeDriver.verify();
       });
+
       it(`should call inner driver's createSession with desired and default capabilities`, async function () {
         let defaultCaps = {'appium:someCap': 'hello'};
         let allCaps = {
@@ -132,6 +134,7 @@ describe('AppiumDriver', function () {
           .once()
           .withArgs(undefined, null, allCaps)
           .returns([SESSION_ID, removeAppiumPrefixes(allCaps.alwaysMatch)]);
+        // @ts-expect-error
         await appium.createSession(undefined, null, W3C_CAPS);
         mockFakeDriver.verify();
       });
@@ -145,6 +148,7 @@ describe('AppiumDriver', function () {
           .once()
           .withArgs(undefined, null, W3C_CAPS)
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS)]);
+        // @ts-expect-error
         await appium.createSession(undefined, null, W3C_CAPS);
         mockFakeDriver.verify();
       });
@@ -172,6 +176,7 @@ describe('AppiumDriver', function () {
           .once()
           .withExactArgs(undefined, null, W3C_CAPS, [])
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS)]);
+        // @ts-expect-error
         await appium.createSession(undefined, null, W3C_CAPS);
 
         sessions = await appium.getSessions();
@@ -188,6 +193,7 @@ describe('AppiumDriver', function () {
           .once()
           .withArgs(undefined, undefined, W3C_CAPS)
           .returns([SESSION_ID, BASE_CAPS]);
+        // @ts-expect-error
         await appium.createSession(undefined, undefined, W3C_CAPS);
         mockFakeDriver.verify();
       });
@@ -212,6 +218,7 @@ describe('AppiumDriver', function () {
           })
           .returns([SESSION_ID, insertAppiumPrefixes(BASE_CAPS)]);
 
+        // @ts-expect-error
         await appium.createSession(undefined, undefined, w3cCaps);
         mockFakeDriver.verify();
       });
@@ -230,6 +237,7 @@ describe('AppiumDriver', function () {
         };
 
         mockFakeDriver.expects('createSession').never();
+        // @ts-expect-error
         await appium.createSession(jsonwpCaps, undefined, w3cCaps);
         mockFakeDriver.verify();
       });
@@ -238,11 +246,12 @@ describe('AppiumDriver', function () {
         class ArgsDriver extends BaseDriver {}
         const args = {driver: {fake: {randomArg: 1234}}};
         [appium, mockFakeDriver] = getDriverAndFakeDriver(args, ArgsDriver);
+        // @ts-expect-error
         const {value} = await appium.createSession(undefined, undefined, W3C_CAPS);
         try {
           fakeDriver.cliArgs.should.eql({randomArg: 1234});
         } finally {
-          await appium.deleteSession(value[0]);
+          await appium.deleteSession(/** @type {any[]} */ (value)[0]);
         }
       });
     });
@@ -320,6 +329,7 @@ describe('AppiumDriver', function () {
     describe('getStatus', function () {
       let appium;
       before(function () {
+        // @ts-expect-error
         appium = new AppiumDriver({});
       });
       it('should return a status', async function () {
@@ -343,7 +353,10 @@ describe('AppiumDriver', function () {
       });
 
       it('should remove session if inner driver unexpectedly exits with an error', async function () {
-        let [sessionId] = (await appium.createSession(null, null, _.clone(W3C_CAPS))).value;
+        let [sessionId] = /** @type {string[]} */ (
+          // @ts-expect-error
+          (await appium.createSession(null, null, _.clone(W3C_CAPS))).value
+        );
         _.keys(appium.sessions).should.contain(sessionId);
         appium.sessions[sessionId].eventEmitter.emit('onUnexpectedShutdown', new Error('Oops'));
         // let event loop spin so rejection is handled
@@ -351,7 +364,10 @@ describe('AppiumDriver', function () {
         _.keys(appium.sessions).should.not.contain(sessionId);
       });
       it('should remove session if inner driver unexpectedly exits with no error', async function () {
-        let [sessionId] = (await appium.createSession(null, null, _.clone(W3C_CAPS))).value; // eslint-disable-line comma-spacing
+        let [sessionId] = /** @type {string[]} */ (
+          // @ts-expect-error
+          (await appium.createSession(null, null, _.clone(W3C_CAPS))).value
+        ); // eslint-disable-line comma-spacing
         _.keys(appium.sessions).should.contain(sessionId);
         appium.sessions[sessionId].eventEmitter.emit('onUnexpectedShutdown');
         // let event loop spin so rejection is handled
@@ -397,6 +413,7 @@ describe('AppiumDriver', function () {
 
       describe('when args are not present', function () {
         it('the `cliArgs` prop should be an empty object', function () {
+          // @ts-expect-error
           const appium = new AppiumDriver({});
           appium.pluginClasses = new Map([
             [NoArgsPlugin, 'noargs'],
@@ -410,6 +427,7 @@ describe('AppiumDriver', function () {
 
       describe('when args are equal to the schema defaults', function () {
         it('the `cliArgs` prop should contain the schema defaults', function () {
+          // @ts-expect-error
           const appium = new AppiumDriver({
             plugin: {args: {randomArg: 2000}},
           });
@@ -424,6 +442,7 @@ describe('AppiumDriver', function () {
 
         describe('when the default is an "object"', function () {
           it('the `cliArgs` prop should contain the schema defaults', function () {
+            // @ts-expect-error
             const appium = new AppiumDriver({
               plugin: {arrayarg: {arr: []}},
             });
@@ -442,10 +461,13 @@ describe('AppiumDriver', function () {
 
       describe('when args are not equal to the schema defaults', function () {
         it('should add cliArgs to the plugin', function () {
+          // @ts-expect-error
           const appium = new AppiumDriver({plugin: {args: {randomArg: 1234}}});
           appium.pluginClasses = new Map([[ArgsPlugin, 'args']]);
           const plugin = _.first(appium.createPluginInstances());
-          plugin.cliArgs.should.eql({randomArg: 1234});
+          /** @type {import('@appium/types').Plugin} */ (plugin).cliArgs.should.eql({
+            randomArg: 1234,
+          });
         });
       });
     });

--- a/packages/appium/test/unit/cli/cli.spec.js
+++ b/packages/appium/test/unit/cli/cli.spec.js
@@ -23,7 +23,17 @@ describe('DriverCommand', function () {
     Manifest.getInstance.cache = new Map();
     sandbox.stub(fs, 'exists').resolves(false);
     config = (await loadExtensions(appiumHome)).driverConfig;
-    config.installedExtensions = {[driver]: {version: '1.0.0', pkgName}};
+    config.installedExtensions = {
+      [driver]: {
+        version: '1.0.0',
+        pkgName,
+        automationName: 'foo',
+        platformNames: ['foo', 'bar'],
+        mainClass: 'buzzo',
+        installType: 'npm',
+        installSpec: 'gorgonzola',
+      },
+    };
     dc = new DriverCommand({config, json: true});
   });
 

--- a/packages/appium/test/unit/cli/schema-args.spec.js
+++ b/packages/appium/test/unit/cli/schema-args.spec.js
@@ -37,7 +37,8 @@ describe('cli/schema-args', function () {
         const argDefsWithMetavar = [...argDefs].filter((arg) => arg[1].metavar);
         expect(argDefsWithMetavar).not.to.be.empty;
         // is there a more idiomatic way to do this?
-        expect(argDefsWithMetavar.every((arg) => /[A-Z_]+/.test(arg[1].metavar))).to.be.true;
+        expect(argDefsWithMetavar.every((arg) => /[A-Z_]+/.test(String(arg[1].metavar)))).to.be
+          .true;
       });
     });
 

--- a/packages/appium/test/unit/config-file.spec.js
+++ b/packages/appium/test/unit/config-file.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import fs from 'fs';
 import {createSandbox} from 'sinon';
 import YAML from 'yaml';

--- a/packages/appium/test/unit/config.spec.js
+++ b/packages/appium/test/unit/config.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import _ from 'lodash';
 import {createSandbox} from 'sinon';
 import {getParser} from '../../lib/cli/parser';

--- a/packages/appium/test/unit/extension/driver-config.spec.js
+++ b/packages/appium/test/unit/extension/driver-config.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {promises as fs} from 'fs';
 import {Manifest} from '../../../lib/extension/manifest';
 import {resetSchema} from '../../../lib/schema';
@@ -316,6 +314,7 @@ describe('DriverConfig', function () {
 
       describe('when the extension data is missing `schema`', function () {
         it('should throw', function () {
+          // @ts-expect-error
           delete extData.schema;
           expect(() => driverConfig.readExtensionSchema(extName, extData)).to.throw(
             TypeError,

--- a/packages/appium/test/unit/extension/manifest.spec.js
+++ b/packages/appium/test/unit/extension/manifest.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import B from 'bluebird';
 import {promises as fs} from 'fs';
 import {DRIVER_TYPE, PLUGIN_TYPE} from '../../../lib/constants';

--- a/packages/appium/test/unit/extension/mocks.js
+++ b/packages/appium/test/unit/extension/mocks.js
@@ -1,5 +1,4 @@
 /* eslint-disable require-await */
-// @ts-check
 
 /**
  * A collection of mocks reused across unit tests.

--- a/packages/appium/test/unit/extension/package-changed.spec.js
+++ b/packages/appium/test/unit/extension/package-changed.spec.js
@@ -1,4 +1,3 @@
-// @ts-check
 import path from 'path';
 import {PKG_HASHFILE_RELATIVE_PATH} from '../../../lib/constants';
 import {rewiremock} from '../../helpers';

--- a/packages/appium/test/unit/extension/plugin-config.spec.js
+++ b/packages/appium/test/unit/extension/plugin-config.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {promises as fs} from 'fs';
 import {Manifest} from '../../../lib/extension/manifest';
 import {resetSchema} from '../../../lib/schema';
@@ -234,7 +232,7 @@ describe('PluginConfig', function () {
       });
 
       describe('when provided an object `schema` property', function () {
-        /** @type {ExtDataWithSchema<PluginType>} */
+        /** @type {ExtManifestWithSchema<PluginType>} */
         let externalManifest;
 
         describe('when the object is a valid schema', function () {
@@ -286,7 +284,7 @@ describe('PluginConfig', function () {
        */
       let pluginConfig;
 
-      /** @type {ExtDataWithSchema<PluginType>} */
+      /** @type {ExtManifestWithSchema<PluginType>} */
       let extData;
 
       const extName = 'stuff';
@@ -351,5 +349,5 @@ describe('PluginConfig', function () {
 
 /**
  * @template {import('@appium/types').ExtensionType} ExtType
- * @typedef {import('appium/types').ExtDataWithSchema<ExtType>} ExtDataWithSchema
+ * @typedef {import('appium/types').ExtManifestWithSchema<ExtType>} ExtManifestWithSchema
  */

--- a/packages/appium/test/unit/grid-register.spec.js
+++ b/packages/appium/test/unit/grid-register.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {createSandbox} from 'sinon';
 import {rewiremock} from '../helpers';
 

--- a/packages/appium/test/unit/logger.spec.js
+++ b/packages/appium/test/unit/logger.spec.js
@@ -4,7 +4,7 @@ import {logger} from '@appium/support';
 
 // temporarily turn on logging to stdio, so we can catch and query
 const forceLogs = process.env._FORCE_LOGS;
-process.env._FORCE_LOGS = 1;
+process.env._FORCE_LOGS = '1';
 const log = logger.getLogger('Appium');
 
 describe('logging', function () {

--- a/packages/appium/test/unit/parser.spec.js
+++ b/packages/appium/test/unit/parser.spec.js
@@ -10,6 +10,8 @@ const ALLOW_FIXTURE = resolveFixture('allow-feat.txt');
 const DENY_FIXTURE = resolveFixture('deny-feat.txt');
 const CAPS_FIXTURE = resolveFixture('caps.json');
 
+const should = chai.should();
+
 describe('parser', function () {
   let p;
 
@@ -181,7 +183,7 @@ describe('parser', function () {
           fakeDriverArgs.fake.sillyWebServerHost,
         ]);
 
-        args.driver.fake.should.eql(config.driver.fake);
+        args.driver.fake.should.eql(config?.server?.driver?.fake);
       });
 
       it('should not yet apply defaults', function () {

--- a/packages/appium/test/unit/schema/arg-spec.spec.js
+++ b/packages/appium/test/unit/schema/arg-spec.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import {DRIVER_TYPE} from '../../../lib/constants';
 import {ArgSpec} from '../../../lib/schema/arg-spec';
 

--- a/packages/appium/test/unit/schema/cli-args.spec.js
+++ b/packages/appium/test/unit/schema/cli-args.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import _ from 'lodash';
 import {PLUGIN_TYPE} from '../../../lib/constants';
 import {finalizeSchema, registerSchema, resetSchema} from '../../../lib/schema';

--- a/packages/appium/test/unit/schema/schema.spec.js
+++ b/packages/appium/test/unit/schema/schema.spec.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import _ from 'lodash';
 import {createSandbox} from 'sinon';
 import {DRIVER_TYPE, PLUGIN_TYPE} from '../../../lib/constants';
@@ -131,7 +129,7 @@ describe('schema', function () {
       describe('when provided `type` and nonempty `schema`, but no `name`', function () {
         it('should throw a TypeError', function () {
           expect(() =>
-            registerSchema(DRIVER_TYPE, undefined, {
+            registerSchema(DRIVER_TYPE, '', {
               title: 'whoopeee',
             })
           ).to.throw(TypeError, /expected extension type/i);

--- a/packages/appium/tsconfig.json
+++ b/packages/appium/tsconfig.json
@@ -12,9 +12,11 @@
       "@appium/test-support": ["../test-support"],
       "appium": ["."]
     },
-    "checkJs": true
+    "checkJs": true,
+    "types": ["node", "mocha", "chai", "sinon-chai", "chai-as-promised", "webdriverio/async", "../../test/types"]
   },
-  "include": ["lib", "types"],
+  "files": ["package.json"],
+  "include": ["lib", "types", "test"],
   "references": [
     {"path": "../schema"},
     {"path": "../types"},

--- a/packages/base-driver/lib/index.js
+++ b/packages/base-driver/lib/index.js
@@ -10,7 +10,6 @@ export {DriverCore} from './basedriver/core';
 export {DeviceSettings} from './basedriver/device-settings';
 
 export {BaseDriver};
-export default BaseDriver;
 
 // MJSONWP exports
 export * from './protocol';
@@ -37,3 +36,5 @@ export {
 
 // Web socket helpers
 export {DEFAULT_WS_PATHNAME_PREFIX} from './express/websocket';
+
+export default BaseDriver;

--- a/packages/base-driver/lib/protocol/errors.js
+++ b/packages/base-driver/lib/protocol/errors.js
@@ -45,6 +45,10 @@ export class NoSuchDriverError extends ProtocolError {
   static error() {
     return 'invalid session id';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'A session is either terminated or not started',
@@ -65,6 +69,10 @@ export class NoSuchElementError extends ProtocolError {
   static error() {
     return 'no such element';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'An element could not be located on the page using the given ' + 'search parameters.',
@@ -85,6 +93,10 @@ export class NoSuchFrameError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.NOT_FOUND;
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -107,6 +119,10 @@ export class UnknownCommandError extends ProtocolError {
   static error() {
     return 'unknown command';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -130,6 +146,10 @@ export class StaleElementReferenceError extends ProtocolError {
   static error() {
     return 'stale element reference';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -152,6 +172,10 @@ export class ElementNotVisibleError extends ProtocolError {
   static error() {
     return 'element not visible';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -174,6 +198,10 @@ export class InvalidElementStateError extends ProtocolError {
   static error() {
     return 'invalid element state';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -217,6 +245,10 @@ export class UnknownMethodError extends ProtocolError {
   static error() {
     return 'unknown method';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'The requested command matched a known URL but did not match an method for that URL',
@@ -237,6 +269,10 @@ export class UnsupportedOperationError extends ProtocolError {
   static error() {
     return 'unsupported operation';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'A server-side error occurred. Command cannot be supported.',
@@ -257,6 +293,10 @@ export class ElementIsNotSelectableError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.BAD_REQUEST;
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'An attempt was made to select an element that cannot be selected.',
@@ -277,6 +317,10 @@ export class ElementClickInterceptedError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.BAD_REQUEST;
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -299,6 +343,10 @@ export class ElementNotInteractableError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.BAD_REQUEST;
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -314,6 +362,10 @@ export class InsecureCertificateError extends ProtocolError {
   static error() {
     return 'insecure certificate';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -335,6 +387,10 @@ export class JavaScriptError extends ProtocolError {
   static error() {
     return 'javascript error';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'An error occurred while executing user supplied JavaScript.',
@@ -355,6 +411,10 @@ export class XPathLookupError extends ProtocolError {
   static error() {
     return 'invalid selector';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'An error occurred while searching for an element by XPath.',
@@ -375,6 +435,10 @@ export class TimeoutError extends ProtocolError {
   static error() {
     return 'timeout';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'An operation did not complete before its timeout expired.',
@@ -395,6 +459,10 @@ export class NoSuchWindowError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.NOT_FOUND;
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -417,6 +485,10 @@ export class InvalidArgumentError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.BAD_REQUEST;
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'The arguments passed to the command are either invalid or malformed',
@@ -437,6 +509,10 @@ export class InvalidCookieDomainError extends ProtocolError {
   static w3cStatus() {
     return HTTPStatusCodes.BAD_REQUEST;
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -459,6 +535,10 @@ export class NoSuchCookieError extends ProtocolError {
   static error() {
     return 'no such cookie';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err ||
@@ -480,6 +560,10 @@ export class UnableToSetCookieError extends ProtocolError {
   static error() {
     return 'unable to set cookie';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || "A request to set a cookie's value could not be satisfied.",
@@ -500,6 +584,10 @@ export class UnexpectedAlertOpenError extends ProtocolError {
   static error() {
     return 'unexpected alert open';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'A modal dialog was open, blocking this operation',
@@ -520,6 +608,10 @@ export class NoAlertOpenError extends ProtocolError {
   static error() {
     return 'no such alert';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'An attempt was made to operate on a modal dialog when one ' + 'was not open.',
@@ -542,6 +634,10 @@ export class ScriptTimeoutError extends ProtocolError {
   static error() {
     return 'script timeout';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'A script did not complete before its timeout expired.',
@@ -562,6 +658,10 @@ export class InvalidElementCoordinatesError extends ProtocolError {
   static error() {
     return 'invalid coordinates';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'The coordinates provided to an interactions operation are invalid.',
@@ -584,6 +684,10 @@ export class IMENotAvailableError extends ProtocolError {
   static error() {
     return 'unsupported operation';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'IME was not available.',
@@ -604,6 +708,10 @@ export class IMEEngineActivationFailedError extends ProtocolError {
   static error() {
     return 'unsupported operation';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'An IME engine could not be started.',
@@ -624,6 +732,10 @@ export class InvalidSelectorError extends ProtocolError {
   static error() {
     return 'invalid selector';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'Argument was an invalid selector (e.g. XPath/CSS).',
@@ -669,6 +781,10 @@ export class MoveTargetOutOfBoundsError extends ProtocolError {
   static error() {
     return 'move target out of bounds';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'Target provided for a move action is out of bounds.',
@@ -683,6 +799,10 @@ export class NoSuchContextError extends ProtocolError {
   static code() {
     return 35;
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(err || 'No such context found.', NoSuchContextError.code());
   }
@@ -692,6 +812,10 @@ export class InvalidContextError extends ProtocolError {
   static code() {
     return 36;
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'That command could not be executed in the current context.',
@@ -702,11 +826,17 @@ export class InvalidContextError extends ProtocolError {
 
 // These are aliases for UnknownMethodError
 export class NotYetImplementedError extends UnknownMethodError {
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(err || 'Method has not yet been implemented');
   }
 }
 export class NotImplementedError extends UnknownMethodError {
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(err || 'Method is not implemented');
   }
@@ -722,6 +852,10 @@ export class UnableToCaptureScreen extends ProtocolError {
   static error() {
     return 'unable to capture screen';
   }
+
+  /**
+   * @param {string} [err]
+   */
   constructor(err) {
     super(
       err || 'A screen capture was made impossible',

--- a/packages/base-driver/lib/protocol/index.js
+++ b/packages/base-driver/lib/protocol/index.js
@@ -7,14 +7,10 @@ import {
   GET_STATUS_COMMAND,
 } from './protocol';
 import {NO_SESSION_ID_COMMANDS, ALL_COMMANDS, METHOD_MAP, routeToCommandName} from './routes';
-import {errors, isErrorType, errorFromMJSONWPStatusCode, errorFromW3CJsonCode} from './errors';
+export * from './errors';
 
 export {
   routeConfiguringFunction,
-  errors,
-  isErrorType,
-  errorFromMJSONWPStatusCode,
-  errorFromW3CJsonCode,
   ALL_COMMANDS,
   METHOD_MAP,
   routeToCommandName,

--- a/packages/test-support/tsconfig.json
+++ b/packages/test-support/tsconfig.json
@@ -8,12 +8,9 @@
       "appium/driver": ["../appium/driver"],
       "@appium/types": ["../types"],
       "appium/support": ["../appium/support"]
-    },
-    "types": [
-      "mocha", "chai", "sinon", "sinon-chai", "chai-as-promised"
-    ]
+    }
   },
-  "include": ["./lib"],
+  "include": ["lib"],
   "references": [
     {"path": "../base-driver"},
     {"path": "../types"},

--- a/packages/types/lib/capabilities.ts
+++ b/packages/types/lib/capabilities.ts
@@ -1,46 +1,55 @@
-import type {Capabilities as WdioCaps} from '@wdio/types';
+import {
+  Capabilities as WdioCapabilities,
+  AppiumCapabilities as WdioAppiumCapabilities,
+  AppiumAndroidCapabilities as WdioAppiumAndroidCapabilities,
+  AppiumIOSCapabilities as WdioAppiumIOSCapabilities,
+  AppiumXCUICommandTimeouts as WdioAppiumXCUICommandTimeouts,
+  AppiumXCUIProcessArguments as WdioAppiumXCUIProcessArguments,
+  AppiumXCUISafariGlobalPreferences as WdioAppiumXCUISafariGlobalPreferences,
+  AppiumXCUITestCapabilities as WdioAppiumXCUITestCapabilities,
+  AppiumW3CCapabilities as WdioAppiumW3CCapabilities,
+} from '@wdio/types/build/Capabilities';
 
 /**
  * The mask of a W3C-style namespaced capability proped name.
  */
-type Namespaced = `${string}:${string}`;
+export type Namespaced = `${string}:${string}`;
 
 /**
  * An object with keys conforming to {@linkcode Namespaced}.
  */
-type NamespacedRecord = Record<Namespaced, any>;
+export type NamespacedRecord = Record<Namespaced, any>;
 
 /**
  * An object with keys for strings.
  */
-type StringRecord = Record<string, any>;
+export type StringRecord = Record<string, any>;
 
 /**
- * All known capabilities derived from wdio's {@linkcode WdioCaps.Capabilities Capabilities} type, accepting additional optional caps.
+ * All known capabilities derived from wdio's {@linkcode WdioCapabilities Capabilities} type, accepting additional optional
  * All properties are optional.
  */
-type BaseCapabilities<OptionalCaps extends StringRecord = StringRecord> = Partial<
-  WdioCaps.Capabilities & OptionalCaps
->;
+export type BaseCapabilities<OptionalCaps extends StringRecord = StringRecord> = WdioCapabilities &
+  OptionalCaps;
 
 /**
- * All known capabilities derived from wdio's {@linkcode WdioCaps.Capabilities Capabilities} type and wdio's {@linkcode WdioCaps.AppiumCapabilities} type, accepting additional optional caps.
+ * All known capabilities derived from wdio's {@linkcode WdioCapabilities Capabilities} type and wdio's {@linkcode WdioAppiumCapabilities} type, accepting additional optional
  *
  * In practice, the properties `platformName` and `automationName` are required by Appium.
  */
 export type Capabilities<OptionalCaps extends StringRecord = StringRecord> = BaseCapabilities<
-  WdioCaps.AppiumCapabilities & OptionalCaps
+  WdioAppiumCapabilities & OptionalCaps
 >;
 
 /**
- * All known capabilities derived from wdio's {@linkcode WdioCaps.Capabilities Capabilities} type and wdio's {@linkcode WdioCaps.AppiumW3CCapabilities} type, accepting additional optional _namespaced_ caps.
+ * All known capabilities derived from wdio's {@linkcode WdioCapabilities Capabilities} type and wdio's {@linkcode WdioAppiumW3CCapabilities} type, accepting additional optional _namespaced_
  */
 export type AppiumW3CCapabilities<
   OptionalNamespacedCaps extends NamespacedRecord = NamespacedRecord
-> = BaseCapabilities<WdioCaps.AppiumW3CCapabilities & OptionalNamespacedCaps>;
+> = BaseCapabilities<WdioAppiumW3CCapabilities & OptionalNamespacedCaps>;
 
 /**
- * All known capabilities derived from wdio's {@linkcode WdioCaps.Capabilities Capabilities} type and wdio's {@linkcode WdioCaps.AppiumW3Capabilities} type, accepting additional optional _namespaced_ caps, in W3C-compatible format (`alwaysMatch`/`firstMatch`).
+ * All known capabilities derived from wdio's {@linkcode WdioCapabilities Capabilities} type and wdio's {@linkcode WdioAppiumW3Capabilities} type, accepting additional optional _namespaced_ caps, in W3C-compatible format (`alwaysMatch`/`firstMatch`).
  * In practice, the properties `appium:platformName` and `appium:automationName` are required by Appium _somewhere_ in this object; this cannot be expressed in TypeScript.
  */
 export type W3CCapabilities<OptionalNamespacedCaps extends NamespacedRecord = NamespacedRecord> = {
@@ -51,9 +60,9 @@ export type W3CCapabilities<OptionalNamespacedCaps extends NamespacedRecord = Na
 /**
  * These may (or should) be reused by drivers.
  */
-export type AppiumAndroidCapabilities = WdioCaps.AppiumAndroidCapabilities;
-export type AppiumIOSCapabilities = WdioCaps.AppiumIOSCapabilities;
-export type AppiumXCUICommandTimeouts = WdioCaps.AppiumXCUICommandTimeouts;
-export type AppiumXCUIProcessArguments = WdioCaps.AppiumXCUIProcessArguments;
-export type AppiumXCUISafariGlobalPreferences = WdioCaps.AppiumXCUISafariGlobalPreferences;
-export type AppiumXCUITestCapabilities = WdioCaps.AppiumXCUITestCapabilities;
+export type AppiumAndroidCapabilities = WdioAppiumAndroidCapabilities;
+export type AppiumIOSCapabilities = WdioAppiumIOSCapabilities;
+export type AppiumXCUICommandTimeouts = WdioAppiumXCUICommandTimeouts;
+export type AppiumXCUIProcessArguments = WdioAppiumXCUIProcessArguments;
+export type AppiumXCUISafariGlobalPreferences = WdioAppiumXCUISafariGlobalPreferences;
+export type AppiumXCUITestCapabilities = WdioAppiumXCUITestCapabilities;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -10,7 +10,7 @@ import type {Logger} from 'npmlog';
 
 export * from './driver';
 export * from './plugin';
-export {AppiumW3CCapabilities} from './capabilities';
+export * from './capabilities';
 export {AppiumConfig, NormalizedAppiumConfig} from './config';
 export * from './appium-config';
 export {ServerArgs, Capabilities, W3CCapabilities};

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -5,8 +5,7 @@
     "outDir": "build",
     "paths": {
       "@appium/schema": ["../schema"]
-    },
-    "lib": ["ES2015"]
+    }
   },
   "include": ["lib"],
   "references": [{"path": "../schema"}]

--- a/packages/universal-xml-plugin/lib/plugin.js
+++ b/packages/universal-xml-plugin/lib/plugin.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-case-declarations */
 
-import BasePlugin from 'appium/plugin';
+import {BasePlugin} from 'appium/plugin';
 import {errors} from 'appium/driver';
 import {transformSourceXml} from './source';
 import {transformQuery} from './xpath';

--- a/packages/universal-xml-plugin/lib/source.js
+++ b/packages/universal-xml-plugin/lib/source.js
@@ -16,10 +16,18 @@ const GEN_OPTS = {
 };
 
 export const ATTR_PREFIX = '@_';
+/** @type {Attr} */
 export const IDX_PATH_PREFIX = `${ATTR_PREFIX}indexPath`;
+/** @type {Attr} */
 export const IDX_PREFIX = `${ATTR_PREFIX}index`;
 
+/**
+ *
+ * @param {any} k
+ * @returns {k is Attr}
+ */
 const isAttr = (k) => k.substring(0, 2) === ATTR_PREFIX;
+
 const isNode = (k) => !isAttr(k);
 
 export function transformSourceXml(xmlStr, platform, {metadata = {}, addIndexPath = false} = {}) {
@@ -59,7 +67,13 @@ export function getUniversalAttrName(attrName, platform) {
   return getUniversalName(ATTR_MAP, attrName, platform);
 }
 
-export function transformNode(nodeObj, platform, {metadata, addIndexPath, parentPath}) {
+/**
+ *
+ * @param {any} nodeObj
+ * @param {string} platform
+ * @param {TransformOptions} [opts]
+ */
+export function transformNode(nodeObj, platform, {metadata, addIndexPath, parentPath} = {}) {
   const unknownNodes = [];
   const unknownAttrs = [];
   if (_.isPlainObject(nodeObj)) {
@@ -103,11 +117,18 @@ export function transformNode(nodeObj, platform, {metadata, addIndexPath, parent
   };
 }
 
+/**
+ *
+ * @param {any} nodeObj
+ * @param {string[]} childNodeNames
+ * @param {string} platform
+ * @param {TransformOptions} [opts]
+ */
 export function transformChildNodes(
   nodeObj,
   childNodeNames,
   platform,
-  {metadata, addIndexPath, parentPath}
+  {metadata, addIndexPath, parentPath} = {}
 ) {
   const unknownNodes = [];
   const unknownAttrs = [];
@@ -165,3 +186,14 @@ export function transformAttrs(nodeObj, attrs, platform) {
   }
   return unknownAttrs;
 }
+
+/**
+ * @typedef {`@_${string}`} Attr
+ */
+
+/**
+ * @typedef TransformOptions
+ * @property {any} [metadata]
+ * @property {boolean} [addIndexPath]
+ * @property {string} [parentPath]
+ */

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -21,7 +21,7 @@
   "types": "./build/lib/plugin.d.ts",
   "files": [
     "index.js",
-    "build",
+    "build/lib",
     "lib"
   ],
   "scripts": {

--- a/packages/universal-xml-plugin/test/unit/plugin.spec.js
+++ b/packages/universal-xml-plugin/test/unit/plugin.spec.js
@@ -1,21 +1,23 @@
+import B from 'bluebird';
 import UniversalXMLPlugin from '../../lib/plugin';
-import BaseDriver from 'appium/driver';
+import {BaseDriver} from 'appium/driver';
 import {XML_IOS, XML_ANDROID, XML_IOS_TRANSFORMED, XML_ANDROID_TRANSFORMED} from '../fixtures';
 import {runQuery, getNodeAttrVal} from '../../lib/xpath';
 
 describe('UniversalXMLPlugin', function () {
   let next;
-  const p = new UniversalXMLPlugin();
+  const p = new UniversalXMLPlugin('UniversalXMLPlugin');
   describe('getPageSource', function () {
     const driver = new BaseDriver();
     it('should transform page source for ios', async function () {
-      next = driver.getPageSource = () => XML_IOS;
+      next = driver.getPageSource = () => B.resolve(XML_IOS);
       driver.caps = {platformName: 'iOS'};
       await p.getPageSource(next, driver).should.eventually.eql(XML_IOS_TRANSFORMED);
     });
     it('should transform page source for android', async function () {
-      next = driver.getPageSourcce = () => XML_ANDROID;
+      next = driver.getPageSource = () => B.resolve(XML_ANDROID);
       driver.caps = {platformName: 'Android'};
+      // @ts-expect-error
       driver.opts = {appPackage: 'io.cloudgrey.the_app'};
       await p.getPageSource(next, driver).should.eventually.eql(XML_ANDROID_TRANSFORMED);
     });
@@ -24,10 +26,12 @@ describe('UniversalXMLPlugin', function () {
   describe('findElement(s)', function () {
     const driver = new BaseDriver();
     it('should turn an xpath query into another query run on the original ios source', async function () {
-      next = driver.getPageSource = () => XML_IOS;
+      next = driver.getPageSource = () => B.resolve(XML_IOS);
       driver.caps = {platformName: 'iOS'};
       // mock out the findElement function to just return an xml node from the fixture
-      driver.findElement = (strategy, selector) => {
+      // @ts-expect-error
+      // eslint-disable-next-line require-await
+      driver.findElement = async (strategy, selector) => {
         const nodes = runQuery(selector, XML_IOS.replace(/<\/?AppiumAUT>/, ''));
         return nodes[0];
       };
@@ -37,9 +41,12 @@ describe('UniversalXMLPlugin', function () {
     });
 
     it('should turn an xpath query into another query run on the original android source', async function () {
-      next = driver.getPageSource = () => XML_ANDROID;
+      next = driver.getPageSource = () => B.resolve(XML_ANDROID);
       driver.caps = {platformName: 'Android'};
+      // @ts-expect-error
       driver.opts = {appPackage: 'io.cloudgrey.the_app'};
+      // @ts-expect-error
+      // eslint-disable-next-line require-await
       driver.findElement = (strategy, selector) => {
         const nodes = runQuery(selector, XML_ANDROID);
         return nodes[0];

--- a/packages/universal-xml-plugin/test/unit/xpath.spec.js
+++ b/packages/universal-xml-plugin/test/unit/xpath.spec.js
@@ -15,13 +15,17 @@ describe('xpath functions', function () {
   describe('transformQuery', function () {
     it('should transform a query into a single new query', function () {
       const {xml} = transformSourceXml(XML_IOS, 'ios', {addIndexPath: true});
-      transformQuery('//TextInput', xml, false).should.eql(
+      const res = transformQuery('//TextInput', xml, false);
+      should.exist(res);
+      res?.should.eql(
         '/*[1]/*[1]/*[1]/*[1]/*[2]/*[1]/*[1]/*[1]/*[1]/*[1]/*[1]/*[2]/*[1]/*[1]/*[1]'
       );
     });
     it('should transform a query into a multiple new queries if asked', function () {
       const {xml} = transformSourceXml(XML_IOS, 'ios', {addIndexPath: true});
-      transformQuery('//Window', xml, true).split('|').should.have.length(2);
+      const res = transformQuery('//Window', xml, true);
+      should.exist(res);
+      res?.split('|').should.have.length(2);
     });
     it('should return null for queries that dont find anything', function () {
       const {xml} = transformSourceXml(XML_IOS, 'ios', {addIndexPath: true});

--- a/packages/universal-xml-plugin/tsconfig.json
+++ b/packages/universal-xml-plugin/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
-    "outDir": "build"
+    "outDir": "build",
+    "checkJs": true
   },
   "extends": "../../config/tsconfig.plugin.json",
-  "include": ["lib"]
+  "include": ["lib", "test"]
 }

--- a/test/types/index.d.ts
+++ b/test/types/index.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  var should: Chai.Should;
+}
+
+export {};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
+  "compilerOptions": {
+    "lib": ["es2016", "dom"]
+  },
   "files": [],
   "references": [
     {


### PR DESCRIPTION
Currently, we don't typecheck anything in `packages/*/test/**` (though your editor might).  This PR causes (more accurately: _will cause_) those checks to happen.  These changes ensure that when writing tests, we're not making silly type errors causing false positives or whatever.

This change can happen piecemeal (per package). I'll break it into separate PRs one I sort out the dependency stack.

One side-effect (which isn't really feasible to avoid) is that type declaration files are generated from test source files--e.g., `somewhere/build/test` will be full of declarations (not JS compiled by Babel, though).  

We don't actually need them _at all_ AFAICT, as the way the build works is that packages can depend on the declarations from _other_ packages--and as of recently, no package depends on the `test` folder of any other package.  Anyway--it's difficult to avoid emitting these files without a completely separate composite project, so I don't want to take on the complexity of trying to manage that.  Declaration files for tests get generated--we'll just have to deal with it.  it _does_ mean we'll probably want to avoid publishing them since they are effectively useless.


