### PR TITLE
feat: create @appium/tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,10 @@
       "resolved": "packages/test-support",
       "link": true
     },
+    "node_modules/@appium/tsconfig": {
+      "resolved": "packages/tsconfig",
+      "link": true
+    },
     "node_modules/@appium/typedoc-plugin-appium": {
       "resolved": "packages/typedoc-plugin-appium",
       "link": true
@@ -3274,8 +3278,8 @@
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "dev": true,
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
@@ -17395,6 +17399,18 @@
       "bin": {
         "android-emu-travis-post": "bin/android-emu-travis-post.sh",
         "android-emu-travis-pre": "bin/android-emu-travis-pre.sh"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=8"
+      }
+    },
+    "packages/tsconfig": {
+      "name": "@appium/tsconfig",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tsconfig/node14": "1.0.3"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",

--- a/packages/tsconfig/README.md
+++ b/packages/tsconfig/README.md
@@ -1,0 +1,19 @@
+# @appium/tsconfig
+
+> Shared TypeScript Config for Appium
+
+## Motivation
+
+Appium projects and extensions are encouraged to use these settings.
+
+## Install
+
+```bash
+npm install appium @appium/tsconfig -D
+```
+
+[appium](https://npm.im/appium) is a peer dependency of this package.
+
+## License
+
+Apache-2.0

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@appium/tsconfig",
+  "version": "0.1.0",
+  "description": "Shared TypeScript Config for Appium",
+  "main": "tsconfig.json",
+  "keywords": [],
+  "license": "Apache-2.0",
+  "files": [
+    "tsconfig*.json"
+  ],
+  "author": "https://github.com/appium",
+  "bugs": {
+    "url": "https://github.com/appium/appium/issues"
+  },
+  "homepage": "https://appium.io",
+  "engines": {
+    "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+    "npm": ">=8"
+  },
+  "dependencies": {
+    "@tsconfig/node14": "1.0.3"
+  },
+  "scripts": {
+    "test:smoke": "node tsconfig.json && node tsconfig.plugin.json"
+  }
+}

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@tsconfig/node14/tsconfig.json",
+  "ts-node": {
+    "transpileOnly": true
+  },
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "resolveJsonModule": true,
+    "strictNullChecks": true,
+    "sourceMap": true,
+    "removeComments": false,
+    "strict": false,
+    "types": ["node", "mocha", "chai", "sinon-chai", "chai-as-promised"]
+  }
+}

--- a/packages/tsconfig/tsconfig.plugin.json
+++ b/packages/tsconfig/tsconfig.plugin.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "appium": ["../packages/appium"],
+      "appium/plugin": ["../packages/appium/plugin"],
+      "@appium/plugin-test-support": ["../packages/plugin-test-support"]
+    },
+    "types": ["webdriverio/async"]
+  },
+  "extends": "./tsconfig.json",
+  "references": [
+    {"path": "../packages/appium"},
+    {"path": "../packages/base-plugin"},
+    {"path": "../packages/types"},
+    {"path": "../packages/plugin-test-support"}
+  ]
+}


### PR DESCRIPTION
For the TypeDoc plugin to correctly pull information from `@appium/types` and `@appium/base-driver`, they both need `tsconfig.json` files.

They currently _have_ `tsconfig.json` files, but they extend base configs in the monorepo root, which is problematic. Moving the configs into a package seems reasonable. Further, all packages must publish `tsconfig.json`. There's precedent for publishing a `tsconfig.json` this way.

FWIW the `paths` and `references` fields in the `tsconfig.json` files seem to be ignored by TypeDoc, so we can get away with this.
