### PR TITLE
chore(renovate): move schedule away from shared config

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>appium/appium//renovate/default"
-  ]
+  "extends": ["github>appium/appium//renovate/default"],
+  "schedule": ["after 10pm and before 5:00am"],
+  "timezone": "America/Vancouver"
 }

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -58,7 +58,6 @@ Appium extension authors--or anyone else--may use this config as well.
 ### Additional Config
 
 - Enables semantic commits
-- Runs on a nightly schedule
 - Attempts transititive remediation of vulns
 
 ## License

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -62,7 +62,5 @@
   ],
   "semanticCommits": "enabled",
   "semanticCommitScope": "{{parentDir}}",
-  "schedule": ["after 10pm and before 5:00am"],
-  "timezone": "America/Vancouver",
   "transitiveRemediation": true
 }


### PR DESCRIPTION
The schedule is helpful in the context of a larger monorepo like Appium, but not so much in the context of a standalone package which consumes the shared config.
