### PR TITLE
feat(base-driver,fake-driver,appium): add convenience methods for defining execute script overloads

### DIFF
--- a/packages/appium/docs/en/ecosystem/build-drivers.md
+++ b/packages/appium/docs/en/ecosystem/build-drivers.md
@@ -582,7 +582,7 @@ driver.executeScript('soundz: playSong', [{song: 'Stairway to Heaven', artist: '
 ```
 
 Then in your driver code you could define the static property `executeMethodMap` as
-a mapping of script names to member functions on your driver. It has the same basic form as
+a mapping of script names to methods on your driver. It has the same basic form as
 `newMethodMap`. All you need to do at that point is implement the `execute` the command to take
 advantage of the built-in `executeMethod` method available on all drivers:
 

--- a/packages/appium/docs/en/ecosystem/build-drivers.md
+++ b/packages/appium/docs/en/ecosystem/build-drivers.md
@@ -581,7 +581,7 @@ call something like:
 driver.executeScript('soundz: playSong', [{song: 'Stairway to Heaven', artist: 'Led Zeppelin'}]);
 ```
 
-Then in your driver code you could simply define the magic static field `executeMethodMap` as
+Then in your driver code you could define the static property `executeMethodMap` as
 a mapping of script names to member functions on your driver. It has the same basic form as
 `newMethodMap`. All you need to do at that point is implement the `execute` the command to take
 advantage of the built-in `executeMethod` method available on all drivers:

--- a/packages/appium/docs/en/ecosystem/build-drivers.md
+++ b/packages/appium/docs/en/ecosystem/build-drivers.md
@@ -609,7 +609,7 @@ A couple notes about this system:
 1. Your overload will always be bound to the driver instance.
 1. Appium does not automatically implement `execute` for you. You may wish, for example, to only
    call the `executeMethod` helper function when you're not in proxy mode!
-1. The `executeMethod` helper will throw an error if a script name doesn't match one of the
+1. The `executeMethod` helper will reject with an `Error` if a script name doesn't match one of the
    script names defined as a command in `executeMethodMap`, or if there are missing parameters.
 
 ### Implement handling of Appium settings

--- a/packages/appium/docs/en/ecosystem/build-drivers.md
+++ b/packages/appium/docs/en/ecosystem/build-drivers.md
@@ -583,8 +583,7 @@ driver.executeScript('soundz: playSong', [{song: 'Stairway to Heaven', artist: '
 
 Then in your driver code you could define the static property `executeMethodMap` as
 a mapping of script names to methods on your driver. It has the same basic form as
-`newMethodMap`. All you need to do at that point is implement the `execute` the command to take
-advantage of the built-in `executeMethod` method available on all drivers:
+`newMethodMap`. Once `executeMethodMap` is defined, you'll need to implement the `execute` command:
 
 ```js
 static executeMethodMap = {

--- a/packages/base-driver/lib/basedriver/commands/execute.js
+++ b/packages/base-driver/lib/basedriver/commands/execute.js
@@ -1,0 +1,67 @@
+// @ts-check
+import _ from 'lodash';
+import {errors, makeArgs, checkParams} from '../../protocol';
+
+/**
+ * @param {SessionBase} Base
+ * @returns {ExecuteBase}
+ */
+export function ExecuteMixin(Base) {
+  /**
+   * @implements {IExecuteCommands}
+   */
+  class ExecuteCommands extends Base {
+    /**
+     * @this {Driver}
+     * @param {string} script
+     * @param {[Record<string, any>]|[]} protoArgs
+     */
+    async executeMethod(script, protoArgs) {
+      // the w3c protocol will give us an array of arguments to apply to a javascript function.
+      // that's not what we're doing. we're going to look for a JS object as the first arg, so we
+      // can perform validation on it. we'll ignore everything else.
+      if (!protoArgs || !_.isArray(protoArgs) || protoArgs.length > 1) {
+        throw new errors.InvalidArgumentError(
+          `Did not get correct format of arguments for execute method. Expected zero or one ` +
+            `arguments to execute script and instead received: ${JSON.stringify(protoArgs)}`
+        );
+      }
+      let args = protoArgs[0] ?? {};
+      if (!_.isPlainObject(args)) {
+        throw new errors.InvalidArgumentError(
+          `Did not receive an appropriate execute method parameters object. It needs to be ` +
+            `deserializable as a plain JS object`
+        );
+      }
+
+      const Driver = /** @type {DriverClass} */ (this.constructor);
+      const availableScripts = _.keys(Driver.executeMethodMap);
+      const commandMetadata = Driver.executeMethodMap[script];
+      if (!commandMetadata) {
+        throw new errors.UnsupportedOperationError(
+          `Unsupported execute method '${script}'. Available methods ` +
+            `are: ${availableScripts.join(', ')}`
+        );
+      }
+      let argsToApply = [];
+      if (!commandMetadata.params) {
+        commandMetadata.params = {required: [], optional: []};
+      } else {
+        commandMetadata.params.required ??= [];
+        commandMetadata.params.optional ??= [];
+        checkParams(commandMetadata.params, args, null);
+      }
+      argsToApply = makeArgs({}, args, commandMetadata.params, null);
+      return await this[Driver.executeMethodMap[script].command](...argsToApply);
+    }
+  }
+  return ExecuteCommands;
+}
+
+/**
+ * @typedef {import('@appium/types').ExecuteCommands} IExecuteCommands
+ * @typedef {import('@appium/types').Driver} Driver
+ * @typedef {import('@appium/types').DriverClass} DriverClass
+ * @typedef {import('./session').SessionBase} SessionBase
+ * @typedef {import('../driver').BaseDriverBase<import('@appium/types').TimeoutCommands & import('@appium/types').EventCommands & import('@appium/types').FindCommands & import('@appium/types').LogCommands & import('@appium/types').SettingsCommands & import('@appium/types').SessionCommands & IExecuteCommands>} ExecuteBase
+ */

--- a/packages/base-driver/lib/basedriver/commands/execute.js
+++ b/packages/base-driver/lib/basedriver/commands/execute.js
@@ -1,4 +1,3 @@
-// @ts-check
 import _ from 'lodash';
 import {errors, makeArgs, checkParams} from '../../protocol';
 
@@ -12,7 +11,6 @@ export function ExecuteMixin(Base) {
    */
   class ExecuteCommands extends Base {
     /**
-     * @this {Driver}
      * @param {string} script
      * @param {[Record<string, any>]|[]} protoArgs
      */

--- a/packages/base-driver/lib/basedriver/commands/index.js
+++ b/packages/base-driver/lib/basedriver/commands/index.js
@@ -6,6 +6,7 @@ import {LogMixin} from './log';
 import {SessionMixin} from './session';
 import {SettingsMixin} from './settings';
 import {TimeoutMixin} from './timeout';
+import {ExecuteMixin} from './execute';
 
 /**
  * Applies all the mixins to the `BaseDriverBase` class.
@@ -19,7 +20,8 @@ export function createBaseDriverClass(Base) {
   const WithLogCommands = LogMixin(WithFindCommands);
   const WithSettingsCommands = SettingsMixin(WithLogCommands);
   const WithSessionCommands = SessionMixin(WithSettingsCommands);
-  return WithSessionCommands;
+  const WithExecuteCommands = ExecuteMixin(WithSessionCommands);
+  return WithExecuteCommands;
 }
 
 /**

--- a/packages/base-driver/lib/basedriver/core.js
+++ b/packages/base-driver/lib/basedriver/core.js
@@ -27,6 +27,9 @@ class DriverCore {
    */
   static baseVersion = BASEDRIVER_VER;
 
+  /** @type {ExecuteMethodMap} */
+  static executeMethodMap = {};
+
   /**
    * @type {string?}
    */
@@ -423,6 +426,7 @@ export {DriverCore};
  * @typedef {import('@appium/types').W3CCapabilities} W3CCapabilities
  * @typedef {import('@appium/types').Driver} Driver
  * @typedef {import('@appium/types').Core} Core
+ * @typedef {import('@appium/types').ExecuteMethodMap} ExecuteMethodMap
  * @typedef {import('@appium/types').ServerArgs} ServerArgs
  * @typedef {import('@appium/types').EventHistory} EventHistory
  * @typedef {import('@appium/types').AppiumLogger} AppiumLogger

--- a/packages/base-driver/lib/protocol/index.js
+++ b/packages/base-driver/lib/protocol/index.js
@@ -5,6 +5,8 @@ import {
   CREATE_SESSION_COMMAND,
   DELETE_SESSION_COMMAND,
   GET_STATUS_COMMAND,
+  makeArgs,
+  checkParams,
 } from './protocol';
 import {NO_SESSION_ID_COMMANDS, ALL_COMMANDS, METHOD_MAP, routeToCommandName} from './routes';
 import {errors, isErrorType, errorFromMJSONWPStatusCode, errorFromW3CJsonCode} from './errors';
@@ -13,6 +15,8 @@ export {
   routeConfiguringFunction,
   errors,
   isErrorType,
+  makeArgs,
+  checkParams,
   errorFromMJSONWPStatusCode,
   errorFromW3CJsonCode,
   ALL_COMMANDS,

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -94,7 +94,7 @@ function unwrapParams(paramSets, jsonObj) {
   return res;
 }
 
-function checkParams(paramSets, jsonObj, protocol) {
+export function checkParams(paramSets, jsonObj, protocol) {
   let requiredParams = [];
   let optionalParams = [];
   let receivedParams = _.keys(jsonObj);
@@ -162,7 +162,7 @@ function checkParams(paramSets, jsonObj, protocol) {
  * on handling parameters. This method returns an array of arguments which will
  * be applied to a command.
  */
-function makeArgs(requestParams, jsonObj, payloadParams, protocol) {
+export function makeArgs(requestParams, jsonObj, payloadParams, protocol) {
   // We want to pass the "url" parameters to the commands in reverse order
   // since the command will sometimes want to ignore, say, the sessionId.
   // This has the effect of putting sessionId last, which means in JS we can

--- a/packages/fake-driver/lib/commands/general.js
+++ b/packages/fake-driver/lib/commands/general.js
@@ -69,6 +69,14 @@ commands.getLog = async function getLog(type) {
   }
 };
 
+commands.execute = async function execute(script, args) {
+  return await this.executeMethod(script, args);
+};
+
+commands.fakeAddition = async function fakeAddition(num1, num2, num3) {
+  return num1 + num2 + (num3 ?? 0);
+};
+
 Object.assign(extensions, commands, helpers);
 export {commands, helpers};
 export default extensions;

--- a/packages/fake-driver/lib/driver.js
+++ b/packages/fake-driver/lib/driver.js
@@ -113,6 +113,20 @@ class FakeDriver extends BaseDriver {
     },
   };
 
+  static executeMethodMap = {
+    'fake: addition': {
+      command: 'fakeAddition',
+      params: {required: ['num1', 'num2'], optional: ['num3']},
+    },
+    'fake: getThing': {
+      command: 'getFakeThing',
+    },
+    'fake: setThing': {
+      command: 'setFakeThing',
+      params: {required: ['thing']},
+    },
+  };
+
   static fakeRoute(req, res) {
     res.send(JSON.stringify({fakedriver: 'fakeResponse'}));
   }

--- a/packages/fake-driver/test/e2e/general-tests.js
+++ b/packages/fake-driver/test/e2e/general-tests.js
@@ -106,6 +106,45 @@ function generalTests() {
       res[0].type.should.eql('pointer');
       res[0].actions.should.have.length(2);
     });
+
+    it('should get and set a fake thing via execute overloads', async function () {
+      let thing = await driver.executeScript('fake: getThing', []);
+      should.not.exist(thing);
+      await driver.executeScript('fake: setThing', [{thing: 1234}]);
+      thing = await driver.executeScript('fake: getThing', []);
+      thing.should.eql(1234);
+    });
+
+    it('should add 2 numbers via execute overloads', async function () {
+      await driver.executeScript('fake: addition', [{num1: 2, num2: 3}]).should.eventually.eql(5);
+      await driver
+        .executeScript('fake: addition', [{num1: 2, num2: 3, num3: 4}])
+        .should.eventually.eql(9);
+    });
+
+    it('should throw not implemented if an execute overload isnt supported', async function () {
+      await driver
+        .executeScript('fake: blarg', [])
+        .should.be.rejectedWith(/Unsupported execute method/);
+    });
+
+    it('should throw an error if a required overload param is missing', async function () {
+      await driver
+        .executeScript('fake: addition', [{num3: 4}])
+        .should.be.rejectedWith(/Parameters were incorrect/);
+    });
+
+    it('should throw an error if sending in wrong types of params', async function () {
+      await driver
+        .executeScript('fake: addition', [4, 5])
+        .should.be.rejectedWith(/correct format of arg/);
+      await driver
+        .executeScript('fake: addition', [4])
+        .should.be.rejectedWith(/not receive an appropriate execute/);
+      await driver
+        .executeScript('fake: addition', [{num1: 2}, {extra: 'bad'}])
+        .should.be.rejectedWith(/correct format of arg/);
+    });
   });
 }
 

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -48,14 +48,14 @@ export interface ExecuteCommands {
   executeMethod(script: string, args: [Record<string, any>]|[]): Promise<any>;
 }
 
-export interface ExecuteOverloadDef {
+export interface ExecuteMethodDef {
   command: string,
   params?: {
     required?: string[],
     optional?: string[],
   }
 };
-export type ExecuteMethodMap = Record<string, ExecuteOverloadDef>;
+export type ExecuteMethodMap = Record<string, ExecuteMethodDef>;
 
 export interface MultiSessionData {
   id: string;

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -44,6 +44,19 @@ export interface SessionCommands {
   getSession(): Promise<SingularSessionData>;
 }
 
+export interface ExecuteCommands {
+  executeMethod(script: string, args: [Record<string, any>]|[]): Promise<any>;
+}
+
+export interface ExecuteOverloadDef {
+  command: string,
+  params?: {
+    required?: string[],
+    optional?: string[],
+  }
+};
+export type ExecuteMethodMap = Record<string, ExecuteOverloadDef>;
+
 export interface MultiSessionData {
   id: string;
   capabilities: Capabilities;
@@ -574,6 +587,7 @@ export interface DriverStatic {
   baseVersion: string;
   updateServer?: UpdateServerCallback;
   newMethodMap?: MethodMap<ExternalDriver>;
+  executeMethodMap: ExecuteMethodMap;
 }
 
 /**


### PR DESCRIPTION
This is such a common pattern in pretty much every driver, I thought I'd take a stab at conventionalizing it. Open to feedback! Once we agree, I can add some unit tests in base-driver.