### PR TITLE
chore(): fix lerna config for v6

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -21,5 +21,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "independent"
+  "version": "independent",
+  "useWorkspaces": true
 }


### PR DESCRIPTION
Suppresses warnings when running `lerna`:

- `useWorkspaces: true` should be in there

We no longer need `packages`, but `sync-monorepo-packages` needs updating to understand npm workspaces.