### PR TITLE
fix(support): use legacy peer deps for npm v7+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,11 +29,9 @@
         "@appium/test-support": "file:packages/test-support",
         "@appium/types": "file:packages/types",
         "@appium/universal-xml-plugin": "file:packages/universal-xml-plugin",
-        "appium": "file:packages/appium",
-        "glob": "8.0.3"
+        "appium": "file:packages/appium"
       },
       "devDependencies": {
-        "@appium/fake-plugin": "1.3.1",
         "@babel/cli": "7.18.9",
         "@babel/core": "7.18.9",
         "@babel/eslint-parser": "7.18.9",

--- a/package.json
+++ b/package.json
@@ -96,11 +96,9 @@
     "@appium/test-support": "file:packages/test-support",
     "@appium/types": "file:packages/types",
     "@appium/universal-xml-plugin": "file:packages/universal-xml-plugin",
-    "appium": "file:packages/appium",
-    "glob": "8.0.3"
+    "appium": "file:packages/appium"
   },
   "devDependencies": {
-    "@appium/fake-plugin": "1.3.1",
     "@babel/cli": "7.18.9",
     "@babel/core": "7.18.9",
     "@babel/eslint-parser": "7.18.9",

--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -206,7 +206,7 @@ export class NPM {
      */
     const installOpts = (await hasAppiumDependency(cwd))
       ? ['--save-dev']
-      : ['--save-dev', '--save-exact', '--global-style', '--no-package-lock'];
+      : ['--save-dev', '--save-exact', '--global-style', '--no-package-lock', '--legacy-peer-deps'];
 
     const res = await this.exec(
       'install',


### PR DESCRIPTION
This partially addresses issue #17287

npm v6 still seems confused, but I think I just need to do further testing on it.  we don't support npm v6 for a dev env so I'm not sure if I should worry about it, but need to determine if the weirdness is more widespread.
