### PR TITLE
feat(docutils): better mkdocs validation

### DIFF
--- a/packages/docutils/lib/cli/command/validate.ts
+++ b/packages/docutils/lib/cli/command/validate.ts
@@ -16,7 +16,7 @@ const opts = {
     group: NAME_GROUP_VALIDATE,
     type: 'boolean',
   },
-  mkdocsYml: {
+  'mkdocs-yml': {
     defaultDescription: './mkdocs.yml',
     description: 'Path to mkdocs.yml',
     group: NAME_GROUP_VALIDATE_PATHS,

--- a/packages/docutils/lib/model.ts
+++ b/packages/docutils/lib/model.ts
@@ -34,6 +34,12 @@ export type TypeDocJson = Jsonify<
 >;
 
 /**
+ * The `nav` prop of an `mkdocs.yml` file
+ * @see {@linkcode MkDocsYml}
+ */
+export type MkDocsYmlNav = Array<string | Record<string, string> | Record<string, MkDocsYmlNav>>;
+
+/**
  * This was built by hand from the MkDocs documentation
  * @see https://www.mkdocs.org/user-guide/configuration/
  */
@@ -48,7 +54,7 @@ export type MkDocsYml = Jsonify<{
   hooks?: string[];
   INHERIT?: string;
   markdown_extensions?: Array<string | Record<string, JsonValue>>;
-  nav?: Array<string | Record<string, string[]>>;
+  nav?: MkDocsYmlNav;
   plugins?: Array<string | Record<string, JsonValue>>;
   repo_name?: string;
   repo_url?: string;


### PR DESCRIPTION
When validating `mkdocs.yml`, `appium-docs` is now aware of the `INHERITS` property, and expands this property (by loading more `mkdocs.yml` files).

Also:

- Updated the types for `mkdocs.yml`
- Squelch warnings from `YAML.parse()`
- Change YAML indentation back to 2, since that seems to be correct and I was confused
