### PR TITLE
chore: add .editorconfig and autoformat json files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -7,4 +7,5 @@ module.exports = {
     'npm run --workspace=./packages/types build',
     'git add -A packages/types/lib/appium-config.ts',
   ],
+  '!(package|package-lock)*.json': ['prettier --write'],
 };

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,8 +3,8 @@
 **/fixtures/**
 **/*.min.*
 **/*.md
-**/*.yml
-**/*.json
+package-lock.json
+package.json
 **/.vscode/**
 **/*.html
 **/generated/**


### PR DESCRIPTION
Many programs (IDEs, editors, eslint, prettier) respect editorconfig files; useful to have around.

The reason markdown has "don't trim trailing whitespace" is due to the GFM convention of "two spaces after the end of line inserts a linebreak/`<br/>`"

This also enables automatic formatting of JSON files _except_ `package.json` and `package-lock.json`, since that is likely to cause too much churn.
