### PR TITLE
chore(): add RouteMatcher type

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -783,6 +783,11 @@ class AppiumDriver extends DriverCore {
     return dstSession && _.isFunction(dstSession.proxyActive) && dstSession.proxyActive(sessionId);
   }
 
+  /**
+   *
+   * @param {string} sessionId
+   * @returns {import('@appium/types').RouteMatcher[]}
+   */
   getProxyAvoidList(sessionId) {
     const dstSession = this.sessions[sessionId];
     return dstSession ? dstSession.getProxyAvoidList() : [];

--- a/packages/base-driver/lib/basedriver/core.js
+++ b/packages/base-driver/lib/basedriver/core.js
@@ -351,7 +351,7 @@ class DriverCore {
   /**
    *
    * @param {string} sessionId
-   * @returns {[string, RegExp][]}
+   * @returns {import('@appium/types').RouteMatcher[]}
    */
   getProxyAvoidList(sessionId) {
     return [];

--- a/packages/test-support/lib/driver-unit-suite.js
+++ b/packages/test-support/lib/driver-unit-suite.js
@@ -448,6 +448,7 @@ export function driverUnitTestSuite(DriverClass, defaultCaps = {}) {
           const avoidStub = sandbox.stub(d, 'getProxyAvoidList');
           avoidStub.returns([
             ['POST', /^foo/],
+            // @ts-expect-error
             ['BAZETE', /^bar/],
           ]);
           (() => {

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -320,7 +320,7 @@ export interface Core {
   assertFeatureEnabled(name: string): void;
   validateLocatorStrategy(strategy: string, webContext?: boolean): void;
   proxyActive(sessionId?: string): boolean;
-  getProxyAvoidList(sessionId?: string): [string, RegExp][];
+  getProxyAvoidList(sessionId?: string): RouteMatcher[];
   canProxy(sessionId?: string): boolean;
   proxyRouteIsAvoided(sessionId: string, method: string, url: string): boolean;
   addManagedDriver(driver: Driver): void;
@@ -615,3 +615,8 @@ export type DriverCommands<TArgs = any, TReturn = unknown> = Record<
   string,
   DriverCommand<TArgs, TReturn>
 >;
+
+/**
+ * Tuple of an HTTP method with a regex matching a request path
+ */
+export type RouteMatcher = [HTTPMethod, RegExp];


### PR DESCRIPTION
Replaces the bare tuple `[string, RegExp]` with a named type.  Used by `Driver.getProxyAvoidList()`

Narrows the type def to only allow known HTTP methods as the first item in the tuple.