### PR TITLE
chore(appium): remove more doc-related scripts

### DIFF
--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -41,7 +41,6 @@
     "types"
   ],
   "scripts": {
-    "build:docs": "node ./scripts/parse-yml-commands.js",
     "build:docs:assets": "node docs/scripts/copy-assets.js",
     "build:docs:cli": "node docs/scripts/gen-cli-args-docs.js",
     "dev:docs": "npm run build:docs:assets && npm run dev:docs:en",
@@ -49,7 +48,6 @@
     "dev:docs:ja": "mkdocs serve -f ./docs/mkdocs-ja.yml",
     "dev:docs:zh": "mkdocs serve -f ./docs/mkdocs-zh.yml",
     "postinstall": "node ./scripts/autoinstall-extensions.js",
-    "publish:docs": "cross-env APPIUM_DOCS_PUBLISH=1 npm run build:docs",
     "test": "npm run test:unit",
     "test:e2e": "mocha --timeout 1m --slow 30s \"./test/e2e/**/*.spec.js\"",
     "test:smoke": "cross-env APPIUM_HOME=./local_appium_home node ./index.js driver install uiautomator2 && cross-env APPIUM_HOME=./local_appium_home node ./index.js driver list",


### PR DESCRIPTION
Removes `build:docs` and `publish:docs` (which called `build:docs`) from `appium` scripts.  I don't know if `build:docs:assets` & `build:docs:cli` also need to be removed or not?  I think we _are_ using `dev:docs:*`.