### PR TITLE
fix(appium): partially revert 2a6a056187ce925d5776b7acc4954b10ecf9221b

### DIFF
--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -4,7 +4,7 @@ import {init as logsinkInit} from './logsink'; // this import needs to come firs
 import logger from './logger'; // logger needs to remain second
 // @ts-ignore
 import {routeConfiguringFunction as makeRouter, server as baseServer} from '@appium/base-driver';
-import {logger as logFactory, util, env, fs} from '@appium/support';
+import {logger as logFactory, util, env} from '@appium/support';
 import {asyncify} from 'asyncbox';
 import _ from 'lodash';
 import {AppiumDriver} from './appium';
@@ -15,7 +15,6 @@ import {
   checkNodeOk,
   getGitRev,
   getNonDefaultServerArgs,
-  rootDir,
   showConfig,
   showBuildInfo,
   validateTmpDir,
@@ -27,9 +26,8 @@ import {DRIVER_TYPE, PLUGIN_TYPE, SERVER_SUBCOMMAND} from './constants';
 import registerNode from './grid-register';
 import {getDefaultsForSchema, validate} from './schema/schema';
 import {inspect} from './utils';
-import path from 'path';
 
-const {resolveAppiumHome, hasAppiumDependency} = env;
+const {resolveAppiumHome} = env;
 
 /**
  *
@@ -171,19 +169,6 @@ function areServerCommandArgs(args) {
  */
 async function init(args) {
   const appiumHome = args?.appiumHome ?? (await resolveAppiumHome());
-
-  // this is here so extensions installed in e.g., `~/.appium` can find the peer dependency
-  // of `appium`, which lives wherever it lives (see `rootDir`).
-  if (!(await hasAppiumDependency(appiumHome))) {
-    try {
-      await fs.mkdirp(path.join(appiumHome, 'node_modules'));
-      await fs.symlink(rootDir, path.join(appiumHome, 'node_modules', 'appium'), 'junction');
-    } catch (err) {
-      if (err.code !== 'EEXIST') {
-        throw new Error(`Unable to create symlink to appium: ${err.message}`);
-      }
-    }
-  }
 
   const {driverConfig, pluginConfig} = await loadExtensions(appiumHome);
 


### PR DESCRIPTION
This removes the symlink we were creating to avoid an extra install of `appium` in `APPIUM_HOME`.  Using a symlink obviously breaks stuff, because (for whatever reason) `npm` wants to run lthe `prepare` lifecycle script in the symlinked `appium`, which will not work outside of a dev environment due to missing dev depenencies.

Because npm v7+'s behavior is to install peer dependencies automatically, this will cause `appium` to be installed alongside any extensions in `APPIUM_HOME`. Each extension will have its own `appium`. This may just be the price we have to pay for using `APPIUM_HOME`, or there may be another solution to avoid the extra install (I'm not sure what it is).  I think it _also_ exposes us to future bugs where the running Appium differs from whatever the peer dependency is set to... which sort of defeats the purpose of peer dependencies.  Either way, the user will get a warning if the currently-running Appium is too new for an extension.
