### PR TITLE
fix: Load configs after server arguments parsing is completed

### DIFF
--- a/packages/appium/test/e2e/schema.e2e.spec.js
+++ b/packages/appium/test/e2e/schema.e2e.spec.js
@@ -38,17 +38,11 @@ describe('CLI behavior controlled by schema', function () {
 
     describe('appiumCliIgnored', function () {
       it('should still support arguments without this keyword', function () {
-        expect(help).to.match(/oliver-boliver/);
+        expect(help).to.match(/^usage:/);
       });
 
       it('should cause the argument to be suppressed', function () {
         expect(help).not.to.match(/mcmonkey-mcbean/);
-      });
-    });
-
-    describe('appiumDeprecated', function () {
-      it('should mark the argument as deprecated', function () {
-        expect(help).to.match(/\[DEPRECATED\] funkytelechy/);
       });
     });
   });


### PR DESCRIPTION
## Proposed changes

We do not want to spend extra time for configs loading if the server is executed with `-v` or `--show-config` args

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
