### PR TITLE
fix(images-plugin,universal-xml-plugin,typedoc-plugin-appium): add missing lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10304,7 +10304,8 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -17194,6 +17195,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/opencv": "^2.0.1",
+        "lodash": "4.17.21",
         "lru-cache": "7.14.1",
         "source-map-support": "0.5.21"
       },
@@ -17534,6 +17536,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "handlebars": "4.7.7",
+        "lodash": "4.17.21",
         "pluralize": "8.0.0",
         "type-fest": "3.5.1"
       },
@@ -17575,6 +17578,7 @@
         "@types/xmldom": "0.1.31",
         "@xmldom/xmldom": "0.8.6",
         "fast-xml-parser": "3.21.1",
+        "lodash": "4.17.21",
         "source-map-support": "0.5.21",
         "xpath": "0.0.32"
       },

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@appium/opencv": "^2.0.1",
+    "lodash": "4.17.21",
     "lru-cache": "7.14.1",
     "source-map-support": "0.5.21"
   },

--- a/packages/typedoc-plugin-appium/package.json
+++ b/packages/typedoc-plugin-appium/package.json
@@ -55,12 +55,13 @@
   "peerDependencies": {
     "appium": "^2.0.0-beta.48",
     "typedoc": "^0.23.14",
-    "typescript": "~4.7.0",
     "typedoc-plugin-markdown": "^3.14.0",
-    "typedoc-plugin-resolve-crossmodule-references": "~0.3.3"
+    "typedoc-plugin-resolve-crossmodule-references": "~0.3.3",
+    "typescript": "~4.7.0"
   },
   "dependencies": {
     "handlebars": "4.7.7",
+    "lodash": "4.17.21",
     "pluralize": "8.0.0",
     "type-fest": "3.5.1"
   }

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -38,6 +38,7 @@
     "@types/xmldom": "0.1.31",
     "@xmldom/xmldom": "0.8.6",
     "fast-xml-parser": "3.21.1",
+    "lodash": "4.17.21",
     "source-map-support": "0.5.21",
     "xpath": "0.0.32"
   },


### PR DESCRIPTION
I found these when fiddling with how `midnight-smoker` installs packages.