### PR TITLE
chore(renovate): add "del", "get-port", "inquirer", "vinyl-paths" to exclusion list

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,14 +13,18 @@
     {
       "matchPackageNames": [
         "@types/wrap-ansi",
+        "del",
         "execa",
         "find-up",
+        "get-port",
         "globby",
+        "inquirer",
         "log-symbols",
         "read-pkg",
         "strip-ansi",
         "supports-color",
         "term-size",
+        "vinyl-paths",
         "wrap-ansi",
         "write-pkg"
       ],


### PR DESCRIPTION
these packages are now ESM-only

Ref: #15926 #17242 #17102 #17270