### PR TITLE
chore: improve package-lock.json merging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto eol=lf
+
+# Handle as a text file but merge as binary.
+package-lock.json merge=binary


### PR DESCRIPTION
Yeah I got sick of this.  It won't help conflicts seen by GitHub, but it'll make our lives easier when rebasing PRs.

So what this does is treats `package-lock.json` as a text file _except_ when attempting to merge. The result will be that if `package-lock.json` is in a conflicted state, it will not contain conflict markers within the file itself like a regular text file would; it will only have the "conflicted" flag set by git.  This means that to resolve a conflict in `package-lock.json` going forward, all one needs to do is run `npm install && git add -A package-lock.json`, as `npm` will fix `package-lock.json` itself.  In theory.

