### PR TITLE
fix(appium): fix manifest migrations

### DIFF
--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -322,6 +322,7 @@ class ExtensionCommand {
 
     // this _should_ be the same as `probablyExtName` as the one derived above unless
     // install type is local.
+    /** @type {string} */
     const extName = receipt[/** @type {string} */ (`${this.type}Name`)];
 
     // check _a second time_ with the more-accurate extName
@@ -360,7 +361,7 @@ class ExtensionCommand {
 
     await this.config.addExtension(extName, extManifest);
 
-    // update the if we've changed the local `package.json`
+    // update the hash if we've changed the local `package.json`
     if (await env.hasAppiumDependency(this.config.appiumHome)) {
       await packageDidChange(this.config.appiumHome);
     }
@@ -782,9 +783,7 @@ export {ExtensionCommand};
 
 /**
  * Possible return value for {@linkcode ExtensionCommand.list}
- * @typedef UninstalledExtensionListData
- * @property {string} pkgName
- * @property {false} installed
+ * @typedef {Partial<InstalledExtensionListData> & {pkgName: string, installed: false}} UninstalledExtensionListData
  */
 
 /**

--- a/packages/appium/lib/extension/manifest-migrations.js
+++ b/packages/appium/lib/extension/manifest-migrations.js
@@ -1,3 +1,4 @@
+import {DRIVER_TYPE, PLUGIN_TYPE} from '../constants';
 import log from '../logger';
 
 /**
@@ -12,7 +13,13 @@ import log from '../logger';
 const SCHEMA_REV_3 = 3;
 
 /**
- * Collection of functions to migrate from one version to another
+ * Collection of functions to migrate from one version to another.
+ *
+ * These functions _should not actually perform the migration_; rather, they
+ * should return `true` if the migration should be performed.  The migration
+ * itself will happen within {@linkcode Manifest.syncWithInstalledExtensions}; the extensions
+ * will be checked and the manifest file updated per the state of the filesystem.
+ *
  * @type {{[P in keyof ManifestDataVersions]?: Migration}}
  */
 const Migrations = {
@@ -24,9 +31,13 @@ const Migrations = {
    *
    * @type {Migration}
    */
-  [SCHEMA_REV_3]: (data) => {
+  [SCHEMA_REV_3]: (manifest) => {
     let shouldSync = false;
-    const allExtData = [...Object.values(data.drivers || {}), ...Object.values(data.plugins || {})];
+    /** @type {Array<ExtManifest<PluginType>|ExtManifest<DriverType>>} */
+    const allExtData = [
+      ...Object.values(manifest.getExtensionData(DRIVER_TYPE)),
+      ...Object.values(manifest.getExtensionData(PLUGIN_TYPE)),
+    ];
     for (const metadata of allExtData) {
       if (!('installPath' in metadata)) {
         shouldSync = true;
@@ -38,14 +49,20 @@ const Migrations = {
 };
 
 /**
- * Set `schemaRev` to a specific version
- * @param {AnyManifestDataVersion} data
+ * Set `schemaRev` to a specific version.
+ *
+ * This _does_ mutate `data` in-place, unlike functions in
+ * {@linkcode Migrations}.
+ *
+ * Again, returning `true` means that the manifest should be--at
+ * minimum--persisted to disk, since we changed it.
+ * @param {Readonly<Manifest>} manifest
  * @param {keyof ManifestDataVersions} version
  * @returns {boolean} Whether the data was modified
  */
-function setSchemaRev(data, version) {
-  if (data.schemaRev ?? 0 < version) {
-    data.schemaRev = version;
+function setSchemaRev(manifest, version) {
+  if (manifest.schemaRev ?? 0 < version) {
+    manifest.setSchemaRev(version);
     return true;
   }
   return false;
@@ -56,44 +73,48 @@ function setSchemaRev(data, version) {
  *
  * `data` is modified in-place.
  *
- * @param {Manifest} manifest
- * @param {AnyManifestDataVersion} data
+ * @param {Readonly<Manifest>} manifest
  * @returns {Promise<boolean>} If `true` existing packages should be synced from disk and the manifest should be persisted.
  */
-export async function migrate(manifest, data) {
+export async function migrate(manifest) {
   let didChange = false;
   for await (const [v, migration] of Object.entries(Migrations)) {
     const version = /** @type {keyof ManifestDataVersions} */ (Number(v));
-    didChange = (await migration(data, manifest)) || didChange;
-    didChange = setSchemaRev(data, version) || didChange;
+    didChange = (await migration(manifest)) || didChange;
+    didChange = setSchemaRev(manifest, version) || didChange;
   }
 
   if (didChange) {
     // this is not _technically_ true, since we don't actually write the file here.
-    log.info(`Upgraded extension manifest to schema v${data.schemaRev}`);
+    log.info(`Upgraded extension manifest to schema v${manifest.schemaRev}`);
   }
+
   return didChange;
 }
 
 /**
- * Migration functions take a {@linkcode Manifest} and its data and **mutates `data` in-place**.
+ * A migration function. It will return `true` if a change _should be made_.
  *
  * A migration function should not modify `schemaRev`, as this is done automatically.
  *
- * A migration function can also call out to, say, {@linkcode Manifest.syncWithInstalledExtensions}, which
- * may apply the mutation itself.
- *
  * Note that at the time of writing, we're not able to determine the version of the _current_ manifest file if there is no `schemaRev` prop present (and we may not want to trust it anyway).
  * @callback Migration
- * @param {AnyManifestDataVersion} data - The raw data from `Manifest`
- * @param {Manifest} manifest - The `Manifest` instance
+ * @param {Readonly<Manifest>} manifest - The `Manifest` instance
  * @returns {boolean|Promise<boolean>} If `true`, then something changed
  */
 
 /**
  * @typedef {import('appium/types').ManifestData} ManifestData
+ * @typedef {import('@appium/types').DriverType} DriverType
+ * @typedef {import('@appium/types').PluginType} PluginType
  * @typedef {import('appium/types').AnyManifestDataVersion} AnyManifestDataVersion
  * @typedef {import('appium/types').ManifestDataVersions} ManifestDataVersions
+ * @typedef {import('@appium/types').ExtensionType} ExtensionType
  * @typedef {import('appium/types').ManifestV2.ManifestData} ManifestDataV2
  * @typedef {import('./manifest').Manifest} Manifest
+ */
+
+/**
+ * @template {ExtensionType} ExtType
+ * @typedef {import('appium/types').ExtManifest<ExtType>} ExtManifest
  */

--- a/packages/appium/test/e2e/e2e-helpers.js
+++ b/packages/appium/test/e2e/e2e-helpers.js
@@ -84,7 +84,7 @@ export const runAppium = _.curry(_runAppium);
 
 /**
  * See {@link runAppiumRaw}.
- * @type {AppiumOptsRunner<import('teen_process').TeenProcessExecResult>}
+ * @type {AppiumOptsRunner<import('teen_process').TeenProcessExecResult<string>>}
  */
 async function _runAppiumRaw(appiumHome, args, opts) {
   try {

--- a/packages/appium/test/unit/extension/extension-config.spec.js
+++ b/packages/appium/test/unit/extension/extension-config.spec.js
@@ -33,6 +33,8 @@ describe('ExtensionConfig', function () {
 
   afterEach(function () {
     sandbox.restore();
+    // avoids a warning about too many listeners, caused by an exit handler in base-driver
+    process.removeAllListeners('exit');
   });
 
   describe('constructor', function () {});
@@ -134,9 +136,8 @@ describe('ExtensionConfig', function () {
           installType: 'npm',
           appiumVersion: APPIUM_VER,
         };
-        manifest.addExtension(DRIVER_TYPE, extData.pkgName, extData);
+        manifest.setExtension(DRIVER_TYPE, extData.pkgName, extData);
         config = new ExtensionConfig(DRIVER_TYPE, manifest);
-        delete this._listDataCache;
       });
 
       describe('when the extension data is missing an `installSpec` field', function () {

--- a/packages/appium/test/unit/extension/manifest.spec.js
+++ b/packages/appium/test/unit/extension/manifest.spec.js
@@ -294,7 +294,7 @@ describe('Manifest', function () {
       });
     });
 
-    describe('addExtension()', function () {
+    describe('setExtension()', function () {
       /** @type {ExtManifest<DriverType>} */
       const extData = {
         automationName: 'derp',
@@ -309,7 +309,7 @@ describe('Manifest', function () {
       };
 
       it('should add a clone of the extension manifest to the internal data object', function () {
-        manifest.addExtension(DRIVER_TYPE, 'foo', extData);
+        manifest.setExtension(DRIVER_TYPE, 'foo', extData);
         expect(manifest.getExtensionData(DRIVER_TYPE).foo)
           .to.eql(extData)
           .and.not.to.equal(extData);
@@ -319,7 +319,7 @@ describe('Manifest', function () {
         /** @type {ExtManifest<DriverType>} */
 
         beforeEach(function () {
-          manifest.addExtension(DRIVER_TYPE, 'foo', extData);
+          manifest.setExtension(DRIVER_TYPE, 'foo', extData);
         });
 
         it('should rewrite', function () {
@@ -327,7 +327,7 @@ describe('Manifest', function () {
             ...extData,
             automationName: 'BLAAHAH',
           };
-          manifest.addExtension(DRIVER_TYPE, 'foo', expected);
+          manifest.setExtension(DRIVER_TYPE, 'foo', expected);
           expect(manifest.getExtensionData(DRIVER_TYPE).foo).to.eql(expected);
         });
       });
@@ -338,7 +338,7 @@ describe('Manifest', function () {
         });
 
         it('should work anyway', function () {
-          manifest.addExtension(DRIVER_TYPE, 'foo', extData);
+          manifest.setExtension(DRIVER_TYPE, 'foo', extData);
           expect(manifest.getExtensionData(DRIVER_TYPE).foo).to.not.have.property('appiumVersion');
         });
       });
@@ -359,7 +359,7 @@ describe('Manifest', function () {
       };
 
       beforeEach(function () {
-        manifest.addExtension(DRIVER_TYPE, 'foo', extData);
+        manifest.setExtension(DRIVER_TYPE, 'foo', extData);
       });
 
       it('should return all extension data for an extension type', function () {
@@ -575,7 +575,7 @@ describe('Manifest', function () {
       describe('when the driver is registered', function () {
         beforeEach(function () {
           // @ts-expect-error
-          manifest.addExtension(DRIVER_TYPE, 'foo', {});
+          manifest.setExtension(DRIVER_TYPE, 'foo', {});
         });
 
         it('should return `true`', function () {
@@ -594,7 +594,7 @@ describe('Manifest', function () {
       describe('when the plugin is registered', function () {
         beforeEach(function () {
           // @ts-expect-error
-          manifest.addExtension(PLUGIN_TYPE, 'foo', {});
+          manifest.setExtension(PLUGIN_TYPE, 'foo', {});
         });
 
         it('should return `true`', function () {


### PR DESCRIPTION
Manifest migrations were not being fully applied due to a method in `Manifest` which refused to overwrite data.

- `Manifest` now has full control of the manifest file and its in-memory representation. Nothing else should ever modify the in-memory data directly; instead, use its API. This restriction also applies to migrations.
- Corrected some incorrect explanations in `manifest-migrations`
- `Manifest#addExtension` became `Manifest#setExtension` and allows overwriting of data, which prevented migrations from being fully applied.
- More tests
