### PR TITLE
chore(vscode): fix launch configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,32 +1,62 @@
 {
-  "version": "0.2.0",
   "configurations": [
     {
-      "args": ["--colors", "--timeout", "0", "${file}"],
-      "internalConsoleOptions": "openOnSessionStart",
-      "name": "Test - Current File",
-      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
-      "runtimeArgs": ["--require", "@babel/register"],
-      "request": "launch",
-      "skipFiles": ["<node_internals>/**", "**/node_modules/mocha/**"],
-      "type": "node",
-      "sourceMaps": true,
+      "args": [
+        "--log-level=debug"
+      ],
+      "console": "integratedTerminal",
       "cwd": "${workspaceFolder}",
       "env": {
-        "NODE_ENV": "test",
-        "BABEL_ENV": "test"
+        "_FORCE_LOGS": "1"
       },
-      "autoAttachChildProcesses": true,
+      "internalConsoleOptions": "openOnSessionStart",
+      "name": "Run Appium",
+      "program": "${workspaceFolder}/node_modules/.bin/appium",
+      "request": "launch",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "sourceMaps": true,
+      "type": "node"
     },
     {
+      "args": [
+        "--colors",
+        "--no-timeout",
+        "${file}"
+      ],
+      "autoAttachChildProcesses": true,
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}",
       "internalConsoleOptions": "openOnSessionStart",
-      "name": "TypeDoc",
+      "name": "Test Current File w/ Mocha",
+      "program": "${workspaceFolder}/node_modules/.bin/mocha",
+      "request": "launch",
+      "runtimeArgs": [
+        "--require",
+        "ts-node/register"
+      ],
+      "skipFiles": [
+        "<node_internals>/**",
+        "**/node_modules/mocha/**",
+        "**/node_modules/ts-node/**"
+      ],
+      "sourceMaps": true,
+      "type": "node"
+    },
+    {
+      "console": "integratedTerminal",
+      "cwd": "${workspaceFolder}",
+      "internalConsoleOptions": "openOnSessionStart",
+      "name": "Typedoc",
       "program": "${workspaceFolder}/node_modules/.bin/typedoc",
       "request": "launch",
-      "skipFiles": ["<node_internals>/**"],
-      "type": "node",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
       "sourceMaps": true,
-      "cwd": "${workspaceFolder}",
+      "type": "node"
     }
-  ]
+  ],
+  "version": "0.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1542,6 +1542,25 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/register": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.18.9.tgz",
+      "integrity": "sha512-ZlbnXDcNYHMR25ITwwNKT88JiaukkdVj/nG7r3wnuXkOTHc60Uy05PwMCPre0hSkY68E6zK3xz+vUJSP2jWmcw==",
+      "dev": true,
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "find-cache-dir": "^2.0.0",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.5",
+        "source-map-support": "^0.5.16"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.20.1",
       "license": "MIT",
@@ -10371,6 +10390,93 @@
       "version": "2.0.0",
       "license": "MIT"
     },
+    "node_modules/find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "license": "MIT",
@@ -19164,6 +19270,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
+      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pixelmatch": {
       "version": "4.0.2",
       "license": "ISC",
@@ -24464,6 +24579,9 @@
         "through2": "4.0.2",
         "vinyl-paths": "3.0.1",
         "yargs": "17.6.2"
+      },
+      "devDependencies": {
+        "@babel/register": "7.18.9"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",

--- a/packages/gulp-plugins/.mocharc.js
+++ b/packages/gulp-plugins/.mocharc.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+'use strict';
+
+module.exports = {
+  require: [require.resolve('./test/setup.js')],
+  // forbids use of .only() in CI
+  forbidOnly: Boolean(process.env.CI),
+  // increase default timeout for CI since it can be slow
+  timeout: process.env.CI ? '5s' : '2s',
+};

--- a/packages/gulp-plugins/package.json
+++ b/packages/gulp-plugins/package.json
@@ -35,9 +35,9 @@
     "build"
   ],
   "scripts": {
+    "build": "gulp transpile",
     "clean": "npx rimraf build",
     "dev": "gulp dev --no-notif",
-    "build": "gulp transpile",
     "prepare": "npm run build",
     "test": "gulp unit-test:run",
     "test:e2e": "gulp e2e-test:run",
@@ -93,6 +93,9 @@
     "through2": "4.0.2",
     "vinyl-paths": "3.0.1",
     "yargs": "17.6.2"
+  },
+  "devDependencies": {
+    "@babel/register": "7.18.9"
   },
   "peerDependencies": {
     "gulp": "^4.0.2"

--- a/packages/gulp-plugins/test/setup.js
+++ b/packages/gulp-plugins/test/setup.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * Mocha will load this file to configure the environment to use Chai as the
+ * assertion library. Since Chai is a singleton, we can run into problems when
+ * running files individually, if we have not carefully configured Chai in every
+ * single test file. This file means less boilerplate and less random test
+ * failures when running single test files.
+ *
+ * For simplicity, this file is _not_ transpiled.  If it were, Mocha would need
+ * to load different versions of this file depending on the test context (are we
+ * running tests against the distfiles, or the source files?).
+ *
+ */
+
+// This configures @babel/register to look for a babel config in parent dir(s) of
+// wherever the tests are run.  This is required if running tests via `mocha` in a package dir
+// instead of the monorepo root. This does not affect `gulp-mocha`, since it has its own `.babelrc`.
+// This file is required _in addition to_ the monorepo root's `test/setup.js`.
+
+require('@babel/register')();
+
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const sinonChai = require('sinon-chai');
+
+// The `chai` global is set if a test needs something special.
+// Most tests won't need this.
+global.chai = chai.use(chaiAsPromised).use(sinonChai);
+
+// `should()` is only necessary when working with some `null` or `undefined` values.
+global.should = chai.should();

--- a/packages/gulp-plugins/test/transpile-specs.js
+++ b/packages/gulp-plugins/test/transpile-specs.js
@@ -90,7 +90,7 @@ describe('transpile-specs', function () {
 
       it(`should use sourcemap when throwing within mocha (${name})`, async function () {
         const [stdout, stderr] = await exec(
-          `${MOCHA} build-fixtures/test/${files.classFile}-throw-specs.js`
+          `${MOCHA} --no-color build-fixtures/test/${files.classFile}-throw-specs.js`
         );
         print(stdout, stderr);
         let output = stdout + stderr;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,15 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/node14/tsconfig.json",
+  "files": [],
   "ts-node": {
     "transpileOnly": true
   },
-  "files": [],
   "compilerOptions": {
-    "noErrorTruncation": true
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "noEmit": true
   },
   "references": [
     {


### PR DESCRIPTION
- Adds a "Run Appium" launch/debug config
- Fixes the "Run Current File" launch/debug config
- Fixes the monorepo's root TS config to handle requiring `ts-node/register` when `mocha` bootstrapped via `node`.  _`node`_ must require `ts-node`; not `mocha`.

Closes #17895.

(@mykola-mokhnach if you don't use VS Code, please ignore the review request)