### PR TITLE
fix(types): base cap webSocketUrl is now a boolean instead of a string.

### DIFF
--- a/packages/types/lib/constraints.js
+++ b/packages/types/lib/constraints.js
@@ -13,7 +13,7 @@ export const BASE_DESIRED_CAP_CONSTRAINTS = /** @type {const} */ ({
     isString: true,
   },
   webSocketUrl: {
-    isString: true,
+    isBoolean: true,
   },
   newCommandTimeout: {
     isNumber: true,


### PR DESCRIPTION
note that it is a string in the server response, but it is expected to be a boolean in the request.  punting on that for now
