### PR TITLE
chore: force http-cache-semantics to v4.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7199,8 +7199,9 @@
       }
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "license": "BSD-2-Clause"
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     },
     "ajv-formats": {
       "ajv": "8.12.0"
-    }
+    },
+    "http-cache-semantics": "4.1.1"
   }
 }


### PR DESCRIPTION
for https://github.com/advisories/GHSA-rc47-6667-2j5j

this override should be removed when upgrading webdriver to v8+.  unfortunately "npm audit" is so stupid that it does not understand overrides, so we will see warnings anyway.

this is a `chore` and not a `fix` because these are only in our dev deps.