### PR TITLE
feat(appium): pass unknown args to extension scripts

### DIFF
--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -214,8 +214,8 @@ function makeRunArgs(type) {
         default: null,
         type: 'str',
         help:
-          `Name of the script to run from the ${type}. The script name must be cached ` +
-          `inside the "scripts" field under "appium" inside the ${type}'s "package.json" file`,
+          `Name of the script to run from the ${type}. The script name must be a key ` +
+          `inside the "appium.scripts" field inside the ${type}'s "package.json" file`,
       },
     ],
   ]);

--- a/packages/appium/lib/cli/driver-command.js
+++ b/packages/appium/lib/cli/driver-command.js
@@ -33,8 +33,8 @@ export default class DriverCommand extends ExtensionCommand {
     return await super._update({installSpec: driver, unsafe});
   }
 
-  async run({driver, scriptName}) {
-    return await super._run({installSpec: driver, scriptName});
+  async run({driver, scriptName, extraArgs}) {
+    return await super._run({installSpec: driver, scriptName, extraArgs});
   }
 
   getPostInstallText({extName, extData}) {

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -628,7 +628,7 @@ class ExtensionCommand {
    * @param {RunOptions} opts
    * @return {Promise<RunOutput>}
    */
-  async _run({installSpec, scriptName}) {
+  async _run({installSpec, scriptName, extraArgs = []}) {
     if (!this.config.isInstalled(installSpec)) {
       throw this._createFatalError(`The ${this.type} "${installSpec}" is not installed`);
     }
@@ -657,7 +657,7 @@ class ExtensionCommand {
       );
     }
 
-    const runner = new SubProcess(process.execPath, [extScripts[scriptName]], {
+    const runner = new SubProcess(process.execPath, [extScripts[scriptName], ...extraArgs], {
       cwd: this.config.getInstallPath(installSpec),
     });
 
@@ -755,6 +755,7 @@ export {ExtensionCommand};
  * @typedef RunOptions
  * @property {string} installSpec - name of the extension to run a script from
  * @property {string} scriptName - name of the script to run
+ * @property {string[]} [extraArgs] - arguments to pass to the script
  */
 
 /**

--- a/packages/appium/lib/cli/extension.js
+++ b/packages/appium/lib/cli/extension.js
@@ -15,9 +15,9 @@ export const commandClasses = Object.freeze(
  * Run a subcommand of the 'appium driver' type. Each subcommand has its own set of arguments which
  * can be represented as a JS object.
  *
- * @param {Object} args - JS object where the key is the parameter name (as defined in
+ * @param {import('appium/types').Args<import('appium/types').WithExtSubcommand>} args - JS object where the key is the parameter name (as defined in
  * driver-parser.js)
- * @template {import('../extension/manifest').ExtensionType} ExtType
+ * @template {ExtensionType} ExtType
  * @param {import('../extension/extension-config').ExtensionConfig<ExtType>} config - Extension config object
  */
 async function runExtensionCommand(args, config) {
@@ -30,6 +30,7 @@ async function runExtensionCommand(args, config) {
     throw new TypeError(`Cannot call ${type} command without a subcommand like 'install'`);
   }
   let {json, suppressOutput} = args;
+  json = Boolean(json);
   if (suppressOutput) {
     json = true;
   }
@@ -56,6 +57,17 @@ async function runExtensionCommand(args, config) {
 export {runExtensionCommand};
 
 /**
- * @template {import('@appium/types').ExtensionType} ExtType
- * @typedef {ExtType extends import('@appium/types').DriverType ? import('@appium/types').Class<DriverCommand> : ExtType extends import('@appium/types').PluginType ? import('@appium/types').Class<PluginCommand> : never} ExtCommand
+ * @template {ExtensionType} ExtType
+ * @typedef {ExtType extends DriverType ? Class<DriverCommand> : ExtType extends PluginType ? Class<PluginCommand> : never} ExtCommand
+ */
+
+/**
+ * @typedef {import('@appium/types').ExtensionType} ExtensionType
+ * @typedef {import('@appium/types').DriverType} DriverType
+ * @typedef {import('@appium/types').PluginType} PluginType
+ */
+
+/**
+ * @template T
+ * @typedef {import('@appium/types').Class<T>} Class
  */

--- a/packages/appium/lib/cli/plugin-command.js
+++ b/packages/appium/lib/cli/plugin-command.js
@@ -33,8 +33,8 @@ export default class PluginCommand extends ExtensionCommand {
     return await super._update({installSpec: plugin, unsafe});
   }
 
-  async run({plugin, scriptName}) {
-    return await super._run({installSpec: plugin, scriptName});
+  async run({plugin, scriptName, extraArgs}) {
+    return await super._run({installSpec: plugin, scriptName, extraArgs});
   }
 
   getPostInstallText({extName, extData}) {

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -222,20 +222,7 @@ async function init(args) {
   // 1. command line args
   // 2. config file
   // 3. defaults from config file.
-  if (!areServerCommandArgs(preConfigArgs)) {
-    // if the user has requested the 'driver' CLI, don't run the normal server,
-    // but instead pass control to the driver CLI
-    if (preConfigArgs.subcommand === DRIVER_TYPE) {
-      await runExtensionCommand(preConfigArgs, driverConfig);
-      return {};
-    }
-    if (preConfigArgs.subcommand === PLUGIN_TYPE) {
-      await runExtensionCommand(preConfigArgs, pluginConfig);
-      return {};
-    }
-    /* istanbul ignore next */
-    return {}; // should never happen
-  } else {
+  if (areServerCommandArgs(preConfigArgs)) {
     const defaults = getDefaultsForSchema(false);
 
     /** @type {ParsedArgs} */
@@ -282,6 +269,22 @@ async function init(args) {
       driverConfig,
       pluginConfig,
     });
+  } else {
+    const extensionCommandArgs = /** @type {Args<import('appium/types').WithExtSubcommand>} */ (
+      preConfigArgs
+    );
+    // if the user has requested the 'driver' CLI, don't run the normal server,
+    // but instead pass control to the driver CLI
+    if (preConfigArgs.subcommand === DRIVER_TYPE) {
+      await runExtensionCommand(extensionCommandArgs, driverConfig);
+      return {};
+    }
+    if (preConfigArgs.subcommand === PLUGIN_TYPE) {
+      await runExtensionCommand(extensionCommandArgs, pluginConfig);
+      return {};
+    }
+    /* istanbul ignore next */
+    return {}; // should never happen
   }
 }
 

--- a/packages/appium/test/e2e/cli.e2e.spec.js
+++ b/packages/appium/test/e2e/cli.e2e.spec.js
@@ -438,28 +438,49 @@ describe('CLI behavior', function () {
       });
 
       describe('run', function () {
+        const driverName = 'fake';
         before(async function () {
           await clear();
           await installLocalExtension(appiumHome, DRIVER_TYPE, FAKE_DRIVER_DIR);
         });
-        it('should run a valid driver, valid script, and result in success', async function () {
-          const driverName = 'fake';
+
+        describe('when the driver and script is valid', function () {
           const scriptName = 'fake-success';
-          const out = await runRun([driverName, scriptName]);
-          out.should.not.have.property('error');
+
+          describe('when the script completes successfully', function () {
+            it('should result in success', async function () {
+              const out = await runRun([driverName, scriptName]);
+              out.should.not.have.property('error');
+            });
+          });
+
+          describe('when the script fails', function () {
+            it('should return an error', async function () {
+              const out = await runRun([driverName, 'fake-error']);
+              out.should.have.property('error');
+            });
+          });
+
+          describe('when passed extra arguments', function () {
+            it('should pass them to the script', async function () {
+              const out = await runRun([driverName, scriptName, '--foo', '--bar']);
+              out.should.not.have.property('error');
+              out.output.should.match(/--foo --bar/);
+            });
+          });
         });
-        it('should run a valid driver, valid error prone script, and return error in json', async function () {
-          const driverName = 'fake';
-          const out = await runRun([driverName, 'fake-error']);
-          out.should.have.property('error');
+
+        describe('when the driver is valid but the script is not', function () {
+          it('should throw an error', async function () {
+            await expect(runRun([driverName, 'foo'])).to.be.rejectedWith(Error);
+          });
         });
-        it('should take a valid driver, invalid script, and throw an error', async function () {
-          const driverName = 'fake';
-          await expect(runRun([driverName, 'foo'])).to.be.rejectedWith(Error);
-        });
-        it('should take an invalid driver, invalid script, and throw an error', async function () {
-          const driverName = 'foo';
-          await expect(runRun([driverName, 'bar'])).to.be.rejectedWith(Error);
+
+        describe('when the driver and script are invalid', function () {
+          it('should throw an error', async function () {
+            const driverName = 'foo';
+            await expect(runRun([driverName, 'bar'])).to.be.rejectedWith(Error);
+          });
         });
       });
     });

--- a/packages/appium/test/fixtures/cli/cli-error-output-unknown.txt
+++ b/packages/appium/test/fixtures/cli/cli-error-output-unknown.txt
@@ -1,1 +1,1 @@
-main.js: error: unrecognized arguments: --pigs=sheep
+[ERROR] Unrecognized arguments: --pigs=sheep

--- a/packages/appium/types/cli.ts
+++ b/packages/appium/types/cli.ts
@@ -92,6 +92,21 @@ export interface ExtArgs extends WithExtSubcommand {
    * Subcommands of `plugin` subcommand
    */
   pluginCommand?: CliExtensionSubcommand;
+
+  /**
+   * Output JSON instead of human-readable text
+   */
+  json?: boolean;
+
+  /**
+   * Output nothing
+   */
+  suppressOutput?: boolean;
+
+  /**
+   * Extra args to pass to extension scripts
+   */
+  extraArgs?: string[];
 }
 
 /**

--- a/packages/fake-driver/lib/scripts/fake-success.js
+++ b/packages/fake-driver/lib/scripts/fake-success.js
@@ -1,3 +1,5 @@
 import log from '../logger';
 
 log.info('Successfully ran the script');
+
+log.info(process.argv.slice(2).join(' '));


### PR DESCRIPTION
Resolves #17250

This change passes any extra unknown arguments to extension scripts _if and only if_ `appium <extension> <name> run` is executed.  In all other cases, unknown arguments result in an error and the `appium` CLI will abort as before.

Example:

```bash
appium driver fake run fake-success --foo --bar
```

In the `fake-success` script of the `fake` driver, `process.argv.slice(2)` will be `['--foo', '--bar']`.  Extra arguments can appear anywhere after the `appium` executable in the command and do not need to appear after the script name.

- In addition, added some missing arguments for extension subcommands to the types (`json`, `suppressOutput`).  Extra arguments are stored in property `extraArgs`.
- Fixed a type problem surfaced by the previous item
- Changed help text for the `run` subcommand to hopefully read more clearly
- Reorganized E2E tests for the `run` subcommand
- Slightly changed error output when unknown argument is provided (given that we now need to DIY this)
