### PR TITLE
fix typedoc / doc build problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "sync-pkgs": "run-p sync-pkgs:*",
     "sync-pkgs:appium-readme": "sync-monorepo-packages --force --no-package-json --packages=packages/appium README.md",
     "sync-pkgs:common-fields": "sync-monorepo-packages --fields=author,license,bugs,homepage,engines",
-    "sync-pkgs:keywords": "sync-monorepo-packages --field=keywords --packages=\"packages/*\" --packages=\"!packages/eslint-config-appium\" --packages=\"!packages/types\" --packages\"!packages/typedoc-plugin-appium\"",
+    "sync-pkgs:keywords": "sync-monorepo-packages --field=keywords --packages=\"packages/*\" --packages=\"!packages/eslint-config-appium\" --packages=\"!packages/types\" --packages=\"!packages/typedoc-plugin-appium\"",
     "sync-pkgs:license": "sync-monorepo-packages --force --no-package-json LICENSE",
     "stage-synced-pkgs": "git add -A packages/appium/README.md \"packages/*/package.json\"",
     "test": "npm-run-all -p lint build -s test:unit",

--- a/packages/appium/docs/scripts/build-reference.js
+++ b/packages/appium/docs/scripts/build-reference.js
@@ -7,7 +7,9 @@ const path = require('path');
 const monorepoRoot = path.resolve(__dirname, '..', '..', '..', '..');
 const {exec} = require('teen_process');
 
-const typedocMap = [[['commands', 'appium_base_driver.md'], ['base_driver.md']]];
+const typedocMap = [
+  [['commands', 'appium_base_driver-1._appium_base_driver.md'], ['base_driver.md']],
+];
 
 async function main() {
   log.info('Generating typedoc reference material');

--- a/packages/typedoc-plugin-appium/lib/converter/method-map.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/method-map.ts
@@ -111,7 +111,7 @@ export function convertMethodMap({
       const method = methods.get(command)?.method;
 
       if (strict && !method) {
-        log.error('(%s) No method found for command "%s"', parentRefl.name, command);
+        log.warn('(%s) No method found for command "%s"; this is a bug', parentRefl.name, command);
         continue;
       }
 

--- a/packages/typedoc-plugin-appium/package.json
+++ b/packages/typedoc-plugin-appium/package.json
@@ -14,14 +14,11 @@
     "directory": "packages/typedoc-plugin-appium"
   },
   "keywords": [
-    "automation",
-    "javascript",
-    "selenium",
-    "webdriver",
-    "ios",
-    "android",
-    "firefoxos",
-    "testing"
+    "typedoc-plugin",
+    "typedocplugin",
+    "typedoc-theme",
+    "appium",
+    "markdown"
   ],
   "author": "https://github.com/appium",
   "types": "./build/lib/index.d.ts",


### PR DESCRIPTION
- There was a problem in a `sync-pkgs` script (which happens at publish) which caused the `keywords` of the typedoc plugin's `package.json` to get overridden, causing `typedoc` to fail to find the plugin.
- There's a problem in `FakeDriver` w/r/t the `doubleClick` method which I'm still investigating; it was causing a fatal error. I reduced the severity to just be a warning.  Regardless, that method will not be documented until I fix the underlying issue.
- The doc generation script was using an incorrect filename for the markdown file generated by `typedoc`.