### PR TITLE
chore(ci): fix target branch for FOSSA job

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
         with:
-          ref: '2.0'
+          ref: 'master'
       - name: fossa analyze
         run: |
           npm install


### PR DESCRIPTION
when we removed `2.0` branch, this broke. 