### PR TITLE
create reusable renovate config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -151,6 +151,10 @@
       "resolved": "packages/relaxed-caps-plugin",
       "link": true
     },
+    "node_modules/@appium/renovate-config": {
+      "resolved": "packages/renovate-config",
+      "link": true
+    },
     "node_modules/@appium/schema": {
       "resolved": "packages/schema",
       "link": true
@@ -26639,6 +26643,14 @@
         "appium": "^2.0.0-beta.35"
       }
     },
+    "packages/renovate-config": {
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14",
+        "npm": ">=8"
+      }
+    },
     "packages/schema": {
       "name": "@appium/schema",
       "version": "0.0.9",
@@ -27248,6 +27260,9 @@
         "lodash": "4.17.21",
         "source-map-support": "0.5.21"
       }
+    },
+    "@appium/renovate-config": {
+      "version": "file:packages/renovate-config"
     },
     "@appium/schema": {
       "version": "file:packages/schema",

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -1,0 +1,43 @@
+# Appium's Renovate Configuration
+
+> Reusable [Renovate](https://www.mend.io) config for Appium and Appium-adjacent projects
+
+## Usage
+
+In your `renovate.json`:
+
+```json
+{
+  "extends": ["github>appium/appium/renovate"]
+}
+```
+
+## Notes
+
+> See the [Renovate docs](https://docs.renovatebot.com/) for more information on what does what.
+
+## Why
+
+### Presets in Use
+
+- `config:js-app` - everything gets pinned except peer deps
+- `:semanticPrefixChore` - Renovate's PRs have the `chore()` scope in its semantic commit message
+- `helpers:pinGitHubActionDigests` - Pins SHAs of GitHub Actions
+- `:enableVulnerabilityAlerts` - For "security" purposes
+- `:rebaseStalePrs` - Renovate will automatically rebase its PRs
+- `group:definitelyTyped` - Groups all `@types/*` packages into one PR
+- `workarounds:typesNodeVersioning` - `@types/node` tracks Node.js versions instead
+
+### Custom Rules
+
+- Automatically merge minor and patch releases / pkg pinning and digests
+- Do not upgrade to major versions of packages which have become ESM-only.  Unfortunately this is an explicit deny-list.
+- Group ESLint updates and [@appium/eslint-config-appium](https://github.com/appium/appium/tree/master/eslint-config-appium) into one PR
+- `main` is default branch; override this if using `master`
+- Enables semantic commits
+- Runs on a nightly schedule
+- Attempts transititive remediation of vulns
+
+## License
+
+Apache-2.0

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Common Renovate config for Appium packages",
+  "extends": [
+    "config:js-app",
+    ":semanticPrefixChore",
+    "helpers:pinGitHubActionDigests",
+    ":enableVulnerabilityAlerts",
+    ":rebaseStalePrs",
+    "group:definitelyTyped",
+    "workarounds:typesNodeVersioning"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": [
+        "@types/wrap-ansi",
+        "delay",
+        "env-paths",
+        "execa",
+        "find-up",
+        "get-port",
+        "globby",
+        "got",
+        "log-symbols",
+        "p-retry",
+        "read-pkg",
+        "strip-ansi",
+        "supports-color",
+        "term-size",
+        "wrap-ansi",
+        "write-pkg"
+      ],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "extends": ["packages:eslint"],
+      "matchPackageNames": ["@appium/eslint-config-appium"],
+      "groupName": "ESLint-related packages",
+      "groupSlug": "eslint"
+    }
+  ],
+  "baseBranches": ["main"],
+  "semanticCommits": "enabled",
+  "semanticCommitScope": "{{parentDir}}",
+  "schedule": ["after 10pm and before 5:00am"],
+  "timezone": "America/Vancouver",
+  "transitiveRemediation": true
+}


### PR DESCRIPTION
Closes #17659

Renovate will be dropping support for shareable configs published to npm, so the canonical way to do this is to use a github reference.  For that reason, this package shouldn't be published and is marked `private`.