### PR TITLE
feat(appium): cull invalid manifest data

### DIFF
--- a/packages/appium/test/e2e/cli-driver.e2e.spec.js
+++ b/packages/appium/test/e2e/cli-driver.e2e.spec.js
@@ -337,7 +337,7 @@ describe('Driver CLI', function () {
     });
   });
 
-  describe('uninstall', function () {
+  describe(UNINSTALL, function () {
     beforeEach(async function () {
       await resetAppiumHome();
       await installLocalExtension(appiumHome, DRIVER_TYPE, FAKE_DRIVER_DIR);
@@ -346,8 +346,9 @@ describe('Driver CLI', function () {
     it('should uninstall a driver based on its driver name', async function () {
       const uninstall = await runUninstall(['fake']);
       uninstall.should.not.have.key('fake');
-      expect(fs.exists(path.join(appiumHome, 'node_modules', '@appium', 'fake-driver'))).to
-        .eventually.be.false;
+      expect(
+        fs.exists(path.join(appiumHome, 'node_modules', '@appium', 'fake-driver'))
+      ).to.eventually.be.false;
     });
   });
 

--- a/packages/appium/test/e2e/manifest.e2e.spec.js
+++ b/packages/appium/test/e2e/manifest.e2e.spec.js
@@ -6,9 +6,11 @@ import {
   CURRENT_SCHEMA_REV,
   DRIVER_TYPE,
   EXT_SUBCOMMAND_LIST as LIST,
+  EXT_SUBCOMMAND_UNINSTALL as UNINSTALL,
 } from '../../lib/constants';
+import {INITIAL_MANIFEST_DATA} from '../../lib/extension/manifest';
 import {FAKE_DRIVER_DIR, resolveFixture} from '../helpers';
-import {installLocalExtension, runAppiumJson} from './e2e-helpers';
+import {installLocalExtension, runAppiumJson, runAppiumRaw} from './e2e-helpers';
 
 const {expect} = chai;
 
@@ -26,7 +28,12 @@ describe('manifest handling', function () {
   /**
    * @type {(args?: string[]) => Promise<ExtensionListData>}
    */
-  let runList;
+  let runDriverList;
+
+  /**
+   * @type {(args: string[]) => Promise<ExtRecord<DriverType>>}
+   */
+  let runDriverUninstall;
 
   async function resetAppiumHome() {
     await fs.rimraf(appiumHome);
@@ -37,8 +44,12 @@ describe('manifest handling', function () {
     appiumHome = await tempDir.openDir();
     manifestPath = path.join(appiumHome, CACHE_DIR_RELATIVE_PATH, 'extensions.yaml');
     const run = runAppiumJson(appiumHome);
-    runList = async (args = []) =>
-      /** @type {ReturnType<typeof runList>} */ (await run([DRIVER_TYPE, LIST, ...args]));
+    runDriverList = async (args = []) =>
+      /** @type {ReturnType<typeof runDriverList>} */ (await run([DRIVER_TYPE, LIST, ...args]));
+    runDriverUninstall = async (args) =>
+      /** @type {ReturnType<typeof runDriverUninstall>} */ (
+        await run([DRIVER_TYPE, UNINSTALL, ...args])
+      );
   });
 
   /**
@@ -48,8 +59,64 @@ describe('manifest handling', function () {
     return YAML.parse(await fs.readFile(manifestPath, 'utf8'));
   }
 
+  async function deleteManifest() {
+    await fs.rimraf(manifestPath);
+  }
+
   after(async function () {
     await fs.rimraf(appiumHome);
+  });
+
+  describe('when no manifest file exists', function () {
+    describe('when no extensions are installed', function () {
+      beforeEach(async function () {
+        await resetAppiumHome();
+      });
+
+      it('should create an empty manifest with the latest revision', async function () {
+        await expect(readManifest()).to.be.rejected;
+        await runDriverList();
+        await expect(readManifest()).to.eventually.eql(INITIAL_MANIFEST_DATA);
+      });
+    });
+
+    describe('when extensions are already installed', function () {
+      /** @type {string} */
+      let stderr;
+
+      before(async function () {
+        // get a clean dir, install fake driver, then delete the manifest file so we have no record of it.
+        await resetAppiumHome();
+        await installLocalExtension(appiumHome, DRIVER_TYPE, FAKE_DRIVER_DIR);
+        await expect(readManifest()).to.eventually.have.nested.property('drivers.fake');
+        await deleteManifest();
+        ({stderr} = await runAppiumRaw(appiumHome, [DRIVER_TYPE, LIST], {}));
+      });
+
+      it('should discover installed extensions', async function () {
+        const manifest = await readManifest();
+
+        expect(manifest.drivers.fake).to.exist;
+        expect(manifest.plugins).to.be.empty;
+        expect(manifest.schemaRev).to.equal(CURRENT_SCHEMA_REV);
+      });
+
+      it('should tell the user a new extension was found', function () {
+        expect(stderr).to.include('Discovered installed driver "fake"');
+      });
+    });
+  });
+
+  describe('uninstallation of extensions', function () {
+    before(async function () {
+      await resetAppiumHome();
+      await installLocalExtension(appiumHome, DRIVER_TYPE, FAKE_DRIVER_DIR);
+      await runDriverUninstall(['fake']);
+    });
+
+    it('should remove the extension from the manifest', async function () {
+      await expect(readManifest()).to.eventually.eql(INITIAL_MANIFEST_DATA);
+    });
   });
 
   describe('migration', function () {
@@ -66,7 +133,7 @@ describe('manifest handling', function () {
       it('should update the manifest file to the latest schema revision', async function () {
         // note: all we need to do to run the migration is invoke appium, so any command
         // would do.
-        await runList();
+        await runDriverList();
         const manifest = await readManifest();
         expect(manifest.schemaRev).to.equal(CURRENT_SCHEMA_REV);
       });
@@ -79,7 +146,7 @@ describe('manifest handling', function () {
       // only does anything if the extension is actually installed.
       before(async function () {
         await installLocalExtension(appiumHome, DRIVER_TYPE, FAKE_DRIVER_DIR);
-        const list = await runList();
+        const list = await runDriverList();
         expect(list.fake).to.exist;
 
         // but the manifest is now at v3, since it's brand new. we will manually downgrade.
@@ -90,7 +157,7 @@ describe('manifest handling', function () {
         tmpManifest = await readManifest();
         expect(tmpManifest.schemaRev).to.equal(2);
         expect(tmpManifest.drivers.fake.installPath).to.not.exist;
-        await runList();
+        await runDriverList();
         manifest = await readManifest();
       });
 
@@ -103,4 +170,58 @@ describe('manifest handling', function () {
       });
     });
   });
+
+  describe('sync installed extensions', function () {
+    beforeEach(async function () {
+      await resetAppiumHome();
+      // appium usually creates this, but we're going to use a custom fixture
+      await fs.mkdirp(path.dirname(manifestPath));
+    });
+
+    describe('when the manifest is current', function () {
+      it('should not sync extensions', async function () {
+        await installLocalExtension(appiumHome, DRIVER_TYPE, FAKE_DRIVER_DIR);
+        await fs.copyFile(resolveFixture('manifest/current-empty.yaml'), manifestPath);
+        await runDriverList();
+        await expect(readManifest()).to.eventually.eql(INITIAL_MANIFEST_DATA);
+      });
+    });
+
+    describe('when the manifest needs migration', function () {
+      describe('when the manifest contains missing extensions', function () {
+        /** @type {string} */
+        let stderr;
+
+        beforeEach(async function () {
+          await fs.copyFile(resolveFixture('manifest/v2.yaml'), manifestPath);
+
+          // prove that the manifest contains the extensions in the first place!
+          const manifest = await readManifest();
+          expect(manifest.drivers.fake).to.exist;
+          expect(manifest.plugins.fake).to.exist;
+
+          ({stderr} = await runAppiumRaw(appiumHome, [DRIVER_TYPE, LIST], {}));
+        });
+
+        it('should remove the missing extensions', async function () {
+          const manifest = await readManifest();
+          expect(manifest.drivers.fake).to.not.exist;
+          expect(manifest.plugins.fake).to.not.exist;
+        });
+
+        it('should log warnings', function () {
+          expect(stderr).to.include(
+            'Removing reference to 1 driver in the manifest that could not be found on disk: fake'
+          );
+          expect(stderr).to.include(
+            'Removing reference to 1 plugin in the manifest that could not be found on disk: fake'
+          );
+        });
+      });
+    });
+  });
 });
+
+/**
+ * @typedef {import('@appium/types').DriverType} DriverType
+ */

--- a/packages/appium/test/fixtures/manifest/current-empty.yaml
+++ b/packages/appium/test/fixtures/manifest/current-empty.yaml
@@ -1,0 +1,3 @@
+drivers: {}
+plugins: {}
+schemaRev: 3 # this will need updating if the manifest version is bumped!!


### PR DESCRIPTION
If, for some reason, an extension doesn't exist on disk yet does exist in the manifest, it probably shouldn't be in the manifest, right? Anyway:

This change causes invalid entries to be culled in the same operation as "sync with installed packages". Those situations are:

- if the manifest file is new
- if the manifest needs a migration
- if `appium` is a local dep and its `package.json` has changed

If none of these are true, synchronization won't happen (extensions won't be automatically discovered), and entries won't be culled.

An argument could be made that we want to sync and/or cull invalid entries regardless of whether we're using a local `appium` or `APPIUM_HOME`, and likewise on any extension subcommand which can modify the manifest (install, uninstall, update). While good housekeeping is in order, it's not free--the system must inspect _every `package.json` in `node_modules`_ to find extensions.

In fact, I'm thinking this should be _opt-in_ behavior if `appium` is a locally-installed dependency; the sync would happen any time `package.json` is modified on-disk.  This might be something like a flag `--sync` flag for `appium driver/plugin list`.  Anyway: that can be a separate PR.