### PR TITLE
fix(appium): eat update info errors

### DIFF
--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -576,13 +576,14 @@ class ExtensionCommand {
     // this is a helper method, 'ext' is assumed to already be installed here, and of the npm
     // install type
     const {version, pkgName} = this.config.installedExtensions[ext];
+    /** @type {string?} */
     let unsafeUpdate = await npm.getLatestVersion(this.config.appiumHome, pkgName);
     let safeUpdate = await npm.getLatestSafeUpgradeVersion(
       this.config.appiumHome,
       pkgName,
       version
     );
-    if (!util.compareVersions(unsafeUpdate, '>', version)) {
+    if (unsafeUpdate !== null && !util.compareVersions(unsafeUpdate, '>', version)) {
       // the latest version is not greater than the current version, so there's no possible update
       unsafeUpdate = null;
       safeUpdate = null;

--- a/packages/appium/test/e2e/cli.e2e.spec.js
+++ b/packages/appium/test/e2e/cli.e2e.spec.js
@@ -171,7 +171,7 @@ describe('CLI behavior', function () {
 
         it('should update package.json', async function () {
           const newPkg = JSON.parse(await fs.readFile(appiumHomePkgPath, 'utf8'));
-          expect(newPkg).to.have.nested.property('devDependencies.test-driver');
+          expect(newPkg).to.have.nested.property('devDependencies.@appium/test-driver');
         });
 
         it('should update the hash', async function () {
@@ -189,7 +189,7 @@ describe('CLI behavior', function () {
 
         it('should actually install both drivers', function () {
           expect(() => resolveFrom(appiumHome, '@appium/fake-driver')).not.to.throw;
-          expect(() => resolveFrom(appiumHome, 'test-driver')).not.to.throw;
+          expect(() => resolveFrom(appiumHome, '@appium/test-driver')).not.to.throw;
         });
       });
     });
@@ -285,6 +285,14 @@ describe('CLI behavior', function () {
           // TODO: this could probably be replaced by looking at updateVersion in the JSON
           const {stderr} = await runAppiumRaw(appiumHome, [DRIVER_TYPE, LIST, '--updates'], {});
           stderr.should.match(new RegExp(`fake.+[${fake.updateVersion} available]`));
+        });
+
+        describe('if a driver is not published to npm', function () {
+          it('should not throw an error', async function () {
+            await clear();
+            await installLocalExtension(appiumHome, DRIVER_TYPE, testDriverPath);
+            await expect(runList(['--updates'])).not.to.be.rejected;
+          });
         });
       });
 

--- a/packages/appium/test/fixtures/test-driver/package.json
+++ b/packages/appium/test/fixtures/test-driver/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-driver",
+  "name": "@appium/test-driver",
   "version": "1.0.0",
   "private": true,
   "peerDependencies": {

--- a/packages/support/test/e2e/npm.e2e.spec.js
+++ b/packages/support/test/e2e/npm.e2e.spec.js
@@ -1,0 +1,51 @@
+import {npm} from '../../lib/npm';
+
+const {expect} = chai;
+
+describe('npm module', function () {
+  describe('getLatestVersion()', function () {
+    describe('when the package is not published to the public registry', function () {
+      it('should not throw', async function () {
+        await expect(
+          npm.getLatestVersion(
+            process.cwd(),
+            'crusher-brush-resize-disfigure-props-desktop-blatancy-prologue'
+          )
+        ).not.to.be.rejected;
+      });
+
+      it('should resolve with "null"', async function () {
+        await expect(
+          npm.getLatestVersion(
+            process.cwd(),
+            'crusher-brush-resize-disfigure-props-desktop-blatancy-prologue'
+          )
+        ).to.eventually.be.null;
+      });
+    });
+  });
+
+  describe('getLatestSafeUpgradeVersion()', function () {
+    describe('when the package is not published to the public registry', function () {
+      it('should not throw', async function () {
+        await expect(
+          npm.getLatestSafeUpgradeVersion(
+            process.cwd(),
+            'crusher-brush-resize-disfigure-props-desktop-blatancy-prologue',
+            '1.0.0'
+          )
+        ).to.eventually.be.null;
+      });
+
+      it('should resolve with "null"', async function () {
+        await expect(
+          npm.getLatestSafeUpgradeVersion(
+            process.cwd(),
+            'crusher-brush-resize-disfigure-props-desktop-blatancy-prologue',
+            '1.0.0'
+          )
+        ).to.eventually.be.null;
+      });
+    });
+  });
+});


### PR DESCRIPTION
If a user runs e.g., "appium driver list --updates" and one of the installed drivers is _not_ published to npm, an error will no longer be emitted.

Closes #17357