### PR TITLE
fix(base-driver,types): driver constructors accept DriverOpts, not ServerArgs

### DIFF
--- a/packages/base-driver/lib/basedriver/core.js
+++ b/packages/base-driver/lib/basedriver/core.js
@@ -36,7 +36,7 @@ class DriverCore {
   sessionId = null;
 
   /**
-   * @type {import('@appium/types').DriverOpts}
+   * @type {DriverOpts}
    */
   opts;
 
@@ -126,6 +126,11 @@ class DriverCore {
    */
   settings = new DeviceSettings();
 
+  /**
+   *
+   * @param {ServerArgs} [opts]
+   * @param {boolean} [shouldValidateCaps]
+   */
   constructor(opts = /** @type {ServerArgs} */ ({}), shouldValidateCaps = true) {
     this._log = logger.getLogger(helpers.generateDriverLogPrefix(this));
 
@@ -430,4 +435,5 @@ export {DriverCore};
  * @typedef {import('@appium/types').ServerArgs} ServerArgs
  * @typedef {import('@appium/types').EventHistory} EventHistory
  * @typedef {import('@appium/types').AppiumLogger} AppiumLogger
+ * @typedef {import('@appium/types').DriverOpts} DriverOpts
  */

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -270,7 +270,14 @@ export interface EventHistoryCommand {
 export interface Core {
   shouldValidateCaps: boolean;
   sessionId: string | null;
+  /**
+   * This contains {@linkcode ServerArgs} (see {@linkcode Core.initialOpts}) but also any {@linkcode Capabilities} provided
+   * by the session.
+   */
   opts: DriverOpts;
+  /**
+   * These are the options as passed in the driver's constructor.
+   */
   initialOpts: ServerArgs;
   caps?: Capabilities;
   originalCaps?: W3CCapabilities;
@@ -579,7 +586,7 @@ export interface DriverStatic {
 export type DriverClass<
   D extends Driver = ExternalDriver,
   S extends DriverStatic = DriverStatic
-> = Class<D, S, [] | [Partial<ServerArgs>] | [Partial<ServerArgs>, boolean]>;
+> = Class<D, S, [] | [Partial<DriverOpts>] | [Partial<DriverOpts>, boolean]>;
 
 /**
  * Options as passed into a driver constructor, which is just a union of {@linkcode ServerArgs} and {@linkcode Capabilities}.


### PR DESCRIPTION
`ServerArgs` are command-line flags; `DriverOpts` are `ServerArgs` _and_ capabilities
