### PR TITLE
chore(deps): upgrade typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "typedoc": "0.23.24",
         "typedoc-plugin-markdown": "3.14.0",
         "typedoc-plugin-resolve-crossmodule-references": "0.3.3",
-        "typescript": "4.7.4",
+        "typescript": "4.9.5",
         "validate.js": "0.13.1",
         "webdriverio": "7.30.1",
         "ws": "8.12.0",
@@ -16048,8 +16048,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "license": "Apache-2.0",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17420,6 +17421,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/docutils/node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "packages/docutils/node_modules/yargs-parser": {
       "version": "20.2.9",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
@@ -17960,7 +17973,7 @@
         "typedoc": "^0.23.14",
         "typedoc-plugin-markdown": "^3.14.0",
         "typedoc-plugin-resolve-crossmodule-references": "~0.3.3",
-        "typescript": "~4.7.0"
+        "typescript": "^4.7.0"
       }
     },
     "packages/types": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "typedoc": "0.23.24",
     "typedoc-plugin-markdown": "3.14.0",
     "typedoc-plugin-resolve-crossmodule-references": "0.3.3",
-    "typescript": "4.7.4",
+    "typescript": "4.9.5",
     "validate.js": "0.13.1",
     "webdriverio": "7.30.1",
     "ws": "8.12.0",

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -693,7 +693,7 @@ class ExtensionCommand {
       );
     }
 
-    if (!(scriptName in extScripts)) {
+    if (!(scriptName in /** @type {Record<string,string>} */ (extScripts))) {
       throw this._createFatalError(
         `The ${this.type} named '${installSpec}' does not support the script: '${scriptName}'`
       );

--- a/packages/appium/lib/extension/extension-config.js
+++ b/packages/appium/lib/extension/extension-config.js
@@ -435,7 +435,7 @@ export class ExtensionConfig {
   /**
    * @param {string} extName
    * @param {ExtManifest<ExtType>} extManifest
-   * @param {ExtensionConfigMutationOpts} [opts]
+   * @param {ExtensionConfigMutationOpts} opts
    * @returns {Promise<void>}
    */
   async addExtension(extName, extManifest, {write = true} = {}) {
@@ -448,7 +448,7 @@ export class ExtensionConfig {
   /**
    * @param {ExtName<ExtType>} extName
    * @param {ExtManifest<ExtType>} extManifest
-   * @param {ExtensionConfigMutationOpts} [opts]
+   * @param {ExtensionConfigMutationOpts} opts
    * @returns {Promise<void>}
    */
   async updateExtension(extName, extManifest, {write = true} = {}) {
@@ -465,7 +465,7 @@ export class ExtensionConfig {
    * Remove an extension from the list of installed extensions, and optionally avoid a write to the manifest file.
    *
    * @param {ExtName<ExtType>} extName
-   * @param {ExtensionConfigMutationOpts} [opts]
+   * @param {ExtensionConfigMutationOpts} opts
    * @returns {Promise<void>}
    */
   async removeExtension(extName, {write = true} = {}) {

--- a/packages/appium/lib/schema/arg-spec.js
+++ b/packages/appium/lib/schema/arg-spec.js
@@ -94,7 +94,7 @@ export class ArgSpec {
    * The _constructor_ is private. Use {@link ArgSpec.create} instead.
    * @private
    * @param {string} name
-   * @param {ArgSpecOptions<D>} [opts]
+   * @param {ArgSpecOptions<D>} opts
    */
   constructor(name, {extType, extName, dest, defaultValue} = {}) {
     // we must normalize the extension name to fit into our convention for CLI

--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -193,10 +193,10 @@ export class NPM {
    * Installs a package w/ `npm`
    * @param {string} cwd
    * @param {string} pkgName
-   * @param {InstallPackageOpts} [opts]
+   * @param {InstallPackageOpts} opts
    * @returns {Promise<NpmInstallReceipt>}
    */
-  async installPackage(cwd, pkgName, {pkgVer, installType}) {
+  async installPackage(cwd, pkgName, {pkgVer, installType} = {}) {
     /** @type {any} */
     let dummyPkgJson;
     const dummyPkgPath = path.join(cwd, 'package.json');

--- a/packages/typedoc-plugin-appium/package.json
+++ b/packages/typedoc-plugin-appium/package.json
@@ -57,7 +57,7 @@
     "typedoc": "^0.23.14",
     "typedoc-plugin-markdown": "^3.14.0",
     "typedoc-plugin-resolve-crossmodule-references": "~0.3.3",
-    "typescript": "~4.7.0"
+    "typescript": "^4.7.0"
   },
   "dependencies": {
     "handlebars": "4.7.7",


### PR DESCRIPTION
anything newer than v4.7.4 fails to ignore an optional arg in `@param {T} [foo]` if `foo` has a default assignment in the function signature.  removing the square brackets fixes the issue.

whether or not this is a bug, I am not entirely sure: it is marked as a bug, but it is also not
something the TS team is in a hurry to fix, so whatevs.
