### PR TITLE
chore(docutils): smol type upgrade

### DIFF
--- a/packages/docutils/lib/model.ts
+++ b/packages/docutils/lib/model.ts
@@ -9,16 +9,10 @@ import type {TypeDocOptions} from 'typedoc';
 
 /**
  * A `tsconfig.json` file w/ `$schema` prop
- *
- * Due to some `unknown` types in {@linkcode type-fest.TsConfigJson}, we cannot use that type
- * directly and need to use `Jsonify`.
- *
  */
-export type TsConfigJson = Jsonify<
-  TsConfigJsonBase & {
-    $schema?: string;
-  }
->;
+export type TsConfigJson = TsConfigJsonBase & {
+  $schema?: string;
+};
 
 /**
  * A `typedoc.json` file w/ `$schema` and `extends` props


### PR DESCRIPTION
`type-fest`@3.6.0 has a `TsConfigJson` type which no longer contains `unknown` (courtesy of yours truly), so we can use it directly instead of wrapping it in `Jsonify`.
