### PR TITLE
chore: do not publish tsconfig.tsbuildinfo 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-tsconfig.tsbuildinfo

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -39,7 +39,8 @@
     "plugin.*",
     "scripts/autoinstall-extensions.js",
     "types",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "build:docs": "node docs/scripts/build-docs.js",

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -33,7 +33,8 @@
     "lib",
     "static",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/base-plugin/package.json
+++ b/packages/base-plugin/package.json
@@ -31,7 +31,8 @@
     "lib",
     "build",
     "index.js",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -35,7 +35,8 @@
     "lib",
     "bin",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -33,7 +33,8 @@
     "base-mkdocs.yml",
     "lib",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/driver-test-support/package.json
+++ b/packages/driver-test-support/package.json
@@ -31,7 +31,8 @@
     "index.js",
     "lib",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -28,7 +28,8 @@
     "build",
     "lib",
     "index.js",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -34,7 +34,8 @@
     "lib",
     "build",
     "test/fixtures",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "build": "cpy lib/screen.png build",

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -30,7 +30,8 @@
     "index.js",
     "lib",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/images-plugin/lib/compare.js
+++ b/packages/images-plugin/lib/compare.js
@@ -29,6 +29,10 @@ const DEFAULT_MATCH_THRESHOLD = 0.4;
  * if `mode` value is incorrect or if there was an unexpected issue while
  * matching the images.
  */
+
+/**
+ * @type {import('@appium/types').PluginCommand<[string, string, string, object|undefined], Promise<OccurrenceResult>>}
+ */
 async function compareImages(mode, firstImage, secondImage, options = {}) {
   const img1 = Buffer.from(firstImage, 'base64');
   const img2 = Buffer.from(secondImage, 'base64');

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -29,7 +29,8 @@
     "docs",
     "lib",
     "index.js",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -31,7 +31,8 @@
     "index.js",
     "lib",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/plugin-test-support/package.json
+++ b/packages/plugin-test-support/package.json
@@ -32,7 +32,8 @@
     "lib",
     "index.js",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -31,7 +31,8 @@
     "index.js",
     "lib",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -28,7 +28,8 @@
     "build",
     "lib",
     "index.js",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "build": "node ./scripts/generate-schema-json.js",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -31,7 +31,8 @@
     "index.js",
     "lib",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -36,7 +36,8 @@
     "bin",
     "lib",
     "build",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -28,7 +28,8 @@
     "build",
     "lib",
     "index.js",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "build": "node ./scripts/generate-schema-types.js",

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -27,7 +27,8 @@
     "index.js",
     "build",
     "lib",
-    "tsconfig.json"
+    "tsconfig.json",
+    "!build/tsconfig.tsbuildinfo"
   ],
   "scripts": {
     "test": "npm run test:unit",


### PR DESCRIPTION
apparently the "files" prop does not take into account what the ".npmignore" file says, so these were still getting published.