### PR TITLE
docs: add appium prefix in webdriverio for 1.x branch

### DIFF
--- a/commands-yml/commands/session/create.yml
+++ b/commands-yml/commands/session/create.yml
@@ -50,13 +50,22 @@ example_usage:
 
   javascript_wdio:
     |
+      # MJSONWP,
       let options = { desiredCapabilities: {
         platformName: 'Android',
         platformVersion: '7.0',
         automationName: 'UiAutomator2',
         app: path.resolve('path', 'to', 'app.apk')
       }};
-      let client = driver.newSession(options);
+      # or W3C
+      options = { capabilities: {
+        platformName: 'Android',
+        platformVersion: '7.0',
+        'appium:automationName': 'UiAutomator2',
+        'appium:app': path.resolve('path', 'to', 'app.apk')
+      }};
+
+      const client = driver.newSession(options);
   ruby:
     |
       APP_PATH = '../../path/to/app.app'

--- a/docs/en/about-appium/getting-started.md
+++ b/docs/en/about-appium/getting-started.md
@@ -221,7 +221,7 @@ expect.
 Putting it all together, the file should look like:
 
 ```js
-// javascript
+// webdriverio as W3C capabilities
 
 const wdio = require("webdriverio");
 const assert = require("assert");
@@ -232,11 +232,11 @@ const opts = {
   capabilities: {
     platformName: "Android",
     platformVersion: "8",
-    deviceName: "Android Emulator",
-    app: "/path/to/the/downloaded/ApiDemos-debug.apk",
-    appPackage: "io.appium.android.apis",
-    appActivity: ".view.TextFields",
-    automationName: "UiAutomator2"
+    "appium:deviceName": "Android Emulator",
+    "appium:app": "/path/to/the/downloaded/ApiDemos-debug.apk",
+    "appium:appPackage": "io.appium.android.apis",
+    "appium:appActivity": ".view.TextFields",
+    "appium:automationName": "UiAutomator2"
   }
 };
 

--- a/docs/ja/about-appium/getting-started.md
+++ b/docs/ja/about-appium/getting-started.md
@@ -231,11 +231,11 @@ const opts = {
   capabilities: {
     platformName: "Android",
     platformVersion: "8",
-    deviceName: "Android Emulator",
-    app: "/path/to/the/downloaded/ApiDemos-debug.apk",
-    appPackage: "io.appium.android.apis",
-    appActivity: ".view.TextFields",
-    automationName: "UiAutomator2"
+    "appium:deviceName": "Android Emulator",
+    "appium:app": "/path/to/the/downloaded/ApiDemos-debug.apk",
+    "appium:appPackage": "io.appium.android.apis",
+    "appium:appActivity": ".view.TextFields",
+    "appium:automationName": "UiAutomator2"
   }
 };
 


### PR DESCRIPTION
## Proposed changes

Our webdriverio new create session examples need `appium:` one as well.
https://github.com/appium/appium/issues/17238

Maybe this work..? I'll check this later...

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla.js.foundation/appium/appium)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
