### PR TITLE
docs(appium): adjust grid docs from appium.io

### DIFF
--- a/packages/appium/docs/en/guides/grid.md
+++ b/packages/appium/docs/en/guides/grid.md
@@ -22,7 +22,7 @@ In the node config file you have to define the `browserName`,
 will re-direct your test to the right device. You will also need to
 configure your **host** details and the **Selenium Grid** details. For
 a full list of all parameters and descriptions look
-[here](https://github.com/SeleniumHQ/selenium/wiki/Grid2)
+[here](https://www.selenium.dev/documentation/legacy/selenium_3/grid_setup/)
 
 Once you start the appium server and it registers with the grid,
 you will see your device on the grid console page:

--- a/packages/appium/docs/en/guides/grid.md
+++ b/packages/appium/docs/en/guides/grid.md
@@ -4,24 +4,23 @@ title: Appium and Selenium Grid
 
 ## Selenium Grid 4
 
-`Relay` feature in Grid 4 allows you to proxy Appium requests to an appium server instance.
+The **relay** feature in Grid 4 allows you to proxy Appium requests to an Appium server instance.
 
 Please check [Relaying commands to a service endpoint that supports WebDriver](https://www.selenium.dev/documentation/grid/configuration/toml_options/#relaying-commands-to-a-service-endpoint-that-supports-webdriver) and [Selenium Grid 4 and Appium together in harmony](https://www.youtube.com/watch?v=3_aP2rsqZD0) about the configuration and for more details.
 
 ## Selenium Grid 3
 
-You are able to register your appium server with a local [Selenium Grid 3](https://www.selenium.dev/documentation/legacy/selenium_3/grid_3/)
+You are able to register your Appium server with a local [Selenium Grid 3](https://www.selenium.dev/documentation/legacy/selenium_3/grid_3/)
 ([setup docs](https://www.selenium.dev/documentation/legacy/grid_3/setting_up_your_own_grid/)) by using the
-`--nodeconfig` server parameter.
+`--nodeconfig` server argument.
 
-```center
-> appium server --nodeconfig /path/to/nodeconfig.json --base-path=/wd/hub
-```
+```bash
+appium server --nodeconfig /path/to/nodeconfig.json --base-path=/wd/hub
 
 In the node config file you have to define the `browserName`,
 `version` and `platform` and based on these parameters the grid
 will re-direct your test to the right device. You will also need to
-configure your **host** details and the **selenium grid** details. For
+configure your **host** details and the **Selenium Grid** details. For
 a full list of all parameters and descriptions look
 [here](https://github.com/SeleniumHQ/selenium/wiki/Grid2)
 
@@ -31,14 +30,14 @@ you will see your device on the grid console page:
 `http://**\<grid-ip-adress\>**:**\<grid-port\>**/grid/console`
 
 
-A new session capabilities should have `appium:` prefix in non-standard capabilities such as
-`automationName` since the grid append the given capabilities in both `desiredCapabilities`
+New session capabilities should use an `appium:` prefix for non-W3C-standard capabilities such as
+`automationName`, since the grid appends the given capabilities in both `desiredCapabilities`
 and `firstMatch` in `capabilities`.
 
 
-### Grid Node Configuration Example json file
+### Example Grid Node Configuration JSON
 
-```xml
+```json
 {
   "capabilities":
       [

--- a/packages/appium/docs/en/guides/grid.md
+++ b/packages/appium/docs/en/guides/grid.md
@@ -2,4 +2,72 @@
 title: Appium and Selenium Grid
 ---
 
-TODO
+## Selenium Grid 4
+
+`Relay` feature in Grid 4 allows you to proxy Appium requests to an appium server instance.
+
+Please check [Relaying commands to a service endpoint that supports WebDriver](https://www.selenium.dev/documentation/grid/configuration/toml_options/#relaying-commands-to-a-service-endpoint-that-supports-webdriver) and [Selenium Grid 4 and Appium together in harmony](https://www.youtube.com/watch?v=3_aP2rsqZD0) about the configuration and for more details.
+
+## Selenium Grid 3
+
+You are able to register your appium server with a local [Selenium Grid 3](https://www.selenium.dev/documentation/legacy/selenium_3/grid_3/)
+([setup docs](https://www.selenium.dev/documentation/legacy/grid_3/setting_up_your_own_grid/)) by using the
+`--nodeconfig` server parameter.
+
+```center
+> appium server --nodeconfig /path/to/nodeconfig.json --base-path=/wd/hub
+```
+
+In the node config file you have to define the `browserName`,
+`version` and `platform` and based on these parameters the grid
+will re-direct your test to the right device. You will also need to
+configure your **host** details and the **selenium grid** details. For
+a full list of all parameters and descriptions look
+[here](https://github.com/SeleniumHQ/selenium/wiki/Grid2)
+
+Once you start the appium server and it registers with the grid,
+you will see your device on the grid console page:
+
+`http://**\<grid-ip-adress\>**:**\<grid-port\>**/grid/console`
+
+
+A new session capabilities should have `appium:` prefix in non-standard capabilities such as
+`automationName` since the grid append the given capabilities in both `desiredCapabilities`
+and `firstMatch` in `capabilities`.
+
+
+### Grid Node Configuration Example json file
+
+```xml
+{
+  "capabilities":
+      [
+        {
+          "browserName": "<e.g._iPhone5_or_iPad4>",
+          "version":"<version_of_iOS_e.g._7.1>",
+          "maxInstances": 1,
+          "platform":"<platform_e.g._MAC_or_ANDROID>"
+        }
+      ],
+  "configuration":
+  {
+    "cleanUpCycle":2000,
+    "timeout":30000,
+    "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
+    "url":"http://<host_name_appium_server_or_ip-address_appium_server>:<appium_port>/wd/hub",
+    "host": "<host_name_appium_server_or_ip-address_appium_server>",
+    "port": <appium_port>,
+    "maxSession": 1,
+    "register": true,
+    "registerCycle": 5000,
+    "hubPort": <grid_port>,
+    "hubHost": "<Grid_host_name_or_grid_ip-address>"
+    "hubProtocol": "<Protocol_of_Grid_defaults_to_http>"
+  }
+}
+```
+
+If `url`, `host`, and `port` are not given, the config will be auto updated
+to point to localhost:whatever-port-Appium-started-on.
+
+If your Appium server is running on a different machine to your Selenium Grid server, make sure you use an external name/IP address in your `host` & `url` docs; `localhost` and `127.0.0.1` will prevent Selenium Grid from connecting correctly.


### PR DESCRIPTION
## Proposed changes

closes https://github.com/appium/appium/issues/16808

From https://appium.io/docs/en/advanced-concepts/grid/

I've adjusted the `appium` command. The grid 4 is just a link to selenium project to keep up to date the documentation. Grid 3 has a few updates for the appium 2 and with `appium:` prefix. Basically clients need to send appium prefix capabilities to the grid server, then the grid server appends them in `desiredCapabilities` and `capabilities`/`firstMatch`.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
