### PR TITLE
chore: update TS configuration

### DIFF
--- a/config/tsconfig.base.json
+++ b/config/tsconfig.base.json
@@ -1,17 +1,20 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "ts-node": {
+    "transpileOnly": true
+  },
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
     "composite": true,
     "declaration": true,
     "declarationMap": true,
-    "module": "CommonJS",
-    "moduleResolution": "node",
     "resolveJsonModule": true,
     "strictNullChecks": true,
+    "sourceMap": true,
     "removeComments": false,
-    "target": "ES2020",
+    "strict": false,
     "types": ["node", "mocha", "chai", "sinon-chai", "chai-as-promised"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@colors/colors": "1.5.0",
         "@commitlint/cli": "17.3.0",
         "@commitlint/config-conventional": "17.3.0",
+        "@tsconfig/node14": "1.0.3",
         "@types/chai": "4.3.4",
         "@types/chai-as-promised": "7.1.5",
         "@types/mocha": "10.0.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@colors/colors": "1.5.0",
     "@commitlint/cli": "17.3.0",
     "@commitlint/config-conventional": "17.3.0",
+    "@tsconfig/node14": "1.0.3",
     "@types/chai": "4.3.4",
     "@types/chai-as-promised": "7.1.5",
     "@types/mocha": "10.0.1",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "build": "node ./scripts/generate-schema-json.js",
-    "clean": "git checkout -- ./lib/appium-config.schema.json",
+    "clean": "git checkout -- ./lib/appium-config.schema.json || true",
     "test:smoke": "node ./index.js"
   },
   "dependencies": {

--- a/packages/support/lib/net.js
+++ b/packages/support/lib/net.js
@@ -145,7 +145,7 @@ async function uploadFileToFtp(
  */
 function isHttpUploadOptions(opts, url) {
   try {
-    const {protocol} = new URL(url);
+    const {protocol} = url;
     return protocol === 'http:' || protocol === 'https:';
   } catch {
     return false;
@@ -160,7 +160,7 @@ function isHttpUploadOptions(opts, url) {
  */
 function isNotHttpUploadOptions(opts, url) {
   try {
-    const {protocol} = new URL(url);
+    const {protocol} = url;
     return protocol === 'ftp:';
   } catch {
     return false;

--- a/packages/typedoc-plugin-appium/index.js
+++ b/packages/typedoc-plugin-appium/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./build/plugin.js');
+module.exports = require('./build/lib/plugin.js');

--- a/packages/typedoc-plugin-appium/package.json
+++ b/packages/typedoc-plugin-appium/package.json
@@ -19,6 +19,8 @@
   "author": "https://github.com/appium",
   "types": "./build/plugin.d.ts",
   "scripts": {
+    "build": "cpy resources build",
+    "clean": "npx rimraf build/resources",
     "test": "exit 0",
     "test:e2e": "exit 0",
     "test:smoke": "node ./index.js",
@@ -34,7 +36,8 @@
   "files": [
     "index.js",
     "lib",
-    "build",
+    "build/lib",
+    "build/resources",
     "resources"
   ],
   "engines": {

--- a/packages/typedoc-plugin-appium/tsconfig.json
+++ b/packages/typedoc-plugin-appium/tsconfig.json
@@ -1,14 +1,8 @@
 {
   "extends": "../../config/tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "lib",
-    "outDir": "build",
-    "strict": true,
-    "module": "CommonJS",
-    "sourceMap": true,
-    "lib": ["ES2022"],
-    "downlevelIteration": true
+    "rootDir": ".",
+    "outDir": "build"
   },
-  "include": ["lib/**/*.ts*"],
-  "references": []
+  "include": ["lib", "test"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "build": "node ./scripts/generate-schema-types.js",
-    "clean": "git checkout -- ./types/lib/appium-config.ts",
+    "clean": "git checkout -- ./types/lib/appium-config.ts || true",
     "test:smoke": "node ./index.js"
   },
   "dependencies": {

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "build",
     "checkJs": true,
+    "strict": true,
     "paths": {
       "@appium/schema": ["../schema"]
     }

--- a/test/setup.js
+++ b/test/setup.js
@@ -13,7 +13,7 @@
  *
  */
 
-require('ts-node').register({transpileOnly: true});
+require('ts-node').register();
 
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,12 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "ts-node": {
+    "transpileOnly": true
+  },
   "files": [],
   "compilerOptions": {
-    "noErrorTruncation": true,
-    "esModuleInterop": true
+    "noErrorTruncation": true
   },
   "references": [
     {
@@ -61,9 +65,6 @@
     },
     {
       "path": "packages/fake-driver"
-    },
-    {
-      "path": "packages/typedoc-plugin-appium"
     },
     {
       "path": "packages/typedoc-plugin-appium"


### PR DESCRIPTION
This pulls in some recommended settings from `@tsconfig/node14` (a proper TS target configuration for Node.js v14; ours wasn't _wrong_ per se, but this is better) and allows us more flexible use of `ts-node`.  Use of this module is recommended by `ts-node` (which we need to run tests).

`ts-node`'s behavior changes _depending on the directory in which it's run_--and this can cause some really nonsensical bugs--so the changes here ensure that it will act the same regardless of if you're running tests from a package directory or the monorepo root.

Also:

- Ensure various `clean` scripts don't fail if they've been run before `build`
- Enable `strict` mode in `@appium/types` cause we can
- Fix a type issue found in `@appium/support`; this does not appear to have been a traditional bug but rather a type disagreement surfaced by the new config
