### PR TITLE
fix(appium): config file should be properly normalized

### DIFF
--- a/.wallaby.js
+++ b/.wallaby.js
@@ -36,7 +36,7 @@ module.exports = (wallaby) => {
       '!**/local_appium_home/**',
     ],
     testFramework: 'mocha',
-    tests: ['./packages/*/test/unit/**/*.spec.js'],
+    tests: ['./packages/*/test/unit/**/*.spec.js', '!**/local_appium_home/**'],
     workers: {
       restart: true,
     },

--- a/packages/appium/lib/config-file.js
+++ b/packages/appium/lib/config-file.js
@@ -161,7 +161,9 @@ export function normalizeConfig(config) {
 
     return _.mapValues(mappedObj, (value, property) => {
       const nextSection = section ? `${section}.${property}` : property;
-      return isSchemaTypeObject(value) ? normalize(config, nextSection) : value;
+      return isSchemaTypeObject(schema.properties?.[property])
+        ? normalize(config, nextSection)
+        : value;
     });
   };
 
@@ -169,7 +171,7 @@ export function normalizeConfig(config) {
    * Returns `true` if the schema prop references an object, or if it's an object itself
    * @param {import('ajv').SchemaObject|object} schema - Referencing schema object
    */
-  const isSchemaTypeObject = (schema) => Boolean(schema.properties);
+  const isSchemaTypeObject = (schema) => Boolean(schema?.properties || schema?.type === 'object');
 
   return normalize(config);
 }

--- a/packages/appium/test/e2e/config-file.e2e.spec.js
+++ b/packages/appium/test/e2e/config-file.e2e.spec.js
@@ -33,7 +33,7 @@ describe('config file behavior', function () {
       it('should return a valid config object', async function () {
         const result = await readConfigFile(GOOD_FILEPATH);
         result.should.deep.equal({
-          config: require(GOOD_FILEPATH),
+          config: normalizeConfig(require(GOOD_FILEPATH)),
           filepath: GOOD_FILEPATH,
           errors: [],
         });
@@ -74,7 +74,7 @@ describe('config file behavior', function () {
           it('should return a valid config object', async function () {
             const result = await readConfigFile(SECURITY_ARRAY_FILEPATH);
             result.should.deep.equal({
-              config: require(SECURITY_ARRAY_FILEPATH),
+              config: normalizeConfig(require(SECURITY_ARRAY_FILEPATH)),
               filepath: SECURITY_ARRAY_FILEPATH,
               errors: [],
             });

--- a/packages/appium/test/unit/config-file.spec.js
+++ b/packages/appium/test/unit/config-file.spec.js
@@ -34,6 +34,11 @@ describe('config-file', function () {
   let formatErrors;
 
   /**
+   * @type {import('appium/lib/config-file').normalizeConfig}
+   */
+  let normalizeConfig;
+
+  /**
    * Mock instance of `lilconfig` containing stubs for
    * `lilconfig#search()` and `lilconfig#load`.
    * Not _actually_ a `SinonStubbedInstance`, but duck-typed.
@@ -93,7 +98,7 @@ describe('config-file', function () {
     // loads the `config-file` module using the lilconfig mock.
     // we only mock lilconfig because it'd otherwise be a pain in the rear to test
     // searching for config files, and it increases the likelihood that we'd load the wrong file.
-    ({readConfigFile, formatErrors} = rewiremock.proxy(
+    ({readConfigFile, formatErrors, normalizeConfig} = rewiremock.proxy(
       () => require('../../lib/config-file'),
       mocks
     ));
@@ -114,19 +119,19 @@ describe('config-file', function () {
 
     it('should support yaml', async function () {
       const {config} = await readConfigFile(GOOD_YAML_CONFIG_FILEPATH);
-      expect(config).to.eql(GOOD_JSON_CONFIG);
+      expect(config).to.eql(normalizeConfig(GOOD_JSON_CONFIG));
       expect(schema.validate).to.have.been.calledOnce;
     });
 
     it('should support json', async function () {
       const {config} = await readConfigFile(GOOD_JSON_CONFIG_FILEPATH);
-      expect(config).to.eql(GOOD_JSON_CONFIG);
+      expect(config).to.eql(normalizeConfig(GOOD_JSON_CONFIG));
       expect(schema.validate).to.have.been.calledOnce;
     });
 
     it('should support js', async function () {
       const {config} = await readConfigFile(GOOD_JS_CONFIG_FILEPATH);
-      expect(config).to.eql(GOOD_JSON_CONFIG);
+      expect(config).to.eql(normalizeConfig(GOOD_JSON_CONFIG));
       expect(schema.validate).to.have.been.calledOnce;
     });
 
@@ -188,7 +193,7 @@ describe('config-file', function () {
 
             it('should resolve with an object having `config` property and empty array of errors', function () {
               expect(result).to.deep.equal({
-                config: GOOD_JSON_CONFIG,
+                config: normalizeConfig(GOOD_JSON_CONFIG),
                 errors: [],
                 filepath: GOOD_JSON_CONFIG_FILEPATH,
               });
@@ -291,7 +296,7 @@ describe('config-file', function () {
             it('should resolve with an object having `config` property and empty array of errors', function () {
               expect(result).to.deep.equal({
                 errors: [],
-                config: GOOD_JSON_CONFIG,
+                config: normalizeConfig(GOOD_JSON_CONFIG),
                 filepath: GOOD_JSON_CONFIG_FILEPATH,
               });
             });

--- a/packages/appium/test/unit/config.spec.js
+++ b/packages/appium/test/unit/config.spec.js
@@ -60,7 +60,7 @@ describe('Config', function () {
             {
               config: {
                 // @ts-expect-error
-                server: {callbackAddress: 'quux'},
+                server: {'callback-address': 'quux'},
               },
             },
             {port: 1234},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "files": [],
+  "compilerOptions": {
+    "esModuleInterop": true
+  },
   "references": [
     {
       "path": "packages/schema"


### PR DESCRIPTION
I'm not sure _what_ happened here other than "the types weren't strict enough" otherwise I would have noticed this earlier.  Anyway; the check to see if we should dig into the config object to normalize the keys was getting passed _something_ but that _something_ wasn't anything it expected.

As a result, I needed to update some tests which assumed `readConfigFile()` resolved w/ an identity w/r/t the config file itself.  It doesn't give the config file back verbatim any longer; the result will be normalized to camel-case keys (or whatever the `appiumCliDest` property is, if it exists)
