### PR TITLE
fix(typedoc-plugin-appium): use simple filenames for ExtensionReflection objects

### DIFF
--- a/packages/appium/docs/mkdocs-en.yml
+++ b/packages/appium/docs/mkdocs-en.yml
@@ -12,50 +12,50 @@ theme:
 nav:
   - Welcome: index.md
   - Introduction:
-    - Intro to Appium:
-      - Overview of Appium: intro/index.md
-      - intro/drivers.md
-      - intro/clients.md
-    - intro/requirements.md
-    - intro/history.md
+      - Intro to Appium:
+          - Overview of Appium: intro/index.md
+          - intro/drivers.md
+          - intro/clients.md
+      - intro/requirements.md
+      - intro/history.md
   - Quickstart:
-    - quickstart/index.md
-    - quickstart/install.md
-    - quickstart/uiauto2-driver.md
-    - Write a Test:
-      - quickstart/test-js.md
-      - quickstart/test-py.md
-      - quickstart/test-java.md
-      - quickstart/test-rb.md
-    - quickstart/next-steps.md
+      - quickstart/index.md
+      - quickstart/install.md
+      - quickstart/uiauto2-driver.md
+      - Write a Test:
+          - quickstart/test-js.md
+          - quickstart/test-py.md
+          - quickstart/test-java.md
+          - quickstart/test-rb.md
+      - quickstart/next-steps.md
   - CLI Reference:
-    - cli/index.md
-    - cli/args.md
-    - cli/extensions.md
+      - cli/index.md
+      - cli/args.md
+      - cli/extensions.md
   - Guides:
-    - guides/migrating-1-to-2.md
-    - guides/managing-exts.md
-    - guides/config.md
-    - guides/security.md
-    - guides/caps.md
-    - guides/context.md
-    - guides/settings.md
-    - guides/execute-methods.md
-    - guides/event-timing.md
-    - guides/log-filters.md
-    - guides/grid.md
-    - guides/caching.md
+      - guides/migrating-1-to-2.md
+      - guides/managing-exts.md
+      - guides/config.md
+      - guides/security.md
+      - guides/caps.md
+      - guides/context.md
+      - guides/settings.md
+      - guides/execute-methods.md
+      - guides/event-timing.md
+      - guides/log-filters.md
+      - guides/grid.md
+      - guides/caching.md
   - Developer Reference:
-      - BaseDriver Commands: reference/commands/appium_base_driver-1._appium_base_driver.md
-      - FakeDriver Commands: reference/commands/appium_fake_driver-1._appium_fake_driver.md
+      - BaseDriver Commands: reference/commands/base-driver.md
+      - FakeDriver Commands: reference/commands/fake-driver.md
   - Ecosystem:
-    - ecosystem/index.md
-    - Developing Appium Extensions:
-      - ecosystem/build-drivers.md
-      - ecosystem/build-plugins.md
-      - ecosystem/build-docs.md
+      - ecosystem/index.md
+      - Developing Appium Extensions:
+          - ecosystem/build-drivers.md
+          - ecosystem/build-plugins.md
+          - ecosystem/build-docs.md
   - Contributing:
-    - contributing/index.md
-    - contributing/config-system.md
+      - contributing/index.md
+      - contributing/config-system.md
   - More Appium Resources: resources.md
   - Issues: https://github.com/appium/appium/issues

--- a/packages/typedoc-plugin-appium/lib/theme/index.ts
+++ b/packages/typedoc-plugin-appium/lib/theme/index.ts
@@ -1,4 +1,11 @@
-import {Application, ContainerReflection, PageEvent, ReflectionKind, Renderer} from 'typedoc';
+import {
+  Application,
+  ContainerReflection,
+  PageEvent,
+  Reflection,
+  ReflectionKind,
+  Renderer,
+} from 'typedoc';
 import {MarkdownTheme} from 'typedoc-plugin-markdown';
 import {AppiumPluginLogger} from '../logger';
 import {AppiumPluginReflectionKind, NS} from '../model';
@@ -59,6 +66,21 @@ export class AppiumTheme extends MarkdownTheme {
     registerHelpers();
   }
 
+  /**
+   * Special-cases `ExtensionReflection` instances to make the filename shorter and thus better
+   * suitable for `mkdocs`.
+   * @param reflection Reflection to get URL for
+   * @returns String URL
+   */
+  public override getUrl(reflection: Reflection) {
+    if (reflection.kindOf(AppiumPluginReflectionKind.Extension as any)) {
+      // I don't know what this replace is for, but the superclass does it, so maybe it's important.
+      return reflection.getAlias().replace('^_', '');
+    }
+    return super.getUrl(reflection);
+  }
+
+  /**
   /**
    * A lookup of {@linkcode ReflectionKind}s to templates.  It also controls in which directory the output files live.
    *


### PR DESCRIPTION
Simplifies filenames when outputting command docs

Closes #18110.
