### PR TITLE
chore(commitlint): disable DUMB RULES

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,8 +1,11 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'header-max-length': [0],
+    'body-leading-blank': [0],
     'body-max-line-length': [0],
     'footer-max-line-length': [0],
+    'header-max-length': [0],
+    'subject-case': [0],
+    'subject-full-stop': [0],
   },
 };


### PR DESCRIPTION
This disables the rules which:

- require specific capitalization
- disallow the use of periods in subjects
- warn if there's no leading blank line in the commit body

because the above are dumb

Closes #17930.
