### PR TITLE
fix(docutils): fix various problems in deploy pipeline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17244,6 +17244,7 @@
         "@sliphua/lilconfig-ts-loader": "3.2.2",
         "consola": "2.15.3",
         "diff": "5.1.0",
+        "find-up": "5.0.0",
         "glob": "8.1.0",
         "json5": "2.2.3",
         "lilconfig": "2.0.6",

--- a/packages/docutils/lib/builder/nav.ts
+++ b/packages/docutils/lib/builder/nav.ts
@@ -135,7 +135,12 @@ function navDataDidChange(
   newNavData: Array<Omit<ParsedNavData, 'name'>>,
   navData: ParsedNavData[]
 ): boolean {
-  return Boolean(_.xor(newNavData, _.map(navData, _.partial(_.omit, _, 'name'))).length);
+  const diff = _.xorWith(
+    newNavData,
+    navData,
+    (a, b) => a.keypath === b.keypath && a.fileOrUrl === b.fileOrUrl
+  );
+  return !_.isEmpty(diff);
 }
 
 /**

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -55,6 +55,7 @@
     "@sliphua/lilconfig-ts-loader": "3.2.2",
     "consola": "2.15.3",
     "diff": "5.1.0",
+    "find-up": "5.0.0",
     "glob": "8.1.0",
     "json5": "2.2.3",
     "lilconfig": "2.0.6",


### PR DESCRIPTION
- Do not send boolean flags to `mike`
- Do not send `mike serve`-specific args to `mike deploy`
- Derive version from `package.json` if no version present (like the CLI docs say it should)
- `version` and `alias` are positional args to `mike deploy`/`mike serve`, not options
- Fix update nav logic
- Fix monkeypatching of TypeDoc if `typedoc` is not installed in the `node_modules` of a workspace
- Fix parsing of `typedoc.json`
- Fix finding of `typedoc.json`
