### PR TITLE
chore(fossa): fix invalid .fossa.yml "revision" prop

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -54,7 +54,5 @@ targets:
     - type: npm
       path: ./packages/docutils
 
-
-
 revision:
-  branch: master
+  - branch: master


### PR DESCRIPTION
This should have been an array [per the spec](https://raw.githubusercontent.com/fossas/fossa-cli/master/docs/references/files/fossa-yml.v3.schema.json).  Now it's an array.

