### PR TITLE
re-enable log filters

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  '*.js': ['eslint --fix', 'prettier --write'],
+  '*.ts*': ['prettier --write'],
+  'appium-config-schema.js': () => [
+    'npm run --workspace=./packages/schema build',
+    'git add -A packages/schema/lib/appium-config.schema.json',
+    'npm run --workspace=./packages/types build',
+    'git add -A packages/types/lib/appium-config.ts',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -69,15 +69,6 @@
     "precommit-msg",
     "precommit-lint"
   ],
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix",
-      "prettier --write"
-    ],
-    "*.ts*": [
-      "prettier --write"
-    ]
-  },
   "prettier": {
     "bracketSpacing": false,
     "printWidth": 100,

--- a/packages/appium/lib/schema/schema.js
+++ b/packages/appium/lib/schema/schema.js
@@ -43,6 +43,8 @@ export class RoachHotelMap extends Map {
  */
 export const ALLOWED_SCHEMA_EXTENSIONS = new Set(['.json', '.js', '.cjs']);
 
+const SCHEMA_KEY = '$schema';
+
 /**
  * A wrapper around Ajv and schema-related functions.
  *
@@ -441,6 +443,9 @@ class AppiumSchema {
     for (const {properties, prefix} of stack) {
       const pairs = _.toPairs(properties);
       for (const [key, value] of pairs) {
+        if (key === SCHEMA_KEY) {
+          continue;
+        }
         const {properties, $ref} = value;
         if (properties) {
           stack.push({

--- a/packages/appium/test/e2e/config-file.e2e.spec.js
+++ b/packages/appium/test/e2e/config-file.e2e.spec.js
@@ -5,20 +5,21 @@ import {readConfigFile} from '../../lib/config-file';
 import {finalizeSchema, registerSchema, resetSchema} from '../../lib/schema/schema';
 import extSchema from '../fixtures/driver-schema';
 import {resolveFixture} from '../helpers';
+import _ from 'lodash';
+
+const resolveConfigFixture = _.partial(resolveFixture, 'config');
 
 describe('config file behavior', function () {
-  const GOOD_FILEPATH = resolveFixture('config', 'appium-config-good.json');
-  const BAD_NODECONFIG_FILEPATH = resolveFixture('config', 'appium-config-bad-nodeconfig.json');
-  const BAD_FILEPATH = resolveFixture('config', 'appium-config-bad.json');
-  const INVALID_JSON_FILEPATH = resolveFixture('config', 'appium-config-invalid.json');
-  const SECURITY_ARRAY_FILEPATH = resolveFixture('config', 'appium-config-security-array.json');
-  const SECURITY_DELIMITED_FILEPATH = resolveFixture(
-    'config',
-    'appium-config-security-delimited.json'
-  );
-  const SECURITY_PATH_FILEPATH = resolveFixture('config', 'appium-config-security-path.json');
-  const UNKNOWN_PROPS_FILEPATH = resolveFixture('config', 'appium-config-ext-unknown-props.json');
-  const EXT_PROPS_FILEPATH = resolveFixture('config', 'appium-config-ext-good.json');
+  const GOOD_FILEPATH = resolveConfigFixture('appium-config-good.json');
+  const BAD_NODECONFIG_FILEPATH = resolveConfigFixture('appium-config-bad-nodeconfig.json');
+  const BAD_FILEPATH = resolveConfigFixture('appium-config-bad.json');
+  const INVALID_JSON_FILEPATH = resolveConfigFixture('appium-config-invalid.json');
+  const SECURITY_ARRAY_FILEPATH = resolveConfigFixture('appium-config-security-array.json');
+  const SECURITY_DELIMITED_FILEPATH = resolveConfigFixture('appium-config-security-delimited.json');
+  const SECURITY_PATH_FILEPATH = resolveConfigFixture('appium-config-security-path.json');
+  const UNKNOWN_PROPS_FILEPATH = resolveConfigFixture('appium-config-ext-unknown-props.json');
+  const EXT_PROPS_FILEPATH = resolveConfigFixture('appium-config-ext-good.json');
+  const LOG_FILTERS_FILEPATH = resolveConfigFixture('appium-config-log-filters.json');
 
   beforeEach(function () {
     finalizeSchema();
@@ -71,7 +72,7 @@ describe('config file behavior', function () {
         });
       });
 
-      describe('server.nodeconfig behavior', function () {
+      describe('`server.nodeconfig` behavior', function () {
         describe('when a string', function () {
           it('should return errors', async function () {
             const result = await readConfigFile(BAD_NODECONFIG_FILEPATH);
@@ -87,7 +88,7 @@ describe('config file behavior', function () {
         });
       });
 
-      describe('server.allow-insecure behavior', function () {
+      describe('`server.allow-insecure` behavior', function () {
         describe('when a string path', function () {
           it('should return errors', async function () {
             const result = await readConfigFile(SECURITY_PATH_FILEPATH);
@@ -112,6 +113,26 @@ describe('config file behavior', function () {
                 },
               },
               filepath: SECURITY_ARRAY_FILEPATH,
+              errors: [],
+            });
+          });
+        });
+      });
+
+      describe('`server.log-filters` behavior', function () {
+        describe('when the log filters are valid', function () {
+          it('should return a valid config object', async function () {
+            const result = await readConfigFile(LOG_FILTERS_FILEPATH);
+            result.should.deep.equal({
+              config: {
+                server: {
+                  logFilters: [
+                    {text: 'foo', replacer: 'bar'},
+                    {pattern: '/foo/', flags: 'i'},
+                  ],
+                },
+              },
+              filepath: LOG_FILTERS_FILEPATH,
               errors: [],
             });
           });

--- a/packages/appium/test/fixtures/config/appium-config-log-filters.json
+++ b/packages/appium/test/fixtures/config/appium-config-log-filters.json
@@ -1,0 +1,14 @@
+{
+  "server": {
+    "log-filters": [
+      {
+        "text": "foo",
+        "replacer": "bar"
+      },
+      {
+        "pattern": "/foo/",
+        "flags": "i"
+      }
+    ]
+  }
+}

--- a/packages/appium/test/fixtures/flattened-schema.js
+++ b/packages/appium/test/fixtures/flattened-schema.js
@@ -252,11 +252,11 @@ export default [
       ref: 'appium.json#/properties/server/properties/log-filters',
     },
     schema: {
-      $comment: 'TODO',
       description: 'One or more log filtering rules',
-      items: {type: 'string'},
       title: 'log-filters config',
       type: 'array',
+      items: {$ref: '#/$defs/logFilter'},
+      appiumCliTransformer: 'json',
     },
   },
   {

--- a/packages/appium/test/fixtures/log-filters.json
+++ b/packages/appium/test/fixtures/log-filters.json
@@ -1,0 +1,10 @@
+[
+  {
+    "text": "foo",
+    "replacer": "bar"
+  },
+  {
+    "pattern": "/foo/",
+    "flags": "i"
+  }
+]

--- a/packages/appium/test/unit/parser.spec.js
+++ b/packages/appium/test/unit/parser.spec.js
@@ -9,6 +9,7 @@ import {resolveFixture} from '../helpers';
 const ALLOW_FIXTURE = resolveFixture('allow-feat.txt');
 const DENY_FIXTURE = resolveFixture('deny-feat.txt');
 const CAPS_FIXTURE = resolveFixture('caps.json');
+const LOG_FILTERS_FIXTURE = resolveFixture('log-filters.json');
 
 describe('parser', function () {
   let p;
@@ -151,6 +152,10 @@ describe('parser', function () {
 
       it('should recognize --log-level', function () {
         p.parseArgs(['--log-level', 'debug']).should.have.property('loglevel', 'debug');
+      });
+
+      it('should parse a file for --log-filters', function () {
+        p.parseArgs(['--log-filters', LOG_FILTERS_FIXTURE]).should.have.property('logFilters');
       });
     });
 

--- a/packages/schema/lib/appium-config-schema.js
+++ b/packages/schema/lib/appium-config-schema.js
@@ -9,6 +9,13 @@ export const AppiumConfigJsonSchema = /** @type {const} */ ({
   additionalProperties: false,
   description: 'A schema for Appium configuration files',
   properties: {
+    $schema: {
+      description: 'The JSON schema for this file',
+      default:
+        'https://raw.githubusercontent.com/appium/appium/master/packages/schema/lib/appium-config.schema.json',
+      type: 'string',
+      format: 'uri',
+    },
     server: {
       additionalProperties: false,
       description: 'Configuration when running Appium as a server',

--- a/packages/schema/lib/appium-config-schema.js
+++ b/packages/schema/lib/appium-config-schema.js
@@ -128,13 +128,11 @@ export const AppiumConfigJsonSchema = /** @type {const} */ ({
           type: 'string',
         },
         'log-filters': {
-          $comment: 'TODO',
           description: 'One or more log filtering rules',
-          items: {
-            type: 'string',
-          },
           title: 'log-filters config',
           type: 'array',
+          items: {$ref: '#/$defs/logFilter'},
+          appiumCliTransformer: 'json',
         },
         'log-level': {
           appiumCliDest: 'loglevel',
@@ -289,4 +287,60 @@ export const AppiumConfigJsonSchema = /** @type {const} */ ({
   },
   title: 'Appium Configuration',
   type: 'object',
+  $defs: {
+    logFilterText: {
+      type: 'object',
+      description: 'Log filter with plain text',
+      properties: {
+        text: {
+          description: 'Text to match',
+          type: 'string',
+        },
+      },
+      required: ['text'],
+      not: {
+        required: ['pattern'],
+      },
+    },
+    logFilterRegex: {
+      type: 'object',
+      description: 'Log filter with regular expression',
+      properties: {
+        pattern: {
+          description: 'Regex pattern to match',
+          type: 'string',
+          format: 'regex',
+        },
+      },
+      required: ['pattern'],
+      not: {
+        required: ['text'],
+      },
+    },
+    logFilter: {
+      type: 'object',
+      description: 'Log filtering rule',
+      allOf: [
+        {
+          type: 'object',
+          properties: {
+            replacer: {
+              description: 'Replacement string for matched text',
+              type: 'string',
+              default: '**SECURE**',
+            },
+            flags: {
+              description:
+                'Matching flags; see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags',
+              type: 'string',
+              pattern: '^[igmsduy](,[igmsduy])*$',
+            },
+          },
+        },
+        {
+          oneOf: [{$ref: '#/$defs/logFilterText'}, {$ref: '#/$defs/logFilterRegex'}],
+        },
+      ],
+    },
+  },
 });

--- a/packages/schema/lib/appium-config.schema.json
+++ b/packages/schema/lib/appium-config.schema.json
@@ -128,13 +128,13 @@
           "type": "string"
         },
         "log-filters": {
-          "$comment": "TODO",
           "description": "One or more log filtering rules",
-          "items": {
-            "type": "string"
-          },
           "title": "log-filters config",
-          "type": "array"
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/logFilter"
+          },
+          "appiumCliTransformer": "json"
         },
         "log-level": {
           "appiumCliDest": "loglevel",
@@ -280,5 +280,75 @@
     }
   },
   "title": "Appium Configuration",
-  "type": "object"
+  "type": "object",
+  "$defs": {
+    "logFilterText": {
+      "type": "object",
+      "description": "Log filter with plain text",
+      "properties": {
+        "text": {
+          "description": "Text to match",
+          "type": "string"
+        }
+      },
+      "required": [
+        "text"
+      ],
+      "not": {
+        "required": [
+          "pattern"
+        ]
+      }
+    },
+    "logFilterRegex": {
+      "type": "object",
+      "description": "Log filter with regular expression",
+      "properties": {
+        "pattern": {
+          "description": "Regex pattern to match",
+          "type": "string",
+          "format": "regex"
+        }
+      },
+      "required": [
+        "pattern"
+      ],
+      "not": {
+        "required": [
+          "text"
+        ]
+      }
+    },
+    "logFilter": {
+      "type": "object",
+      "description": "Log filtering rule",
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "replacer": {
+              "description": "Replacement string for matched text",
+              "type": "string",
+              "default": "**SECURE**"
+            },
+            "flags": {
+              "description": "Matching flags; see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags",
+              "type": "string",
+              "pattern": "^[igmsduy](,[igmsduy])*$"
+            }
+          }
+        },
+        {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/logFilterText"
+            },
+            {
+              "$ref": "#/$defs/logFilterRegex"
+            }
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/packages/schema/lib/appium-config.schema.json
+++ b/packages/schema/lib/appium-config.schema.json
@@ -3,6 +3,12 @@
   "additionalProperties": false,
   "description": "A schema for Appium configuration files",
   "properties": {
+    "$schema": {
+      "description": "The JSON schema for this file",
+      "default": "https://raw.githubusercontent.com/appium/appium/master/packages/schema/lib/appium-config.schema.json",
+      "type": "string",
+      "format": "uri"
+    },
     "server": {
       "additionalProperties": false,
       "description": "Configuration when running Appium as a server",

--- a/packages/support/lib/log-internal.js
+++ b/packages/support/lib/log-internal.js
@@ -3,6 +3,15 @@ import _ from 'lodash';
 
 const DEFAULT_REPLACER = '**SECURE**';
 
+/**
+ * Type guard for log filter type
+ * @param {object} value
+ * @returns {value is import('@appium/types').LogFilterRegex}
+ */
+function isLogFilterRegex(value) {
+  return 'pattern' in value;
+}
+
 class SecureValuesPreprocessor {
   constructor() {
     this._rules = [];
@@ -19,7 +28,7 @@ class SecureValuesPreprocessor {
   /**
    * Parses single rule from the given JSON file
    *
-   * @param {string|Rule} rule The rule might either be represented as a single string
+   * @param {string|import('@appium/types').LogFilter} rule The rule might either be represented as a single string
    * or a configuration object
    * @throws {Error} If there was an error while parsing the rule
    * @returns {SecureValuePreprocessingRule} The parsed rule
@@ -34,7 +43,7 @@ class SecureValuesPreprocessor {
       }
       pattern = `\\b${_.escapeRegExp(rule)}\\b`;
     } else if (_.isPlainObject(rule)) {
-      if (_.has(rule, 'pattern')) {
+      if (isLogFilterRegex(rule)) {
         if (!_.isString(rule.pattern) || rule.pattern.length === 0) {
           throw new Error(
             `${JSON.stringify(rule)} -> The value of 'pattern' must be a valid non-empty string`
@@ -81,7 +90,7 @@ class SecureValuesPreprocessor {
   /**
    * Loads rules from the given JSON file
    *
-   * @param {string|string[]|Rule[]} source The full path to the JSON file containing secure
+   * @param {string|string[]|import('@appium/types').LogFiltersConfig} source The full path to the JSON file containing secure
    * values replacement rules or the rules themselves represented as an array
    * @throws {Error} If the format of the source file is invalid or
    * it does not exist
@@ -143,19 +152,6 @@ const SECURE_VALUES_PREPROCESSOR = new SecureValuesPreprocessor();
 
 export {SECURE_VALUES_PREPROCESSOR, SecureValuesPreprocessor};
 export default SECURE_VALUES_PREPROCESSOR;
-
-/**
- * @typedef Rule
- * @property {string} pattern A valid RegExp pattern to be replaced
- * @property {string} text A text match to replace. Either this property or the
- * above one must be provided. `pattern` has priority over `text` if both are provided.
- * @property {string} [flags] Regular expression flags for the given pattern.
- * Supported flag are the same as for the standard JavaScript RegExp constructor:
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags_2
- * The 'g' (global matching) is always enabled though.
- * @property {string} [replacer] The replacer value to use. By default
- * equals to `DEFAULT_SECURE_REPLACER`
- */
 
 /**
  * @typedef SecureValuePreprocessingRule

--- a/packages/support/lib/logging.js
+++ b/packages/support/lib/logging.js
@@ -137,10 +137,9 @@ function getLogger(prefix = null) {
  * appear in Appium logs.
  * Each call to this method replaces the previously loaded rules if any existed.
  *
- * @param {string|string[]|import('./log-internal').Rule[]} rulesJsonPath The full path to the JSON file containing
+ * @param {string|string[]|import('@appium/types').LogFiltersConfig} rulesJsonPath The full path to the JSON file containing
  * the replacement rules. Each rule could either be a string to be replaced
- * or an object with predefined properties. See the `Rule` type definition in
- * `log-internals.js` to get more details on its format.
+ * or an object with predefined properties.
  * @throws {Error} If the given file cannot be loaded
  * @returns {Promise<LoadResult>}
  */

--- a/packages/support/test/unit/log-internals.spec.js
+++ b/packages/support/test/unit/log-internals.spec.js
@@ -6,6 +6,7 @@ import {SecureValuesPreprocessor} from '../../lib/log-internal';
 const CONFIG_PATH = path.resolve(os.tmpdir(), 'rules.json');
 
 describe('Log Internals', function () {
+  /** @type {import('../../lib/log-internal').SecureValuesPreprocessor} */
   let preprocessor;
 
   beforeEach(function () {
@@ -45,6 +46,7 @@ describe('Log Internals', function () {
   });
 
   it(`should preprocess a string and apply a rule where 'pattern' has priority over 'text'`, async function () {
+    // NOTE: this is disallowed in the config schema, but is currently allowed when using an external JSON file.
     const replacer = '***';
     const issues = await preprocessor.loadRules([{pattern: '^:', text: 'yo', replacer}]);
     issues.length.should.eql(0);

--- a/packages/types/lib/appium-config.ts
+++ b/packages/types/lib/appium-config.ts
@@ -134,6 +134,10 @@ export type WebhookConfig = string;
  * A schema for Appium configuration files
  */
 export interface AppiumConfiguration {
+  /**
+   * The JSON schema for this file
+   */
+  $schema?: string;
   server?: ServerConfig;
 }
 /**

--- a/packages/types/lib/appium-config.ts
+++ b/packages/types/lib/appium-config.ts
@@ -50,9 +50,23 @@ export type LocalTimezoneConfig = boolean;
  */
 export type LogConfig = string;
 /**
+ * Log filtering rule
+ */
+export type LogFilter = {
+  /**
+   * Replacement string for matched text
+   */
+  replacer?: string;
+  /**
+   * Matching flags; see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#advanced_searching_with_flags
+   */
+  flags?: string;
+  [k: string]: unknown;
+} & (LogFilterText | LogFilterRegex);
+/**
  * One or more log filtering rules
  */
-export type LogFiltersConfig = string[];
+export type LogFiltersConfig = LogFilter[];
 /**
  * Log level (console[:file])
  */
@@ -185,6 +199,26 @@ export interface DefaultCapabilitiesConfig {
  * Driver-specific configuration. Keys should correspond to driver package names
  */
 export interface DriverConfig {
+  [k: string]: unknown;
+}
+/**
+ * Log filter with plain text
+ */
+export interface LogFilterText {
+  /**
+   * Text to match
+   */
+  text: string;
+  [k: string]: unknown;
+}
+/**
+ * Log filter with regular expression
+ */
+export interface LogFilterRegex {
+  /**
+   * Regex pattern to match
+   */
+  pattern: string;
   [k: string]: unknown;
 }
 /**


### PR DESCRIPTION
Server option `log-filters` is now supported via embedding in Appium config files _or_ via CLI using an external JSON file.  This option became broken during the switchover to config files.  Note that a config file cannot reference an external JSON file.

Example fixtures included.

Note that the `Rule` type has been replaced with the `LogFilter` type automatically generated from the schema (see previous commit).

Additionally, to support this change:

1. `$schema` is now an allowed property in a config file, so that a config file author can refer to the Appium config schema for validation.  We should actually host this schema JSON somewhere and version it properly.
2. As a pre-commit hook, any change to the master Appium config schema `.js` file causes a) a `.json` equivalent to be generated and added to the changeset, and b) the config file TS declaration to get updated and added to the changeset.