### PR TITLE
chore(execute-driver-plugin,support,types): use named tuples

### DIFF
--- a/packages/execute-driver-plugin/lib/plugin.js
+++ b/packages/execute-driver-plugin/lib/plugin.js
@@ -32,7 +32,7 @@ export default class ExecuteDriverPlugin extends BasePlugin {
    *
    * @returns {Promise<any>} - a JSONifiable object representing the return value of
    * the script
-   * @type {import('@appium/types').PluginCommand<[string, string?, number?]>}
+   * @type {import('@appium/types').PluginCommand<[script: string, scriptType: string?, timeoutMs: number?], any>}
    * @throws {Error}
    */
   async executeDriverScript(

--- a/packages/support/test/mocks.js
+++ b/packages/support/test/mocks.js
@@ -87,5 +87,5 @@ export function initMocks(sandbox = createSandbox()) {
  */
 
 /**
- * @typedef { { exec: sinon.SinonStub<[string, string[], import('teen_process').TeenProcessExecOptions], import('teen_process').TeenProcessExecResult>, __stdout: string, __stderr: string, __code: number} } MockTeenProcess
+ * @typedef { { exec: sinon.SinonStub<[command: string, args: string[], opts: import('teen_process').TeenProcessExecOptions], import('teen_process').TeenProcessExecResult>, __stdout: string, __stderr: string, __code: number} } MockTeenProcess
  */

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -15,7 +15,7 @@ import {
   ExecuteMethodMap,
 } from '.';
 import {ServerArgs} from './config';
-import {AsyncReturnType, ConditionalPick} from 'type-fest';
+import {AsyncReturnType, Entries} from 'type-fest';
 
 export interface ITimeoutCommands {
   /**
@@ -411,7 +411,7 @@ export interface SessionHandler<
    *
    * @param w3cCaps1 - the new session capabilities
    * @param w3cCaps2 - another place the new session capabilities could be sent (typically left undefined)
-   * @param w3cCaps - another place the new session capabilities could be sent (typically left undefined)
+   * @param w3cCaps3 - another place the new session capabilities could be sent (typically left undefined)
    * @param driverData - a list of DriverData objects representing other sessions running for this
    * driver on the same Appium server. This information can be used to help ensure no conflict of
    * resources
@@ -537,7 +537,7 @@ export interface StopScreenRecordOptions {
   method?: string;
   headers?: Record<string, string>;
   fileFieldName?: string;
-  formFields: Record<string, string> | Array<[string, string]>;
+  formFields: Record<string, string> | Entries<Record<string, string>>;
 }
 
 // JSONWP
@@ -676,7 +676,7 @@ export interface Driver<
     ITimeoutCommands,
     IEventCommands,
     IExecuteCommands,
-    SessionHandler<[string, any], void, C>,
+    SessionHandler<[sessionId: string, caps: any], void, C>,
     Core {
   /**
    * The set of command line arguments set for this driver

--- a/packages/types/lib/plugin.ts
+++ b/packages/types/lib/plugin.ts
@@ -90,5 +90,5 @@ export type PluginCommand<
 export type PluginClass<P extends Plugin = Plugin> = Class<
   P,
   PluginStatic<P>,
-  [string, Record<string, unknown>]
+  [pluginName: string, cliArgs: Record<string, unknown>]
 >;


### PR DESCRIPTION
The "old" way of defining tuples is `[T, U]`, but I think TS 4.7 introduced "named" tuples, which at least provides a little bit of context to consumers, e.g., `[foo: T, bar: U]`.  Since a tuple is just a fixed-length array, the names aren't actually used in code, but are surfaced in type information and error messages regardless.

Anyway, name tuples seem objectively better than unnamed tuples.

Also:

- Fixed bad param name in definition of `SessionHandler`
- Used a semantically-correct type for `StopScreenRecordOptions.formFields`
