### PR TITLE
chore(gulp-plugins): remove unused babel-eslint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8397,31 +8397,6 @@
         "form-data": "^4.0.0"
       }
     },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
-      }
-    },
-    "node_modules/babel-eslint/node_modules/eslint-visitor-keys": {
-      "version": "1.3.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "license": "MIT",
@@ -26352,7 +26327,6 @@
         "@types/through2": "2.0.36",
         "ansi-red": "0.1.1",
         "axios": "0.27.2",
-        "babel-eslint": "10.1.0",
         "babel-plugin-istanbul": "6.1.1",
         "babel-plugin-source-map-support": "2.2.0",
         "bluebird": "3.7.2",
@@ -26810,7 +26784,6 @@
         "@types/through2": "2.0.36",
         "ansi-red": "0.1.1",
         "axios": "0.27.2",
-        "babel-eslint": "10.1.0",
         "babel-plugin-istanbul": "6.1.1",
         "babel-plugin-source-map-support": "2.2.0",
         "bluebird": "3.7.2",
@@ -33127,22 +33100,6 @@
       "requires": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
-      }
-    },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "1.3.0"
-        }
       }
     },
     "babel-plugin-dynamic-import-node": {

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -56,7 +56,6 @@
     "@types/through2": "2.0.36",
     "ansi-red": "0.1.1",
     "axios": "0.27.2",
-    "babel-eslint": "10.1.0",
     "babel-plugin-istanbul": "6.1.1",
     "babel-plugin-source-map-support": "2.2.0",
     "bluebird": "3.7.2",


### PR DESCRIPTION
We had `@babel/eslint-parser` and `babel-eslint` in there, and we don't need the latter.  At least.... I hope not.