### PR TITLE
feat(doctor): print APPIUM_HOME

### DIFF
--- a/packages/doctor/lib/general.js
+++ b/packages/doctor/lib/general.js
@@ -5,8 +5,20 @@ import NodeDetector from './node-detector';
 import {util} from '@appium/support';
 import {EOL} from 'os';
 import '@colors/colors';
+import {resolveAppiumHome} from '@appium/support/build/lib/env';
 
 let checks = [];
+
+class AppiumHomeCheck extends DoctorCheck {
+  async diagnose() {
+    return ok(`Default APPIUM_HOME is ${await resolveAppiumHome()}`);
+  }
+
+  fix() {
+    return;
+  }
+}
+checks.push(new AppiumHomeCheck());
 
 // Node Binary
 class NodeBinaryCheck extends DoctorCheck {
@@ -23,7 +35,7 @@ class NodeBinaryCheck extends DoctorCheck {
 }
 checks.push(new NodeBinaryCheck());
 
-const REQUIRED_NODE_VERSION = '10.0.0';
+const REQUIRED_NODE_VERSION = '14.0.0';
 
 // Node version
 class NodeVersionCheck extends DoctorCheck {
@@ -91,6 +103,7 @@ class OptionalMjpegConsumerCommandCheck extends DoctorCheck {
 checks.push(new OptionalMjpegConsumerCommandCheck());
 
 export {
+  AppiumHomeCheck,
   NodeBinaryCheck,
   NodeVersionCheck,
   OptionalFfmpegCommandCheck,

--- a/packages/doctor/lib/general.js
+++ b/packages/doctor/lib/general.js
@@ -2,21 +2,18 @@ import {ok, nok, okOptional, nokOptional, resolveExecutablePath, getNpmPackageIn
 import {exec} from 'teen_process';
 import {DoctorCheck} from './doctor';
 import NodeDetector from './node-detector';
-import {util} from '@appium/support';
+import {util, env} from '@appium/support';
 import {EOL} from 'os';
 import '@colors/colors';
-import {resolveAppiumHome} from '@appium/support/build/lib/env';
 
 let checks = [];
 
 class AppiumHomeCheck extends DoctorCheck {
   async diagnose() {
-    return ok(`Default APPIUM_HOME is ${await resolveAppiumHome()}`);
+    return ok(`APPIUM_HOME is ${await env.resolveAppiumHome()}`);
   }
 
-  fix() {
-    return;
-  }
+  fix() {}
 }
 checks.push(new AppiumHomeCheck());
 

--- a/packages/doctor/test/unit/general.spec.js
+++ b/packages/doctor/test/unit/general.spec.js
@@ -55,11 +55,11 @@ describe('general', function () {
         mocks.tp
           .expects('exec')
           .once()
-          .returns(B.resolve({stdout: 'v10.0.0', stderr: ''}));
+          .returns(B.resolve({stdout: 'v14.0.0', stderr: ''}));
         (await check.diagnose()).should.deep.equal({
           ok: true,
           optional: false,
-          message: 'Node version is 10.0.0',
+          message: 'Node version is 14.0.0',
         });
         mocks.verify();
       });
@@ -72,7 +72,7 @@ describe('general', function () {
         (await check.diagnose()).should.deep.equal({
           ok: false,
           optional: false,
-          message: 'Node version should be at least 10.0.0!',
+          message: 'Node version should be at least 14.0.0!',
         });
         mocks.verify();
       });
@@ -108,7 +108,7 @@ describe('general', function () {
           .once()
           .returns({
             stdout: `ffmpeg version 4.1 Copyright (c) 2000-2018 the FFmpeg developers
-      built with Apple LLVM version 10.0.0 (clang-1000.11.45.5)
+      built with Apple LLVM version 14.0.0 (clang-1000.11.45.5)
       configuration: --prefix=/usr/local/Cellar/ffmpeg/4.1_1 --enable-shared --enable-pthreads --enable-version3 --enable-hardcoded-tables --enable-avresample --cc=clang --host-cflags= --host-ldflags= --enable-ffplay --enable-gpl --enable-libmp3lame --enable-libopus --enable-libsnappy --enable-libtheora --enable-libvorbis --enable-libvpx --enable-libx264 --enable-libx265 --enable-libxvid --enable-lzma --enable-opencl --enable-videotoolbox
       libavutil      56. 22.100 / 56. 22.100
       libpostproc    55.  3.100 / 55.  3.100`,


### PR DESCRIPTION
## Proposed changes

We can show APPIUM_HOME in the doctor to show where will be the home in the doctor command:

```
info AppiumDoctor Appium Doctor v.1.16.28
info AppiumDoctor ### Diagnostic for necessary dependencies starting ###
info AppiumDoctor  ✔ Default APPIUM_HOME is /Users/kazu/GitHub/appium
info AppiumDoctor  ✔ The Node.js binary was found at: /Users/kazu/.nvm/versions/node/v16.15.1/bin/node
info AppiumDoctor  ✔ Node version is 16.15.1
```

```
info AppiumDoctor ### Diagnostic for necessary dependencies starting ###
info AppiumDoctor  ✔ Default APPIUM_HOME is /Users/kazu/.appium
info AppiumDoctor  ✔ The Node.js binary was found at: /Users/kazu/.nvm/versions/node/v16.15.1/bin/node
```

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
