### PR TITLE
chore(docutils): reorganize some build-related modules into a 'builder' subdir

### DIFF
--- a/packages/docutils/lib/builder/index.ts
+++ b/packages/docutils/lib/builder/index.ts
@@ -1,0 +1,2 @@
+export * from './site';
+export * from './reference';

--- a/packages/docutils/lib/cli/command/build.ts
+++ b/packages/docutils/lib/cli/command/build.ts
@@ -1,6 +1,5 @@
 import {CommandModule, InferredOptionTypes, Options} from 'yargs';
-import {buildMkDocs} from '../../mkdocs';
-import {buildReference} from '../../typedoc';
+import {buildReferenceDocs, buildSite} from '../../builder';
 import logger from '../../logger';
 import {updateNav} from '../../nav';
 import {stopwatch} from '../../util';
@@ -100,11 +99,11 @@ const buildCommand: CommandModule<{}, BuildOptions> = {
       );
     }
     if (args.site) {
-      await buildReference(args);
+      await buildReferenceDocs(args);
     }
     if (args.reference) {
       await updateNav(args);
-      await buildMkDocs(args);
+      await buildSite(args);
     }
     log.success('Done! (total: %dms)', stop());
   },

--- a/packages/docutils/lib/index.js
+++ b/packages/docutils/lib/index.js
@@ -1,3 +1,0 @@
-// eslint-disable-next-line import/no-unresolved
-export * from './mkdocs';
-export * from './mike';

--- a/packages/docutils/lib/index.ts
+++ b/packages/docutils/lib/index.ts
@@ -1,0 +1,5 @@
+export * from './mike';
+export * from './builder';
+export * from './validate';
+export * from './scaffold';
+export * from './constants';

--- a/packages/docutils/lib/util.ts
+++ b/packages/docutils/lib/util.ts
@@ -5,6 +5,7 @@
 
 import _ from 'lodash';
 import path from 'node:path';
+import type {SubProcess} from 'teen_process';
 
 /**
  * Computes a relative path, prepending `./`
@@ -44,3 +45,32 @@ export type TupleToObject<
 export const isStringArray = _.overEvery(_.isArray, _.partial(_.every, _, _.isString)) as (
   value: any
 ) => value is string[];
+
+/**
+ * Converts an object of string values to an array of arguments for CLI
+ *
+ * Supports `boolean` and `number` values as well.  `boolean`s are assumed to be flags which default
+ * to `false`, so they will only be added to the array if the value is `true`.
+ */
+export const argify: (obj: Record<string, string | number | boolean | undefined>) => string[] =
+  _.flow(
+    _.entries,
+    _.flatten,
+    (list) =>
+      list.map((value, idx) => {
+        if (value === true) {
+          return `--${value}`;
+        } else if (value === false || value === undefined) {
+          return;
+        }
+        return idx % 2 === 0 ? `--${value}` : value;
+      }),
+    _.compact
+  );
+
+/**
+ * Conversion of the parameters of {@linkcode Subprocess.start} to an object.
+ */
+export type TeenProcessSubprocessStartOpts = Partial<
+  TupleToObject<Parameters<SubProcess['start']>, ['startDetector', 'detach', 'timeoutMs']>
+>;

--- a/packages/docutils/test/unit/mike.spec.js
+++ b/packages/docutils/test/unit/mike.spec.js
@@ -1,4 +1,4 @@
-import {Mike} from '../../lib';
+import {Mike} from '../..';
 import {expect} from 'chai';
 
 describe('Mike', function () {


### PR DESCRIPTION
Also rename a few things.  `typedoc` module is now `reference` and `mkdocs` module is now `site`.

Moved a couple things into `util` as well

The `nav` module will be in stacked PR
