### PR TITLE
chore(appium): Remove logging from adjustNodePath helper

### DIFF
--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -226,7 +226,6 @@ function adjustNodePath() {
       require('module').Module._initPaths();
       return true;
     } catch (e) {
-      logger.info(`Module init paths cannot be refreshed. Original error: ${e.message}`);
       return false;
     }
   };
@@ -234,7 +233,6 @@ function adjustNodePath() {
   if (!process.env.NODE_PATH) {
     process.env.NODE_PATH = nodeModulesRoot;
     if (refreshRequirePaths()) {
-      logger.info(`Setting NODE_PATH to '${nodeModulesRoot}'`);
       process.env.APPIUM_OMIT_PEER_DEPS = '1';
     } else {
       delete process.env.NODE_PATH;
@@ -244,7 +242,6 @@ function adjustNodePath() {
 
   const nodePathParts = process.env.NODE_PATH.split(path.delimiter);
   if (nodePathParts.includes(nodeModulesRoot)) {
-    logger.info(`NODE_PATH already includes '${nodeModulesRoot}'`);
     process.env.APPIUM_OMIT_PEER_DEPS = '1';
     return;
   }
@@ -252,7 +249,6 @@ function adjustNodePath() {
   nodePathParts.push(nodeModulesRoot);
   process.env.NODE_PATH = nodePathParts.join(path.delimiter);
   if (refreshRequirePaths()) {
-    logger.info(`Adding '${nodeModulesRoot}' to NODE_PATH`);
     process.env.APPIUM_OMIT_PEER_DEPS = '1';
   } else {
     process.env.NODE_PATH = _.without(nodePathParts, nodeModulesRoot).join(path.delimiter);


### PR DESCRIPTION
## Proposed changes

I can observe these logs appear even after running the binary with `-v`, which is ugly. So it would be better to remove them for good

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
