### PR TITLE
fix: run "npm audit fix" because there was a warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15654,8 +15654,9 @@
       }
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.1",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dependencies": {
         "minimist": "^1.2.0"
       },


### PR DESCRIPTION
looks like it wanted to upgrade a transitive dep (`json5`) to a patch version