### PR TITLE
fix(support): Make upgradable versions parsing more permissive

### DIFF
--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -156,14 +156,14 @@ export class NPM {
    */
   getLatestSafeUpgradeFromVersions(curVersion, allVersions) {
     let safeUpgradeVer = null;
-    const curSemver = semver.parse(curVersion);
+    const curSemver = semver.parse(curVersion) ?? semver.parse(semver.coerce(curVersion));
     if (curSemver === null) {
       throw new Error(`Could not parse current version '${curVersion}'`);
     }
     for (const testVer of allVersions) {
-      const testSemver = semver.parse(testVer);
+      const testSemver = semver.parse(testVer) ?? semver.parse(semver.coerce(testVer));
       if (testSemver === null) {
-        throw new Error(`Could not parse version to test against: '${testVer}'`);
+        continue;
       }
       // if the test version is a prerelease, ignore it
       if (testSemver.prerelease.length > 0) {

--- a/packages/support/test/unit/npm.spec.js
+++ b/packages/support/test/unit/npm.spec.js
@@ -25,6 +25,14 @@ describe('npm', function () {
       npm.getLatestSafeUpgradeFromVersions('1.0.0', versions1).should.eql('1.2.7');
       npm.getLatestSafeUpgradeFromVersions('0.2.0', versions1).should.eql('0.2.5');
     });
+    it('should throw if the current version cannot be parsed', function () {
+      should.throw(() => {
+        npm.getLatestSafeUpgradeFromVersions('', versions1).should.eql('0.2.5');
+      });
+    });
+    it('should ignore an error if one of versions cannot be parsed', function () {
+      npm.getLatestSafeUpgradeFromVersions('0.1.0', ['', '0.2.0']).should.eql('0.2.0');
+    });
   });
 
   it('should have many more unit tests');

--- a/packages/support/test/unit/npm.spec.js
+++ b/packages/support/test/unit/npm.spec.js
@@ -33,6 +33,9 @@ describe('npm', function () {
     it('should ignore an error if one of versions cannot be parsed', function () {
       npm.getLatestSafeUpgradeFromVersions('0.1.0', ['', '0.2.0']).should.eql('0.2.0');
     });
+    it('should return null if no newer version is found', function () {
+      npm.getLatestSafeUpgradeFromVersions('10', versions1).should.eql(null);
+    });
   });
 
   it('should have many more unit tests');

--- a/packages/support/test/unit/npm.spec.js
+++ b/packages/support/test/unit/npm.spec.js
@@ -1,6 +1,5 @@
 // transpile:mocha
 
-import { should } from 'chai';
 import {NPM} from '../../lib/npm';
 
 describe('npm', function () {

--- a/packages/support/test/unit/npm.spec.js
+++ b/packages/support/test/unit/npm.spec.js
@@ -27,7 +27,7 @@ describe('npm', function () {
     });
     it('should throw if the current version cannot be parsed', function () {
       should.throw(() => {
-        npm.getLatestSafeUpgradeFromVersions('', versions1).should.eql('0.2.5');
+        npm.getLatestSafeUpgradeFromVersions('', versions1);
       });
     });
     it('should ignore an error if one of versions cannot be parsed', function () {

--- a/packages/support/test/unit/npm.spec.js
+++ b/packages/support/test/unit/npm.spec.js
@@ -1,5 +1,6 @@
 // transpile:mocha
 
+import { should } from 'chai';
 import {NPM} from '../../lib/npm';
 
 describe('npm', function () {
@@ -34,7 +35,7 @@ describe('npm', function () {
       npm.getLatestSafeUpgradeFromVersions('0.1.0', ['', '0.2.0']).should.eql('0.2.0');
     });
     it('should return null if no newer version is found', function () {
-      npm.getLatestSafeUpgradeFromVersions('10', versions1).should.eql(null);
+      (null === npm.getLatestSafeUpgradeFromVersions('10', versions1)).should.be.true;
     });
   });
 


### PR DESCRIPTION
## Proposed changes

https://discuss.appium.io/t/fatal-error-could-not-parse-version-to-test-against-0/

Npm is being weird sometimes and returns versions in non-semver format. This causes the whole Appium parser to freak out, which is unexpected. The PR makes the check more flexible and tries to coerce incompatible version number if possible and/or skip them if they cannot be parsed at all.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)