### PR TITLE
docs(1.x): Add missing parameter to start-activity.

### DIFF
--- a/commands-yml/commands/device/activity/start-activity.yml
+++ b/commands-yml/commands/device/activity/start-activity.yml
@@ -76,6 +76,9 @@ endpoint:
     - name: appWaitPackage
       type: string
       description: Automation will begin after this package starts
+    - name: appWaitActivity
+      type: string
+      description: Automation will begin after this activity starts
     - name: intentAction
       type: string
       description: "[Intent](https://developer.android.com/reference/android/content/Intent.html) action which will be used to start activity"


### PR DESCRIPTION
## Proposed changes

Add missing `appWaitActivity` parameter to start-activity. This parameter is present in appium-base-dir's [routes.js](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js#L536) file but is missing from the docs.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
