### PR TITLE
display commands by command name, not http route

### DIFF
--- a/packages/typedoc-plugin-appium/lib/model/reflection/command.ts
+++ b/packages/typedoc-plugin-appium/lib/model/reflection/command.ts
@@ -107,6 +107,7 @@ export class CommandReflection extends DeclarationReflection {
       commentSource,
       parameters,
       signature,
+      command,
     } = data;
 
     // kind-specific data
@@ -119,7 +120,7 @@ export class CommandReflection extends DeclarationReflection {
       if (!route) {
         throw new TypeError('"route" arg is required for a non-execute-method command');
       }
-      name = route;
+      name = command;
       kind = AppiumPluginReflectionKind.Command;
       httpMethod = data.httpMethod;
     }

--- a/packages/typedoc-plugin-appium/lib/theme/resources/partials/command.hbs
+++ b/packages/typedoc-plugin-appium/lib/theme/resources/partials/command.hbs
@@ -1,6 +1,8 @@
 {{#unless hasOwnDocument}}
 
-### {{#ifNamedAnchors}} <a id="{{anchor}}" name="{{this.anchor}}"></a> {{/ifNamedAnchors}}`{{httpMethod}}` `{{name}}`
+### {{#ifNamedAnchors}} <a id="{{anchor}}" name="{{this.anchor}}"></a> {{/ifNamedAnchors}}`{{name}}`
+
+`{{httpMethod}}` **`{{route}}`**
 
 {{#if hasComment}}
 {{> comment}}

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -405,7 +405,7 @@ export interface SessionHandler<
    * Start a new automation session
    * @see {@link https://w3c.github.io/webdriver/#new-session}
    *
-   * @remarks
+   * @privateRemarks
    * The shape of this method is strange because it used to support both JSONWP and W3C
    * capabilities. This will likely change in the future to simplify.
    *


### PR DESCRIPTION
Per discussion with @jlipps this changes the command output to create headings based on the _command
name_ and not the pairing of the HTTP method and path (the "route").

This will provide easier navigation.
