### PR TITLE
chore(renovate): update semantic commit behavior

### DIFF
--- a/renovate/README.md
+++ b/renovate/README.md
@@ -43,7 +43,8 @@ Appium extension authors--or anyone else--may use this config as well.
 - `:automergeDigest` - Automatically merges "digest" updates (assuming they pass CI)
 - `:enableVulnerabilityAlerts` - For "security" purposes
 - `:rebaseStalePrs` - Renovate will automatically rebase its PRs
-- `:semanticPrefixChore` - Renovate's PRs have the `chore()` scope in its semantic commit message
+- `:semanticCommits` - Renovate will use semantic commit messages
+- `:semanticPrefixChore` - Renovate's PRs have the `chore` prefix in its semantic commit message
 
 ### Custom Rules
 
@@ -57,7 +58,7 @@ Appium extension authors--or anyone else--may use this config as well.
 
 ### Additional Config
 
-- Enables semantic commits
+- Uses the parent directory for the commit scope if applicable; otherwise uses `deps`. The parent directory is _typically_ only applicable in monorepos.
 - Attempts transititive remediation of vulns
 
 ## License

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -11,6 +11,7 @@
     ":automergeDigest",
     ":enableVulnerabilityAlerts",
     ":rebaseStalePrs",
+    ":sematicCommits",
     ":semanticPrefixChore"
   ],
   "packageRules": [
@@ -60,7 +61,6 @@
       "groupSlug": "appium"
     }
   ],
-  "semanticCommits": "enabled",
-  "semanticCommitScope": "{{parentDir}}",
+  "semanticCommitScope": "{{#if parentDir}}{{parentDir}}{{else}}deps{{/if}}",
   "transitiveRemediation": true
 }


### PR DESCRIPTION
The current intended behavior (to use the "parent dir") as the scope is often or always broken.  An empty scope within parens is actually an invalid conventional commit message.  So instead of `chore():` it will be `chore:`.

We could instead pick a scope (like `deps` or something) but figured it was not important enough to do.
