### PR TITLE
chore: Remove obsolete jpeg-js version override

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,7 +139,6 @@
     "access": "public"
   },
   "overrides": {
-    "jpeg-js": "0.4.4",
     "@sidvind/better-ajv-errors": {
       "ajv": "8.12.0"
     },

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -55,8 +55,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "gitHead": "84b211330dc84849af9cc1f3a5c5ad32e15b2e72",
-  "overrides": {
-    "jpeg-js": "0.4.4"
-  }
+  "gitHead": "84b211330dc84849af9cc1f3a5c5ad32e15b2e72"
 }

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -110,8 +110,5 @@
   "gitHead": "84b211330dc84849af9cc1f3a5c5ad32e15b2e72",
   "typedoc": {
     "entryPoint": "./lib/index.js"
-  },
-  "overrides": {
-    "jpeg-js": "0.4.4"
   }
 }


### PR DESCRIPTION
The recent version of jimp does not use this module anymore