### PR TITLE
fix broken manifest migration persistence

### DIFF
--- a/packages/appium/lib/extension/manifest-migrations.js
+++ b/packages/appium/lib/extension/manifest-migrations.js
@@ -26,7 +26,7 @@ const Migrations = {
    */
   [SCHEMA_REV_3]: (data) => {
     let shouldSync = false;
-    const allExtData = [...Object.values(data.drivers), ...Object.values(data.plugins)];
+    const allExtData = [...Object.values(data.drivers || {}), ...Object.values(data.plugins || {})];
     for (const metadata of allExtData) {
       if (!('installPath' in metadata)) {
         shouldSync = true;

--- a/packages/appium/lib/extension/manifest.js
+++ b/packages/appium/lib/extension/manifest.js
@@ -378,7 +378,7 @@ export class Manifest {
         ((await env.hasAppiumDependency(this.appiumHome)) &&
           (await packageDidChange(this.appiumHome)))
       ) {
-        shouldWrite = await this.syncWithInstalledExtensions();
+        shouldWrite = (await this.syncWithInstalledExtensions()) || shouldWrite;
       }
 
       if (isNewFile || shouldWrite) {

--- a/packages/appium/test/e2e/manifest.e2e.spec.js
+++ b/packages/appium/test/e2e/manifest.e2e.spec.js
@@ -1,0 +1,61 @@
+import {resolveFixture} from '../helpers';
+import YAML from 'yaml';
+import {runAppiumJson} from './e2e-helpers';
+import {fs, tempDir} from '@appium/support';
+import {
+  CACHE_DIR_RELATIVE_PATH,
+  CURRENT_SCHEMA_REV,
+  DRIVER_TYPE,
+  EXT_SUBCOMMAND_LIST as LIST,
+} from '../../lib/constants';
+import path from 'node:path';
+
+const {expect} = chai;
+
+describe('manifest handling', function () {
+  /**
+   * @type {string}
+   */
+  let appiumHome;
+
+  /**
+   * @type {string}
+   */
+  let manifestPath;
+
+  /**
+   * @type {(args?: string[]) => Promise<ExtensionListData>}
+   */
+  let runList;
+
+  async function resetAppiumHome() {
+    await fs.rimraf(appiumHome);
+    await fs.mkdirp(appiumHome);
+  }
+
+  before(async function () {
+    appiumHome = await tempDir.openDir();
+    manifestPath = path.join(appiumHome, CACHE_DIR_RELATIVE_PATH, 'extensions.yaml');
+    const run = runAppiumJson(appiumHome);
+    runList = async (args = []) =>
+      /** @type {ReturnType<typeof runList>} */ (await run([DRIVER_TYPE, LIST, ...args]));
+  });
+
+  after(async function () {
+    await fs.rimraf(appiumHome);
+  });
+
+  describe('migration', function () {
+    beforeEach(async function () {
+      await resetAppiumHome();
+      await fs.mkdirp(path.dirname(manifestPath));
+      await fs.copyFile(resolveFixture('manifest/v2-empty.yaml'), manifestPath);
+    });
+
+    it('should update the manifest file to the latest schema revision', async function () {
+      await runList();
+      const manifest = YAML.parse(await fs.readFile(manifestPath, 'utf8'));
+      expect(manifest.schemaRev).to.equal(CURRENT_SCHEMA_REV);
+    });
+  });
+});

--- a/packages/appium/test/fixtures/manifest/v2-empty.yaml
+++ b/packages/appium/test/fixtures/manifest/v2-empty.yaml
@@ -1,0 +1,3 @@
+drivers: {}
+plugins: {}
+schemaRev: 2

--- a/packages/support/lib/env.js
+++ b/packages/support/lib/env.js
@@ -84,10 +84,12 @@ export const findAppiumDependencyPackage = _.memoize(
     try {
       const {json: list} = await npm.exec('list', ['--long', '--json'], {cwd});
       ({path: pkgDir} = list);
-      if (pkgDir) {
-        log.debug(`Determined package/workspace root from ${cwd} => ${pkgDir}`);
-      } else {
-        pkgDir = cwd;
+      if (pkgDir !== cwd) {
+        if (pkgDir) {
+          log.debug(`Determined package/workspace root from ${cwd} => ${pkgDir}`);
+        } else {
+          pkgDir = cwd;
+        }
       }
     } catch {
       pkgDir = cwd;


### PR DESCRIPTION
- Manifest migrations were not always applied to disk.  This fixes that problem and adds a test.
- I confirmed that #17901 was otherwise a non-issue and verified it works as expected within the context of an external driver's working copy.

Closes #17901.