### PR TITLE
fix(base-driver): update type for logExtraCaps

### DIFF
--- a/packages/base-driver/lib/basedriver/driver.js
+++ b/packages/base-driver/lib/basedriver/driver.js
@@ -371,7 +371,7 @@ export class BaseDriverCore extends DriverCore {
 
   /**
    *
-   * @param {Capabilities} caps
+   * @param {Capabilities<C>} caps
    */
   logExtraCaps(caps) {
     let extraCaps = _.difference(_.keys(caps), _.keys(this._desiredCapConstraints));


### PR DESCRIPTION
this was generating an error for a new driver for some reason