### PR TITLE
docs: rename C# repository to 'dotnet-client'

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ for the particular driver or whether it supports parallel sessions.
    [WebDriver](https://w3c.github.io/webdriver/webdriver-spec.html)-compatible
    language such as [Java](https://github.com/appium/java-client),
    [JavaScript](https://webdriver.io/), [Python](https://github.com/appium/python-client),
-   [Ruby](https://github.com/appium/ruby_lib), [C#](https://github.com/appium/appium-dotnet-driver)
+   [Ruby](https://github.com/appium/ruby_lib), [C#](https://github.com/appium/dotnet-client)
    with the Selenium WebDriver API. There are also various third party
    client implementations for other languages.
 3. You can use any testing framework.

--- a/packages/appium/README.md
+++ b/packages/appium/README.md
@@ -193,7 +193,7 @@ for the particular driver or whether it supports parallel sessions.
    [WebDriver](https://w3c.github.io/webdriver/webdriver-spec.html)-compatible
    language such as [Java](https://github.com/appium/java-client),
    [JavaScript](https://webdriver.io/), [Python](https://github.com/appium/python-client),
-   [Ruby](https://github.com/appium/ruby_lib), [C#](https://github.com/appium/appium-dotnet-driver)
+   [Ruby](https://github.com/appium/ruby_lib), [C#](https://github.com/appium/dotnet-client)
    with the Selenium WebDriver API. There are also various third party
    client implementations for other languages.
 3. You can use any testing framework.

--- a/packages/appium/docs/en/ecosystem/index.md
+++ b/packages/appium/docs/en/ecosystem/index.md
@@ -48,7 +48,7 @@ the Appium client depends on) since that is what you will use as your primary in
 |[Appium Python client](https://github.com/appium/python-client)|Python|Appium Team|
 |[Appium Ruby client](https://github.com/appium/ruby_lib)|Ruby|Appium Team|
 |[WebDriverIO](https://webdriver.io)|Node.js|Community|
-|[Appium .NET client](https://github.com/appium/appium-dotnet-driver)|C#|Appium Team*|
+|[Appium .NET client](https://github.com/appium/dotnet-client)|C#|Appium Team*|
 |[RobotFramework](https://github.com/serhatbolsu/robotframework-appiumlibrary)|DSL|Community|
 
 !!! warning

--- a/packages/appium/docs/ja/about/appium-clients.md
+++ b/packages/appium/docs/ja/about/appium-clients.md
@@ -11,7 +11,7 @@ Appium サーバー自体が公式プロトコルへのカスタム拡張を定�
 Ruby | [https://github.com/appium/ruby_lib_core](https://github.com/appium/ruby_lib_core)(推奨), [https://github.com/appium/ruby_lib](https://github.com/appium/ruby_lib)
 Python | [https://github.com/appium/python-client](https://github.com/appium/python-client)
 Java | [https://github.com/appium/java-client](https://github.com/appium/java-client)
-C# (.NET) | [https://github.com/appium/appium-dotnet-driver](https://github.com/appium/appium-dotnet-driver)
+C# (.NET) | [https://github.com/appium/dotnet-client](https://github.com/appium/dotnet-client)
 
 ### Community based
 


### PR DESCRIPTION
## Proposed changes

I think the [C#](https://github.com/appium/appium-dotnet-driver) repository should get in line with the java and python clients in regard to the naming. (dotnet-client)
I've updated in advance the related docs files on the Appium repo to match the new name.

Related PR: https://github.com/appium/appium-dotnet-driver/pull/547

Side note: Although I'm considered a Collaborator, I don't have permission to re-naming the [repo](https://github.com/appium/appium-dotnet-driver).

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
