### PR TITLE
fix(appium): add npm version check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -25953,7 +25953,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "packages/appium/node_modules/find-up": {
@@ -26048,7 +26048,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "packages/base-plugin": {
@@ -26060,7 +26060,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "packages/doctor": {
@@ -26086,7 +26086,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "packages/doctor/node_modules/ansi-styles": {
@@ -26209,7 +26209,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "packages/eslint-config-appium": {
@@ -26218,7 +26218,7 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       },
       "peerDependencies": {
         "@babel/core": "7.18.9",
@@ -26245,7 +26245,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       },
       "peerDependencies": {
         "appium": "^2.0.0-beta.35"
@@ -26270,7 +26270,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       },
       "peerDependencies": {
         "appium": "^2.0.0-beta.35"
@@ -26291,7 +26291,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       },
       "peerDependencies": {
         "appium": "^2.0.0-beta.35"
@@ -26357,7 +26357,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       },
       "peerDependencies": {
         "gulp": "^4.0.2"
@@ -26375,7 +26375,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       },
       "peerDependencies": {
         "appium": "^2.0.0-beta.35"
@@ -26396,7 +26396,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "packages/relaxed-caps-plugin": {
@@ -26410,7 +26410,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       },
       "peerDependencies": {
         "appium": "^2.0.0-beta.35"
@@ -26422,11 +26422,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "7.0.11",
-        "json-schema": "0.4.0"
+        "json-schema": "0.4.0",
+        "source-map-support": "0.5.21"
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "packages/support": {
@@ -26494,7 +26495,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "packages/test-support": {
@@ -26520,7 +26521,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       },
       "peerDependencies": {
         "appium": "^2.0.0-beta.35"
@@ -26539,7 +26540,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       }
     },
     "packages/universal-xml-plugin": {
@@ -26556,7 +26557,7 @@
       },
       "engines": {
         "node": ">=14",
-        "npm": ">=6"
+        "npm": ">=8"
       },
       "peerDependencies": {
         "appium": "^2.0.0-beta.35"
@@ -26846,7 +26847,8 @@
       "version": "file:packages/schema",
       "requires": {
         "@types/json-schema": "7.0.11",
-        "json-schema": "0.4.0"
+        "json-schema": "0.4.0",
+        "source-map-support": "0.5.21"
       }
     },
     "@appium/support": {

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -19,6 +19,7 @@ import {
   showBuildInfo,
   validateTmpDir,
   warnNodeDeprecations,
+  checkNpmOk,
 } from './config';
 import {readConfigFile} from './config-file';
 import {loadExtensions, getActivePlugins, getActiveDrivers} from './extension';
@@ -37,6 +38,7 @@ const {resolveAppiumHome} = env;
 async function preflightChecks(args, throwInsteadOfExit = false) {
   try {
     checkNodeOk();
+    await checkNpmOk();
     if (args.longStacktrace) {
       require('longjohn').async_trace_limit = -1;
     }

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -101,7 +101,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public",

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -72,7 +72,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/base-plugin/package.json
+++ b/packages/base-plugin/package.json
@@ -35,7 +35,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "types": "./build/lib/plugin.d.ts",
   "gitHead": "5c7af8ee73078018e4ec52fccf19fe3f77249d72",

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -64,7 +64,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -51,7 +51,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/eslint-config-appium/package.json
+++ b/packages/eslint-config-appium/package.json
@@ -42,7 +42,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -56,6 +56,6 @@
   "gitHead": "5c7af8ee73078018e4ec52fccf19fe3f77249d72",
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   }
 }

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -61,7 +61,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -46,7 +46,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "appium": {
     "pluginName": "fake",

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -101,7 +101,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -54,6 +54,6 @@
   "homepage": "https://appium.io",
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   }
 }

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -54,7 +54,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -40,7 +40,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "appium": {
     "pluginName": "relaxed-caps",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -39,16 +39,17 @@
     "prepare": "npm run build",
     "test:smoke": "node ./index.js"
   },
+  "dependencies": {
+    "@types/json-schema": "7.0.11",
+    "json-schema": "0.4.0",
+    "source-map-support": "0.5.21"
+  },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "5c7af8ee73078018e4ec52fccf19fe3f77249d72",
-  "dependencies": {
-    "@types/json-schema": "7.0.11",
-    "json-schema": "0.4.0"
-  }
+  "gitHead": "5c7af8ee73078018e4ec52fccf19fe3f77249d72"
 }

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -104,7 +104,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -65,7 +65,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -40,7 +40,7 @@
   },
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -52,6 +52,6 @@
   "gitHead": "5c7af8ee73078018e4ec52fccf19fe3f77249d72",
   "engines": {
     "node": ">=14",
-    "npm": ">=6"
+    "npm": ">=8"
   }
 }


### PR DESCRIPTION
This adds a warning for a too-old `npm` version and elimiates engine-related errors from being output twice.
