### PR TITLE
fix(docutils): fix bad option name and ignore most falsy args

### DIFF
--- a/packages/appium/docs/scripts/build-docs.js
+++ b/packages/appium/docs/scripts/build-docs.js
@@ -52,7 +52,7 @@ async function main() {
     log.info(`Building docs for language '${lang}' and version ${majMinVer}`);
     const configFile = path.join(DOCS_DIR, `mkdocs-${lang}.yml`);
     await deploy({
-      mkDocsYml: configFile,
+      mkdocsYml: configFile,
       branch,
       prefix: path.join(basePrefix, lang),
       remote,

--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -74,7 +74,7 @@ async function findDeployVersion(packageJsonPath?: string, cwd = process.cwd()):
  * @param opts Options
  */
 export async function deploy({
-  mkDocsYml: mkDocsYmlPath,
+  mkdocsYml: mkDocsYmlPath,
   packageJson: packageJsonPath,
   deployVersion: version,
   cwd = process.cwd(),
@@ -111,7 +111,10 @@ export async function deploy({
     host,
   };
   if (serve) {
-    const mikeArgs = [...argify(_.pickBy(mikeOpts, Boolean)), version];
+    const mikeArgs = [
+      ...argify(_.pickBy(mikeOpts, (value) => _.isNumber(value) || Boolean(value))),
+      version,
+    ];
     if (alias) {
       mikeArgs.push(alias);
     }
@@ -120,7 +123,10 @@ export async function deploy({
   } else {
     const mikeArgs = [
       ...argify(
-        _.omitBy(mikeOpts, (value, key) => _.includes(['port', 'host'], key) || value === false)
+        _.omitBy(
+          mikeOpts,
+          (value, key) => _.includes(['port', 'host'], key) || (!_.isNumber(value) && !value)
+        )
       ),
       version,
     ];
@@ -140,7 +146,7 @@ export interface DeployOpts {
   /**
    * Path to `mike.yml`
    */
-  mkDocsYml?: string;
+  mkdocsYml?: string;
 
   /**
    * Current working directory


### PR DESCRIPTION
- in type `DeployOpts`, `mkDocsYml` should have been `mkdocsYml`
- arguments were only being omitted from being passed to `mike` if they were `false`, but it needed
  to also consider `undefined` values and empty string values.  `0` is falsy, but we should not
  disallow this.  thus... "most" falsy values get ignored.
