### PR TITLE
fix(support): add missing @appium/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26446,6 +26446,7 @@
       "version": "2.59.4",
       "license": "Apache-2.0",
       "dependencies": {
+        "@appium/types": "0.3.1",
         "@babel/runtime": "7.18.9",
         "@colors/colors": "1.5.0",
         "@types/archiver": "5.3.1",
@@ -26864,6 +26865,7 @@
     "@appium/support": {
       "version": "file:packages/support",
       "requires": {
+        "@appium/types": "0.3.1",
         "@babel/runtime": "7.18.9",
         "@colors/colors": "1.5.0",
         "@types/archiver": "5.3.1",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -44,6 +44,7 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
+    "@appium/types": "0.3.1",
     "@babel/runtime": "7.18.9",
     "@colors/colors": "1.5.0",
     "@types/archiver": "5.3.1",


### PR DESCRIPTION
This package was missing `@appium/types`, which means packages consuming `@appium/support` which _don't_ also consume `appium` in some capacity will have types that won't compile, e.g., `teen_process`.
