### PR TITLE
fix(renovate): do not upgrade "figures" package to a major

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -23,6 +23,7 @@
         "delay",
         "env-paths",
         "execa",
+        "figures",
         "find-up",
         "get-port",
         "globby",


### PR DESCRIPTION
`figures` @ v5+ is ESM-only. added to list
