### PR TITLE
fix(appium): inability to find automationName inside appium:options

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -9,6 +9,7 @@ import {
   CREATE_SESSION_COMMAND,
   DELETE_SESSION_COMMAND,
   GET_STATUS_COMMAND,
+  promoteAppiumOptions,
 } from '@appium/base-driver';
 import AsyncLock from 'async-lock';
 import {parseCapsForInnerDriver, pullSettings} from './utils';
@@ -240,7 +241,7 @@ class AppiumDriver extends DriverCore {
       // Parse the caps into a format that the InnerDriver will accept
       const parsedCaps = parseCapsForInnerDriver(
         jsonwpCaps,
-        w3cCapabilities,
+        promoteAppiumOptions(w3cCapabilities),
         this.desiredCapConstraints,
         defaultCapabilities
       );

--- a/packages/appium/test/e2e/driver.e2e.spec.js
+++ b/packages/appium/test/e2e/driver.e2e.spec.js
@@ -258,6 +258,43 @@ describe('FakeDriver via HTTP', function () {
       }
     });
 
+    it('should allow appium-prefixed caps sent via appium:options', async function () {
+      // Try with valid capabilities and check that it returns a session ID
+      const appiumOptsCaps = {
+        capabilities: {
+          alwaysMatch: {
+            'appium:options': {
+              automationName: 'Fake',
+              deviceName: 'Fake',
+              app: TEST_FAKE_APP,
+            },
+            platformName: 'Fake',
+          },
+          firstMatch: [{}],
+        },
+      };
+
+      // Create the session
+      const {status, value, sessionId} = (
+        await axios.post(testServerBaseSessionUrl, appiumOptsCaps)
+      ).data;
+      try {
+        should.not.exist(status); // Test that it's a W3C session by checking that 'status' is not in the response
+        should.not.exist(sessionId);
+        value.sessionId.should.be.a.string;
+        value.should.exist;
+        value.capabilities.should.deep.equal({
+          automationName: 'Fake',
+          platformName: 'Fake',
+          deviceName: 'Fake',
+          app: TEST_FAKE_APP,
+        });
+      } finally {
+        // End session
+        await axios.delete(`${testServerBaseSessionUrl}/${value.sessionId}`);
+      }
+    });
+
     it('should reject invalid W3C capabilities and respond with a 400 Bad Parameters error', async function () {
       const badW3Ccaps = {
         capabilities: {

--- a/packages/base-driver/lib/basedriver/capabilities.js
+++ b/packages/base-driver/lib/basedriver/capabilities.js
@@ -225,7 +225,7 @@ function parseCaps(caps, constraints = /** @type {C} */ ({}), shouldValidateCaps
   // In the future, reject 'firstMatch' argument if its array did not have one or more entries (#3.2)
   if (allFirstMatchCaps.length === 0) {
     log.warn(
-      `The firstMatch array in the given capabilities has no entries. Adding an empty entry fo rnow, ` +
+      `The firstMatch array in the given capabilities has no entries. Adding an empty entry for now, ` +
         `but it will require one or more entries as W3C spec.`
     );
     allFirstMatchCaps.push({});

--- a/packages/base-driver/lib/basedriver/driver.js
+++ b/packages/base-driver/lib/basedriver/driver.js
@@ -1,12 +1,7 @@
 /* eslint-disable require-await */
 /* eslint-disable no-unused-vars */
 
-import {
-  validateCaps,
-  PREFIXED_APPIUM_OPTS_CAP,
-  processCapabilities,
-  promoteAppiumOptions,
-} from './capabilities';
+import {validateCaps, PREFIXED_APPIUM_OPTS_CAP, processCapabilities} from './capabilities';
 import {DriverCore} from './core';
 import {util} from '@appium/support';
 import B from 'bluebird';
@@ -298,7 +293,7 @@ export class BaseDriverCore extends DriverCore {
     let caps;
     try {
       caps = processCapabilities(
-        promoteAppiumOptions(originalCaps),
+        originalCaps,
         this._desiredCapConstraints,
         this.shouldValidateCaps
       );

--- a/packages/base-driver/lib/index.js
+++ b/packages/base-driver/lib/index.js
@@ -34,6 +34,7 @@ export {
   processCapabilities,
   isStandardCap,
   validateCaps,
+  promoteAppiumOptions,
 } from './basedriver/capabilities';
 
 // Web socket helpers

--- a/packages/base-driver/test/e2e/basedriver/driver.e2e.spec.js
+++ b/packages/base-driver/test/e2e/basedriver/driver.e2e.spec.js
@@ -1,12 +1,5 @@
-import {BaseDriver, server, routeConfiguringFunction, PREFIXED_APPIUM_OPTS_CAP} from '../../../lib';
-import {
-  driverE2ETestSuite,
-  getTestPort,
-  TEST_HOST,
-  createSessionHelpers,
-} from '@appium/driver-test-support';
-
-const {expect} = chai;
+import {BaseDriver} from '../../../lib';
+import {driverE2ETestSuite} from '@appium/driver-test-support';
 
 const DEFAULT_CAPS = {
   platformName: 'iOS',
@@ -14,58 +7,6 @@ const DEFAULT_CAPS = {
 };
 
 driverE2ETestSuite(BaseDriver, DEFAULT_CAPS);
-
-describe('BaseDriver', function () {
-  // only run this test on basedriver, not other drivers which also use these tests, since we
-  // don't want them to try and start sessions with these random capabilities that are
-  // necessary to test the appium options logic
-  describe('special appium:options capability', function () {
-    /** @type {SessionHelpers['startSession']} */
-    let startSession;
-    /** @type {SessionHelpers['endSession']} */
-    let endSession;
-    /** @type {import('@appium/types').AppiumServer} */
-    let baseServer;
-    /** @type {BaseDriver} */
-    let d;
-
-    before(async function () {
-      const port = await getTestPort();
-      d = new BaseDriver({port, address: TEST_HOST});
-      baseServer = await server({
-        routeConfiguringFunction: routeConfiguringFunction(d),
-        port,
-        hostname: TEST_HOST,
-      });
-
-      ({startSession, endSession} = createSessionHelpers(port));
-    });
-
-    after(async function () {
-      await baseServer.close();
-    });
-
-    it('should be able to start a session with caps held in appium:options', async function () {
-      const ret = await startSession({
-        capabilities: {
-          alwaysMatch: {
-            platformName: 'iOS',
-            [PREFIXED_APPIUM_OPTS_CAP]: {
-              platformVersion: '11.4',
-              'appium:deviceName': 'iPhone 11',
-            },
-          },
-        },
-      });
-      try {
-        expect(d.opts.platformVersion).to.equal('11.4');
-        expect(d.opts.deviceName).to.equal('iPhone 11');
-      } finally {
-        await endSession(ret.sessionId);
-      }
-    });
-  });
-});
 
 /**
  * @typedef {import('@appium/driver-test-support').SessionHelpers} SessionHelpers


### PR DESCRIPTION
we fixed this before but only fixed it in basedriver's createSession, which is not actually called by Appium's createSession (though maybe it should be)