### PR TITLE
fix(types): add missing @types/ws dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7424,8 +7424,8 @@
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -25917,17 +25917,17 @@
       }
     },
     "packages/appium": {
-      "version": "2.0.0-beta.42",
+      "version": "2.0.0-beta.43",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/base-driver": "^8.6.1",
-        "@appium/base-plugin": "^1.10.1",
-        "@appium/docutils": "^0.0.9",
+        "@appium/base-driver": "^8.7.0",
+        "@appium/base-plugin": "^1.10.2",
+        "@appium/docutils": "^0.0.10",
         "@appium/schema": "^0.0.9",
-        "@appium/support": "^2.59.4",
-        "@appium/test-support": "^1.4.1",
-        "@appium/types": "^0.3.1",
+        "@appium/support": "^2.59.5",
+        "@appium/test-support": "^1.5.0",
+        "@appium/types": "^0.4.0",
         "@babel/runtime": "7.18.9",
         "@sidvind/better-ajv-errors": "2.0.0",
         "@types/argparse": "2.0.10",
@@ -26030,10 +26030,10 @@
     },
     "packages/base-driver": {
       "name": "@appium/base-driver",
-      "version": "8.6.1",
+      "version": "8.7.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^2.59.4",
+        "@appium/support": "^2.59.5",
         "@babel/runtime": "7.18.9",
         "@colors/colors": "1.5.0",
         "@types/async-lock": "1.1.5",
@@ -26065,10 +26065,10 @@
     },
     "packages/base-plugin": {
       "name": "@appium/base-plugin",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^2.59.4"
+        "@appium/support": "^2.59.5"
       },
       "engines": {
         "node": ">=14",
@@ -26077,10 +26077,10 @@
     },
     "packages/doctor": {
       "name": "@appium/doctor",
-      "version": "1.16.24",
+      "version": "1.16.25",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^2.59.4",
+        "@appium/support": "^2.59.5",
         "@babel/runtime": "7.18.9",
         "@colors/colors": "1.5.0",
         "@types/bluebird": "3.5.36",
@@ -26208,10 +26208,10 @@
     },
     "packages/docutils": {
       "name": "@appium/docutils",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^2.59.4",
+        "@appium/support": "^2.59.5",
         "@babel/runtime": "7.18.9",
         "docdash": "1.2.0",
         "jsdoc": "3.6.11",
@@ -26263,7 +26263,7 @@
     },
     "packages/fake-driver": {
       "name": "@appium/fake-driver",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.18.9",
@@ -26288,11 +26288,11 @@
     },
     "packages/fake-plugin": {
       "name": "@appium/fake-plugin",
-      "version": "2.0.5",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/base-plugin": "^1.10.1",
-        "@appium/support": "^2.59.4",
+        "@appium/base-plugin": "^1.10.2",
+        "@appium/support": "^2.59.5",
         "@babel/runtime": "7.18.9",
         "@types/bluebird": "3.5.36",
         "bluebird": "3.7.2",
@@ -26309,7 +26309,7 @@
     },
     "packages/gulp-plugins": {
       "name": "@appium/gulp-plugins",
-      "version": "7.0.4",
+      "version": "7.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/eslint-config-appium": "^6.0.4",
@@ -26672,7 +26672,7 @@
     },
     "packages/images-plugin": {
       "name": "@appium/images-plugin",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/opencv": "^1.0.11",
@@ -26739,10 +26739,10 @@
     },
     "packages/support": {
       "name": "@appium/support",
-      "version": "2.59.4",
+      "version": "2.59.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/types": "0.3.1",
+        "@appium/types": "^0.4.0",
         "@babel/runtime": "7.18.9",
         "@colors/colors": "1.5.0",
         "@types/archiver": "5.3.1",
@@ -26808,7 +26808,7 @@
     },
     "packages/test-support": {
       "name": "@appium/test-support",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "7.18.9",
@@ -26837,12 +26837,13 @@
     },
     "packages/types": {
       "name": "@appium/types",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/schema": "^0.0.9",
         "@types/express": "4.17.13",
         "@types/npmlog": "4.1.4",
+        "@types/ws": "8.5.3",
         "@wdio/types": "7.20.7",
         "type-fest": "2.18.0"
       },
@@ -26893,7 +26894,7 @@
     "@appium/base-driver": {
       "version": "file:packages/base-driver",
       "requires": {
-        "@appium/support": "^2.59.4",
+        "@appium/support": "^2.59.5",
         "@babel/runtime": "7.18.9",
         "@colors/colors": "1.5.0",
         "@types/async-lock": "1.1.5",
@@ -26922,13 +26923,13 @@
     "@appium/base-plugin": {
       "version": "file:packages/base-plugin",
       "requires": {
-        "@appium/support": "^2.59.4"
+        "@appium/support": "^2.59.5"
       }
     },
     "@appium/doctor": {
       "version": "file:packages/doctor",
       "requires": {
-        "@appium/support": "^2.59.4",
+        "@appium/support": "^2.59.5",
         "@babel/runtime": "7.18.9",
         "@colors/colors": "1.5.0",
         "@types/bluebird": "3.5.36",
@@ -27015,7 +27016,7 @@
     "@appium/docutils": {
       "version": "file:packages/docutils",
       "requires": {
-        "@appium/support": "^2.59.4",
+        "@appium/support": "^2.59.5",
         "@babel/runtime": "7.18.9",
         "docdash": "1.2.0",
         "jsdoc": "3.6.11",
@@ -27056,8 +27057,8 @@
     "@appium/fake-plugin": {
       "version": "file:packages/fake-plugin",
       "requires": {
-        "@appium/base-plugin": "^1.10.1",
-        "@appium/support": "^2.59.4",
+        "@appium/base-plugin": "^1.10.2",
+        "@appium/support": "^2.59.5",
         "@babel/runtime": "7.18.9",
         "@types/bluebird": "3.5.36",
         "bluebird": "3.7.2",
@@ -27387,7 +27388,7 @@
     "@appium/support": {
       "version": "file:packages/support",
       "requires": {
-        "@appium/types": "0.3.1",
+        "@appium/types": "^0.4.0",
         "@babel/runtime": "7.18.9",
         "@colors/colors": "1.5.0",
         "@types/archiver": "5.3.1",
@@ -27469,6 +27470,7 @@
         "@appium/schema": "^0.0.9",
         "@types/express": "4.17.13",
         "@types/npmlog": "4.1.4",
+        "@types/ws": "*",
         "@wdio/types": "7.20.7",
         "type-fest": "2.18.0"
       }
@@ -32853,7 +32855,8 @@
     },
     "@types/ws": {
       "version": "8.5.3",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+      "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
       "requires": {
         "@types/node": "*"
       }
@@ -33102,13 +33105,13 @@
     "appium": {
       "version": "file:packages/appium",
       "requires": {
-        "@appium/base-driver": "^8.6.1",
-        "@appium/base-plugin": "^1.10.1",
-        "@appium/docutils": "^0.0.9",
+        "@appium/base-driver": "^8.7.0",
+        "@appium/base-plugin": "^1.10.2",
+        "@appium/docutils": "^0.0.10",
         "@appium/schema": "^0.0.9",
-        "@appium/support": "^2.59.4",
-        "@appium/test-support": "^1.4.1",
-        "@appium/types": "^0.3.1",
+        "@appium/support": "^2.59.5",
+        "@appium/test-support": "^1.5.0",
+        "@appium/types": "^0.4.0",
         "@babel/runtime": "7.18.9",
         "@sidvind/better-ajv-errors": "2.0.0",
         "@types/argparse": "2.0.10",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -35,6 +35,7 @@
     "@appium/schema": "^0.0.9",
     "@types/express": "4.17.13",
     "@types/npmlog": "4.1.4",
+    "@types/ws": "8.5.3",
     "@wdio/types": "7.20.7",
     "type-fest": "2.18.0"
   },


### PR DESCRIPTION
Cannot consume these types without this dep...

```
node_modules/@appium/types/build/index.d.ts:3:41 - error TS2307: Cannot find module 'ws' or its corresponding type declarations.

3 import type { Server as WSServer } from 'ws';
                                          ~~~~
```