### PR TITLE
feat(types): adds types to derive capabilities from constraints

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "*.js": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "*.ts*": [
+      "prettier --write"
     ]
   },
   "prettier": {

--- a/packages/types/lib/capabilities.ts
+++ b/packages/types/lib/capabilities.ts
@@ -1,4 +1,5 @@
 import type {Capabilities as WdioCaps} from '@wdio/types';
+import {Constraint, Constraints, Driver} from '.';
 
 /**
  * The mask of a W3C-style namespaced capability proped name.
@@ -57,3 +58,78 @@ export type AppiumXCUICommandTimeouts = WdioCaps.AppiumXCUICommandTimeouts;
 export type AppiumXCUIProcessArguments = WdioCaps.AppiumXCUIProcessArguments;
 export type AppiumXCUISafariGlobalPreferences = WdioCaps.AppiumXCUISafariGlobalPreferences;
 export type AppiumXCUITestCapabilities = WdioCaps.AppiumXCUITestCapabilities;
+
+/**
+ * Given a {@linkcode Constraint} `C` and a type `T`, see if `inclusion`/`inclusionCaseInsensitive` is present, and create a union of its allowed literals; otherwise just use `T`.
+ */
+type ConstraintChoice<C extends Constraint, T> = C['inclusionCaseInsensitive'] extends ReadonlyArray<T> ? AnyCase<C['inclusionCaseInsensitive'][number]> : C['inclusion'] extends ReadonlyArray<T> ? C['inclusion'][number] : T;
+
+/**
+ * Given {@linkcode Constraint} `C`, determine the associated type of the capability.
+ * 
+ * Notes:
+ * 
+ * - Only `number` and `string` values can have "choices" (`inclusion`/`inclusionCaseInesnsitive`) associated with them. 
+ * - If `isArray` is `true`, the type is always of type `string[]`. If this is incorrect, then it will be `any[]`.
+ * - There is no way to express the shape of an object if `ifObject` is `true`.
+ */
+type ConstraintToCapKind<C extends Constraint> = C['isString'] extends true
+  ? ConstraintChoice<C, string>
+  : C['isNumber'] extends true
+  ? ConstraintChoice<C, number>
+  : C['isBoolean'] extends true
+  ? boolean
+  : C['isArray'] extends true
+  ? string[]
+  : C['isObject'] extends true
+  ? object
+  : any;
+
+/**
+ * Given {@linkcode Constraint} `C`, determine if it is required or optional.
+ * 
+ * In practice, _all_ capabilities are considered optional per types, but various errors might be thrown if some are not present.
+ */
+type ConstraintToCap<C extends Constraint> = C['presence'] extends true | {allowEmpty: true}
+  ? ConstraintToCapKind<C>
+  : ConstraintToCapKind<C> | undefined;
+
+/**
+ * Given `string` `T`, this is a case-insensitive version of `T`.
+ */
+export type AnyCase<T extends string> = string extends T
+  ? string
+  : T extends `${infer F1}${infer F2}${infer R}`
+  ? `${Uppercase<F1> | Lowercase<F1>}${Uppercase<F2> | Lowercase<F2>}${AnyCase<R>}`
+  : T extends `${infer F}${infer R}`
+  ? `${Uppercase<F> | Lowercase<F>}${AnyCase<R>}`
+  : '';
+
+/**
+ * Given {@linkcode StringRecord} `T` and namespace string `NS`, a type with the key names prefixed by `${NS}:`.  `NS` defaults to `appium`.  If `T` is already namespaced, well, it'll get _double_-namespaced.
+ */
+export type NamespacedObject<T extends StringRecord, NS extends string = 'appium'> = {
+  [K in keyof T as K extends keyof WdioCaps.Capabilities ? K : `${NS}:${K & string}`]: T[K];
+};
+
+/**
+ * Converts {@linkcode Constraint} `C` to a {@linkcode Capabilities} object.
+ */
+export type ConstraintsToCaps<C extends Constraints> = {
+  [K in keyof C]: ConstraintToCap<C[K]>;
+};
+
+/**
+ * Given {@linkcode Driver} `D`, return the entire set of capabilities it supports (including whatever is in its desired caps).
+ */
+
+export type DriverCaps<D extends Driver> = 
+  ConstraintsToCaps<D['desiredCapConstraints']>;
+
+/**
+ * Like {@linkcode DriverCaps}, except W3C-style.
+ */
+
+export type DriverW3CCaps<D extends Driver> = W3CCapabilities<
+  NamespacedObject<ConstraintsToCaps<D['desiredCapConstraints']>>
+>;

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -11,7 +11,7 @@ import type {Logger} from 'npmlog';
 export * from './driver';
 export * from './action';
 export * from './plugin';
-export {AppiumW3CCapabilities} from './capabilities';
+export {AppiumW3CCapabilities, DriverCaps, DriverW3CCaps, NamespacedObject, AnyCase, ConstraintsToCaps} from './capabilities';
 export {AppiumConfig, NormalizedAppiumConfig} from './config';
 export * from './appium-config';
 export {ServerArgs, Capabilities, W3CCapabilities};


### PR DESCRIPTION
Driver authors and end-users may find these types useful.  I still haven't fleshed out how to best provide these to end-users, but we can use `DriverCaps<MyDriver>` which is an object containing Appium's caps _in addition to_ those defined by the `desiredCapConstraints` of `MyDriver`, e.g.:

```js

class MyClass {
  desiredCapConstraints = {foo: {isString: true, inclusion: ['bar', 'baz']}, quux: {isNumber: true}}
}

/** @typedef {DriverCaps<MyClass>} MyClassCaps */
// looks like {platformName: string, ..., foo: 'bar' | baz', quux: number}
```

DRY4eva