### PR TITLE
chore(appium,base-driver,driver-test-support,types): overhaul types for constraints & caps

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -14,13 +14,9 @@ import AsyncLock from 'async-lock';
 import {parseCapsForInnerDriver, pullSettings} from './utils';
 import {util, node, logger} from '@appium/support';
 import {getDefaultsForExtension} from './schema';
-import {DRIVER_TYPE, PLUGIN_TYPE} from './constants';
+import {DRIVER_TYPE} from './constants';
 
-/**
- * Invariant set of base constraints
- * @type {Readonly<Constraints>}
- */
-const desiredCapabilityConstraints = Object.freeze({
+const desiredCapabilityConstraints = /** @type {const} */ ({
   automationName: {
     presence: true,
     isString: true,
@@ -30,6 +26,9 @@ const desiredCapabilityConstraints = Object.freeze({
     isString: true,
   },
 });
+/**
+ * @typedef {typeof desiredCapabilityConstraints} AppiumDriverConstraints
+ */
 
 const sessionsListGuard = new AsyncLock();
 const pendingDriversGuard = new AsyncLock();
@@ -181,10 +180,10 @@ class AppiumDriver extends DriverCore {
   /**
    * Retrieves all CLI arguments for a specific plugin.
    * @param {string} extName - Plugin name
-   * @returns {Record<string,unknown>} Arguments object. If none, an empty object.
+   * @returns {StringRecord} Arguments object. If none, an empty object.
    */
   getCliArgsForPlugin(extName) {
-    return /** @type {Record<string,unknown>} */ (this.args.plugin?.[extName] ?? {});
+    return /** @type {StringRecord} */ (this.args.plugin?.[extName] ?? {});
   }
 
   /**
@@ -194,12 +193,10 @@ class AppiumDriver extends DriverCore {
    *
    * _Note that this behavior currently (May 18 2022) differs from how plugins are handled_ (see {@linkcode AppiumDriver.getCliArgsForPlugin}).
    * @param {string} extName - Driver name
-   * @returns {Record<string,unknown>|undefined} Arguments object. If none, `undefined`
+   * @returns {StringRecord|undefined} Arguments object. If none, `undefined`
    */
   getCliArgsForDriver(extName) {
-    const allCliArgsForExt = /** @type {Record<string,unknown>|undefined} */ (
-      this.args.driver?.[extName]
-    );
+    const allCliArgsForExt = /** @type {StringRecord|undefined} */ (this.args.driver?.[extName]);
 
     if (!_.isEmpty(allCliArgsForExt)) {
       const defaults = getDefaultsForExtension(DRIVER_TYPE, extName);
@@ -214,9 +211,9 @@ class AppiumDriver extends DriverCore {
 
   /**
    * Create a new session
-   * @param {W3CCapabilities} jsonwpCaps JSONWP formatted desired capabilities
-   * @param {W3CCapabilities} reqCaps Required capabilities (JSONWP standard)
-   * @param {W3CCapabilities} w3cCapabilities W3C capabilities
+   * @param {W3CCapabilities<AppiumDriverConstraints>} jsonwpCaps JSONWP formatted desired capabilities
+   * @param {W3CCapabilities<AppiumDriverConstraints>} reqCaps Required capabilities (JSONWP standard)
+   * @param {W3CCapabilities<AppiumDriverConstraints>} w3cCapabilities W3C capabilities
    * @param {DriverData[]} [driverData]
    */
   async createSession(jsonwpCaps, reqCaps, w3cCapabilities, driverData) {
@@ -249,9 +246,11 @@ class AppiumDriver extends DriverCore {
       );
 
       const {desiredCaps, processedJsonwpCapabilities, processedW3CCapabilities} =
-        /** @type {import('./utils').ParsedDriverCaps} */ (parsedCaps);
+        /** @type {import('./utils').ParsedDriverCaps<AppiumDriverConstraints>} */ (parsedCaps);
       protocol = parsedCaps.protocol;
-      const error = /** @type {import('./utils').InvalidCaps} */ (parsedCaps).error;
+      const error = /** @type {import('./utils').InvalidCaps<AppiumDriverConstraints>} */ (
+        parsedCaps
+      ).error;
       // If the parsing of the caps produced an error, throw it in here
       if (error) {
         throw error;
@@ -831,7 +830,6 @@ export {AppiumDriver};
  * @typedef {import('@appium/types').ExternalDriver} ExternalDriver
  * @typedef {import('@appium/types').Driver} Driver
  * @typedef {import('@appium/types').DriverClass} DriverClass
- * @typedef {import('@appium/types').W3CCapabilities} W3CCapabilities
  * @typedef {import('@appium/types').DriverData} DriverData
  * @typedef {import('@appium/types').ServerArgs} DriverOpts
  * @typedef {import('@appium/types').Constraints} Constraints
@@ -842,6 +840,7 @@ export {AppiumDriver};
  * @typedef {import('@appium/types').PluginClass} PluginClass
  * @typedef {import('@appium/types').PluginType} PluginType
  * @typedef {import('@appium/types').DriverType} DriverType
+ * @typedef {import('@appium/types').StringRecord} StringRecord
  * @typedef {import('@appium/types').SessionHandler<SessionHandlerResult<any[]>,SessionHandlerResult<void>>} SessionHandler
  */
 
@@ -853,4 +852,14 @@ export {AppiumDriver};
  * @property {V} [value]
  * @property {Error} [error]
  * @property {string} [protocol]
+ */
+
+/**
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').W3CCapabilities<C>} W3CCapabilities
+ */
+
+/**
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').Capabilities<C>} Capabilities
  */

--- a/packages/appium/lib/extension/driver-config.js
+++ b/packages/appium/lib/extension/driver-config.js
@@ -133,7 +133,8 @@ export class DriverConfig extends ExtensionConfig {
 
   /**
    * Given capabilities, find a matching driver within the config. Load its class and return it along with version and driver name.
-   * @param {Capabilities} caps
+   * @template {import('@appium/types').StringRecord} C
+   * @param {C} caps
    * @returns {MatchedDriver}
    */
   findMatchingDriver({automationName, platformName}) {

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -166,13 +166,10 @@ function parseCapsForInnerDriver(
  */
 function insertAppiumPrefixes(caps) {
   return /** @type {NSCapabilities<C>} */ (
-    /** @type {unknown} */ (
-      _.mapKeys(caps, (value, key) => {
-        if (STANDARD_CAPS_LOWERCASE.has(key.toLowerCase()) || key.includes(':')) {
-          return key;
-        }
-        return `${W3C_APPIUM_PREFIX}:${key}`;
-      })
+    _.mapKeys(caps, (_, key) =>
+      STANDARD_CAPS_LOWERCASE.has(key.toLowerCase()) || key.includes(':')
+        ? key
+        : `${W3C_APPIUM_PREFIX}:${key}`
     )
   );
 }

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -1,11 +1,12 @@
 import _ from 'lodash';
 import logger from './logger';
-import {processCapabilities, PROTOCOLS} from '@appium/base-driver';
+import {processCapabilities, PROTOCOLS, STANDARD_CAPS} from '@appium/base-driver';
 import {inspect as dump} from 'util';
 import {node} from '@appium/support';
 import path from 'path';
 
 const W3C_APPIUM_PREFIX = 'appium';
+const STANDARD_CAPS_LOWERCASE = new Set([...STANDARD_CAPS].map((cap) => cap.toLowerCase()));
 
 /**
  *
@@ -35,16 +36,18 @@ const inspect = _.flow(
  * Takes the caps that were provided in the request and translates them
  * into caps that can be used by the inner drivers.
  *
- * @param {any} jsonwpCapabilities
- * @param {W3CCapabilities} w3cCapabilities
- * @param {import('@appium/types').Constraints} constraints
- * @param {import('@appium/types').DefaultCapabilitiesConfig} [defaultCapabilities]
- * @returns {ParsedDriverCaps|InvalidCaps}
+ * @template {Constraints} C
+ * @template [J=any]
+ * @param {J} jsonwpCapabilities
+ * @param {W3CCapabilities<C>} w3cCapabilities
+ * @param {C} constraints
+ * @param {NSCapabilities<C>} [defaultCapabilities]
+ * @returns {ParsedDriverCaps<C,J>|InvalidCaps<C,J>}
  */
 function parseCapsForInnerDriver(
   jsonwpCapabilities,
   w3cCapabilities,
-  constraints = {},
+  constraints = /** @type {C} */ ({}),
   defaultCapabilities = {}
 ) {
   // Check if the caller sent JSONWP caps, W3C caps, or both
@@ -52,14 +55,14 @@ function parseCapsForInnerDriver(
     _.isPlainObject(w3cCapabilities) &&
     (_.has(w3cCapabilities, 'alwaysMatch') || _.has(w3cCapabilities, 'firstMatch'));
   const hasJSONWPCaps = _.isPlainObject(jsonwpCapabilities);
-  let desiredCaps = /** @type {ParsedDriverCaps['desiredCaps']} */ ({});
-  /** @type {ParsedDriverCaps['processedW3CCapabilities']} */
+  let desiredCaps = /** @type {ParsedDriverCaps<C>['desiredCaps']} */ ({});
+  /** @type {ParsedDriverCaps<C>['processedW3CCapabilities']} */
   let processedW3CCapabilities;
-  /** @type {ParsedDriverCaps['processedJsonwpCapabilities']} */
+  /** @type {ParsedDriverCaps<C>['processedJsonwpCapabilities']} */
   let processedJsonwpCapabilities;
 
   if (!hasW3CCaps) {
-    return /** @type {InvalidCaps} */ ({
+    return /** @type {InvalidCaps<C>} */ ({
       protocol: PROTOCOLS.W3C,
       error: new Error('W3C capabilities should be provided'),
     });
@@ -78,7 +81,7 @@ function parseCapsForInnerDriver(
       for (const [defaultCapKey, defaultCapValue] of _.toPairs(defaultCapabilities)) {
         let isCapAlreadySet = false;
         // Check if the key is already present in firstMatch entries
-        for (const firstMatchEntry of w3cCapabilities.firstMatch || []) {
+        for (const firstMatchEntry of w3cCapabilities.firstMatch ?? []) {
           if (
             _.isPlainObject(firstMatchEntry) &&
             _.has(removeAppiumPrefixes(firstMatchEntry), removeAppiumPrefix(defaultCapKey))
@@ -102,7 +105,9 @@ function parseCapsForInnerDriver(
 
         // Only add the default capability if it is not overridden
         if (_.isEmpty(w3cCapabilities.firstMatch)) {
-          w3cCapabilities.firstMatch = [{[defaultCapKey]: defaultCapValue}];
+          w3cCapabilities.firstMatch = /** @type {W3CCapabilities<C>['firstMatch']} */ ([
+            {[defaultCapKey]: defaultCapValue},
+          ]);
         } else {
           w3cCapabilities.firstMatch[0][defaultCapKey] = defaultCapValue;
         }
@@ -129,7 +134,7 @@ function parseCapsForInnerDriver(
       desiredCaps = processCapabilities(w3cCapabilities, constraints, true);
     } catch (error) {
       logger.info(`Could not parse W3C capabilities: ${error.message}`);
-      return /** @type {InvalidCaps} */ ({
+      return /** @type {InvalidCaps<C,J>} */ ({
         desiredCaps,
         processedJsonwpCapabilities,
         processedW3CCapabilities,
@@ -145,7 +150,7 @@ function parseCapsForInnerDriver(
     };
   }
 
-  return /** @type {ParsedDriverCaps} */ ({
+  return /** @type {ParsedDriverCaps<C,J>} */ ({
     desiredCaps,
     processedJsonwpCapabilities,
     processedW3CCapabilities,
@@ -155,57 +160,46 @@ function parseCapsForInnerDriver(
 
 /**
  * Takes a capabilities objects and prefixes capabilities with `appium:`
- * @param {Capabilities} caps Desired capabilities object
- * @returns {AppiumW3CCapabilities}
+ * @template {Constraints} [C={}]
+ * @param {Capabilities<C>} caps - Desired capabilities object
+ * @returns {NSCapabilities<C>}
  */
 function insertAppiumPrefixes(caps) {
-  // Standard, non-prefixed capabilities (see https://www.w3.org/TR/webdriver/#dfn-table-of-standard-capabilities)
-  const STANDARD_CAPS = [
-    'browserName',
-    'browserVersion',
-    'platformName',
-    'acceptInsecureCerts',
-    'pageLoadStrategy',
-    'proxy',
-    'setWindowRect',
-    'timeouts',
-    'unhandledPromptBehavior',
-  ];
-
-  let prefixedCaps = {};
-  for (let [name, value] of _.toPairs(caps)) {
-    if (STANDARD_CAPS.includes(name) || name.includes(':')) {
-      prefixedCaps[name] = value;
-    } else {
-      prefixedCaps[`${W3C_APPIUM_PREFIX}:${name}`] = value;
-    }
-  }
-  return prefixedCaps;
+  return /** @type {NSCapabilities<C>} */ (
+    /** @type {unknown} */ (
+      _.mapKeys(caps, (value, key) => {
+        if (STANDARD_CAPS_LOWERCASE.has(key.toLowerCase()) || key.includes(':')) {
+          return key;
+        }
+        return `${W3C_APPIUM_PREFIX}:${key}`;
+      })
+    )
+  );
 }
 
 /**
- *
- * @param {AppiumW3CCapabilities} caps
- * @returns {Capabilities}
+ * @template {Constraints} [C={}]
+ * @param {NSCapabilities<C>} caps
+ * @returns {Capabilities<C>}
  */
 function removeAppiumPrefixes(caps) {
-  if (!_.isPlainObject(caps)) {
-    return caps;
-  }
-
-  /** @type {Capabilities} */
-  const fixedCaps = {};
-  for (let [name, value] of _.toPairs(caps)) {
-    fixedCaps[removeAppiumPrefix(name)] = value;
-  }
-  return fixedCaps;
+  return /** @type {Capabilities<C>} */ (_.mapKeys(caps, (_, key) => removeAppiumPrefix(key)));
 }
 
+/**
+ * @param {string} key
+ * @returns {string}
+ */
 function removeAppiumPrefix(key) {
   const prefix = `${W3C_APPIUM_PREFIX}:`;
   return _.startsWith(key, prefix) ? key.substring(prefix.length) : key;
 }
 
+/**
+ *
+ * @param {string} pkgName
+ * @returns {string|undefined}
+ */
 function getPackageVersion(pkgName) {
   const pkgInfo = require(`${pkgName}/package.json`) || {};
   return pkgInfo.version;
@@ -313,26 +307,60 @@ export {
 };
 
 /**
- * @todo protocol is more specific
+ * @typedef {import('@appium/types').StringRecord} StringRecord
+ * @typedef {import('@appium/types').BaseDriverCapConstraints} BaseDriverCapConstraints
+ */
+
+/**
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template [J=any]
  * @typedef ParsedDriverCaps
- * @property {Capabilities} desiredCaps
+ * @property {Capabilities<C>} desiredCaps
  * @property {string} protocol
- * @property {any} [processedJsonwpCapabilities]
- * @property {W3CCapabilities} [processedW3CCapabilities]
+ * @property {J} [processedJsonwpCapabilities]
+ * @property {W3CCapabilities<C>} [processedW3CCapabilities]
  */
 
 /**
  * @todo protocol is more specific
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template [J=any]
  * @typedef InvalidCaps
  * @property {Error} error
  * @property {string} protocol
- * @property {Capabilities} [desiredCaps]
- * @property {any} [processedJsonwpCapabilities]
- * @property {W3CCapabilities} [processedW3CCapabilities]
+ * @property {Capabilities<C>} [desiredCaps]
+ * @property {J} [processedJsonwpCapabilities]
+ * @property {W3CCapabilities<C>} [processedW3CCapabilities]
  */
 
 /**
- * @typedef {import('@appium/types').W3CCapabilities} W3CCapabilities
- * @typedef {import('@appium/types').Capabilities} Capabilities
- * @typedef {import('@appium/types').AppiumW3CCapabilities} AppiumW3CCapabilities
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template {StringRecord|void} [Extra=void]
+ * @typedef {import('@appium/types').Capabilities<C, Extra>} Capabilities
+ */
+
+/**
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template {StringRecord|void} [Extra=void]
+ * @typedef {import('@appium/types').W3CCapabilities<C, Extra>} W3CCapabilities
+ */
+
+/**
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template {StringRecord|void} [Extra=void]
+ * @typedef {import('@appium/types').NSCapabilities<C, Extra>} NSCapabilities
+ */
+
+/**
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').ConstraintsToCaps<C>} ConstraintsToCaps
+ */
+
+/**
+ * @template T
+ * @typedef {import('type-fest').StringKeyOf<T>} StringKeyOf
+ */
+
+/**
+ * @typedef {import('@appium/types').Constraints} Constraints
  */

--- a/packages/base-driver/lib/basedriver/capabilities.js
+++ b/packages/base-driver/lib/basedriver/capabilities.js
@@ -62,10 +62,12 @@ function validateCaps(caps, constraints = /** @type {C} */ ({}), opts = {}) {
         ? /** @param {Constraint} constraint */
           (constraint) => _.omit(constraint, 'presence')
         : /** @param {Constraint} constraint */
-          (constraint) =>
-            constraint.presence === true
-              ? {..._.omit(constraint, 'presence'), presence: {allowEmpty: false}}
-              : constraint
+          (constraint) => {
+            if (constraint.presence === true) {
+              return {..._.omit(constraint, 'presence'), presence: {allowEmpty: false}};
+            }
+            return constraint;
+          }
     )
   );
 

--- a/packages/base-driver/lib/basedriver/core.js
+++ b/packages/base-driver/lib/basedriver/core.js
@@ -17,8 +17,10 @@ const {version: BASEDRIVER_VER} = fs.readPackageJsonFrom(__dirname);
 const NEW_COMMAND_TIMEOUT_MS = 60 * 1000;
 
 const ON_UNEXPECTED_SHUTDOWN_EVENT = 'onUnexpectedShutdown';
+
 /**
- * @implements {Core}
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @implements {Core<C>}
  */
 class DriverCore {
   /**
@@ -36,7 +38,7 @@ class DriverCore {
   sessionId = null;
 
   /**
-   * @type {import('@appium/types').DriverOpts}
+   * @type {import('@appium/types').DriverOpts<C>}
    */
   opts;
 
@@ -44,16 +46,6 @@ class DriverCore {
    * @type {ServerArgs}
    */
   initialOpts;
-
-  /**
-   * @type {Capabilities}
-   */
-  caps;
-
-  /**
-   * @type {W3CCapabilities}
-   */
-  originalCaps;
 
   helpers = helpers;
 
@@ -126,7 +118,11 @@ class DriverCore {
    */
   settings = new DeviceSettings();
 
-  constructor(opts = /** @type {ServerArgs} */ ({}), shouldValidateCaps = true) {
+  /**
+   * @param {DriverOpts<C>} opts
+   * @param {boolean} [shouldValidateCaps]
+   */
+  constructor(opts = /** @type {DriverOpts<C>} */ ({}), shouldValidateCaps = true) {
     this._log = logger.getLogger(helpers.generateDriverLogPrefix(this));
 
     // setup state
@@ -140,7 +136,7 @@ class DriverCore {
     this.shouldValidateCaps = shouldValidateCaps;
 
     // keeping track of initial opts
-    this.initialOpts = _.cloneDeep(this.opts);
+    this.initialOpts = _.cloneDeep(opts);
 
     this.sessionId = null;
   }
@@ -240,7 +236,7 @@ class DriverCore {
    * method required by MJSONWP in order to determine if the command should
    * be proxied directly to the driver
    * @param {string} sessionId
-   * @returns {Core | null}
+   * @returns {Core<C> | null}
    */
   driverForSession(sessionId) {
     return this;
@@ -422,12 +418,32 @@ class DriverCore {
 export {DriverCore};
 
 /**
- * @typedef {import('@appium/types').Capabilities} Capabilities
- * @typedef {import('@appium/types').W3CCapabilities} W3CCapabilities
  * @typedef {import('@appium/types').Driver} Driver
- * @typedef {import('@appium/types').Core} Core
+ * @typedef {import('@appium/types').Constraints} Constraints
  * @typedef {import('@appium/types').ExecuteMethodMap} ExecuteMethodMap
  * @typedef {import('@appium/types').ServerArgs} ServerArgs
  * @typedef {import('@appium/types').EventHistory} EventHistory
  * @typedef {import('@appium/types').AppiumLogger} AppiumLogger
+ * @typedef {import('@appium/types').StringRecord} StringRecord
+ * @typedef {import('@appium/types').BaseDriverCapConstraints} BaseDriverCapConstraints
+ */
+
+/**
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template {StringRecord|void} [Extra=void]
+ * @typedef {import('@appium/types').Capabilities<C, Extra>} Capabilities
+ */
+/**
+ * @template {StringRecord} [T={}]
+ * @typedef {import('@appium/types').W3CCapabilities<T>} W3CCapabilities
+ */
+
+/**
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').Core<C>} Core
+ */
+
+/**
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').DriverOpts<C>} DriverOpts
  */

--- a/packages/base-driver/lib/basedriver/desired-caps.js
+++ b/packages/base-driver/lib/basedriver/desired-caps.js
@@ -2,60 +2,10 @@ import log from './logger';
 import _validator from 'validate.js';
 import B from 'bluebird';
 
-const validator =
+export const validator =
   /** @type {import('validate.js').ValidateJS & {promise: typeof import('bluebird')}} */ (
     _validator
   );
-
-/** @type {import('@appium/types').Constraints} */
-let desiredCapabilityConstraints = {
-  platformName: {
-    presence: true,
-    isString: true,
-  },
-  deviceName: {
-    isString: true,
-  },
-  platformVersion: {
-    isString: true,
-  },
-  newCommandTimeout: {
-    isNumber: true,
-  },
-  automationName: {
-    isString: true,
-  },
-  autoLaunch: {
-    isBoolean: true,
-  },
-  udid: {
-    isString: true,
-  },
-  orientation: {
-    inclusion: ['LANDSCAPE', 'PORTRAIT'],
-  },
-  autoWebview: {
-    isBoolean: true,
-  },
-  noReset: {
-    isBoolean: true,
-  },
-  fullReset: {
-    isBoolean: true,
-  },
-  language: {
-    isString: true,
-  },
-  locale: {
-    isString: true,
-  },
-  eventTimings: {
-    isBoolean: true,
-  },
-  printPageSourceOnFindFailure: {
-    isBoolean: true,
-  },
-};
 
 validator.validators.isString = function isString(value) {
   if (typeof value === 'string') {
@@ -147,5 +97,3 @@ validator.promise = B;
 validator.prettify = function prettify(val) {
   return val;
 };
-
-export {desiredCapabilityConstraints, validator};

--- a/packages/base-driver/lib/helpers/capabilities.js
+++ b/packages/base-driver/lib/helpers/capabilities.js
@@ -26,19 +26,20 @@ function isW3cCaps(caps) {
 
 /**
  *
- * @param {Capabilities} originalCaps
- * @param {Constraints} desiredCapConstraints
+ * @template {Constraints} C
+ * @param {any} oldCaps
+ * @param {C} desiredCapConstraints
  * @param {AppiumLogger} log
- * @returns {Capabilities}
+ * @returns {Capabilities<C>}
  */
-function fixCaps(originalCaps, desiredCapConstraints, log) {
-  let caps = _.clone(originalCaps);
+function fixCaps(oldCaps, desiredCapConstraints, log) {
+  let caps = _.clone(oldCaps);
 
   // boolean capabilities can be passed in as strings 'false' and 'true'
   // which we want to translate into boolean values
   let booleanCaps = _.keys(_.pickBy(desiredCapConstraints, (k) => k.isBoolean === true));
   for (let cap of booleanCaps) {
-    let value = originalCaps[cap];
+    let value = oldCaps[cap];
     if (_.isString(value)) {
       value = value.toLowerCase();
       if (value === 'true' || value === 'false') {
@@ -51,9 +52,11 @@ function fixCaps(originalCaps, desiredCapConstraints, log) {
   }
 
   // int capabilities are often sent in as strings by frameworks
-  let intCaps = _.keys(_.pickBy(desiredCapConstraints, (k) => k.isNumber === true));
+  let intCaps = /** @type {import('type-fest').StringKeyOf<typeof caps>[]} */ (
+    _.keys(_.pickBy(desiredCapConstraints, (k) => k.isNumber === true))
+  );
   for (let cap of intCaps) {
-    let value = originalCaps[cap];
+    let value = oldCaps[cap];
     if (_.isString(value)) {
       value = value.trim();
       let newValue = parseInt(value, 10);
@@ -73,7 +76,14 @@ function fixCaps(originalCaps, desiredCapConstraints, log) {
 export {isW3cCaps, fixCaps};
 
 /**
- * @typedef {import('@appium/types').Capabilities} Capabilities
  * @typedef {import('@appium/types').Constraints} Constraints
  * @typedef {import('@appium/types').AppiumLogger} AppiumLogger
+ * @typedef {import('@appium/types').StringRecord} StringRecord
+ * @typedef {import('@appium/types').BaseDriverCapConstraints} BaseDriverCapConstraints
+ */
+
+/**
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template {StringRecord|void} [Extra=void]
+ * @typedef {import('@appium/types').Capabilities<C, Extra>} Capabilities
  */

--- a/packages/base-driver/lib/index.js
+++ b/packages/base-driver/lib/index.js
@@ -30,6 +30,7 @@ export {getSummaryByCode, codes as statusCodes} from './jsonwp-status/status';
 // W3C capabilities parser
 export {
   PREFIXED_APPIUM_OPTS_CAP,
+  STANDARD_CAPS,
   processCapabilities,
   isStandardCap,
   validateCaps,

--- a/packages/base-driver/test/unit/basedriver/capabilities.spec.js
+++ b/packages/base-driver/test/unit/basedriver/capabilities.spec.js
@@ -9,7 +9,7 @@ import {
   stripAppiumPrefixes,
 } from '../../../lib/basedriver/capabilities';
 import _ from 'lodash';
-import {desiredCapabilityConstraints} from '../../../lib/basedriver/desired-caps';
+import {BASE_DESIRED_CAP_CONSTRAINTS} from '@appium/types';
 import {isW3cCaps} from '../../../lib/helpers/capabilities';
 
 describe('caps', function () {
@@ -231,7 +231,9 @@ describe('caps', function () {
           },
         };
 
-        parseCaps(caps, constraints).validatedFirstMatchCaps.should.deep.equal(caps.firstMatch);
+        parseCaps(caps, constraints).validatedFirstMatchCaps.should.deep.equal(
+          caps.firstMatch.map(stripAppiumPrefixes)
+        );
       });
 
       it('returns no vendor prefix error if the firstMatch[2] does not have it because of no bject', function () {
@@ -353,7 +355,7 @@ describe('caps', function () {
     });
 
     describe('validate Appium constraints', function () {
-      const constraints = {...desiredCapabilityConstraints};
+      const constraints = {...BASE_DESIRED_CAP_CONSTRAINTS};
       const expectedMatchingCaps = {
         platformName: 'Fake',
         automationName: 'Fake',
@@ -547,8 +549,7 @@ describe('caps', function () {
     const nonAppiumCaps = {
       platformName: 'iOS',
     };
-    const appiumUnprefixedCaps = _.clone(appiumCaps);
-    stripAppiumPrefixes(appiumUnprefixedCaps);
+    const appiumUnprefixedCaps = stripAppiumPrefixes(appiumCaps);
     const simpleCaps = {
       ...nonAppiumCaps,
       ...appiumUnprefixedCaps,

--- a/packages/base-driver/test/unit/basedriver/capability.spec.js
+++ b/packages/base-driver/test/unit/basedriver/capability.spec.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 import B from 'bluebird';
-import {BaseDriver, errors} from '../../../lib';
+import {BaseDriver, errors} from '../../../lib/index';
 import {validator} from '../../../lib/basedriver/desired-caps';
 import {createSandbox} from 'sinon';
 
@@ -78,7 +78,7 @@ describe('Desired Capabilities', function () {
   });
 
   it('should check added required caps in addition to base', async function () {
-    d.desiredCapConstraints = {
+    d.desiredCapConstraints = /** @type {const} */ ({
       necessary: {
         presence: true,
       },
@@ -87,7 +87,7 @@ describe('Desired Capabilities', function () {
         isString: true,
         inclusion: ['Delorean', 'Reventon'],
       },
-    };
+    });
 
     await d
       .createSession(null, null, {
@@ -100,15 +100,19 @@ describe('Desired Capabilities', function () {
   });
 
   it('should accept extra capabilities', async function () {
-    await d.createSession(null, null, {
-      alwaysMatch: {
-        platformName: 'iOS',
-        'appium:deviceName': 'Delorean',
-        'appium:extra': 'cheese',
-        'appium:hold the': 'sauce',
-      },
-      firstMatch: [{}],
-    }).should.be.fulfilled;
+    await d.createSession(
+      null,
+      null,
+      /** @type {import('@appium/types').W3CCapabilities<{'hold the':string}>} */ ({
+        alwaysMatch: {
+          platformName: 'iOS',
+          'appium:deviceName': 'Delorean',
+          'appium:extra': 'cheese',
+          'appium:hold the': 'sauce',
+        },
+        firstMatch: [{}],
+      })
+    ).should.be.fulfilled;
   });
 
   it('should log the use of extra caps', async function () {

--- a/packages/driver-test-support/lib/e2e-suite.js
+++ b/packages/driver-test-support/lib/e2e-suite.js
@@ -101,7 +101,7 @@ export function createSessionHelpers(port, address = TEST_HOST) {
  * Creates E2E test suites for a driver.
  * @template {Driver} P
  * @param {DriverClass<P>} DriverClass
- * @param {AppiumW3CCapabilities} [defaultCaps]
+ * @param {Partial<BaseNSCapabilities>} [defaultCaps]
  */
 export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
   let address = defaultCaps['appium:address'] ?? TEST_HOST;
@@ -130,7 +130,7 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
     let postCommand;
     before(async function () {
       port = port ?? (await getTestPort());
-      defaultCaps = {...defaultCaps, 'appium:port': port};
+      defaultCaps = {...defaultCaps};
       d = new DriverClass({port, address});
       baseServer = await server({
         routeConfiguringFunction: routeConfiguringFunction(d),
@@ -320,7 +320,7 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
         });
         await B.delay(400);
         const value = await getSession(/** @type {string} */ (sessionId));
-        value.error.should.equal('invalid session id');
+        /** @type {string} */ (value.error).should.equal('invalid session id');
         should.equal(d.sessionId, null);
         const resp = (await endSession(newSession.sessionId)).data.value;
         /** @type {string} */ (/** @type { {error: string} } */ (resp).error).should.equal(
@@ -426,10 +426,12 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
  */
 
 /**
- * @typedef {import('@appium/types').Capabilities} Capabilities
  * @typedef {import('@appium/types').Driver} Driver
+ * @typedef {import('@appium/types').Constraints} Constraints
  * @typedef {import('@appium/types').DriverStatic} DriverStatic
- * @typedef {import('@appium/types').AppiumW3CCapabilities} AppiumW3CCapabilities
+ * @typedef {import('@appium/types').StringRecord} StringRecord
+ * @typedef {import('@appium/types').BaseDriverCapConstraints} BaseDriverCapConstraints
+ * @typedef {import('@appium/types').BaseNSCapabilities} BaseNSCapabilities
  * @typedef {import('axios').AxiosRequestConfig} AxiosRequestConfig
  * @typedef {import('@appium/types').SingularSessionData} SingularSessionData
  */
@@ -440,14 +442,18 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
  */
 
 /**
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template {StringRecord|void} [Extra=void]
  * @typedef NewSessionData
- * @property {import('type-fest').RequireAtLeastOne<import('@appium/types').W3CCapabilities, 'firstMatch'|'alwaysMatch'>} capabilities
+ * @property {import('type-fest').RequireAtLeastOne<import('@appium/types').W3CCapabilities<C, Extra>, 'firstMatch'|'alwaysMatch'>} capabilities
  */
 
 /**
+ * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template {StringRecord|void} [Extra=void]
  * @typedef NewSessionResponse
  * @property {string} sessionId,
- * @property {import('@appium/types').Capabilities} capabilities
+ * @property {import('@appium/types').Capabilities<C, Extra>} capabilities
  */
 
 /**

--- a/packages/driver-test-support/lib/index.js
+++ b/packages/driver-test-support/lib/index.js
@@ -1,9 +1,14 @@
-export * from './e2e-suite';
+export {createSessionHelpers, driverE2ETestSuite} from './e2e-suite';
 export * from './unit-suite';
 export * from './helpers';
 
 /**
  * @typedef {import('@appium/types').DriverClass} DriverClass
- * @typedef {import('@appium/types').W3CCapabilities} W3CCapabilities
- * @typedef {import('@appium/types').AppiumW3CCapabilities} AppiumW3CCapabilities
+ * @typedef {import('@appium/types').BaseNSCapabilities} BaseNSCapabilities
+ */
+
+/**
+ * @template {import('@appium/types').Constraints} [C=import('@appium/types').BaseDriverCapConstraints]
+ * @template {import('@appium/types').StringRecord|void} [Extra=void]
+ * @typedef {import('@appium/types').W3CCapabilities<C, Extra>} W3CCapabilities
  */

--- a/packages/driver-test-support/lib/unit-suite.js
+++ b/packages/driver-test-support/lib/unit-suite.js
@@ -13,7 +13,7 @@ const {expect} = chai;
 /**
  * Creates unit test suites for a driver.
  * @param {DriverClass} DriverClass
- * @param {AppiumW3CCapabilities} [defaultCaps]
+ * @param {Partial<BaseNSCapabilities>} [defaultCaps]
  */
 
 export function driverUnitTestSuite(DriverClass, defaultCaps = {}) {
@@ -627,6 +627,11 @@ export function driverUnitTestSuite(DriverClass, defaultCaps = {}) {
 
 /**
  * @typedef {import('@appium/types').DriverClass} DriverClass
- * @typedef {import('@appium/types').W3CCapabilities} W3CCapabilities
- * @typedef {import('@appium/types').AppiumW3CCapabilities} AppiumW3CCapabilities
+ * @typedef {import('@appium/types').BaseNSCapabilities} BaseNSCapabilities
+ */
+
+/**
+ * @template {import('@appium/types').Constraints} [C=import('@appium/types').BaseDriverCapConstraints]
+ * @template {import('@appium/types').StringRecord|void} [Extra=void]
+ * @typedef {import('@appium/types').W3CCapabilities<C, Extra>} W3CCapabilities
  */

--- a/packages/types/lib/capabilities.ts
+++ b/packages/types/lib/capabilities.ts
@@ -167,9 +167,9 @@ export type DriverCaps<
  * Includes {@linkcode BaseCapabilities}.
  *
  * @example
- * ```js
+ * ```ts
  * class MyDriver extends BaseDriver {
- *   async createSession (w3ccaps: W3CDriverCaps<MyDriverConstraints>, ...args) {
+ *   async createSession (w3ccaps: W3CDriverCaps<MyDriverConstraints>, ...args: any[]) {
  *     // ...
  *   }
  * }

--- a/packages/types/lib/constraints.ts
+++ b/packages/types/lib/constraints.ts
@@ -1,0 +1,53 @@
+export const BASE_DESIRED_CAP_CONSTRAINTS = {
+  platformName: {
+    presence: true,
+    isString: true,
+  },
+  app: {
+    isString: true,
+  },
+  deviceName: {
+    isString: true,
+  },
+  platformVersion: {
+    isString: true,
+  },
+  newCommandTimeout: {
+    isNumber: true,
+  },
+  automationName: {
+    isString: true,
+  },
+  autoLaunch: {
+    isBoolean: true,
+  },
+  udid: {
+    isString: true,
+  },
+  orientation: {
+    inclusion: ['LANDSCAPE', 'PORTRAIT'],
+  },
+  autoWebview: {
+    isBoolean: true,
+  },
+  noReset: {
+    isBoolean: true,
+  },
+  fullReset: {
+    isBoolean: true,
+  },
+  language: {
+    isString: true,
+  },
+  locale: {
+    isString: true,
+  },
+  eventTimings: {
+    isBoolean: true,
+  },
+  printPageSourceOnFindFailure: {
+    isBoolean: true,
+  },
+} as const;
+
+export type BaseDriverCapConstraints = typeof BASE_DESIRED_CAP_CONSTRAINTS;

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -318,7 +318,7 @@ export interface Core<C extends Constraints = BaseDriverCapConstraints> {
   getManagedDrivers(): Driver[];
   clearNewCommandTimeout(): Promise<void>;
   logEvent(eventName: string): void;
-  driverForSession(sessionId: string): Core | null;
+  driverForSession(sessionId: string): Core<C> | null;
 }
 
 /**

--- a/packages/types/lib/index.ts
+++ b/packages/types/lib/index.ts
@@ -3,7 +3,6 @@ import type {Socket} from 'net';
 import type {Server} from 'http';
 import type {Class as _Class, ConditionalPick, MultidimensionalReadonlyArray} from 'type-fest';
 import {ServerArgs} from './config';
-import {Capabilities, W3CCapabilities} from './capabilities';
 import type {Express} from 'express';
 import {ExternalDriver} from './driver';
 import type {Logger} from 'npmlog';
@@ -11,10 +10,12 @@ import type {Logger} from 'npmlog';
 export * from './driver';
 export * from './action';
 export * from './plugin';
-export {AppiumW3CCapabilities, DriverCaps, DriverW3CCaps, NamespacedObject, AnyCase, ConstraintsToCaps} from './capabilities';
-export {AppiumConfig, NormalizedAppiumConfig} from './config';
+export * from './capabilities';
+export * from './constraints';
+export * from './config';
 export * from './appium-config';
-export {ServerArgs, Capabilities, W3CCapabilities};
+
+export type StringRecord = Record<string, any>;
 
 /**
  * A log prefix for {@linkcode AppiumLogger}
@@ -63,15 +64,10 @@ export type AppiumServer = Omit<Server, 'close'> & AppiumServerExtension;
 
 export interface AppiumServerExtension {
   close(): Promise<void>;
-  addWebSocketHandler(
-    handlerPathname: string,
-    handlerServer: WSServer
-  ): Promise<void>;
+  addWebSocketHandler(handlerPathname: string, handlerServer: WSServer): Promise<void>;
   removeWebSocketHandler(handlerPathname: string): Promise<boolean>;
   removeAllWebSocketHandlers(): Promise<boolean>;
-  getWebSocketHandlers(
-    keysFilter: string | null | undefined
-  ): Promise<Record<string, WSServer>>;
+  getWebSocketHandlers(keysFilter: string | null | undefined): Promise<Record<string, WSServer>>;
   webSocketsMapping: Record<string, WSServer>;
 }
 
@@ -164,8 +160,11 @@ export type ExtensionType = DriverType | PluginType;
  * @param httpServer - the node HTTP server that hosts the app
  * @param cliArgs - Arguments from config files, CLI, etc.
  */
-export type UpdateServerCallback = (expressApp: Express, httpServer: AppiumServer, cliArgs: ServerArgs) => Promise<void>;
-
+export type UpdateServerCallback = (
+  expressApp: Express,
+  httpServer: AppiumServer,
+  cliArgs: ServerArgs
+) => Promise<void>;
 
 /**
  * Possible HTTP methods, as stolen from `axios`.
@@ -173,14 +172,23 @@ export type UpdateServerCallback = (expressApp: Express, httpServer: AppiumServe
  * @see https://npm.im/axios
  */
 export type HTTPMethod =
-  | 'get' | 'GET'
-  | 'delete' | 'DELETE'
-  | 'head' | 'HEAD'
-  | 'options' | 'OPTIONS'
-  | 'post' | 'POST'
-  | 'put' | 'PUT'
-  | 'patch' | 'PATCH'
-  | 'purge' | 'PURGE'
-  | 'link' | 'LINK'
-  | 'unlink' | 'UNLINK';
-
+  | 'get'
+  | 'GET'
+  | 'delete'
+  | 'DELETE'
+  | 'head'
+  | 'HEAD'
+  | 'options'
+  | 'OPTIONS'
+  | 'post'
+  | 'POST'
+  | 'put'
+  | 'PUT'
+  | 'patch'
+  | 'PATCH'
+  | 'purge'
+  | 'PURGE'
+  | 'link'
+  | 'LINK'
+  | 'unlink'
+  | 'UNLINK';

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,6 +23,7 @@
     "build",
     "lib"
   ],
+  "main": "./build/index.js",
   "scripts": {
     "build": "node ./scripts/generate-schema-types.js",
     "dev": "npm run build -- --watch",

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -6,6 +6,8 @@
     "paths": {
       "@appium/schema": ["../schema"]
     },
+    "emitDeclarationOnly": false,
+    "module": "CommonJS",
     "lib": ["ES2015"]
   },
   "include": ["lib"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "files": [],
   "compilerOptions": {
+    "noErrorTruncation": true,
     "esModuleInterop": true
   },
   "references": [


### PR DESCRIPTION
The big idea here is:

1. `desiredCapConstraints` should always contain the constraints _for that driver_; it no longer contains the "base" constraints. This is the only thing that really required any logic changes (though they are somewhat spread out).  The "merged" constraints object is available via `_desiredCapConstraints`.
2. `Capabilities` and W3C-style `W3CCapabilities` are now _derived from_ constraints.  This absolves us (and extension authors) from needing to create an interface describing their capabilities.
3. Changes to caps and constraints now reflect in `DriverOpts` (`this.opts`) in drivers
4. `caps` and `originalCaps` declarations have moved from `Core` to `Driver`
5. TypeScript compiles the JS output from `@appium/types` (which is just a static "constraints" object)

Also, from what I can tell, the shape of any given "capabilities" object should be fully typed; the only caveat is that the constraints object must be declared as a "constant" (this is what `/** @type {const} */` is doing, if you see it anywhere) so that the contents are recursively read-only and any primitives are interpreted as literals.  There is still a disconnect between what is optional per the type (everything) vs. what is actually optional per Appium (e.g., `platformName` is not).  It's trivial to disable "everything is optional", but the result would require a lot of work to wipe up--most of which is just appeasing the compiler.

Resolves #17518
