### PR TITLE
test(appium): add smoke test for driver installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10300,6 +10300,23 @@
         "sha.js": "^2.4.8"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-fetch": {
       "version": "3.1.5",
       "license": "MIT",
@@ -25950,6 +25967,7 @@
         "asyncbox": "2.9.2",
         "axios": "0.27.2",
         "bluebird": "3.7.2",
+        "cross-env": "7.0.3",
         "find-up": "5.0.0",
         "lilconfig": "2.0.6",
         "lodash": "4.17.21",
@@ -32721,6 +32739,7 @@
         "asyncbox": "2.9.2",
         "axios": "0.27.2",
         "bluebird": "3.7.2",
+        "cross-env": "*",
         "find-up": "5.0.0",
         "lilconfig": "2.0.6",
         "lodash": "4.17.21",
@@ -34392,6 +34411,14 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-fetch": {

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -54,10 +54,10 @@
     "postinstall": "node ./scripts/autoinstall-extensions.js",
     "lint": "eslint -c ../../.eslintrc --ignore-path ../../.eslintignore .",
     "prepare": "npm run build",
-    "publish:docs": "APPIUM_DOCS_PUBLISH=1 npm run build:docs",
+    "publish:docs": "cross-env APPIUM_DOCS_PUBLISH=1 npm run build:docs",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 1m --slow 30s \"./test/e2e/**/*.spec.js\"",
-    "test:smoke": "node ./index.js --show-build-info",
+    "test:smoke": "cross-env APPIUM_HOME=./local_appium_home node ./index.js driver install uiautomator2 && cross-env APPIUM_HOME=./local_appium_home node ./index.js driver list",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
@@ -83,6 +83,7 @@
     "asyncbox": "2.9.2",
     "axios": "0.27.2",
     "bluebird": "3.7.2",
+    "cross-env": "7.0.3",
     "find-up": "5.0.0",
     "lilconfig": "2.0.6",
     "lodash": "4.17.21",


### PR DESCRIPTION
This adds a test (which currently only runs automatically in CI) which installs the uiautomator2 driver.  This will ensure that driver installation does not only work in a dev environment!

Due to needing to support Windows and not wishing to befoul the default `APPIUM_HOME`, we need `cross-env` as a production dependency (otherwise the smoke test would fail) to set a temporary `APPIUM_HOME` (`local_appium_home`) which is relative to the temp dir used by the smoke test (see https://github.com/boneskull/nodejs-production-test-action)
