### PR TITLE
feat(appium): Adjust NODE_PATH so NPM could properly resolve component peer dependencies

### DIFF
--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -365,7 +365,8 @@ class ExtensionCommand {
 
       return this.getExtensionFields(pkgJsonData);
     } catch (err) {
-      throw this._createFatalError(`Encountered an error when installing package: ${err.message}`);
+      throw this._createFatalError(`Encountered an error when installing package: ${err.message}\n` +
+        `env: ${JSON.stringify(process.env)}`);
     }
   }
 

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -365,8 +365,7 @@ class ExtensionCommand {
 
       return this.getExtensionFields(pkgJsonData);
     } catch (err) {
-      throw this._createFatalError(`Encountered an error when installing package: ${err.message}\n` +
-        `env: ${JSON.stringify(process.env)}`);
+      throw this._createFatalError(`Encountered an error when installing package: ${err.message}`);
     }
   }
 

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -2,6 +2,8 @@ import _ from 'lodash';
 import logger from './logger';
 import {processCapabilities, PROTOCOLS} from '@appium/base-driver';
 import {inspect as dump} from 'util';
+import {fs} from '@appium/support';
+import path from 'path';
 
 const W3C_APPIUM_PREFIX = 'appium';
 
@@ -210,6 +212,49 @@ function getPackageVersion(pkgName) {
 }
 
 /**
+ * Adjusts NODE_PATH environment variable,
+ * so drivers and plugins could load their peer dependencies.
+ * Read https://nodejs.org/api/modules.html#loading-from-the-global-folders
+ * for more details.
+ * @returns {Promise<void>}
+ */
+async function adjustNodePath() {
+  const pathParts = __filename.split(path.sep);
+  let nodeModulesRoot = null;
+  for (let folderIdx = pathParts.length - 1; folderIdx >= 0; folderIdx--) {
+    const currentRoot = path.join(...(pathParts.slice(0, folderIdx + 1)));
+    const manifestPath = path.join(currentRoot, 'package.json');
+    if (!await fs.exists(manifestPath)) {
+      continue;
+    }
+    try {
+      if (JSON.parse(await fs.readFile(manifestPath, 'utf8')).name === 'appium') {
+        nodeModulesRoot = currentRoot;
+        break;
+      }
+    } catch (ign) {}
+  }
+  if (!nodeModulesRoot) {
+    return;
+  }
+
+  if (!process.env.NODE_PATH) {
+    logger.info(`Setting NODE_PATH to '${nodeModulesRoot}'`);
+    process.env.NODE_PATH = nodeModulesRoot;
+    return;
+  }
+
+  const nodePathParts = process.env.NODE_PATH.split(path.delimiter);
+  if (nodePathParts.includes(nodeModulesRoot)) {
+    return;
+  }
+
+  nodePathParts.push(nodeModulesRoot);
+  logger.info(`Adding '${nodeModulesRoot}' to NODE_PATH`);
+  process.env.NODE_PATH = nodePathParts.join(path.delimiter);
+}
+
+/**
  * Pulls the initial values of Appium settings from the given capabilities argument.
  * Each setting item must satisfy the following format:
  * `setting[setting_name]: setting_value`
@@ -250,6 +295,7 @@ export {
   getPackageVersion,
   pullSettings,
   removeAppiumPrefixes,
+  adjustNodePath,
 };
 
 /**

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -219,17 +219,16 @@ function getPackageVersion(pkgName) {
  * @returns {Promise<void>}
  */
 async function adjustNodePath() {
-  const pathParts = __filename.split(path.sep);
+  const pathParts = path.resolve(...(__filename.split(path.sep))).split(path.sep);
   let nodeModulesRoot = null;
-  for (let folderIdx = pathParts.length - 1; folderIdx >= 0; folderIdx--) {
-    const currentRootParts = pathParts.slice(0, folderIdx + 1);
-    const manifestPath = path.join(...currentRootParts, 'package.json');
+  for (let folderIdx = pathParts.length - 1; folderIdx > 0; --folderIdx) {
+    const manifestPath = path.join(...(pathParts.slice(0, folderIdx + 1)), 'package.json');
     if (!await fs.exists(manifestPath)) {
       continue;
     }
     try {
       if (JSON.parse(await fs.readFile(manifestPath, 'utf8')).name === 'appium') {
-        nodeModulesRoot = path.resolve(...currentRootParts);
+        nodeModulesRoot = path.join(...(pathParts.slice(0, folderIdx)));
         break;
       }
     } catch (ign) {}

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -241,11 +241,15 @@ async function adjustNodePath() {
 
   const refreshRequirePaths = () => {
     try {
-      // https://gist.github.com/branneman/8048520#7-the-hack
+      // ! This hack allows us to avoid modification of import
+      // ! statements in client modules. It uses a private API though,
+      // ! so it could break (maybe, eventually).
+      // See https://gist.github.com/branneman/8048520#7-the-hack
       // @ts-ignore
       require('module').Module._initPaths();
       return true;
-    } catch {
+    } catch (e) {
+      logger.info(`Module init paths cannot be refreshed. Original error: ${e.message}`);
       return false;
     }
   };

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -219,7 +219,9 @@ function getPackageVersion(pkgName) {
  * @returns {Promise<void>}
  */
 async function adjustNodePath() {
-  const pathParts = path.resolve(...(__filename.split(path.sep))).split(path.sep);
+  const pathParts = path.resolve(...(__filename.split(path.sep)))
+    .split(path.sep)
+    .map((x) => x === '' ? path.sep : x);
   let nodeModulesRoot = null;
   for (let folderIdx = pathParts.length - 1; folderIdx > 0; --folderIdx) {
     const manifestPath = path.join(...(pathParts.slice(0, folderIdx + 1)), 'package.json');

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -223,14 +223,14 @@ async function adjustNodePath() {
     .split(path.sep)
     .map((x) => x === '' ? path.sep : x);
   let nodeModulesRoot = null;
-  for (let folderIdx = pathParts.length - 1; folderIdx > 0; --folderIdx) {
-    const manifestPath = path.join(...(pathParts.slice(0, folderIdx + 1)), 'package.json');
+  for (let pathItemIdx = pathParts.length - 1; pathItemIdx > 0; --pathItemIdx) {
+    const manifestPath = path.join(...(pathParts.slice(0, pathItemIdx)), 'package.json');
     if (!await fs.exists(manifestPath)) {
       continue;
     }
     try {
       if (JSON.parse(await fs.readFile(manifestPath, 'utf8')).name === 'appium') {
-        nodeModulesRoot = path.join(...(pathParts.slice(0, folderIdx)));
+        nodeModulesRoot = path.join(...(pathParts.slice(0, pathItemIdx - 1)));
         break;
       }
     } catch (ign) {}

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -222,14 +222,14 @@ async function adjustNodePath() {
   const pathParts = __filename.split(path.sep);
   let nodeModulesRoot = null;
   for (let folderIdx = pathParts.length - 1; folderIdx >= 0; folderIdx--) {
-    const currentRoot = path.join(...(pathParts.slice(0, folderIdx + 1)));
-    const manifestPath = path.join(currentRoot, 'package.json');
+    const currentRootParts = pathParts.slice(0, folderIdx + 1);
+    const manifestPath = path.join(...currentRootParts, 'package.json');
     if (!await fs.exists(manifestPath)) {
       continue;
     }
     try {
       if (JSON.parse(await fs.readFile(manifestPath, 'utf8')).name === 'appium') {
-        nodeModulesRoot = currentRoot;
+        nodeModulesRoot = path.resolve(...currentRootParts);
         break;
       }
     } catch (ign) {}

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -239,9 +239,18 @@ async function adjustNodePath() {
     return;
   }
 
+  const refreshRequirePaths = () => {
+    try {
+      // https://gist.github.com/branneman/8048520#7-the-hack
+      // @ts-ignore
+      require('module').Module._initPaths();
+    } catch {}
+  };
+
   if (!process.env.NODE_PATH) {
     logger.info(`Setting NODE_PATH to '${nodeModulesRoot}'`);
     process.env.NODE_PATH = nodeModulesRoot;
+    refreshRequirePaths();
     return;
   }
 
@@ -253,6 +262,7 @@ async function adjustNodePath() {
   nodePathParts.push(nodeModulesRoot);
   logger.info(`Adding '${nodeModulesRoot}' to NODE_PATH`);
   process.env.NODE_PATH = nodePathParts.join(path.delimiter);
+  refreshRequirePaths();
 }
 
 /**

--- a/packages/appium/test/e2e/cli.e2e.spec.js
+++ b/packages/appium/test/e2e/cli.e2e.spec.js
@@ -38,6 +38,22 @@ describe('CLI behavior', function () {
     resolveFixture('test-driver-invalid-peer-dep/package.json')
   );
 
+  describe('when appium is already installed', function () {
+    before(async function () {
+      appiumHome = await tempDir.openDir();
+    });
+
+    after(async function () {
+      await fs.rimraf(appiumHome);
+    });
+
+    it('should not duplicate it as peer dependencies for drivers', async function () {
+      const run = runAppiumJson(appiumHome);
+      await run([DRIVER_TYPE, INSTALL, 'appium-fake-driver', '--source', 'npm']);
+      await fs.exists(path.join(appiumHome, 'node_modules', 'appium')).should.eventually.be.false;
+    });
+  });
+
   describe('when appium is a dependency of the project in the current working directory', function () {
     /** @type {string} */
     let hashPath;
@@ -171,10 +187,6 @@ describe('CLI behavior', function () {
         it('should actually install both drivers', function () {
           expect(() => resolveFrom(appiumHome, '@appium/fake-driver')).not.to.throw;
           expect(() => resolveFrom(appiumHome, 'test-driver')).not.to.throw;
-        });
-
-        it('should not install peer dependencies', async function () {
-          await fs.exists(path.join(appiumHome, 'node_modules', 'appium')).should.eventually.be.false;
         });
       });
     });

--- a/packages/appium/test/e2e/cli.e2e.spec.js
+++ b/packages/appium/test/e2e/cli.e2e.spec.js
@@ -172,10 +172,6 @@ describe('CLI behavior', function () {
           expect(() => resolveFrom(appiumHome, '@appium/fake-driver')).not.to.throw;
           expect(() => resolveFrom(appiumHome, 'test-driver')).not.to.throw;
         });
-
-        it('should not install peer dependencies', async function () {
-          await fs.exists(path.join(appiumHome, 'node_modules', 'appium')).should.eventually.be.false;
-        });
       });
     });
   });

--- a/packages/appium/test/e2e/cli.e2e.spec.js
+++ b/packages/appium/test/e2e/cli.e2e.spec.js
@@ -172,6 +172,10 @@ describe('CLI behavior', function () {
           expect(() => resolveFrom(appiumHome, '@appium/fake-driver')).not.to.throw;
           expect(() => resolveFrom(appiumHome, 'test-driver')).not.to.throw;
         });
+
+        it('should not install peer dependencies', async function () {
+          await fs.exists(path.join(appiumHome, 'node_modules', 'appium')).should.eventually.be.false;
+        });
       });
     });
   });

--- a/packages/appium/test/unit/utils.spec.js
+++ b/packages/appium/test/unit/utils.spec.js
@@ -270,7 +270,7 @@ describe('utils', function () {
       }
     });
 
-    it('should ajust NODE_PATH', async function () {
+    it('should adjust NODE_PATH', async function () {
       await adjustNodePath();
       (await fs.exists(process.env.NODE_PATH)).should.be.true;
     });

--- a/packages/appium/test/unit/utils.spec.js
+++ b/packages/appium/test/unit/utils.spec.js
@@ -4,12 +4,14 @@ import {
   pullSettings,
   removeAppiumPrefixes,
   inspect,
+  adjustNodePath,
 } from '../../lib/utils';
 import {BASE_CAPS, W3C_CAPS} from '../helpers';
 import _ from 'lodash';
 import {stripColors} from '@colors/colors';
 import {createSandbox} from 'sinon';
 import logger from '../../lib/logger';
+import {fs} from '@appium/support';
 
 describe('utils', function () {
   describe('parseCapsForInnerDriver()', function () {
@@ -250,6 +252,27 @@ describe('utils', function () {
       stripColors(/** @type {sinon.SinonStub} */ (logger.info).firstCall.firstArg).should.match(
         /\{\s*\n*foo:\s'bar'\s*\n*\}/
       );
+    });
+  });
+
+  describe('adjustNodePath()', function () {
+    let prevValue = process.env.NODE_PATH;
+
+    beforeEach(function () {
+      if (process.env.NODE_PATH) {
+        delete process.env.NODE_PATH;
+      }
+    });
+
+    afterEach(function () {
+      if (prevValue) {
+        process.env.NODE_PATH = prevValue;
+      }
+    });
+
+    it('should ajust NODE_PATH', async function () {
+      await adjustNodePath();
+      (await fs.exists(process.env.NODE_PATH)).should.be.true;
     });
   });
 });

--- a/packages/appium/test/unit/utils.spec.js
+++ b/packages/appium/test/unit/utils.spec.js
@@ -256,7 +256,7 @@ describe('utils', function () {
   });
 
   describe('adjustNodePath()', function () {
-    let prevValue = process.env.NODE_PATH;
+    const prevValue = process.env.NODE_PATH;
 
     beforeEach(function () {
       if (process.env.NODE_PATH) {

--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -194,7 +194,7 @@ export class NPM {
     }
 
     /**
-     * If we've found a `package.json` containined the `appiumCreated` property,
+     * If we've found a `package.json` contained the `appiumCreated` property,
      * then we can do whatever we please with it, since we created it.  This is
      * likely when `APPIUM_HOME` is the default (in `~/.appium`).  In that case,
      * we want `--global-style` to avoid deduping, and we also do not need a
@@ -204,9 +204,10 @@ export class NPM {
      * "dummy" and is controlled by the user.  So we'll just add it as a dev
      * dep; whatever else it does is up to the user's npm config.
      */
-    const installOpts = (await hasAppiumDependency(cwd))
-      ? ['--save-dev']
-      : ['--save-dev', '--save-exact', '--global-style', '--no-package-lock'];
+    const installOpts = ['--save-dev', '--omit=peer'];
+    if (await hasAppiumDependency(cwd)) {
+      installOpts.push('--save-exact', '--global-style', '--no-package-lock');
+    }
 
     const res = await this.exec(
       'install',

--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -205,7 +205,7 @@ export class NPM {
      * dep; whatever else it does is up to the user's npm config.
      */
     const installOpts = ['--save-dev', '--omit', 'peer'];
-    if (await hasAppiumDependency(cwd)) {
+    if (!await hasAppiumDependency(cwd)) {
       installOpts.push('--save-exact', '--global-style', '--no-package-lock');
     }
 

--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -193,19 +193,11 @@ export class NPM {
       }
     }
 
-    /**
-     * If we've found a `package.json` contained the `appiumCreated` property,
-     * then we can do whatever we please with it, since we created it.  This is
-     * likely when `APPIUM_HOME` is the default (in `~/.appium`).  In that case,
-     * we want `--global-style` to avoid deduping, and we also do not need a
-     * `package-lock.json`.
-     *
-     * If we _haven't_ found such a key, then this `package.json` isn't a
-     * "dummy" and is controlled by the user.  So we'll just add it as a dev
-     * dep; whatever else it does is up to the user's npm config.
-     */
-    const installOpts = ['--save-dev', '--omit=peer'];
+    const installOpts = ['--save-dev'];
     if (!await hasAppiumDependency(cwd)) {
+      if (process.env.APPIUM_OMIT_PEER_DEPS) {
+        installOpts.push('--omit=peer');
+      }
       installOpts.push('--save-exact', '--global-style', '--no-package-lock');
     }
 

--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -204,7 +204,7 @@ export class NPM {
      * "dummy" and is controlled by the user.  So we'll just add it as a dev
      * dep; whatever else it does is up to the user's npm config.
      */
-    const installOpts = ['--save-dev', '--omit=peer'];
+    const installOpts = ['--save-dev', '--omit', 'peer'];
     if (await hasAppiumDependency(cwd)) {
       installOpts.push('--save-exact', '--global-style', '--no-package-lock');
     }

--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -204,7 +204,7 @@ export class NPM {
      * "dummy" and is controlled by the user.  So we'll just add it as a dev
      * dep; whatever else it does is up to the user's npm config.
      */
-    const installOpts = ['--save-dev', '--omit', 'peer'];
+    const installOpts = ['--save-dev', '--omit=peer'];
     if (!await hasAppiumDependency(cwd)) {
       installOpts.push('--save-exact', '--global-style', '--no-package-lock');
     }


### PR DESCRIPTION
## Proposed changes

According to https://nodejs.org/api/modules.html#loading-from-the-global-folders NPM should respect NODE_PATH every time it tries to resolve a module path. The idea here is that all NPM processes we start using `appium` CLI should automatically inherit parent process env, so this variable should always contain a valid path to `node_modules` root where `appium` monorepo is installed. I assume this solution would allow to avoid issues we got in https://github.com/appium/appium/pull/17297 and at the same time would allow to reduce the deployment size and the unnecessary modules duplication. This approach should also work for older NPM releases

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
