### PR TITLE
fix(types): Driver extends ExecuteCommands

### DIFF
--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -341,6 +341,7 @@ export interface Driver
     TimeoutCommands,
     EventCommands,
     SessionHandler<[string, any], void>,
+    ExecuteCommands,
     Core {
   cliArgs?: Record<string, any>;
   // The following methods are implemented by `BaseDriver`.


### PR DESCRIPTION
Closes #17359
