### PR TITLE
feat(docutils): add support for deploying with mike

### DIFF
--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -1,0 +1,188 @@
+/**
+ * Functions for running `mike`
+ *
+ * @module
+ */
+
+import {exec, SubProcess, TeenProcessExecOptions} from 'teen_process';
+import {
+  DEFAULT_DEPLOY_BRANCH,
+  DEFAULT_DEPLOY_REMOTE,
+  DEFAULT_SERVE_HOST,
+  DEFAULT_SERVE_PORT,
+  NAME_BIN,
+  NAME_MKDOCS_YML,
+} from '../constants';
+import {DocutilsError} from '../error';
+import {findMkDocsYml, whichMike} from '../fs';
+import logger from '../logger';
+import {argify, stopwatch, TeenProcessSubprocessStartOpts} from '../util';
+
+const log = logger.withTag('builder:deploy');
+
+/**
+ * Runs `mike serve`
+ * @param args Extra args to `mike build`
+ * @param opts Extra options for `teen_process.Subprocess.start`
+ * @param mikePath Path to `mike` executable
+ */
+async function doServe(
+  args: string[] = [],
+  {startDetector, detach, timeoutMs}: TeenProcessSubprocessStartOpts = {},
+  mikePath?: string
+) {
+  mikePath = mikePath ?? (await whichMike());
+  const finalArgs = ['serve', ...args];
+  log.debug('Launching %s with args: %O', mikePath, finalArgs);
+  const proc = new SubProcess(mikePath, finalArgs);
+  return await proc.start(startDetector, detach, timeoutMs);
+}
+
+/**
+ * Runs `mike build`
+ * @param args Extra args to `mike build`
+ * @param opts Extra options to `teen_process.exec`
+ * @param mikePath Path to `mike` executable
+ */
+async function doDeploy(args: string[] = [], opts: TeenProcessExecOptions = {}, mikePath?: string) {
+  mikePath = mikePath ?? (await whichMike());
+  const finalArgs = ['deploy', ...args];
+  log.debug('Launching %s with args: %O', mikePath, finalArgs);
+  return await exec(mikePath, finalArgs, opts);
+}
+
+/**
+ * Runs `mike build` or `mike serve`
+ * @param opts
+ */
+export async function deploy({
+  mkDocsYml: mkDocsYmlPath,
+  cwd = process.cwd(),
+  serve = false,
+  push = false,
+  branch = DEFAULT_DEPLOY_BRANCH,
+  remote = DEFAULT_DEPLOY_REMOTE,
+  prefix,
+  message,
+  deployVersion,
+  alias,
+  rebase = true,
+  port = DEFAULT_SERVE_PORT,
+  host = DEFAULT_SERVE_HOST,
+  serveOpts,
+  execOpts,
+}: DeployOpts = {}) {
+  const stop = stopwatch('deploy');
+  mkDocsYmlPath = mkDocsYmlPath ?? (await findMkDocsYml(cwd));
+  if (!mkDocsYmlPath) {
+    throw new DocutilsError(
+      `Could not find ${NAME_MKDOCS_YML} from ${cwd}; run "${NAME_BIN} init" to create it`
+    );
+  }
+
+  const mikeOpts = {
+    'config-file': mkDocsYmlPath,
+    push,
+    remote,
+    branch,
+    prefix,
+    message,
+    deployVersion,
+    alias,
+    rebase,
+    port,
+    host,
+  };
+  const mikeArgs = argify(mikeOpts);
+  if (serve) {
+    // unsure about how SIGHUP is handled here
+    await doServe(mikeArgs, serveOpts);
+  } else {
+    await doDeploy(mikeArgs, execOpts);
+
+    log.success('Mike finished deployment into branch %s (%dms)', branch, stop());
+  }
+}
+
+/**
+ * Options for {@linkcode deploy}.
+ */
+export interface DeployOpts {
+  /**
+   * Path to `mike.yml`
+   */
+  mkDocsYml?: string;
+
+  /**
+   * Current working directory
+   * @defaultValue `process.cwd()`
+   */
+  cwd?: string;
+
+  /**
+   * Path to `package.json`
+   *
+   * Used to find `mike.yml` if unspecified.
+   */
+  packageJson?: string;
+
+  /**
+   * If `true`, run `mike serve` instead of `mike build`
+   */
+  serve?: boolean;
+
+  /**
+   * If `true`, push `branch` to `remote`
+   */
+  push?: boolean;
+  /**
+   * Branch to commit to
+   * @defaultValue gh-pages
+   */
+  branch?: string;
+  /**
+   * Remote to push to
+   * @defaultValue origin
+   */
+  remote?: string;
+  /**
+   * Subdirectory within `branch` to deploy to
+   */
+  prefix?: string;
+  /**
+   * Commit message
+   */
+  message?: string;
+  /**
+   * Version (dir) to deploy build to
+   */
+  deployVersion?: string;
+  /**
+   * Alias for the build (e.g., `latest`); triggers alias update
+   */
+  alias?: string;
+  /**
+   * If `true`, rebase `branch` before pushing
+   */
+  rebase?: boolean;
+  /**
+   * Port to serve on
+   * @defaultValue 8000
+   */
+  port?: number;
+  /**
+   * Host to serve on
+   * @defaultValue localhost
+   */
+  host?: string;
+
+  /**
+   * Extra options for {@linkcode teen_process.exec}
+   */
+  execOpts?: TeenProcessExecOptions;
+
+  /**
+   * Extra options for {@linkcode teen_process.Subprocess.start}
+   */
+  serveOpts?: TeenProcessSubprocessStartOpts;
+}

--- a/packages/docutils/lib/builder/index.ts
+++ b/packages/docutils/lib/builder/index.ts
@@ -1,2 +1,3 @@
+export * from './deploy';
 export * from './site';
 export * from './reference';

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -2,7 +2,6 @@
  * Constants used across various modules in this package
  * @module
  */
-
 import {LogLevel} from 'consola';
 import {readFileSync} from 'node:fs';
 import {fs} from '@appium/support';
@@ -48,6 +47,11 @@ export const NAME_SCHEMA = '$schema';
  * Name of the `mkdocs` executable
  */
 export const NAME_MKDOCS = 'mkdocs';
+
+/**
+ * Name of the `mike` executable
+ */
+export const NAME_MIKE = 'mike';
 
 /**
  * Name of the `typedoc` executable
@@ -110,6 +114,26 @@ export const REQUIREMENTS_TXT_PATH = path.join(PKG_ROOT_DIR, NAME_REQUIREMENTS_T
 export const DEFAULT_REL_TYPEDOC_OUT_PATH = path.join('docs', 'reference');
 
 /**
+ * The default branch to deploy to
+ */
+export const DEFAULT_DEPLOY_BRANCH = 'gh-pages';
+
+/**
+ * The default remote to push the deployed branch to
+ */
+export const DEFAULT_DEPLOY_REMOTE = 'origin';
+
+/**
+ * The default port for serving docs
+ */
+export const DEFAULT_SERVE_PORT = 8000;
+
+/**
+ * The default host for serving docs
+ */
+export const DEFAULT_SERVE_HOST = 'localhost';
+
+/**
  * Mapping of `@appium/docutils`' log levels to `consola` log levels
  */
 export const LogLevelMap = {
@@ -119,3 +143,8 @@ export const LogLevelMap = {
   info: LogLevel.Info,
   debug: LogLevel.Debug,
 } as const;
+
+/**
+ * Default site nav header text
+ */
+export const DEFAULT_NAV_HEADER = 'Reference';

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -20,6 +20,7 @@ import {
   NAME_MKDOCS,
   NAME_NPM,
   NAME_PYTHON,
+  NAME_MIKE,
 } from './constants';
 import {DocutilsError} from './error';
 import {MkDocsYml} from './model';
@@ -216,6 +217,11 @@ export const whichNpm = _.partial(cachedWhich, NAME_NPM);
  * Finds `python` executable
  */
 export const whichPython = _.partial(cachedWhich, NAME_PYTHON);
+
+/**
+ * Finds `mike` executable
+ */
+export const whichMike = _.partial(cachedWhich, NAME_MIKE);
 
 /**
  * Reads an `mkdocs.yml` file, merges inherited configs, and returns the result. The result is cached.

--- a/packages/docutils/lib/mike.js
+++ b/packages/docutils/lib/mike.js
@@ -6,6 +6,9 @@ const DEFAULT_REMOTE = 'origin';
 const DEFAULT_BRANCH = 'gh-pages';
 const MIKE_VER_STRING = 'mike 1.';
 
+/**
+ * @deprecated Use the `deploy` export from `@appium/docutils`
+ */
 export class Mike {
   /** @type {string} */ remote;
   /** @type {string} */ branch;


### PR DESCRIPTION
This is enabled via `appium-docs build --deploy`.  Instead of invoking `mkdocs` directly, `mike` will be invoked.

Implementation is in `lib/builder/deploy.ts`.  It's very similar to the MkDocs implementation in `lib/builder/site.ts`; just with new/different options.

I marked the `Mike` class as deprecated, since the new one is fancy
