### PR TITLE
feat(base-driver): add wd-proxy as w3c-only alternative to jsonwp-proxy

### DIFF
--- a/packages/base-driver/lib/index.js
+++ b/packages/base-driver/lib/index.js
@@ -24,6 +24,9 @@ export {server, normalizeBasePath} from './express/server';
 // jsonwp-proxy exports
 export {JWProxy} from './jsonwp-proxy/proxy';
 
+// wd-proxy exports
+export {WDProxy} from './wd-proxy/proxy';
+
 // jsonwp-status exports
 export {getSummaryByCode, codes as statusCodes} from './jsonwp-status/status';
 

--- a/packages/base-driver/lib/wd-proxy/proxy.js
+++ b/packages/base-driver/lib/wd-proxy/proxy.js
@@ -1,0 +1,417 @@
+import _ from 'lodash';
+import axios from 'axios';
+import {logger, util} from '@appium/support';
+import {
+  errors,
+  isErrorType,
+  errorFromW3CJsonCode,
+  getResponseForW3CError,
+} from '../protocol/errors';
+import {routeToCommandName} from '../protocol';
+import {MAX_LOG_BODY_LENGTH, DEFAULT_BASE_PATH} from '../constants';
+import http from 'http';
+import https from 'https';
+
+const DEFAULT_LOG = logger.getLogger('WD Proxy');
+const DEFAULT_REQUEST_TIMEOUT = 240000;
+const COMPACT_ERROR_PATTERNS = [/\bECONNREFUSED\b/, /socket hang up/];
+
+const ALLOWED_OPTS = [
+  'scheme',
+  'server',
+  'port',
+  'base',
+  'reqBasePath',
+  'sessionId',
+  'timeout',
+  'log',
+  'keepAlive',
+];
+
+export class WDProxy {
+  /** @type {string} */
+  scheme;
+  /** @type {string} */
+  server;
+  /** @type {number} */
+  port;
+  /** @type {string} */
+  base;
+  /** @type {string} */
+  reqBasePath;
+  /** @type {string?} */
+  sessionId;
+  /** @type {number} */
+  timeout;
+
+  constructor(opts = {}) {
+    opts = _.pick(opts, ALLOWED_OPTS);
+
+    // omit 'log' in the defaults assignment here because 'log' is a getter and we are going to set
+    // it to this._log (which lies behind the getter) further down
+    const options = _.defaults(_.omit(opts, 'log'), {
+      scheme: 'http',
+      server: 'localhost',
+      port: 4444,
+      base: DEFAULT_BASE_PATH,
+      reqBasePath: DEFAULT_BASE_PATH,
+      sessionId: null,
+      timeout: DEFAULT_REQUEST_TIMEOUT,
+    });
+    options.scheme = options.scheme.toLowerCase();
+    Object.assign(this, options);
+
+    this._activeRequests = [];
+    const agentOpts = {
+      keepAlive: opts.keepAlive ?? true,
+      maxSockets: 10,
+      maxFreeSockets: 5,
+    };
+    this.httpAgent = new http.Agent(agentOpts);
+    this.httpsAgent = new https.Agent(agentOpts);
+    this._log = opts.log;
+  }
+
+  get log() {
+    return this._log ?? DEFAULT_LOG;
+  }
+
+  /**
+   * Performs requests to the downstream server
+   *
+   * @private - Do not call this method directly,
+   * it uses client-specific arguments and responses!
+   *
+   * @param {import('axios').AxiosRequestConfig} requestConfig
+   * @returns {Promise<import('axios').AxiosResponse<W3CResponse>>}
+   */
+  async request(requestConfig) {
+    const reqPromise = axios(requestConfig);
+    this._activeRequests.push(reqPromise);
+    try {
+      return await reqPromise;
+    } finally {
+      _.pull(this._activeRequests, reqPromise);
+    }
+  }
+
+  getActiveRequestsCount() {
+    return this._activeRequests.length;
+  }
+
+  cancelActiveRequests() {
+    this._activeRequests = [];
+  }
+
+  /**
+   * @param {string} endpoint
+   */
+  endpointRequiresSessionId(endpoint) {
+    return !_.includes(['/session', '/sessions', '/status'], endpoint);
+  }
+
+  /**
+   * @param {string} url
+   */
+  getUrlForProxy(url) {
+    if (url === '') {
+      url = '/';
+    }
+    const proxyBase = `${this.scheme}://${this.server}:${this.port}${this.base}`;
+    const endpointRe = '(/(session|status))';
+    let remainingUrl = '';
+    if (/^http/.test(url)) {
+      const first = new RegExp(`(https?://.+)${endpointRe}`).exec(url);
+      if (!first) {
+        throw new Error('Got a complete url but could not extract a WebDriver endpoint');
+      }
+      remainingUrl = url.replace(first[1], '');
+    } else if (new RegExp('^/').test(url)) {
+      remainingUrl = url;
+    } else {
+      throw new Error(`Did not know what to do with url '${url}'`);
+    }
+
+    const stripPrefixRe = new RegExp('^.*?(/(session|status).*)$');
+    if (stripPrefixRe.test(remainingUrl)) {
+      remainingUrl = /** @type {RegExpExecArray} */ (stripPrefixRe.exec(remainingUrl))[1];
+    }
+
+    if (!new RegExp(endpointRe).test(remainingUrl)) {
+      remainingUrl = `/session/${this.sessionId}${remainingUrl}`;
+    }
+
+    const requiresSessionId = this.endpointRequiresSessionId(remainingUrl);
+
+    if (requiresSessionId && this.sessionId === null) {
+      throw new Error('Trying to proxy a session command without session id');
+    }
+
+    const sessionBaseRe = new RegExp('^/session/([^/]+)');
+    if (sessionBaseRe.test(remainingUrl)) {
+      if (this.sessionId === null) {
+        throw new ReferenceError(
+          `Session ID is not set, but saw a URL path referencing a session (${remainingUrl}). This may be a bug in your client.`
+        );
+      }
+      // we have something like /session/:id/foobar, so we need to replace
+      // the session id
+      const match = sessionBaseRe.exec(remainingUrl);
+      // TODO: if `requiresSessionId` is `false` and `sessionId` is `null`, this is a bug.
+      // are we sure `sessionId` is not `null`?
+      remainingUrl = remainingUrl.replace(
+        /** @type {RegExpExecArray} */ (match)[1],
+        /** @type {string} */ (this.sessionId)
+      );
+    } else if (requiresSessionId) {
+      throw new Error(`Could not find :session section for url: ${remainingUrl}`);
+    }
+    remainingUrl = remainingUrl.replace(/\/$/, ''); // can't have trailing slashes
+
+    return proxyBase + remainingUrl;
+  }
+
+  /**
+   * @param {string} url
+   * @param {string} method
+   * @returns {Promise<{status: number, headers: import('axios').AxiosResponseHeaders, data: W3CResponse}>}
+   */
+  async proxy(url, method, body = null) {
+    method = method.toUpperCase();
+    const newUrl = this.getUrlForProxy(url);
+    const truncateBody = (/** @type {any} */ content) =>
+      _.truncate(_.isString(content) ? content : JSON.stringify(content), {
+        length: MAX_LOG_BODY_LENGTH,
+      });
+    /** @type {import('axios').AxiosRequestConfig} */
+    const reqOpts = {
+      url: newUrl,
+      method,
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'user-agent': 'appium',
+        accept: 'application/json, */*',
+      },
+      proxy: false,
+      timeout: this.timeout,
+      httpAgent: this.httpAgent,
+      httpsAgent: this.httpsAgent,
+    };
+    // GET methods shouldn't have any body. Most servers are OK with this, but WebDriverAgent throws 400 errors
+    if (util.hasValue(body) && method !== 'GET') {
+      if (typeof body !== 'object') {
+        try {
+          reqOpts.data = JSON.parse(body);
+        } catch (e) {
+          throw new Error(`Cannot interpret the request body as valid JSON: ${truncateBody(body)}`);
+        }
+      } else {
+        reqOpts.data = body;
+      }
+    }
+
+    this.log.debug(
+      `Proxying [${method} ${url || '/'}] to [${method} ${newUrl}] ` +
+        (reqOpts.data ? `with body: ${truncateBody(reqOpts.data)}` : 'with no body')
+    );
+
+    const throwProxyError = (/** @type {any} */ data) => {
+      const err = /** @type {ProxyError} */ (new Error(`The request to ${url} has failed`));
+      err.response = {
+        data,
+        status: 500,
+      };
+      throw err;
+    };
+    let isResponseLogged = false;
+    try {
+      const {data, status, headers} = await this.request(reqOpts);
+      // `data` might be really big
+      // Be careful while handling it to avoid memory leaks
+      if (!_.isPlainObject(data)) {
+        // The response should be a valid JSON object
+        // If it cannot be coerced to an object then the response is wrong
+        throwProxyError(data);
+      }
+      this.log.debug(`Got response with status ${status}: ${truncateBody(data)}`);
+      if (!_.has(data, 'value')) {
+        const errMsg = `Expected W3C protocol response to contain a 'value' property`;
+        throw new errors.ProxyRequestError(errMsg, data, status);
+      }
+      isResponseLogged = true;
+      const isSessionCreationRequest = /\/session$/.test(url) && method === 'POST';
+      if (isSessionCreationRequest && status === 200) {
+        if (this.sessionId) {
+          this.log.warn(
+            `Warning; sessionId was previously set to ${this.sessionId} but ` +
+              `will be changed as a result of new session response`
+          );
+        }
+        if (!_.isString(data?.value?.sessionId)) {
+          const errMsg = `Expected new session response to contain a 'value.sessionId' property`;
+          throw new errors.ProxyRequestError(errMsg, data, status);
+        }
+        this.sessionId = data.value?.sessionId;
+      }
+      return {status, headers, data};
+    } catch (e) {
+      // We only consider an error unexpected if this was not
+      // an async request module error or if the response cannot be cast to
+      // a valid JSON
+      let proxyErrorMsg = e.message;
+      if (util.hasValue(e.response)) {
+        if (!isResponseLogged) {
+          const error = truncateBody(e.response.data);
+          this.log.info(
+            util.hasValue(e.response.status)
+              ? `Got response with status ${e.response.status}: ${error}`
+              : `Got response with unknown status: ${error}`
+          );
+        }
+      } else {
+        proxyErrorMsg = `Could not proxy command to the remote server. Original error: ${e.message}`;
+        if (COMPACT_ERROR_PATTERNS.some((p) => p.test(e.message))) {
+          this.log.info(e.message);
+        } else {
+          this.log.info(e.stack);
+        }
+      }
+      throw new errors.ProxyRequestError(proxyErrorMsg, e.response?.data, e.response?.status);
+    }
+  }
+
+  /**
+   *
+   * @param {string} url
+   * @param {import('@appium/types').HTTPMethod} method
+   * @returns {string|undefined}
+   */
+  requestToCommandName(url, method) {
+    /**
+     *
+     * @param {RegExp} pattern
+     * @returns {string|undefined}
+     */
+    const extractCommandName = (pattern) => {
+      const pathMatch = pattern.exec(url);
+      if (pathMatch) {
+        return routeToCommandName(pathMatch[1], method, this.reqBasePath);
+      }
+    };
+    let commandName = routeToCommandName(url, method, this.reqBasePath);
+    if (!commandName && _.includes(url, `${this.reqBasePath}/session/`)) {
+      commandName = extractCommandName(
+        new RegExp(`${_.escapeRegExp(this.reqBasePath)}/session/[^/]+(.+)`)
+      );
+    }
+    if (!commandName && _.includes(url, this.reqBasePath)) {
+      commandName = extractCommandName(new RegExp(`${_.escapeRegExp(this.reqBasePath)}(/.+)`));
+    }
+    return commandName;
+  }
+
+  /**
+   * @param {string} url
+   * @param {import('@appium/types').HTTPMethod} method
+   * @returns {Promise<{status: number, headers: import('axios').AxiosResponseHeaders, data: W3CResponse}>}
+   */
+  async proxyCommand(url, method, body = null) {
+    const commandName = this.requestToCommandName(url, method);
+    if (commandName) {
+      this.log.debug(`Matched '${url}' to command name '${commandName}'`);
+    }
+    return await this.proxy(url, method, body);
+  }
+
+  /**
+   * @param {string} url
+   * @param {import('@appium/types').HTTPMethod} method
+   * @returns {Promise<any>}
+   */
+  async command(url, method, body = null) {
+    let status, data;
+    try {
+      ({status, data} = await this.proxyCommand(url, method, body));
+    } catch (err) {
+      if (isErrorType(err, errors.ProxyRequestError)) {
+        throw err.getActualError();
+      }
+      throw new errors.UnknownError(err.message);
+    }
+    if (status < 300) {
+      return data.value;
+    }
+    if (_.isPlainObject(data.value) && data.value.error) {
+      throw errorFromW3CJsonCode(data.value.error, data.value.message, data.value.stacktrace);
+    }
+    throw new errors.UnknownError(
+      `Did not know what to do with response code '${status}' ` +
+        `and response body '${_.truncate(JSON.stringify(data), {
+          length: 300,
+        })}'`
+    );
+  }
+
+  /**
+   * @param {string} url
+   * @returns {string?}
+   */
+  getSessionIdFromUrl(url) {
+    const match = url.match(/\/session\/([^/]+)/);
+    return match ? match[1] : null;
+  }
+
+  /**
+   * @param {import('express').Request} req
+   * @param {import('express').Response} res
+   */
+  async proxyReqRes(req, res) {
+    // ! this method must not throw any exceptions
+    // ! make sure to call res.send before return
+    let status, headers, data;
+    const method = /** @type {import('@appium/types').HTTPMethod} */ (req.method);
+    try {
+      ({status, headers, data} = await this.proxyCommand(req.originalUrl, method, req.body));
+      res.set(headers);
+    } catch (err) {
+      [status, data] = getResponseForW3CError(
+        isErrorType(err, errors.ProxyRequestError) ? err.getActualError() : err
+      );
+    }
+    res.set('content-type', 'application/json; charset=utf-8');
+    if (!_.isPlainObject(data)) {
+      const error = new errors.UnknownError(
+        `The downstream server response with the status code ${status} is not a valid JSON object: ` +
+          _.truncate(`${data}`, {length: 300})
+      );
+      [status, data] = getResponseForW3CError(error);
+    }
+
+    // if the proxied response contains a sessionId that the downstream
+    // driver has generated, we don't want to return that to the client.
+    // Instead, return the id from the request or from current session
+    if (_.has(data, 'sessionId')) {
+      const reqSessionId = this.getSessionIdFromUrl(req.originalUrl);
+      if (reqSessionId) {
+        this.log.info(`Replacing sessionId ${data.sessionId} with ${reqSessionId}`);
+        data.sessionId = reqSessionId;
+      } else if (this.sessionId) {
+        this.log.info(`Replacing sessionId ${data.sessionId} with ${this.sessionId}`);
+        data.sessionId = this.sessionId;
+      }
+    }
+    if (data.value === undefined) {
+      // we sometimes return undefined from commands as a convenience, but the w3c protocol insists
+      // that things are null
+      data.value = null;
+    }
+    res.status(status).send(JSON.stringify(data));
+  }
+}
+
+export default WDProxy;
+
+/**
+ * @typedef {{value: any | {error: string, message: string, stacktrace: string}}} W3CResponse
+ * @typedef {Error & {response: {data: import('type-fest').JsonObject, status: import('http-status-codes').StatusCodes}}} ProxyError
+ */

--- a/packages/base-driver/test/e2e/wd-proxy/proxy.e2e.spec.js
+++ b/packages/base-driver/test/e2e/wd-proxy/proxy.e2e.spec.js
@@ -1,0 +1,48 @@
+import {WDProxy, server, routeConfiguringFunction} from '../../../lib';
+import {FakeDriver} from '../protocol/fake-driver';
+
+describe('proxy', function () {
+  const wdproxy = new WDProxy();
+  let baseServer;
+  before(async function () {
+    baseServer = await server({
+      routeConfiguringFunction: routeConfiguringFunction(new FakeDriver()),
+      port: 4444,
+    });
+  });
+  after(async function () {
+    await baseServer.close();
+  });
+
+  it('should proxy status straight', async function () {
+    let {status, data} = await wdproxy.proxy('/status', 'GET');
+    status.should.equal(200);
+    data.value.should.equal(`I'm fine`);
+  });
+  it('should proxy status as command', async function () {
+    const res = await wdproxy.command('/status', 'GET');
+    res.should.eql(`I'm fine`);
+  });
+  describe('new session', function () {
+    afterEach(async function () {
+      await wdproxy.command('', 'DELETE');
+    });
+    it('should start a new session', async function () {
+      const caps = {browserName: 'fake'};
+      const res = await wdproxy.command('/session', 'POST', {
+        capabilities: {alwaysMatch: caps},
+      });
+      res.capabilities.alwaysMatch.should.have.property('browserName');
+      wdproxy.sessionId.should.have.length(48);
+    });
+  });
+  describe('delete session', function () {
+    beforeEach(async function () {
+      await wdproxy.command('/session', 'POST', {capabilities: {alwaysMatch: {}}});
+    });
+    it('should quit a session', async function () {
+      const res = await wdproxy.command('', 'DELETE');
+      should.not.exist(res);
+    });
+  });
+});

--- a/packages/base-driver/test/unit/wd-proxy/mock-request.js
+++ b/packages/base-driver/test/unit/wd-proxy/mock-request.js
@@ -1,0 +1,44 @@
+function resFixture(url, method, json, opts) {
+  if (/\/status$/.test(url)) {
+    return [200, {value: {foo: 'bar'}}];
+  }
+  if (/\/element\/bad\/text$/.test(url)) {
+    return [400, {value: {error: 'invalid element state'}}];
+  }
+  if (/\/element\/200\/text$/.test(url)) {
+    return [400, {value: {error: 'invalid element state'}}];
+  }
+  if (/\/element\/200\/attribute\/value$/.test(url)) {
+    return [200, {value: 'foobar'}];
+  }
+  if (/\/session$/.test(url) && method === 'POST') {
+    if (opts.noSessionId) {
+      return [200, {value: {browserName: 'boo'}}];
+    }
+    return [200, {value: {sessionId: '123', browserName: 'boo'}}];
+  }
+  if (/\/novalue$/.test(url)) {
+    return [200, {foo: 'bar'}];
+  }
+  if (/\/nochrome$/.test(url)) {
+    return [500, {value: {error: 'unknown error', message: 'chrome not reachable'}}];
+  }
+  throw new Error("Can't handle url " + url);
+}
+
+// eslint-disable-next-line require-await
+async function request(opts, fixtureOpts) {
+  const {url, method, json} = opts;
+  if (/badurl$/.test(url)) {
+    throw new Error('noworky');
+  }
+
+  const [status, data] = resFixture(url, method, json, fixtureOpts);
+  return {
+    status,
+    headers: {'content-type': 'application/json; charset=utf-8'},
+    data,
+  };
+}
+
+export default request;

--- a/packages/base-driver/test/unit/wd-proxy/proxy.spec.js
+++ b/packages/base-driver/test/unit/wd-proxy/proxy.spec.js
@@ -1,17 +1,19 @@
-import {JWProxy} from '../../../lib';
+import {WDProxy} from '../../../lib';
 import request from './mock-request';
 import {isErrorType, errors} from '../../../lib/protocol/errors';
 import {getTestPort, buildReqRes, TEST_HOST} from '@appium/driver-test-support';
 
+const NEW_SESSION_BODY = {capabilities: {alwaysMatch: {}}};
+
 describe('proxy', function () {
   let port;
 
-  function mockProxy(opts = {}) {
+  function mockProxy(opts = {}, fixtureOpts = {}) {
     // sets default server/port
     opts = {server: TEST_HOST, port, ...opts};
-    let proxy = new JWProxy(opts);
-    proxy.request = async function (...args) {
-      return await request(...args);
+    let proxy = new WDProxy(opts);
+    proxy.request = async function (reqOpts) {
+      return await request(reqOpts, fixtureOpts);
     };
     return proxy;
   }
@@ -25,15 +27,7 @@ describe('proxy', function () {
     j.server.should.equal('127.0.0.2');
     j.port.should.equal(port);
   });
-  it('should save session id on session creation', async function () {
-    let j = mockProxy();
-    let [res, body] = await j.proxy('/session', 'POST', {
-      desiredCapabilities: {},
-    });
-    res.statusCode.should.equal(200);
-    body.should.eql({status: 0, sessionId: '123', value: {browserName: 'boo'}});
-    j.sessionId.should.equal('123');
-  });
+
   describe('getUrlForProxy', function () {
     it('should modify session id, host, and port', function () {
       let j = mockProxy({sessionId: '123'});
@@ -85,26 +79,48 @@ describe('proxy', function () {
       should.exist(newUrl);
     });
   });
+
   describe('straight proxy', function () {
     it('should successfully proxy straight', async function () {
       let j = mockProxy();
-      let [res, body] = await j.proxy('/status', 'GET');
-      res.statusCode.should.equal(200);
-      body.should.eql({status: 0, value: {foo: 'bar'}});
+      let {status, data} = await j.proxy('/status', 'GET');
+      status.should.equal(200);
+      data.should.eql({value: {foo: 'bar'}});
+    });
+    it('should save session id on session creation', async function () {
+      let j = mockProxy();
+      let {status, data} = await j.proxy('/session', 'POST', NEW_SESSION_BODY);
+      status.should.equal(200);
+      data.should.eql({value: {sessionId: '123', browserName: 'boo'}});
+      j.sessionId.should.equal('123');
+    });
+    it('should throw an error if sessionid not included in new session response', async function () {
+      let j = mockProxy({}, {noSessionId: true});
+      await j.proxy('/session', 'POST', NEW_SESSION_BODY).should.be.rejectedWith('sessionId');
+    });
+    it('should overwrite session id when new session generates one', async function () {
+      let j = mockProxy({sessionId: '456'});
+      let {status, data} = await j.proxy('/session', 'POST', NEW_SESSION_BODY);
+      status.should.equal(200);
+      data.should.eql({value: {sessionId: '123', browserName: 'boo'}});
+      j.sessionId.should.equal('123');
+    });
+    it('should throw an error if the w3c value prop is not a part of the response', async function () {
+      let j = mockProxy({sessionId: '123'});
+      await j.proxy('/novalue', 'GET').should.be.rejectedWith('value');
     });
     it('should pass along request errors', function () {
       let j = mockProxy({sessionId: '123'});
       j.proxy('/badurl', 'GET').should.be.rejectedWith('Could not proxy');
     });
-    it('should proxy error responses and codes', async function () {
+    it('should proxy error responses and codes without throwing', async function () {
       let j = mockProxy({sessionId: '123'});
-      try {
-        await j.proxy('/element/bad/text', 'GET');
-      } catch (e) {
-        isErrorType(e.getActualError(), errors.ElementNotVisibleError).should.be.true;
-      }
+      const {status, data} = await j.proxy('/element/bad/text', 'GET');
+      status.should.equal(400);
+      data.should.eql({value: {error: 'invalid element state'}});
     });
   });
+
   describe('command proxy', function () {
     it('should successfully proxy command', async function () {
       let j = mockProxy();
@@ -124,31 +140,11 @@ describe('proxy', function () {
         e = err;
       }
       should.exist(e);
-      e.message.should.contain('Invisible element');
-    });
-    it('should throw when a command fails with a 200 because the status is not 0', async function () {
-      let j = mockProxy({sessionId: '123'});
-      let e = null;
-      try {
-        await j.command('/element/200/text', 'GET');
-      } catch (err) {
-        e = err;
-      }
-      should.exist(e);
-      e.error.should.eql('element not visible');
-    });
-    it('should throw when a command fails with a 100', async function () {
-      let j = mockProxy({sessionId: '123'});
-      let e = null;
-      try {
-        await j.command('/session/badchrome/nochrome', 'GET');
-      } catch (err) {
-        e = err;
-      }
-      should.exist(e);
-      e.message.should.contain('chrome not reachable');
+      isErrorType(e, errors.InvalidElementStateError).should.be.true;
+      e.error.should.eql('invalid element state');
     });
   });
+
   describe('req/res proxy', function () {
     it('should successfully proxy via req and send to res', async function () {
       let j = mockProxy();
@@ -160,15 +156,15 @@ describe('proxy', function () {
     });
     it('should rewrite the inner session id so it doesnt change', async function () {
       let j = mockProxy({sessionId: '123'});
-      let [req, res] = buildReqRes('/element/200/value', 'GET');
+      let [req, res] = buildReqRes('/element/200/attribute/value', 'GET');
       await j.proxyReqRes(req, res);
-      res.sentBody.should.eql({value: 'foobar', sessionId: '123'});
+      res.sentBody.should.eql({value: 'foobar'});
     });
-    it('should rewrite the inner session id with sessionId in url', async function () {
+    it('should still work even if session id in url is different from the stored one', async function () {
       let j = mockProxy({sessionId: '123'});
-      let [req, res] = buildReqRes('/session/456/element/200/value', 'POST');
+      let [req, res] = buildReqRes('/session/456/element/200/attribute/value', 'POST');
       await j.proxyReqRes(req, res);
-      res.sentBody.should.eql({value: 'foobar', sessionId: '456'});
+      res.sentBody.should.eql({value: 'foobar'});
     });
     it('should pass through urls that do not require session IDs', async function () {
       let j = mockProxy({sessionId: '123'});
@@ -180,8 +176,8 @@ describe('proxy', function () {
       let j = mockProxy({sessionId: '123'});
       let [req, res] = buildReqRes('/nochrome', 'GET');
       await j.proxyReqRes(req, res);
-      res.sentCode.should.equal(100);
-      res.sentBody.should.eql({value: {message: 'chrome not reachable'}});
+      res.sentCode.should.equal(500);
+      res.sentBody.should.eql({value: {error: 'unknown error', message: 'chrome not reachable'}});
     });
   });
 });

--- a/packages/base-driver/test/unit/wd-proxy/url.spec.js
+++ b/packages/base-driver/test/unit/wd-proxy/url.spec.js
@@ -1,0 +1,141 @@
+import {WDProxy} from '../../../lib';
+import {getTestPort, TEST_HOST, createAppiumURL} from '@appium/driver-test-support';
+import _ from 'lodash';
+
+describe('WDProxy', function () {
+  let port;
+
+  let createTestURL;
+  let testStatusURL;
+  let createTestSessionURL;
+  let testNewSessionURL;
+
+  const PROXY_HOST = '127.0.0.2';
+  const PROXY_PORT = 4723;
+
+  const createProxyURL = createAppiumURL(PROXY_HOST, PROXY_PORT);
+  const PROXY_STATUS_URL = createProxyURL('', 'status');
+
+  function createWDProxy(opts = {}) {
+    return new WDProxy({server: TEST_HOST, port, ...opts});
+  }
+
+  before(async function () {
+    port = await getTestPort();
+    createTestURL = createAppiumURL(TEST_HOST, port);
+    testStatusURL = createTestURL('', 'status');
+    createTestSessionURL = createTestURL(_, '');
+    testNewSessionURL = createTestURL('', 'session');
+  });
+
+  describe('proxying full urls', function () {
+    it('should translate host and port', function () {
+      let incomingUrl = PROXY_STATUS_URL;
+      let j = createWDProxy();
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(testStatusURL);
+    });
+    it('should translate the scheme', function () {
+      let incomingUrl = PROXY_STATUS_URL;
+      let j = createWDProxy({scheme: 'HTTPS'});
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(createAppiumURL(`https://${TEST_HOST}`, port, '', 'status'));
+    });
+    it('should translate the base', function () {
+      let incomingUrl = PROXY_STATUS_URL;
+      let j = createWDProxy({base: ''});
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(testStatusURL);
+    });
+    it('should translate the session id', function () {
+      let incomingUrl = createProxyURL('foobar', 'element');
+      let j = createWDProxy({sessionId: 'barbaz'});
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(createTestURL('barbaz', 'element'));
+    });
+    it('should error when translating session commands without session id', function () {
+      let incomingUrl = createProxyURL('foobar', 'element');
+      let j = createWDProxy();
+      (() => {
+        j.getUrlForProxy(incomingUrl);
+      }).should.throw('session id');
+    });
+  });
+
+  describe('proxying partial urls', function () {
+    it('should proxy /status', function () {
+      let incomingUrl = '/status';
+      let j = createWDProxy();
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(testStatusURL);
+    });
+    it('should proxy /session', function () {
+      let incomingUrl = '/session';
+      let j = createWDProxy();
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(testNewSessionURL);
+    });
+    it('should proxy /sessions', function () {
+      let incomingUrl = '/sessions';
+      let j = createWDProxy();
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(createTestURL('', 'sessions'));
+    });
+    it('should proxy session commands based off /session', function () {
+      let incomingUrl = '/session/foobar/element';
+      let j = createWDProxy({sessionId: 'barbaz'});
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(createTestURL('barbaz', 'element'));
+    });
+    it('should error session commands based off /session without session id', function () {
+      let incomingUrl = '/session/foobar/element';
+      let j = createWDProxy();
+      (() => {
+        j.getUrlForProxy(incomingUrl);
+      }).should.throw('session id');
+    });
+    it('should proxy session commands based off ', function () {
+      let incomingUrl = '/session/3d001db2-7987-42a7-975d-8d5d5304083f/timeouts/implicit_wait';
+      let j = createWDProxy({sessionId: '123'});
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(createTestURL('123', 'timeouts/implicit_wait'));
+    });
+    it('should proxy session commands based off /session as ""', function () {
+      let incomingUrl = '';
+      let j = createWDProxy();
+      (() => {
+        j.getUrlForProxy(incomingUrl);
+      }).should.throw('session id');
+      j = createWDProxy({sessionId: '123'});
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(createTestSessionURL('123'));
+    });
+    it('should proxy session commands without /session', function () {
+      let incomingUrl = '/element';
+      let j = createWDProxy({sessionId: 'barbaz'});
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(createTestURL('barbaz', 'element'));
+    });
+    it(`should proxy session commands when '/session' is in the url`, function () {
+      let incomingUrl =
+        '/session/82a9b7da-faaf-4a1d-8ef3-5e4fb5812200/cookie/session-something-or-other';
+      let j = createWDProxy({sessionId: 'barbaz'});
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(createTestURL('barbaz', 'cookie/session-something-or-other'));
+    });
+    it(`should proxy session commands when '/session' is in the url and not base on the original url`, function () {
+      let incomingUrl =
+        '/session/82a9b7da-faaf-4a1d-8ef3-5e4fb5812200/cookie/session-something-or-other';
+      let j = createWDProxy({sessionId: 'barbaz'});
+      let proxyUrl = j.getUrlForProxy(incomingUrl);
+      proxyUrl.should.equal(createTestURL('barbaz', 'cookie/session-something-or-other'));
+    });
+    it('should error session commands without /session without session id', function () {
+      let incomingUrl = '/element';
+      let j = createWDProxy();
+      (() => {
+        j.getUrlForProxy(incomingUrl);
+      }).should.throw('session id');
+    });
+  });
+});


### PR DESCRIPTION
Sooner or later we will want to jettison the cruft that comes with maintaining support for talking to JSONWP servers. I decided to reimplement jsonwp-proxy as w3c-only. I slightly changed the return interface for several of the functions but otherwise it's the same idea. Just less code. Figured we could start using it in new situations where we need a new proxy, or slowly convert existing usage of JWProxy to WDProxy.