### PR TITLE
chore(renovate): group appium updates & other improvements

### DIFF
--- a/renovate/README.md
+++ b/renovate/README.md
@@ -4,13 +4,23 @@
 
 ## Usage
 
-In your `renovate.json`:
+Modify your Renovate config file (`renovate.json`, etc.) to extend:
+
+```json
+"github>appium/appium//renovate/default"
+```
+
+For example, a JSON config should contain:
 
 ```json
 {
-  "extends": ["github>appium/appium/renovate"]
+  "extends": [
+    "github>appium/appium//renovate/default"
+  ]
 }
 ```
+
+If you already have a top-level `extends`, then append this to the list.
 
 ## Notes
 
@@ -18,22 +28,35 @@ In your `renovate.json`:
 
 ## Why
 
+Appium-the-project has many repos--not just this one!  We found ourselves duplicating most of this config across packages, so here's a reusable config.
+
+Appium extension authors--or anyone else--may use this config as well.
+
 ### Presets in Use
 
-- `config:js-app` - everything gets pinned except peer deps
-- `:semanticPrefixChore` - Renovate's PRs have the `chore()` scope in its semantic commit message
+- `config:js-app` - everything gets pinned except peer deps (plus a bunch of other reasonable defaults)
+- `group:definitelyTyped` - Groups all `@types/*` packages into one PR
 - `helpers:pinGitHubActionDigests` - Pins SHAs of GitHub Actions
+- `workarounds:typesNodeVersioning` - `@types/node` tracks Node.js versions instead
+- `:automergePatch` - Automatically merges "patch" and "pin" updates (assuming they pass CI)
+- `:automergeMinor` - Automatically merges "minor" updates (assuming they pass CI)
+- `:automergeDigest` - Automatically merges "digest" updates (assuming they pass CI)
 - `:enableVulnerabilityAlerts` - For "security" purposes
 - `:rebaseStalePrs` - Renovate will automatically rebase its PRs
-- `group:definitelyTyped` - Groups all `@types/*` packages into one PR
-- `workarounds:typesNodeVersioning` - `@types/node` tracks Node.js versions instead
+- `:semanticPrefixChore` - Renovate's PRs have the `chore()` scope in its semantic commit message
 
 ### Custom Rules
 
-- Automatically merge minor and patch releases / pkg pinning and digests
 - Do not upgrade to major versions of packages which have become ESM-only.  Unfortunately this is an explicit deny-list.
-- Group ESLint updates and [@appium/eslint-config-appium](https://github.com/appium/appium/tree/master/eslint-config-appium) into one PR
-- `main` is default branch; override this if using `master`
+- Groups (groups updates into single PR):
+  - ESLint-related and [@appium/eslint-config-appium](https://github.com/appium/appium/tree/master/eslint-config-appium)
+  - [teen_process](https://github.com/appium/node-teen_process) and its DT types
+  - Appium-scoped (`@appium`) packages. This applies to _other_ repos which depend on Appium, such as official drivers.
+
+> Note: The packages in the do-not-upgrade-majors list _may or may not be used_ by Appium; the intent is to not remove anything from this list (unless they start publishing CJS again).
+
+### Additional Config
+
 - Enables semantic commits
 - Runs on a nightly schedule
 - Attempts transititive remediation of vulns

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -3,18 +3,17 @@
   "description": "Common Renovate config for Appium packages",
   "extends": [
     "config:js-app",
-    ":semanticPrefixChore",
+    "group:definitelyTyped",
     "helpers:pinGitHubActionDigests",
+    "workarounds:typesNodeVersioning",
+    ":automergePatch",
+    ":automergeMinor",
+    ":automergeDigest",
     ":enableVulnerabilityAlerts",
     ":rebaseStalePrs",
-    "group:definitelyTyped",
-    "workarounds:typesNodeVersioning"
+    ":semanticPrefixChore"
   ],
   "packageRules": [
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true
-    },
     {
       "matchPackageNames": [
         "@types/wrap-ansi",
@@ -53,6 +52,12 @@
       "matchPackageNames": ["teen_process", "@types/teen_process"],
       "groupName": "teen_process-related packages",
       "groupSlug": "teen_process"
+    },
+    {
+      "matchPackagePrefixes": ["@appium/"],
+      "excludePackageNames": ["@appium/eslint-config-appium"],
+      "groupName": "Appium-related packages",
+      "groupSlug": "appium"
     }
   ],
   "semanticCommits": "enabled",


### PR DESCRIPTION
This PR groups all `@appium/*` packages together, but also:

- Replaces a handrolled config with some official presets
- Updates `README.md` with the correct usage and accurate information
