### PR TITLE
automatic command doc gen for plugins

### DIFF
--- a/packages/execute-driver-plugin/lib/execute-child.js
+++ b/packages/execute-driver-plugin/lib/execute-child.js
@@ -6,7 +6,7 @@ import {attach} from 'webdriverio';
 
 const log = logger.getLogger('ExecuteDriver Child');
 /**
- * @type {Promise<void>}
+ * @type {(res: ScriptResult) => Promise<void>}
  */
 let send;
 
@@ -176,8 +176,8 @@ if (require.main === module && _.isFunction(process.send)) {
 
 /**
  * @typedef ScriptResult
- * @property {any} success
- * @property {ScriptResultError} error
+ * @property {any} [success]
+ * @property {ScriptResultError} [error]
  */
 
 /**
@@ -189,5 +189,5 @@ if (require.main === module && _.isFunction(process.send)) {
 /**
  * @typedef RunScriptResult
  * @property {any} result
- * @property {Object} logs
+ * @property {object} logs
  */

--- a/packages/execute-driver-plugin/lib/plugin.js
+++ b/packages/execute-driver-plugin/lib/plugin.js
@@ -23,15 +23,16 @@ export default class ExecuteDriverPlugin extends BasePlugin {
    * a new nodejs VM, and which has available a webdriverio driver object, having
    * already been attached to the currently running session.
    *
-   * @param {function} next - standard behaviour for executeDriverScript
+   * @param {import('@appium/types').NextPluginCallback} next - standard behaviour for executeDriverScript
    * @param {import('@appium/types').ExternalDriver} driver - Appium driver handling this command
    * @param {string} script - the string representing the driver script to run
    * @param {string} [scriptType='webdriverio'] - the name of the driver script
    * library (currently only webdriverio is supported)
    * @param {number} [timeoutMs=3600000] - timeout for the script process
    *
-   * @returns {Object} - a JSONifiable object representing the return value of
+   * @returns {Promise<any>} - a JSONifiable object representing the return value of
    * the script
+   * @type {import('@appium/types').PluginCommand<[string, string?, number?]>}
    * @throws {Error}
    */
   async executeDriverScript(

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -23,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
+  "types": "./build/lib/plugin.d.ts",
   "files": [
     "build",
     "lib",
@@ -46,6 +47,10 @@
   "peerDependencies": {
     "appium": "^2.0.0-beta.35"
   },
+  "engines": {
+    "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+    "npm": ">=8"
+  },
   "publishConfig": {
     "access": "public"
   },
@@ -54,8 +59,7 @@
     "mainClass": "ExecuteDriverPlugin"
   },
   "gitHead": "5c7af8ee73078018e4ec52fccf19fe3f77249d72",
-  "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-    "npm": ">=8"
+  "typedoc": {
+    "entryPoint": "./lib/plugin.js"
   }
 }

--- a/packages/execute-driver-plugin/tsconfig.json
+++ b/packages/execute-driver-plugin/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "outDir": "build"
+    "outDir": "build",
+    "checkJs": true
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib"]

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -12,6 +12,7 @@
     "firefoxos",
     "testing"
   ],
+  "homepage": "https://appium.io",
   "bugs": {
     "url": "https://github.com/appium/appium/issues"
   },
@@ -22,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
+  "types": "./build/lib/plugin.d.ts",
   "files": [
     "build",
     "docs",
@@ -43,15 +45,16 @@
   "peerDependencies": {
     "appium": "^2.0.0-beta.35"
   },
+  "engines": {
+    "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+    "npm": ">=8"
+  },
   "appium": {
     "pluginName": "images",
     "mainClass": "ImageElementPlugin"
   },
-  "types": "./build/lib/plugin.d.ts",
   "gitHead": "5c7af8ee73078018e4ec52fccf19fe3f77249d72",
-  "homepage": "https://appium.io",
-  "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-    "npm": ">=8"
+  "typedoc": {
+    "entryPoint": "./lib/plugin.js"
   }
 }

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -2,6 +2,17 @@
   "name": "@appium/relaxed-caps-plugin",
   "version": "1.0.0-beta.14",
   "description": "An Appium 2.0 plugin that loosens requirements for vendor prefixes on caps",
+  "keywords": [
+    "automation",
+    "javascript",
+    "selenium",
+    "webdriver",
+    "ios",
+    "android",
+    "firefoxos",
+    "testing"
+  ],
+  "homepage": "https://appium.io",
   "bugs": {
     "url": "https://github.com/appium/appium/issues"
   },
@@ -12,6 +23,7 @@
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",
+  "types": "./build/lib/plugin.d.ts",
   "directories": {
     "lib": "./lib"
   },
@@ -45,15 +57,7 @@
   "tags": [
     "appium"
   ],
-  "homepage": "https://appium.io",
-  "keywords": [
-    "automation",
-    "javascript",
-    "selenium",
-    "webdriver",
-    "ios",
-    "android",
-    "firefoxos",
-    "testing"
-  ]
+  "typedoc": {
+    "entryPoint": "./lib/plugin.js"
+  }
 }

--- a/packages/typedoc-plugin-appium/lib/converter/comment.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/comment.ts
@@ -5,7 +5,7 @@
 
 import _ from 'lodash';
 import {Comment, CommentDisplayPart} from 'typedoc';
-import {AsyncMethodDeclarationReflection, KnownMethods} from './types';
+import {CommandMethodDeclarationReflection, KnownMethods} from './types';
 
 export const stats = _.fill(new Array(5), 0);
 
@@ -21,7 +21,7 @@ export const stats = _.fill(new Array(5), 0);
 export function deriveComment(
   command: string,
   knownMethods?: KnownMethods,
-  refl?: AsyncMethodDeclarationReflection,
+  refl?: CommandMethodDeclarationReflection,
   extraComment?: Comment
 ): CommentData | undefined {
   const commentFinders: CommentFinder[] = [

--- a/packages/typedoc-plugin-appium/lib/converter/exec-method-map.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/exec-method-map.ts
@@ -39,6 +39,10 @@ export interface ConvertExecuteMethodMapOpts {
    * If `true`, do not add a route if the method it references cannot be found
    */
   strict?: boolean;
+  /**
+   * If `true`, handle commands as `PluginCommand`s, which affects which parameters get used
+   */
+  isPluginCommand?: boolean;
 }
 
 /**
@@ -52,6 +56,7 @@ export function convertExecuteMethodMap({
   execMethodMapRefl,
   methods,
   strict = false,
+  isPluginCommand = false,
 }: ConvertExecuteMethodMapOpts): ExecMethodDataSet {
   const commandRefs: ExecMethodDataSet = new Set();
   if (!execMethodMapRefl) {
@@ -114,6 +119,7 @@ export function convertExecuteMethodMap({
         refl: method,
         comment: commentData?.comment,
         commentSource: commentData?.commentSource,
+        isPluginCommand,
       })
     );
 

--- a/packages/typedoc-plugin-appium/lib/converter/method-map.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/method-map.ts
@@ -46,6 +46,11 @@ export interface ConvertMethodMapOpts {
    * If `true`, do not add a route if the method it references cannot be found
    */
   strict?: boolean;
+
+  /**
+   * If `true`, handle commands as `PluginCommand`s, which affects which parameters get used
+   */
+  isPluginCommand?: boolean;
 }
 
 /**
@@ -60,6 +65,7 @@ export function convertMethodMap({
   methods,
   knownMethods = new Map(),
   strict = false,
+  isPluginCommand = false,
 }: ConvertMethodMapOpts): RouteMap {
   const routes: RouteMap = new Map();
 
@@ -129,6 +135,7 @@ export function convertMethodMap({
           commentSource: commentData?.commentSource,
           refl: method,
           parentRefl,
+          isPluginCommand,
         })
       );
 

--- a/packages/typedoc-plugin-appium/lib/converter/types.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/types.ts
@@ -28,6 +28,9 @@ type WithKind<K extends ReflectionKind, R> = R & {kind: K};
  */
 type WithSomeType<T extends SomeType, R> = R & {type: T};
 
+/**
+ * Utility to narrow by name and kind
+ */
 type WithNameAndKind<S extends string, K extends ReflectionKind, R> = R & {name: S; kind: K};
 
 /**
@@ -107,11 +110,16 @@ export type Guard<T> = (value: any) => value is T;
 export type ExecMethodDeclarationReflection = WithName<
   typeof NAME_EXECUTE_METHOD_MAP,
   DeclarationReflectionWithReflectedType
-> & {
-  flags: ReflectionFlags & {isStatic: true};
-};
+> &
+  WithStaticFlag;
 
+/**
+ * Whatever has this flag will be a static member
+ */
 export type WithStaticFlag = {flags: ReflectionFlags & {isStatic: true}};
+/**
+ * Whatever has this flag will _not_ be a static member
+ */
 export type WithoutStaticFlag = {flags: ReflectionFlags & {isStatic: false}};
 
 /**
@@ -165,9 +173,9 @@ export type AsyncCallSignatureReflection = CallSignatureReflection & {
 };
 
 /**
- * An async method or reference to an async method.  A command's method must be of this type.
+ * An async method or reference to an async method.  In a driver, a command's method must be of this type.
  */
-export type AsyncMethodDeclarationReflection<
+export type CommandMethodDeclarationReflection<
   T extends ReferenceType | ReflectionType = ReferenceType
 > = WithSomeType<T, DeclarationReflection> &
   WithKind<
@@ -195,7 +203,7 @@ export type AsyncMethodDeclarationReflection<
  */
 export interface KnownMethodData {
   comment?: Comment;
-  method: AsyncMethodDeclarationReflection;
+  method: CommandMethodDeclarationReflection;
 }
 
 /**
@@ -207,6 +215,33 @@ export type KnownMethods = Map<string, KnownMethodData>;
  * A {@linkcode DeclarationReflection} which is a `class`.
  */
 export type ClassDeclarationReflection = WithKind<ReflectionKind.Class, DeclarationReflection>;
+
+/**
+ * A constructor
+ */
+export type ConstructorDeclarationReflection = WithNameAndKind<
+  'constructor',
+  ReflectionKind.Constructor,
+  DeclarationReflection
+>;
+
+/**
+ * A {@linkcode ReferenceType} referencing the constructor of `BasePlugin`
+ */
+export type BasePluginConstructorReferenceType = ReferenceType & {name: 'BasePlugin.constructor'};
+
+/**
+ * A {@linkcode DeclarationReflection} for the constructor of a class extending `BasePlugin`
+ */
+export type BasePluginConstructorDeclarationReflection = WithSomeType<
+  ReferenceType,
+  DeclarationReflection
+> &
+  ConstructorDeclarationReflection &
+  (
+    | {inheritedFrom: BasePluginConstructorReferenceType}
+    | {overwrites: BasePluginConstructorReferenceType}
+  );
 
 /**
  * One of {@linkcode ExecMethodDefParamsPropDeclarationReflection} or

--- a/packages/typedoc-plugin-appium/lib/model/reflection/command.ts
+++ b/packages/typedoc-plugin-appium/lib/model/reflection/command.ts
@@ -1,5 +1,5 @@
 import {Comment, DeclarationReflection, ParameterReflection} from 'typedoc';
-import {AsyncMethodDeclarationReflection, CommentSourceType} from '../../converter';
+import {CommandMethodDeclarationReflection, CommentSourceType} from '../../converter';
 import {isExecMethodData} from '../../guards';
 import {CommandData, ExecMethodData} from '../command-data';
 import {AllowedHttpMethod, Route} from '../types';
@@ -53,7 +53,7 @@ export class CommandReflection extends DeclarationReflection {
   public readonly comment?: Comment;
 
   public readonly commentSource?: CommentSourceType;
-  public readonly refl?: AsyncMethodDeclarationReflection;
+  public readonly refl?: CommandMethodDeclarationReflection;
 
   public readonly parameters?: ParameterReflection[];
 

--- a/packages/typedoc-plugin-appium/test/unit/converter/builtin-method-map.spec.ts
+++ b/packages/typedoc-plugin-appium/test/unit/converter/builtin-method-map.spec.ts
@@ -11,7 +11,7 @@ import {BuiltinCommands} from '../../../lib/model/builtin-commands';
 import {AppiumPluginLogger} from '../../../lib/logger';
 import {initConverter, NAME_FAKE_DRIVER_MODULE} from '../helpers';
 
-describe('BaseDriverConverter', function () {
+describe('BuiltinMethodMapConverter', function () {
   let sandbox: SinonSandbox;
 
   beforeEach(function () {
@@ -66,6 +66,7 @@ describe('BaseDriverConverter', function () {
             requiredParams: [],
             route: '/session',
             optionalParams: ['desiredCapabilities', 'requiredCapabilities', 'capabilities'],
+            isPluginCommand: false,
           });
           expect(firstCommand.methodRefl!.name).to.equal('createSession');
           expect(firstCommand.comment).to.be.an.instanceof(Comment);

--- a/packages/types/lib/plugin.ts
+++ b/packages/types/lib/plugin.ts
@@ -1,4 +1,4 @@
-import {MethodMap, UpdateServerCallback, Class, AppiumLogger, PluginType} from '.';
+import {MethodMap, UpdateServerCallback, Class, AppiumLogger} from '.';
 import {Driver, ExternalDriver} from './driver';
 
 /**
@@ -77,12 +77,14 @@ export type NextPluginCallback = () => Promise<void>;
 
 /**
  * Implementation of a command within a plugin
+ *
+ * At minimum, `D` must be `ExternalDriver`, but a plugin can be more narrow about which drivers it supports.
  */
-export type PluginCommand<TArgs = any> = (
-  next: NextPluginCallback,
-  driver: ExternalDriver,
-  ...args: TArgs[]
-) => Promise<void>;
+export type PluginCommand<
+  D extends ExternalDriver = ExternalDriver,
+  TArgs extends readonly any[] = any[],
+  TReturn = any
+> = (next: NextPluginCallback, driver: D, ...args: TArgs) => Promise<TReturn>;
 
 /**
  * Mainly for internal use.

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -44,13 +44,16 @@
   "peerDependencies": {
     "appium": "^2.0.0-beta.35"
   },
+  "engines": {
+    "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+    "npm": ">=8"
+  },
   "appium": {
     "pluginName": "universal-xml",
     "mainClass": "UniversalXMLPlugin"
   },
   "gitHead": "5c7af8ee73078018e4ec52fccf19fe3f77249d72",
-  "engines": {
-    "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
-    "npm": ">=8"
+  "typedoc": {
+    "entryPoint": "./lib/index.js"
   }
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -9,7 +9,11 @@
     "./packages/types",
     "./packages/base-plugin",
     "./packages/fake-driver",
-    "./packages/typedoc-plugin-appium"
+    "./packages/typedoc-plugin-appium",
+    "./packages/universal-xml-plugin",
+    "./packages/relaxed-caps-plugin",
+    "./packages/images-plugin",
+    "./packages/execute-driver-plugin"
   ],
   "name": "Appium",
   "out": "typedoc-docs",


### PR DESCRIPTION
This enables automatic command docs for plugins:

- Adds logic to `@appium/typedoc-plugin-appium` to do so
- Configures monorepo to consider plugin entry points
