### PR TITLE
chore: add prepack script

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "doctor": "node ./packages/doctor",
     "husky-install": "husky install",
     "generate-docs": "npm run --workspace=packages/appium generate-docs",
-    "prepare": "run-p husky-install build:all || true",
+    "prepare": "run-p husky-install build:all",
     "lint": "eslint .",
     "lint:fix": "run-s \"lint -- --fix\"",
     "lint:commit": "commitlint",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "tsc -b",
     "build:all": "run-s build build:packages",
     "build:packages": "lerna run build",
-    "clean": "run-s \"clean:artifacts:*\" clean:workspaces",
+    "clean": "run-s clean:artifacts clean:workspaces",
     "clean:artifacts": "run-p \"clean:artifacts:*\"",
     "clean:artifacts:distfiles": "npx rimraf \"./packages/*/build\" \"./packages/*/.tsconfig.tsbuildinfo\"",
     "clean:artifacts:packages": "lerna run clean || true",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "lint:fix": "run-s \"lint -- --fix\"",
     "lint:commit": "commitlint",
     "lint:staged": "lint-staged",
-    "pack-all": "npm pack --workspaces --include-workspace-root",
     "prepublishOnly": "run-s rebuild",
     "reinstall": "run-s clean ci",
     "rebuild": "run-s clean:artifacts build:all",
@@ -63,7 +62,8 @@
     "test:unit": "lerna run test",
     "typedoc": "typedoc --logLevel Verbose",
     "upload": "gulp github-upload",
-    "preversion": "run-s rebuild sync-pkgs stage-synced-pkgs",
+    "preversion": "run-s sync-pkgs stage-synced-pkgs",
+    "prepack": "npm run rebuild",
     "zip": "zip -qr ./appium.zip ./packages/appium",
     "zip-and-upload": "run-s zip upload"
   },


### PR DESCRIPTION
sometimes (when?) the smoke tests can pack the workspaces before they have actually been built, which will of course cause an error. this adds a `prepack` script to avoid the problem

removes `pack-all` script, which I added for reasons
