### PR TITLE
chore: revert 840a3b4a021274b2c0b9c9a7dc2056f056417215

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "sync-pkgs:appium-readme": "sync-monorepo-packages --force --no-package-json --packages=packages/appium README.md",
     "sync-pkgs:common-fields": "sync-monorepo-packages --fields=author,license,bugs,homepage,engines",
     "sync-pkgs:keywords": "sync-monorepo-packages --field=keywords --packages=\"packages/*\" --packages=\"!packages/eslint-config-appium\" --packages=\"!packages/types\"",
-    "sync-pkgs:license": "sync-monorepo-packages --force --packages=\"packages/*\" --no-package-json LICENSE",
+    "sync-pkgs:license": "sync-monorepo-packages --force --no-package-json LICENSE",
     "stage-synced-pkgs": "git add -A packages/appium/README.md \"packages/*/package.json\"",
     "test": "npm-run-all -p lint build -s test:unit",
     "test:ci": "run-s test:smoke test:unit test:e2e",


### PR DESCRIPTION
This reverts a workaround for a bug which has since been fixed in `sync-monorepo-packages@1.0.2`.

fyi @jlipps 