### PR TITLE
chore: replace usage of public class field assignments

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -45,7 +45,7 @@ class AppiumDriver extends DriverCore {
    * It is not recommended to access this property directly from the outside
    * @type {Record<string,ExternalDriver>}
    */
-  sessions = {};
+  sessions;
 
   /**
    * Access to pending drivers list must be guarded with a Semaphore, because
@@ -53,14 +53,14 @@ class AppiumDriver extends DriverCore {
    * It is not recommended to access this property directly from the outside
    * @type {Record<string,ExternalDriver[]>}
    */
-  pendingDrivers = {};
+  pendingDrivers;
 
   /**
    * Note that {@linkcode AppiumDriver} has no `newCommandTimeout` method.
    * `AppiumDriver` does not set and observe its own timeouts; individual
    * sessions (managed drivers) do instead.
    */
-  newCommandTimeoutMs = 0;
+  newCommandTimeoutMs;
 
   /**
    * List of active plugins
@@ -72,13 +72,13 @@ class AppiumDriver extends DriverCore {
    * map of sessions to actual plugin instances per session
    * @type {Record<string,InstanceType<PluginClass>[]>}
    */
-  sessionPlugins = {};
+  sessionPlugins;
 
   /**
    * some commands are sessionless, so we need a set of plugins for them
    * @type {InstanceType<PluginClass>[]}
    */
-  sessionlessPlugins = [];
+  sessionlessPlugins;
 
   /** @type {DriverConfig} */
   driverConfig;
@@ -86,7 +86,11 @@ class AppiumDriver extends DriverCore {
   /** @type {AppiumServer} */
   server;
 
-  desiredCapConstraints = desiredCapabilityConstraints;
+  /**
+   * @type {AppiumDriverConstraints}
+   * @readonly
+   */
+  desiredCapConstraints;
 
   /** @type {DriverOpts} */
   args;
@@ -106,6 +110,13 @@ class AppiumDriver extends DriverCore {
     super(opts);
 
     this.args = {...opts};
+    this.sessions = {};
+    this.pendingDrivers = {};
+    this.newCommandTimeoutMs = 0;
+    this.pluginClasses = new Map();
+    this.sessionPlugins = {};
+    this.sessionlessPlugins = [];
+    this.desiredCapConstraints = desiredCapabilityConstraints;
 
     // allow this to happen in the background, so no `await`
     (async () => {

--- a/packages/base-driver/lib/basedriver/core.js
+++ b/packages/base-driver/lib/basedriver/core.js
@@ -35,7 +35,7 @@ class DriverCore {
   /**
    * @type {string?}
    */
-  sessionId = null;
+  sessionId;
 
   /**
    * @type {import('@appium/types').DriverOpts<C>}
@@ -47,7 +47,8 @@ class DriverCore {
    */
   initialOpts;
 
-  helpers = helpers;
+  /** @type {typeof helpers} */
+  helpers;
 
   /**
    * basePath is used for several purposes, for example in setting up
@@ -56,39 +57,43 @@ class DriverCore {
    * initially but it is automatically updated during any actual program
    * execution by the routeConfiguringFunction, which is necessarily run as
    * the entrypoint for any Appium server
+   * @type {string}
    */
-  basePath = DEFAULT_BASE_PATH;
+  basePath;
 
-  relaxedSecurityEnabled = false;
-
-  /** @type {string[]} */
-  allowInsecure = [];
+  /** @type {boolean} */
+  relaxedSecurityEnabled;
 
   /** @type {string[]} */
-  denyInsecure = [];
-
-  newCommandTimeoutMs = NEW_COMMAND_TIMEOUT_MS;
-
-  implicitWaitMs = 0;
+  allowInsecure;
 
   /** @type {string[]} */
-  locatorStrategies = [];
+  denyInsecure;
+
+  /** @type {number} */
+  newCommandTimeoutMs;
+
+  /** @type {number} */
+  implicitWaitMs;
 
   /** @type {string[]} */
-  webLocatorStrategies = [];
+  locatorStrategies;
+
+  /** @type {string[]} */
+  webLocatorStrategies;
 
   /** @type {Driver[]} */
-  managedDrivers = [];
+  managedDrivers;
 
   /** @type {NodeJS.Timeout?} */
-  noCommandTimer = null;
+  noCommandTimer;
 
   /** @type {EventHistory} */
-  _eventHistory = {commands: []};
+  _eventHistory;
 
   // used to handle driver events
   /** @type {NodeJS.EventEmitter} */
-  eventEmitter = new EventEmitter();
+  eventEmitter;
 
   /**
    * @type {AppiumLogger}
@@ -97,8 +102,9 @@ class DriverCore {
 
   /**
    * @protected
+   * @type {boolean}
    */
-  shutdownUnexpectedly = false;
+  shutdownUnexpectedly;
 
   /**
    * @type {boolean}
@@ -107,16 +113,18 @@ class DriverCore {
 
   /**
    * @protected
+   * @type {AsyncLock}
    */
-  commandsQueueGuard = new AsyncLock();
+  commandsQueueGuard;
 
   /**
    * settings should be instantiated by drivers which extend BaseDriver, but
    * we set it to an empty DeviceSettings instance here to make sure that the
    * default settings are applied even if an extending driver doesn't utilize
    * the settings functionality itself
+   * @type {DeviceSettings}
    */
-  settings = new DeviceSettings();
+  settings;
 
   /**
    * @param {DriverOpts<C>} opts
@@ -139,6 +147,22 @@ class DriverCore {
     this.initialOpts = _.cloneDeep(opts);
 
     this.sessionId = null;
+    this.helpers = helpers;
+    this.basePath = DEFAULT_BASE_PATH;
+    this.relaxedSecurityEnabled = false;
+    this.allowInsecure = [];
+    this.denyInsecure = [];
+    this.newCommandTimeoutMs = NEW_COMMAND_TIMEOUT_MS;
+    this.implicitWaitMs = 0;
+    this.locatorStrategies = [];
+    this.webLocatorStrategies = [];
+    this.managedDrivers = [];
+    this.noCommandTimer = null;
+    this._eventHistory = {commands: []};
+    this.eventEmitter = new EventEmitter();
+    this.shutdownUnexpectedly = false;
+    this.commandsQueueGuard = new AsyncLock();
+    this.settings = new DeviceSettings();
   }
 
   get log() {

--- a/packages/base-driver/lib/basedriver/driver.js
+++ b/packages/base-driver/lib/basedriver/driver.js
@@ -1,7 +1,7 @@
 /* eslint-disable require-await */
 /* eslint-disable no-unused-vars */
 
-import {validateCaps, PREFIXED_APPIUM_OPTS_CAP, processCapabilities} from './capabilities';
+import {validateCaps, processCapabilities} from './capabilities';
 import {DriverCore} from './core';
 import {util} from '@appium/support';
 import B from 'bluebird';

--- a/packages/fake-plugin/lib/plugin.js
+++ b/packages/fake-plugin/lib/plugin.js
@@ -5,7 +5,20 @@ import {BasePlugin} from 'appium/plugin';
 import B from 'bluebird';
 
 class FakePlugin extends BasePlugin {
-  fakeThing = 'PLUGIN_FAKE_THING';
+  /**
+   * @type {string}
+   * @readonly
+   */
+  fakeThing;
+
+  /**
+   * @param {string} name
+   * @param {Record<string,unknown>} cliArgs
+   */
+  constructor(name, cliArgs) {
+    super(name, cliArgs);
+    this.fakeThing = 'PLUGIN_FAKE_THING';
+  }
 
   static newMethodMap = /** @type {const} */ ({
     '/session/:sessionId/fake_data': {

--- a/packages/types/lib/action.ts
+++ b/packages/types/lib/action.ts
@@ -4,8 +4,9 @@
  * @see https://github.com/w3c-webdriver/w3c-webdriver
  */
 
-export interface Element {
-  'element-6066-11e4-a52e-4f735466cecf': string;
+export interface Element<Id extends string = string> {
+  ELEMENT?: Id;
+  'element-6066-11e4-a52e-4f735466cecf': Id;
 }
 
 /**
@@ -72,11 +73,7 @@ export type KeyAction = PauseAction | KeyDownAction | KeyUpAction;
 /**
  * @group Actions
  */
-export type PointerAction =
-  | PauseAction
-  | PointerMoveAction
-  | PointerUpAction
-  | PointerDownAction;
+export type PointerAction = PauseAction | PointerMoveAction | PointerUpAction | PointerDownAction;
 
 /**
  * @group Actions
@@ -116,10 +113,7 @@ export type PointerActionSequence = {
 /**
  * @group Actions
  */
-export type ActionSequence =
-  | NullActionSequence
-  | KeyActionSequence
-  | PointerActionSequence;
+export type ActionSequence = NullActionSequence | KeyActionSequence | PointerActionSequence;
 
 /**
  * @group Actions
@@ -194,5 +188,5 @@ export enum Key {
   R_ARROWRIGHT = '\uE05A',
   R_ARROWDOWN = '\uE05B',
   R_INSERT = '\uE05C',
-  R_DELETE = '\uE05D'
+  R_DELETE = '\uE05D',
 }

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -183,7 +183,7 @@ export interface IExecuteCommands {
    *
    * @returns The result of calling the Execute Method
    */
-  executeMethod(script: string, args: [StringRecord] | []): Promise<any>;
+  executeMethod<TReturn = any>(script: string, args: [StringRecord] | any[]): Promise<TReturn>;
 }
 
 export interface MultiSessionData<
@@ -569,6 +569,8 @@ export interface Credential {
   signCount: number;
   largeBlob?: string;
 }
+
+export type Orientation = 'LANDSCAPE' | 'PORTRAIT';
 
 export interface EventHistory {
   commands: EventHistoryCommand[];

--- a/packages/universal-xml-plugin/lib/plugin.js
+++ b/packages/universal-xml-plugin/lib/plugin.js
@@ -1,20 +1,12 @@
 /* eslint-disable no-case-declarations */
 
-import BasePlugin from 'appium/plugin';
+import {BasePlugin} from 'appium/plugin';
 import {errors} from 'appium/driver';
 import {transformSourceXml} from './source';
 import {transformQuery} from './xpath';
 import log from './logger';
 
 export default class UniversalXMLPlugin extends BasePlugin {
-  commands = [
-    'getPageSource',
-    'findElement',
-    'findElements',
-    'findElementFromElement',
-    'findElementsFromElement',
-  ];
-
   async getPageSource(next, driver, sessId, addIndexPath = false) {
     const source = next ? await next() : await driver.getPageSource();
     const metadata = {};

--- a/packages/universal-xml-plugin/tsconfig.json
+++ b/packages/universal-xml-plugin/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "outDir": "build"
+    "outDir": "build",
+    "checkJs": true
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib"]


### PR DESCRIPTION
Basically, public class fields don't work the way you'd expect, so I'd like to avoid assignment to them whenever possible.  Compounding the situation is the fact that `tsc` (and Babel, fwiw) both transpile in a way that deviates slightly from the official specification.

Given the following example:

```js
class A {
  value = 'a';
  constructor() {
    console.log(this.value);
  }
}

class B extends A {
  value = 'b';
}
```

What is logged by `new B()`?  If you guessed `b`, you'd be both reasonable and wrong.  What's happening is that the super class does not know anything about public class fields in subclasses.  If `value` was instead a method or getter, this _would_ work as you'd expect.

Probably better to avoid them whenever possible.  It is perfectly safe to _declare_ them for type inference & the like, but assignment should be avoided until it's absolutely the right thing to do.

Note that `tsc` has a flag to change the transpilation behavior to act in-line with the spec, but it does not change anything in the above regard, AFAICT.

