### PR TITLE
feat(docutils): implement mkdocs validation

### DIFF
--- a/packages/docutils/lib/cli/command/validate.ts
+++ b/packages/docutils/lib/cli/command/validate.ts
@@ -6,9 +6,34 @@ import logger from '../../logger';
 
 const log = logger.withTag('validate');
 
-const NAME_GROUP_VALIDATE = 'Validation:';
+const NAME_GROUP_VALIDATE = 'Validation Behavior:';
+const NAME_GROUP_VALIDATE_PATHS = 'Paths:';
 
 const opts = {
+  mkdocs: {
+    default: true,
+    description: 'Validate MkDocs environment',
+    group: NAME_GROUP_VALIDATE,
+    type: 'boolean',
+  },
+  mkdocsYml: {
+    defaultDescription: './mkdocs.yml',
+    description: 'Path to mkdocs.yml',
+    group: NAME_GROUP_VALIDATE_PATHS,
+    nargs: 1,
+    normalize: true,
+    requiresArg: true,
+    type: 'string',
+  },
+  'npm-path': {
+    defaultDescription: '(derived from shell)',
+    description: 'Path to npm executable',
+    group: NAME_GROUP_VALIDATE_PATHS,
+    nargs: 1,
+    normalize: true,
+    requiresArg: true,
+    type: 'string',
+  },
   python: {
     default: true,
     description: 'Validate Python 3 environment',
@@ -18,7 +43,7 @@ const opts = {
   'python-path': {
     defaultDescription: '(derived from shell)',
     description: 'Path to python 3 executable',
-    group: NAME_GROUP_VALIDATE,
+    group: NAME_GROUP_VALIDATE_PATHS,
     nargs: 1,
     normalize: true,
     requiresArg: true,
@@ -27,7 +52,7 @@ const opts = {
   'tsconfig-json': {
     defaultDescription: './tsconfig.json',
     describe: 'Path to tsconfig.json',
-    group: NAME_GROUP_VALIDATE,
+    group: NAME_GROUP_VALIDATE_PATHS,
     nargs: 1,
     normalize: true,
     requiresArg: true,
@@ -35,14 +60,14 @@ const opts = {
   },
   typedoc: {
     default: true,
-    description: 'Validate TypoDoc config',
+    description: 'Validate TypoDoc environment',
     group: NAME_GROUP_VALIDATE,
     type: 'boolean',
   },
   'typedoc-json': {
     defaultDescription: './typedoc.json',
     describe: 'Path to typedoc.json',
-    group: NAME_GROUP_VALIDATE,
+    group: NAME_GROUP_VALIDATE_PATHS,
     nargs: 1,
     normalize: true,
     requiresArg: true,
@@ -50,27 +75,9 @@ const opts = {
   },
   typescript: {
     default: true,
-    description: 'Validate TypeScript config',
+    description: 'Validate TypeScript environment',
     group: NAME_GROUP_VALIDATE,
     type: 'boolean',
-  },
-  mkdocsYml: {
-    defaultDescription: './mkdocs.yml',
-    description: 'Path to mkdocs.yml',
-    group: NAME_GROUP_VALIDATE,
-    nargs: 1,
-    normalize: true,
-    requiresArg: true,
-    type: 'string',
-  },
-  npmPath: {
-    defaultDescription: '(derived from shell)',
-    description: 'Path to npm executable',
-    group: NAME_GROUP_VALIDATE,
-    nargs: 1,
-    normalize: true,
-    requiresArg: true,
-    type: 'string',
   },
 } as const;
 opts as Record<string, Options>;
@@ -80,10 +87,10 @@ const validateCommand: CommandModule<{}, ValidateOptions> = {
   describe: 'Validate Environment',
   builder: opts,
   async handler(args) {
-    if (!args.python && !args.typedoc && !args.typescript) {
+    if (!args.python && !args.typedoc && !args.typescript && !args.mkdocs) {
       // specifically not a DocutilsError
       throw new Error(
-        'No validation targets specified; one or more of --python, --typescript or --typedoc must be provided'
+        'No validation targets specified; one or more of --python, --typescript, --typedoc or --mkdocs must be provided'
       );
     }
 

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -71,6 +71,19 @@ export const NAME_NPM = 'npm';
  */
 export const NAME_TYPESCRIPT = 'typescript';
 
+/**
+ * Code for a "file not found" error
+ */
+export const NAME_ERR_ENOENT = 'ENOENT';
+
+/**
+ * Code for a "file already exists" error
+ */
+export const NAME_ERR_EEXIST = 'EEXIST';
+
+/**
+ * Default log level
+ */
 export const DEFAULT_LOG_LEVEL = 'info';
 /**
  * Blocking I/O

--- a/packages/docutils/lib/scaffold.ts
+++ b/packages/docutils/lib/scaffold.ts
@@ -13,9 +13,7 @@ import {DocutilsError} from './error';
 import {relative} from './util';
 import _ from 'lodash';
 import {stringifyJson, readPackageJson, safeWriteFile} from './fs';
-
-const NAME_ERR_ENOENT = 'ENOENT';
-const NAME_ERR_EEXIST = 'EEXIST';
+import {NAME_ERR_ENOENT, NAME_ERR_EEXIST} from './constants';
 
 const log = logger.withTag('init');
 const dryRunLog = log.withTag('dry-run');

--- a/packages/docutils/lib/util.ts
+++ b/packages/docutils/lib/util.ts
@@ -35,3 +35,12 @@ export type TupleToObject<
   T extends readonly any[],
   M extends Record<Exclude<keyof T, keyof any[]>, PropertyKey>
 > = {[K in Exclude<keyof T, keyof any[]> as M[K]]: T[K]};
+
+/**
+ * Type guard to narrow an array to a string array
+ * @param value any value
+ * @returns `true` if the array is `string[]`
+ */
+export const isStringArray = _.overEvery(_.isArray, _.partial(_.every, _, _.isString)) as (
+  value: any
+) => value is string[];


### PR DESCRIPTION
- Better grouping of `validate` command options in `--help`
- Move some more constants into the module
- Removed the "guess" functions and replaced them with functions which use `which` to actually find the necessary executables
- Moved `isStringArray()` to `util`
- Fixed some error messages and added more
- Simplified use of `DocutilsValidator#fail()`
- Removed option for custom path to `requirements.txt`

![image](https://user-images.githubusercontent.com/924465/216492052-ab51a4e5-9deb-47e1-b3ca-34312bbdf7f6.png)
