### PR TITLE
chore(appium): fix E2E test for update functionality

### DIFF
--- a/packages/appium/test/e2e/cli-driver.e2e.spec.js
+++ b/packages/appium/test/e2e/cli-driver.e2e.spec.js
@@ -118,14 +118,15 @@ describe('Driver CLI', function () {
         /** @type {Record<string,import('appium/lib/cli/extension-command').InstalledExtensionListData>} */ (
           await runList(['--updates'])
         );
+      const updateVersion = String(fake.updateVersion || fake.unsafeUpdateVersion);
       util.compareVersions(
-        String(fake.updateVersion),
+        String(updateVersion),
         '>',
         penultimateFakeDriverVersionAsOfRightNow
       ).should.be.true;
       // TODO: this could probably be replaced by looking at updateVersion in the JSON
       const {stderr} = await runAppiumRaw(appiumHome, [DRIVER_TYPE, LIST, '--updates'], {});
-      stderr.should.match(new RegExp(`fake.+[${fake.updateVersion} available]`));
+      stderr.should.match(new RegExp(`fake.+[${updateVersion} available]`));
     });
 
     describe('if a driver is not published to npm', function () {


### PR DESCRIPTION
The problem was that after we published a new major of `@appium/fake-driver`, the `updateVersion` field of the response was `null`, but `unsafeUpdateVersion` was populated; the test only used the former.  Now, the test uses `updateVersion` but falls back to `unsafeUpdateVersion`.

This should get the `master` build green again and allow PRs to pass checks (assuming they otherwise would).