### PR TITLE
chore(): do not publish tsconfig.tsbuildinfo

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+tsconfig.tsbuildinfo


### PR DESCRIPTION
This build cache file was getting into our releases (because it lives in `build/` and everything in `build/` is published).  I guess I could have just modified the `files` prop of every `package.json` but this seemed more expedient.