### PR TITLE
fix: add 'webSocketUrl' as standard cap for bidi support

### DIFF
--- a/packages/base-driver/lib/basedriver/capabilities.js
+++ b/packages/base-driver/lib/basedriver/capabilities.js
@@ -104,6 +104,7 @@ export const STANDARD_CAPS = Object.freeze(
       'setWindowRect',
       'timeouts',
       'unhandledPromptBehavior',
+      'webSocketUrl',
     ])
   )
 );
@@ -348,7 +349,9 @@ function promoteAppiumOptions(originalCaps) {
     }
 
     if (!_.isPlainObject(appiumOptions)) {
-      throw new errors.SessionNotCreatedError(`The ${PREFIXED_APPIUM_OPTS_CAP} capability must be an object`);
+      throw new errors.SessionNotCreatedError(
+        `The ${PREFIXED_APPIUM_OPTS_CAP} capability must be an object`
+      );
     }
     if (_.isEmpty(appiumOptions)) {
       return obj;
@@ -377,7 +380,7 @@ function promoteAppiumOptions(originalCaps) {
     };
     const preprocessedOptions = _(appiumOptions)
       .mapKeys((value, key) => verifyIfAcceptable(key))
-      .mapKeys((value, key) => shouldAddVendorPrefix(key) ? `${APPIUM_VENDOR_PREFIX}${key}` : key)
+      .mapKeys((value, key) => (shouldAddVendorPrefix(key) ? `${APPIUM_VENDOR_PREFIX}${key}` : key))
       .value();
     // warn if we are going to overwrite any keys on the base caps object
     const overwrittenKeys = _.intersection(Object.keys(obj), Object.keys(preprocessedOptions));
@@ -388,8 +391,8 @@ function promoteAppiumOptions(originalCaps) {
       );
     }
     return _.cloneDeep({
-      ...(_.omit(obj, PREFIXED_APPIUM_OPTS_CAP)),
-      ...preprocessedOptions
+      ..._.omit(obj, PREFIXED_APPIUM_OPTS_CAP),
+      ...preprocessedOptions,
     });
   };
 

--- a/packages/types/lib/constraints.js
+++ b/packages/types/lib/constraints.js
@@ -12,6 +12,9 @@ export const BASE_DESIRED_CAP_CONSTRAINTS = /** @type {const} */ ({
   platformVersion: {
     isString: true,
   },
+  webSocketUrl: {
+    isString: true,
+  },
   newCommandTimeout: {
     isNumber: true,
   },


### PR DESCRIPTION
cc @christian-bromann this should be added to the w3c spec as a standard cap once bidi is ratified, yes? i think we'll need to add it already for appium to support bidi well.