### PR TITLE
chore(types): remove @wdio/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17599,7 +17599,6 @@
         "@types/express": "4.17.15",
         "@types/npmlog": "4.1.4",
         "@types/ws": "8.5.4",
-        "@wdio/types": "7.26.0",
         "type-fest": "3.5.2"
       },
       "engines": {

--- a/packages/types/lib/capabilities.ts
+++ b/packages/types/lib/capabilities.ts
@@ -1,8 +1,9 @@
-import type {Capabilities as WdioCaps} from '@wdio/types';
+import {StandardCapabilities} from './standard-caps';
 import {StringRecord, Constraint, Constraints} from '.';
 import {BaseDriverCapConstraints} from './constraints';
 
-export type StandardCapabilities = WdioCaps.Capabilities;
+export {StandardCapabilities};
+
 export type W3C_APPIUM_PREFIX = 'appium';
 
 /**
@@ -14,16 +15,6 @@ export type BaseCapabilities = ConstraintsToCaps<BaseDriverCapConstraints>;
  * Like {@linkcode BaseCapabilities}, except all Appium-specific keys are namespaced.
  */
 export type BaseNSCapabilities = CapsToNSCaps<ConstraintsToCaps<BaseDriverCapConstraints>>;
-
-/**
- * These may (or should) be reused by drivers.
- */
-export type AppiumAndroidCapabilities = WdioCaps.AppiumAndroidCapabilities;
-export type AppiumIOSCapabilities = WdioCaps.AppiumIOSCapabilities;
-export type AppiumXCUICommandTimeouts = WdioCaps.AppiumXCUICommandTimeouts;
-export type AppiumXCUIProcessArguments = WdioCaps.AppiumXCUIProcessArguments;
-export type AppiumXCUISafariGlobalPreferences = WdioCaps.AppiumXCUISafariGlobalPreferences;
-export type AppiumXCUITestCapabilities = WdioCaps.AppiumXCUITestCapabilities;
 
 /**
  * Given a {@linkcode Constraint} `C` and a type `T`, see if `inclusion`/`inclusionCaseInsensitive` is present, and create a union of its allowed literals; otherwise just use `T`.

--- a/packages/types/lib/standard-caps.ts
+++ b/packages/types/lib/standard-caps.ts
@@ -1,0 +1,65 @@
+export type PageLoadingStrategy = 'none' | 'eager' | 'normal';
+export type ProxyTypes = 'pac' | 'noproxy' | 'autodetect' | 'system' | 'manual';
+export interface ProxyObject {
+  proxyType?: ProxyTypes;
+  proxyAutoconfigUrl?: string;
+  ftpProxy?: string;
+  ftpProxyPort?: number;
+  httpProxy?: string;
+  httpProxyPort?: number;
+  sslProxy?: string;
+  sslProxyPort?: number;
+  socksProxy?: string;
+  socksProxyPort?: number;
+  socksVersion?: string;
+  socksUsername?: string;
+  socksPassword?: string;
+}
+export type Timeouts = Record<'script' | 'pageLoad' | 'implicit', number>;
+
+export interface StandardCapabilities {
+  /**
+   * Identifies the user agent.
+   */
+  browserName?: string;
+  /**
+   * Identifies the version of the user agent.
+   */
+  browserVersion?: string;
+  /**
+   * Identifies the operating system of the endpoint node.
+   */
+  platformName?: string;
+  /**
+   * Indicates whether untrusted and self-signed TLS certificates are implicitly trusted on navigation for the duration of the session.
+   */
+  acceptInsecureCerts?: boolean;
+  /**
+   * Defines the current session’s page load strategy.
+   */
+  pageLoadStrategy?: PageLoadingStrategy;
+  /**
+   * Defines the current session’s proxy configuration.
+   */
+  proxy?: ProxyObject;
+  /**
+   * Indicates whether the remote end supports all of the resizing and repositioning commands.
+   */
+  setWindowRect?: boolean;
+  /**
+   * Describes the timeouts imposed on certain session operations.
+   */
+  timeouts?: Timeouts;
+  /**
+   * Defines the current session’s strict file interactability.
+   */
+  strictFileInteractability?: boolean;
+  /**
+   * Describes the current session’s user prompt handler. Defaults to the dismiss and notify state.
+   */
+  unhandledPromptBehavior?: string;
+  /**
+   * WebDriver clients opt in to a bidirectional connection by requesting a capability with the name "webSocketUrl" and value true.
+   */
+  webSocketUrl?: boolean;
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -41,7 +41,6 @@
     "@types/express": "4.17.15",
     "@types/npmlog": "4.1.4",
     "@types/ws": "8.5.4",
-    "@wdio/types": "7.26.0",
     "type-fest": "3.5.2"
   },
   "engines": {


### PR DESCRIPTION
Due to problems where multiple versions of `@wdio/types` can be installed in the dep tree of external modules, and the fact we are not using most of the types we pull in, it makes sense to remove this module.

The "standard" W3C caps have been pulled out of `@wdio/types`.  We do not need any webdriverio or vendor-specific cap types.  Those only make sense when consuming wdio itself and/or writing client-side code.

This will also make it easier to upgrade `webdriverio`; it too depends on `@wdio/types`.

Note: there were several Appium-specific caps in `@wdio/types` that I did not recognize.  Perhaps these were driver-specific and not accurately labeled as such.  Driver-specific caps belong in drivers.

See #18090