### PR TITLE
fix(appium): do not throw ENAMETOOLONG on long cli arg

### DIFF
--- a/packages/appium/lib/schema/cli-transformers.js
+++ b/packages/appium/lib/schema/cli-transformers.js
@@ -94,8 +94,9 @@ export const transformers = {
       json = readFileSync(jsonOrPath, 'utf8');
       loadedFromFile = true;
     } catch (err) {
-      // unreadable files don't count... but other problems do.
-      if (err.code !== 'ENOENT') {
+      // unreadable files don't count.
+      // also `ENAMETOOLONG` can happen if we try to open a file that's a huge JSON string.
+      if (err.code !== 'ENOENT' && err.code !== 'ENAMETOOLONG') {
         throw err;
       }
     }


### PR DESCRIPTION
Some CLI args can be interpreted as filenames or JSON/CSV blobs.  Appium first assumes the value is a file and attempts to open it.  But if a blob is given and it is of some _problematic length_, the OS will throw an `ENAMETOOLONG` exception trying to open a filepath with a huge blob.  If the JSON is reasonably small, an `ENOENT` will be thrown instead.  Previous to this change, we were only looking for `ENOENT`; now we treat `ENAMETOOLONG` errors meaning "we have a JSON blob".  If the problem is that the filename _is_ actually too long, the user will get an "invalid JSON" error, which will probably be confusing, but is less likely to happen than the more-common error this addresses.

If someone complains about it in the future, we can take another look, but it's going to take more effort than it's worth atm to fix it (imo).

Closes #17308