### PR TITLE
docs(appium): address ruby_core_lib as recommended one

### DIFF
--- a/packages/appium/docs/en/quickstart/test-rb.md
+++ b/packages/appium/docs/en/quickstart/test-rb.md
@@ -3,7 +3,7 @@ title: Write a Test (Ruby)
 ---
 
 
-The [AppiumLib](https://github.com/appium/ruby_lib) and the [AppiumLibCore](https://github.com/appium/ruby_lib_core) (**recommended**) are Appium official client libraries in Ruby, which are available via gem under the [appium_lib](https://rubygems.org/gems/appium_lib) and the [appium_lib_core](https://rubygems.org/gems/appium_lib_core) package names. The appium_lib_core inherits from the Selenium Ruby Binding, and the appium_lib inherits from the appium_lib_core, so installing these libraries include the selenium binding. We recommend `appium_lib_core` if you needed less complexity in the client library. The `appium_lib` has some useful methods the core does not have, but it also has code complexity by historical reasons.
+The [AppiumLib](https://github.com/appium/ruby_lib) and the [AppiumLibCore](https://github.com/appium/ruby_lib_core) (**recommended**) are official Appium client libraries in Ruby, which are available via gem under the [appium_lib](https://rubygems.org/gems/appium_lib) and the [appium_lib_core](https://rubygems.org/gems/appium_lib_core) package names. The appium_lib_core inherits from the Selenium Ruby Binding, and the appium_lib inherits from the appium_lib_core, so installing these libraries include the selenium binding. We recommend `appium_lib_core` if you need a less complex client-side solution. The `appium_lib` has some useful methods the core does not have, but for the cost of greater complexity.
 
 ```bash
 gem install appium_lib

--- a/packages/appium/docs/en/quickstart/test-rb.md
+++ b/packages/appium/docs/en/quickstart/test-rb.md
@@ -3,7 +3,7 @@ title: Write a Test (Ruby)
 ---
 
 
-The [AppiumLib](https://github.com/appium/ruby_lib) and the [AppiumLibCore](https://github.com/appium/ruby_lib_core) are Appium officcial client libraries in Ruby, which are available via gem under the [appium_lib](https://rubygems.org/gems/appium_lib) and the [appium_lib_core](https://rubygems.org/gems/appium_lib_core) package names. The appium_lib_core inherits from the Selenium Ruby Binding, and the appium_lib inherits from the appium_lib_core, so intalling these libraries include the selenium binding.
+The [AppiumLib](https://github.com/appium/ruby_lib) and the [AppiumLibCore](https://github.com/appium/ruby_lib_core) (**recommended**) are Appium official client libraries in Ruby, which are available via gem under the [appium_lib](https://rubygems.org/gems/appium_lib) and the [appium_lib_core](https://rubygems.org/gems/appium_lib_core) package names. The appium_lib_core inherits from the Selenium Ruby Binding, and the appium_lib inherits from the appium_lib_core, so installing these libraries include the selenium binding. We recommend `appium_lib_core` if you needed less complexity in the client library. The `appium_lib` has some useful methods the core does not have, but it also has code complexity by historical reasons.
 
 ```bash
 gem install appium_lib
@@ -12,7 +12,7 @@ gem install appium_lib_core
 ```
 
 The `appium_lib_core` is the main part as an Appium client.
-`appium_lib` has various helper methods, but the driver instance was ordinally designed to be used as a global variable. It could causes an issue to handle the instance.
+`appium_lib` has various helper methods, but the driver instance was ordinary designed to be used as a global variable. It could causes an issue to handle the instance.
 `appium_lib_core` does not have such a global variable.
 
 This example is by the `appium_lib_core` with `test-unit` gem module.
@@ -29,7 +29,7 @@ Tes code in `appium_lib` should be similar.
 
     - You may want to read up particularly on Appium [Capabilities](../guides/caps.md).
     - [functional test code](https://github.com/appium/ruby_lib_core/tree/master/test/functional) in the appium_lib_core GitHub repository should help to find more working example.
-    - Documentation [appium_lib_core](https://www.rubydoc.info/github/appium/ruby_lib_core) and [appium_lib](https://www.rubydoc.info/github/appium/ruby_lib) also helps to find avvailable methods.
+    - Documentation [appium_lib_core](https://www.rubydoc.info/github/appium/ruby_lib_core) and [appium_lib](https://www.rubydoc.info/github/appium/ruby_lib) also helps to find available methods.
 
 
 Basically, this code is doing the following:

--- a/packages/appium/docs/ja/about/appium-clients.md
+++ b/packages/appium/docs/ja/about/appium-clients.md
@@ -8,7 +8,7 @@ Appium サーバー自体が公式プロトコルへのカスタム拡張を定�
 
 言語/フレームワーク | Github のリポジトリとインストール手順 |
 ----- | ----- |
-Ruby | [https://github.com/appium/ruby_lib](https://github.com/appium/ruby_lib), [https://github.com/appium/ruby_lib_core](https://github.com/appium/ruby_lib_core)
+Ruby | [https://github.com/appium/ruby_lib_core](https://github.com/appium/ruby_lib_core)(推奨), [https://github.com/appium/ruby_lib](https://github.com/appium/ruby_lib)
 Python | [https://github.com/appium/python-client](https://github.com/appium/python-client)
 Java | [https://github.com/appium/java-client](https://github.com/appium/java-client)
 C# (.NET) | [https://github.com/appium/appium-dotnet-driver](https://github.com/appium/appium-dotnet-driver)


### PR DESCRIPTION
## Proposed changes

I'd like to address ruby_lib_core is recommended Ruby binding than ruby_lib since Appium 2's documentation.

In historical reason, the ruby_lib has complex implementation than other bindings. The core one is similar to other bindings, the client itself has less logic, for example.

So, I'd like to recommend the ruby_lib_core one as a primary Ruby binding.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
