### PR TITLE
docutils cli: fail-fast validation of paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16624,7 +16624,6 @@
         "lodash": "4.17.21",
         "log-symbols": "4.1.0",
         "pkg-dir": "5.0.0",
-        "pluralize": "8.0.0",
         "read-pkg": "5.2.0",
         "semver": "7.3.8",
         "source-map-support": "0.5.21",

--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -10,8 +10,9 @@ import {getDefaultsForSchema, getAllArgSpecs} from './schema/schema';
 const npmPackage = fs.readPackageJsonFrom(__dirname);
 
 const APPIUM_VER = npmPackage.version;
-const MIN_NODE_VERSION = npmPackage.engines.node;
-const MIN_NPM_VERSION = npmPackage.engines.npm;
+const ENGINES = /** @type {Record<string,string>} */ (npmPackage.engines);
+const MIN_NODE_VERSION = ENGINES.node;
+const MIN_NPM_VERSION = ENGINES.npm;
 
 const GIT_META_ROOT = '.git';
 const GIT_BINARY = `git${system.isWindows() ? '.exe' : ''}`;

--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -5,7 +5,7 @@
  */
 
 import _ from 'lodash';
-import {exec, SubProcess, TeenProcessExecOptions} from 'teen_process';
+import {exec, SubProcess, SubProcessOptions, TeenProcessExecOptions} from 'teen_process';
 import path from 'node:path';
 import {
   DEFAULT_DEPLOY_BRANCH,
@@ -35,8 +35,9 @@ async function doServe(
 ) {
   mikePath = mikePath ?? (await whichMike());
   const finalArgs = ['serve', ...args];
-  log.debug('Launching %s with args: %O', mikePath, finalArgs);
-  const proc = new SubProcess(mikePath, finalArgs);
+  const opts: SubProcessOptions = {stdio: 'inherit'};
+  log.debug('Launching %s with args: %s', mikePath, finalArgs);
+  const proc = new SubProcess(mikePath, finalArgs, opts);
   return await proc.start(startDetector, detach, timeoutMs);
 }
 

--- a/packages/docutils/lib/builder/index.ts
+++ b/packages/docutils/lib/builder/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Exports APIs used by build-related commands
+ * @module
+ */
+
 export * from './deploy';
 export * from './site';
 export * from './reference';

--- a/packages/docutils/lib/builder/site.ts
+++ b/packages/docutils/lib/builder/site.ts
@@ -7,7 +7,7 @@
 
 import path from 'node:path';
 import {exec, SubProcess, SubProcessOptions, TeenProcessExecOptions} from 'teen_process';
-import {NAME_BIN, NAME_MKDOCS, NAME_THEME, NAME_MKDOCS_YML} from '../constants';
+import {NAME_BIN, NAME_THEME, NAME_MKDOCS_YML} from '../constants';
 import {DocutilsError} from '../error';
 import {findMkDocsYml, readMkDocsYml, whichMkDocs} from '../fs';
 import logger from '../logger';

--- a/packages/docutils/lib/builder/site.ts
+++ b/packages/docutils/lib/builder/site.ts
@@ -28,8 +28,9 @@ async function doServe(
 ) {
   mkDocsPath = mkDocsPath ?? (await whichMkDocs());
   const finalArgs = ['serve', ...args];
-  log.debug('Launching %s with args: %O', mkDocsPath, finalArgs);
-  const proc = new SubProcess(mkDocsPath, finalArgs);
+  const opts: SubProcessOptions = {stdio: 'inherit'};
+  log.debug('Launching %s with args: %s', mkDocsPath, finalArgs);
+  const proc = new SubProcess(mkDocsPath, finalArgs, opts);
   return await proc.start(startDetector, detach, timeoutMs);
 }
 

--- a/packages/docutils/lib/cli/check.ts
+++ b/packages/docutils/lib/cli/check.ts
@@ -3,10 +3,9 @@
  * @module
  */
 
-import {fs} from '@appium/support';
+import {fs, util} from '@appium/support';
 import _ from 'lodash';
-import pluralize from 'pluralize';
-import {InferredOptionTypes, Options} from 'yargs';
+import type {Options} from 'yargs';
 import logger from '../logger';
 
 const log = logger.withTag('check');
@@ -72,7 +71,7 @@ export async function checkMissingPaths<T extends Record<string, Options>>(
 
   log.debug(
     'Checking for existence of %s: %s',
-    pluralize('path', pathsToCheck.length),
+    util.pluralize('path', pathsToCheck.length),
     _.map(pathsToCheck, 'path')
   );
 

--- a/packages/docutils/lib/cli/check.ts
+++ b/packages/docutils/lib/cli/check.ts
@@ -1,0 +1,88 @@
+/**
+ * Provides functions to validate user-provided options as part of Yargs' post-parsing "check" phase
+ * @module
+ */
+
+import {fs} from '@appium/support';
+import _ from 'lodash';
+import pluralize from 'pluralize';
+import {InferredOptionTypes, Options} from 'yargs';
+import logger from '../logger';
+
+const log = logger.withTag('check');
+
+/**
+ * Given a list of objects with `id` and `path` props, filters out the ones that do not exist
+ * @param paths Filepaths
+ * @returns Missing files
+ */
+async function filterMissing(paths: MissingFileData[]): Promise<MissingFileData[]> {
+  const exists = await Promise.all(
+    paths.map(async ({id, path}) => ({id, path, exists: await fs.exists(path)}))
+  );
+  const results = _.reject(exists, 'exists');
+  return _.map(results, (result) => _.omit(result, 'exists'));
+}
+
+/**
+ * Data structure describing a missing file; returned by {@linkcode filterMissing}
+ */
+interface MissingFileData {
+  /**
+   * Arbitrary identifier; intent was to map to an option name
+   */
+  id: string;
+  /**
+   * Normalized filepath
+   */
+  path: string;
+}
+
+/**
+ * Takes user-provided paths and checks for existence.
+ *
+ * Filters options to consider based on group name only.
+ *
+ * Meant to be used as a "fail-fast" strategy on the CLI, so we don't go all the way through some
+ * expensive behavior before realizing we're missing a path.
+ * @param opts Options object for a yargs command
+ * @param group Group name to filter on
+ * @param argv User-provided args
+ * @returns `true` if all paths exist or otherwise an error message
+ */
+export async function checkMissingPaths<T extends Record<string, Options>>(
+  opts: T,
+  group: string,
+  argv: Record<string, unknown>
+): Promise<true | string> {
+  const argsToCheck = _.keys(
+    _.pickBy(opts, (opt: Options, id: string) => opt?.group === group && id in argv) as Partial<T>
+  );
+
+  // yargs is pretty loose about allowing CLI args multiple times, and the value could potentially
+  // be a `string[]` instead of `string`; we don't want to allow more than one path per arg.
+  if (!argsToCheck.every((id) => _.isString(argv[id]))) {
+    return 'Paths may only be provided once each';
+  }
+
+  const pathsToCheck: MissingFileData[] = _.map(argsToCheck, (id) => ({
+    id,
+    path: String(argv[id]), // this must be a string per the above check
+  }));
+
+  log.debug(
+    'Checking for existence of %s: %s',
+    pluralize('path', pathsToCheck.length),
+    _.map(pathsToCheck, 'path')
+  );
+
+  const missingPaths = await filterMissing(pathsToCheck);
+
+  if (missingPaths.length) {
+    return missingPaths
+      .map(({id, path}) => `Path specified using --${_.kebabCase(id)} (${path}) does not exist`)
+      .join('\n');
+  }
+
+  return true;
+}

--- a/packages/docutils/lib/cli/command/build.ts
+++ b/packages/docutils/lib/cli/command/build.ts
@@ -5,7 +5,7 @@
 
 import path from 'node:path';
 import _ from 'lodash';
-import {CommandModule, InferredOptionTypes, Options} from 'yargs';
+import type {CommandModule, InferredOptionTypes, Options} from 'yargs';
 import {buildReferenceDocs, buildSite, deploy, updateNav} from '../../builder';
 import {NAME_BIN} from '../../constants';
 import {checkMissingPaths} from '../check';

--- a/packages/docutils/lib/cli/command/build.ts
+++ b/packages/docutils/lib/cli/command/build.ts
@@ -1,53 +1,65 @@
+/**
+ * Yargs command module for the `build` command.
+ * @module
+ */
+
+import path from 'node:path';
+import _ from 'lodash';
 import {CommandModule, InferredOptionTypes, Options} from 'yargs';
 import {buildReferenceDocs, buildSite, deploy, updateNav} from '../../builder';
 import {NAME_BIN} from '../../constants';
+import {checkMissingPaths} from '../check';
 import logger from '../../logger';
 import {stopwatch} from '../../util';
 
 const log = logger.withTag('build');
 
-const NAME_GROUP_BUILD = 'Build Options:';
-const NAME_GROUP_DEPLOY = 'Deployment Options:';
-const NAME_GROUP_SERVE = 'Serve Options:';
-const NAME_GROUP_BUILD_PATHS = 'Paths:';
+enum BuildCommandGroup {
+  Build = 'Build Config:',
+  Deploy = 'Deployment Config:',
+  Serve = 'Dev Server Config:',
+  BuildPaths = 'Custom Paths:',
+}
 
-const opts = Object.freeze({
+const opts = {
   reference: {
     describe: 'Run TypeDoc command API reference build (Markdown)',
-    group: NAME_GROUP_BUILD,
+    group: BuildCommandGroup.Build,
     type: 'boolean',
     default: true,
   },
   site: {
     describe: 'Run MkDocs build (HTML)',
-    group: NAME_GROUP_BUILD,
+    group: BuildCommandGroup.Build,
     type: 'boolean',
     default: true,
   },
   'site-dir': {
     alias: 'd',
     describe: 'HTML output directory',
-    group: NAME_GROUP_BUILD_PATHS,
+    group: BuildCommandGroup.Build,
     nargs: 1,
     requiresArg: true,
     type: 'string',
     normalize: true,
+    coerce: path.resolve,
     implies: 'site',
     defaultDescription: '(from mkdocs.yml)',
   },
   'package-json': {
     defaultDescription: './package.json',
     describe: 'Path to package.json',
-    group: NAME_GROUP_BUILD_PATHS,
+    group: BuildCommandGroup.BuildPaths,
     nargs: 1,
     normalize: true,
+    coerce: path.resolve,
     requiresArg: true,
     type: 'string',
   },
   title: {
     defaultDescription: '(extension package name)',
     describe: 'Title of the API reference',
-    group: NAME_GROUP_BUILD,
+    group: BuildCommandGroup.Build,
     nargs: 1,
     requiresArg: true,
     type: 'string',
@@ -55,45 +67,48 @@ const opts = Object.freeze({
   'tsconfig-json': {
     defaultDescription: './tsconfig.json',
     describe: 'Path to tsconfig.json',
-    group: NAME_GROUP_BUILD_PATHS,
+    group: BuildCommandGroup.BuildPaths,
     nargs: 1,
     normalize: true,
     requiresArg: true,
+    coerce: path.resolve,
     type: 'string',
   },
   'mkdocs-yml': {
     defaultDescription: './mkdocs.yml',
     description: 'Path to mkdocs.yml',
-    group: NAME_GROUP_BUILD_PATHS,
+    group: BuildCommandGroup.BuildPaths,
     nargs: 1,
     normalize: true,
     requiresArg: true,
+    coerce: path.resolve,
     type: 'string',
   },
   'typedoc-json': {
     defaultDescription: './typedoc.json',
     describe: 'Path to typedoc.json',
-    group: NAME_GROUP_BUILD_PATHS,
+    group: BuildCommandGroup.BuildPaths,
     nargs: 1,
     normalize: true,
     requiresArg: true,
+    coerce: path.resolve,
     type: 'string',
   },
   all: {
     describe: 'Output all reference docs (not just Appium comands)',
-    group: NAME_GROUP_BUILD,
+    group: BuildCommandGroup.Build,
     implies: 'site',
     type: 'boolean',
   },
   deploy: {
-    describe: 'Commit HTML output',
-    group: NAME_GROUP_DEPLOY,
+    describe: 'Commit HTML output to a branch using mike',
+    group: BuildCommandGroup.Deploy,
     type: 'boolean',
     implies: 'site',
   },
   push: {
     describe: 'Push after deploy',
-    group: NAME_GROUP_DEPLOY,
+    group: BuildCommandGroup.Deploy,
     type: 'boolean',
     implies: 'deploy',
   },
@@ -101,7 +116,7 @@ const opts = Object.freeze({
     alias: 'b',
     describe: 'Branch to commit to',
     implies: 'deploy',
-    group: NAME_GROUP_DEPLOY,
+    group: BuildCommandGroup.Deploy,
     type: 'string',
     requiresArg: true,
     nargs: 1,
@@ -111,7 +126,7 @@ const opts = Object.freeze({
     alias: 'r',
     describe: 'Remote to push to',
     implies: ['deploy', 'push'],
-    group: NAME_GROUP_DEPLOY,
+    group: BuildCommandGroup.Deploy,
     type: 'string',
     requiresArg: true,
     nargs: 1,
@@ -120,7 +135,7 @@ const opts = Object.freeze({
   prefix: {
     describe: 'Subdirectory within <branch> to commit to',
     implies: ['deploy', 'branch'],
-    group: NAME_GROUP_DEPLOY,
+    group: BuildCommandGroup.Deploy,
     type: 'string',
     nargs: 1,
     requiresArg: true,
@@ -129,7 +144,7 @@ const opts = Object.freeze({
     alias: 'm',
     describe: 'Commit message. Use "%s" for version placeholder',
     implies: 'deploy',
-    group: NAME_GROUP_DEPLOY,
+    group: BuildCommandGroup.Deploy,
     type: 'string',
     nargs: 1,
     requiresArg: true,
@@ -137,7 +152,7 @@ const opts = Object.freeze({
   'deploy-version': {
     describe: 'Version (directory) to deploy build to',
     implies: 'deploy',
-    group: NAME_GROUP_DEPLOY,
+    group: BuildCommandGroup.Deploy,
     type: 'string',
     nargs: 1,
     requiresArg: true,
@@ -146,7 +161,7 @@ const opts = Object.freeze({
   alias: {
     describe: 'Alias for the build (e.g., "latest"); triggers alias update',
     implies: 'deploy',
-    group: NAME_GROUP_DEPLOY,
+    group: BuildCommandGroup.Deploy,
     type: 'string',
     nargs: 1,
     requiresArg: true,
@@ -155,18 +170,18 @@ const opts = Object.freeze({
   rebase: {
     describe: 'Rebase <branch> with remote before deploy',
     implies: ['deploy', 'branch', 'remote'],
-    group: NAME_GROUP_DEPLOY,
+    group: BuildCommandGroup.Deploy,
     type: 'boolean',
   },
   serve: {
     describe: 'Start development server',
-    group: NAME_GROUP_SERVE,
+    group: BuildCommandGroup.Serve,
     type: 'boolean',
   },
   port: {
     alias: 'p',
     describe: 'Development server port',
-    group: NAME_GROUP_SERVE,
+    group: BuildCommandGroup.Serve,
     type: 'number',
     defaultDescription: '8000',
     implies: 'serve',
@@ -176,31 +191,35 @@ const opts = Object.freeze({
   host: {
     alias: 'h',
     describe: 'Development server host',
-    group: NAME_GROUP_SERVE,
+    group: BuildCommandGroup.Serve,
     type: 'string',
     nargs: 1,
     requiresArg: true,
     implies: 'serve',
     defaultDescription: 'localhost',
   },
-}) satisfies Record<string, Options>;
+} as const satisfies Record<string, Options>;
 
 type BuildOptions = InferredOptionTypes<typeof opts>;
 
 export default {
   command: 'build',
-  describe: 'Build Appium extension documentation',
-  builder: (yargs) =>
-    yargs.options(opts).check((argv) => {
-      // either this method doesn't provide camel-cased props, or the types are wrong.
-      if (argv.deploy === true && argv['site-dir']) {
-        log.error(
-          `--site-dir is unsupported when running "${NAME_BIN} deploy"; use --prefix if needd, but remember that the default behavior is to deploy to the root of the branch (${argv.branch}) instead of a subdirectory`
-        );
-        return false;
-      }
-      return true;
-    }),
+  describe: 'Build Appium extension documentation using TypeDoc & MkDocs',
+  builder(yargs) {
+    return yargs
+      .options(opts)
+      .check(async (argv) => {
+        // either this method doesn't provide camel-cased props, or the types are wrong.
+        if (argv.deploy === true && argv['site-dir']) {
+          return `--site-dir is unsupported when running "${NAME_BIN} deploy"; use --prefix if needed, but remember that the default behavior is to deploy to the root of the branch (${argv.branch}) instead of a subdirectory`;
+        }
+
+        return await checkMissingPaths(opts, BuildCommandGroup.BuildPaths, argv);
+      })
+      .epilog(
+        'For help with further configuration, see:\n  - MkDocs: https://www.mkdocs.org\n  - TypeDoc: https://typedoc.org\n  - Mike: https://github.com/jimporter/mike'
+      );
+  },
   async handler(args) {
     const stop = stopwatch('build');
     log.debug('Build command called with args: %O', args);

--- a/packages/docutils/lib/cli/command/index.ts
+++ b/packages/docutils/lib/cli/command/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Exports all command modules
+ * @module
+ */
+
 export {default as init} from './init';
 export {default as validate} from './validate';
 export {default as build} from './build';

--- a/packages/docutils/lib/cli/command/init.ts
+++ b/packages/docutils/lib/cli/command/init.ts
@@ -4,11 +4,12 @@
  */
 
 import _ from 'lodash';
-import {CommandModule, InferredOptionTypes, Options} from 'yargs';
+import type {CommandModule, InferredOptionTypes, Options} from 'yargs';
 import {init} from '../../init';
 import logger from '../../logger';
 import {stopwatch} from '../../util';
 import {checkMissingPaths} from '../check';
+
 const log = logger.withTag('init');
 
 enum InitCommandGroup {

--- a/packages/docutils/lib/cli/command/validate.ts
+++ b/packages/docutils/lib/cli/command/validate.ts
@@ -1,25 +1,33 @@
+/**
+ * Yargs command module for the `validate` command.
+ * @module
+ */
+
 import pluralize from 'pluralize';
 import {CommandModule, InferredOptionTypes, Options} from 'yargs';
 import {DocutilsError} from '../../error';
 import {DocutilsValidator, ValidationKind} from '../../validate';
 import logger from '../../logger';
+import {checkMissingPaths} from '../check';
 
 const log = logger.withTag('validate');
 
-const NAME_GROUP_VALIDATE = 'Validation Behavior:';
-const NAME_GROUP_VALIDATE_PATHS = 'Paths:';
+enum ValidateCommandGroup {
+  Behavior = 'Validation Behavior:',
+  Paths = 'Custom Paths:',
+}
 
-const opts = Object.freeze({
+const opts = {
   mkdocs: {
     default: true,
     description: 'Validate MkDocs environment',
-    group: NAME_GROUP_VALIDATE,
+    group: ValidateCommandGroup.Behavior,
     type: 'boolean',
   },
   'mkdocs-yml': {
     defaultDescription: './mkdocs.yml',
     description: 'Path to mkdocs.yml',
-    group: NAME_GROUP_VALIDATE_PATHS,
+    group: ValidateCommandGroup.Paths,
     nargs: 1,
     normalize: true,
     requiresArg: true,
@@ -28,7 +36,7 @@ const opts = Object.freeze({
   'npm-path': {
     defaultDescription: '(derived from shell)',
     description: 'Path to npm executable',
-    group: NAME_GROUP_VALIDATE_PATHS,
+    group: ValidateCommandGroup.Paths,
     nargs: 1,
     normalize: true,
     requiresArg: true,
@@ -37,13 +45,13 @@ const opts = Object.freeze({
   python: {
     default: true,
     description: 'Validate Python 3 environment',
-    group: NAME_GROUP_VALIDATE,
+    group: ValidateCommandGroup.Behavior,
     type: 'boolean',
   },
   'python-path': {
     defaultDescription: '(derived from shell)',
     description: 'Path to python 3 executable',
-    group: NAME_GROUP_VALIDATE_PATHS,
+    group: ValidateCommandGroup.Paths,
     nargs: 1,
     normalize: true,
     requiresArg: true,
@@ -52,7 +60,7 @@ const opts = Object.freeze({
   'tsconfig-json': {
     defaultDescription: './tsconfig.json',
     describe: 'Path to tsconfig.json',
-    group: NAME_GROUP_VALIDATE_PATHS,
+    group: ValidateCommandGroup.Paths,
     nargs: 1,
     normalize: true,
     requiresArg: true,
@@ -61,13 +69,13 @@ const opts = Object.freeze({
   typedoc: {
     default: true,
     description: 'Validate TypoDoc environment',
-    group: NAME_GROUP_VALIDATE,
+    group: ValidateCommandGroup.Behavior,
     type: 'boolean',
   },
   'typedoc-json': {
     defaultDescription: './typedoc.json',
     describe: 'Path to typedoc.json',
-    group: NAME_GROUP_VALIDATE_PATHS,
+    group: ValidateCommandGroup.Paths,
     nargs: 1,
     normalize: true,
     requiresArg: true,
@@ -76,25 +84,25 @@ const opts = Object.freeze({
   typescript: {
     default: true,
     description: 'Validate TypeScript environment',
-    group: NAME_GROUP_VALIDATE,
+    group: ValidateCommandGroup.Behavior,
     type: 'boolean',
   },
-}) satisfies Record<string, Options>;
+} as const satisfies Record<string, Options>;
 
 type ValidateOptions = InferredOptionTypes<typeof opts>;
 
 export default {
   command: 'validate',
   describe: 'Validate Environment',
-  builder: opts,
+  builder(yargs) {
+    return yargs.options(opts).check(async (argv) => {
+      if (!argv.python && !argv.typedoc && !argv.typescript && !argv.mkdocs) {
+        return 'No validation targets specified; one or more of --python, --typescript, --typedoc or --mkdocs must be provided';
+      }
+      return checkMissingPaths(opts, ValidateCommandGroup.Paths, argv);
+    });
+  },
   async handler(args) {
-    if (!args.python && !args.typedoc && !args.typescript && !args.mkdocs) {
-      // specifically not a DocutilsError
-      throw new Error(
-        'No validation targets specified; one or more of --python, --typescript, --typedoc or --mkdocs must be provided'
-      );
-    }
-
     let errorCount = 0;
     const validator = new DocutilsValidator(args)
       .once(DocutilsValidator.BEGIN, (kinds: ValidationKind[]) => {

--- a/packages/docutils/lib/cli/command/validate.ts
+++ b/packages/docutils/lib/cli/command/validate.ts
@@ -3,8 +3,8 @@
  * @module
  */
 
-import pluralize from 'pluralize';
-import {CommandModule, InferredOptionTypes, Options} from 'yargs';
+import {util} from '@appium/support';
+import type {CommandModule, InferredOptionTypes, Options} from 'yargs';
 import {DocutilsError} from '../../error';
 import {DocutilsValidator, ValidationKind} from '../../validate';
 import logger from '../../logger';
@@ -122,7 +122,7 @@ export default {
 
     if (errorCount) {
       throw new DocutilsError(
-        `Validation failed with ${errorCount} ${pluralize('error', errorCount)}`
+        `Validation failed with ${errorCount} ${util.pluralize('error', errorCount)}`
       );
     }
   },

--- a/packages/docutils/lib/cli/index.ts
+++ b/packages/docutils/lib/cli/index.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+/**
+ * Main CLI entry point for `@appium/docutils`
+ * @module
+ */
+
 import logger from '../logger';
 
 import _ from 'lodash';

--- a/packages/docutils/lib/cli/index.ts
+++ b/packages/docutils/lib/cli/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 import logger from '../logger';
 
 import _ from 'lodash';
@@ -8,6 +9,10 @@ import {DEFAULT_LOG_LEVEL, LogLevelMap, NAME_BIN} from '../constants';
 import {DocutilsError} from '../error';
 import {build, init, validate} from './command';
 import {findConfig} from './config';
+import {fs} from '@appium/support';
+import {sync as readPkg} from 'read-pkg';
+
+const pkg = readPkg({cwd: fs.findRoot(__dirname)});
 
 const log = logger.withTag('cli');
 export async function main(argv = hideBin(process.argv)) {
@@ -45,7 +50,7 @@ export async function main(argv = hideBin(process.argv)) {
         describe: 'Disable config file discovery',
       },
     })
-    .middleware(
+    .middleware([
       /**
        * Configures logging; `--verbose` implies `--log-level=debug`
        */
@@ -55,8 +60,15 @@ export async function main(argv = hideBin(process.argv)) {
           log.debug('Debug logging enabled via --verbose');
         }
         log.level = LogLevelMap[argv.logLevel];
-      }
-    )
+      },
+      /**
+       * Writes a startup message, if logging is enabled
+       */
+      async () => {
+        log.info(`${pkg.name} @ v${pkg.version} (Node.js ${process.version})`);
+      },
+    ])
+    .epilog(`Please report bugs at ${pkg.bugs?.url}`)
     .fail(
       /**
        * Custom failure handler so we can log nicely.
@@ -67,6 +79,7 @@ export async function main(argv = hideBin(process.argv)) {
           log.error(error.message);
         } else {
           y.showHelp();
+          console.log();
           log.error(msg ?? error.message);
         }
         y.exit(1, error);

--- a/packages/docutils/lib/error.ts
+++ b/packages/docutils/lib/error.ts
@@ -1,1 +1,7 @@
+/**
+ * A custom error class. This exists so we can use `instanceof` to differentiate between "expected"
+ * exceptions and unexpected ones.
+ * @module
+ */
+
 export class DocutilsError extends Error {}

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -127,7 +127,10 @@ async function _readPkgJson(
   cwd: string,
   normalize: true
 ): Promise<{pkgPath: string; pkg: NormalizedPackageJson}>;
-async function _readPkgJson(cwd: string): Promise<{pkgPath: string; pkg: PackageJson}>;
+async function _readPkgJson(
+  cwd: string,
+  normalize?: false
+): Promise<{pkgPath: string; pkg: PackageJson}>;
 async function _readPkgJson(
   cwd: string,
   normalize?: boolean

--- a/packages/docutils/lib/index.ts
+++ b/packages/docutils/lib/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Main entry point
+ * @module
+ */
+
 export * from './mike';
 export * from './builder';
 export * from './validate';

--- a/packages/docutils/lib/mike.js
+++ b/packages/docutils/lib/mike.js
@@ -1,3 +1,8 @@
+/**
+ * API around `mike`, a tool for deploying multiple versions of MkDocs-built sites to GitHub Pages
+ * @module
+ */
+
 import {exec} from 'teen_process';
 // eslint-disable-next-line import/no-unresolved
 import log from './logger';

--- a/packages/docutils/lib/util.ts
+++ b/packages/docutils/lib/util.ts
@@ -32,6 +32,9 @@ export function stopwatch(id: string) {
 }
 stopwatch.cache = new Map<string, number>();
 
+/**
+ * Converts a tuple to an object; use for extracting parameter types from a function signature
+ */
 export type TupleToObject<
   T extends readonly any[],
   M extends Record<Exclude<keyof T, keyof any[]>, PropertyKey>
@@ -69,7 +72,7 @@ export const argify: (obj: Record<string, string | number | boolean | undefined>
   );
 
 /**
- * Conversion of the parameters of {@linkcode Subprocess.start} to an object.
+ * Conversion of the parameters of {@linkcode SubProcess.start} to an object.
  */
 export type TeenProcessSubprocessStartOpts = Partial<
   TupleToObject<Parameters<SubProcess['start']>, ['startDetector', 'detach', 'timeoutMs']>

--- a/packages/docutils/lib/validate.ts
+++ b/packages/docutils/lib/validate.ts
@@ -1,15 +1,14 @@
 /**
- * Validates an environment for building documentation
+ * Validates an environment for building documentation; used by `validate` command
  *
  * @module
  */
 
-import {fs} from '@appium/support';
+import {fs, util} from '@appium/support';
 import chalk from 'chalk';
 import _ from 'lodash';
 import {EventEmitter} from 'node:events';
 import path from 'node:path';
-import pluralize from 'pluralize';
 import {satisfies} from 'semver';
 import {exec} from 'teen_process';
 import {
@@ -36,7 +35,6 @@ import {
   findMkDocsYml,
   readJson5,
   readTypedocJson,
-  readYaml,
   whichMkDocs,
   whichNpm,
   whichPython,
@@ -312,6 +310,9 @@ export class DocutilsValidator extends EventEmitter {
     this.emittedErrors.clear();
   }
 
+  /**
+   * Validates that the correct version of `mkdocs` is installed
+   */
   protected async validateMkDocs() {
     let mkDocsPath: string | undefined;
     try {
@@ -466,7 +467,7 @@ export class DocutilsValidator extends EventEmitter {
     const msgParts = [];
     if (missingPackages.length) {
       msgParts.push(
-        `The following required ${pluralize(
+        `The following required ${util.pluralize(
           'package',
           missingPackages.length
         )} could not be found:\n${missingPackages
@@ -476,7 +477,7 @@ export class DocutilsValidator extends EventEmitter {
     }
     if (invalidVersionPackages.length) {
       msgParts.push(
-        `The following required ${pluralize(
+        `The following required ${util.pluralize(
           'package',
           invalidVersionPackages.length
         )} are installed, but at the wrong version:\n${invalidVersionPackages

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -63,7 +63,6 @@
     "lodash": "4.17.21",
     "log-symbols": "4.1.0",
     "pkg-dir": "5.0.0",
-    "pluralize": "8.0.0",
     "read-pkg": "5.2.0",
     "semver": "7.3.8",
     "source-map-support": "0.5.21",

--- a/packages/support/lib/fs.js
+++ b/packages/support/lib/fs.js
@@ -290,12 +290,14 @@ const fs = {
    * @param {string} dir - Directory to search from
    * @param {import('read-pkg').Options} [opts] - Additional options for `read-pkg`
    * @throws {Error} If there were problems finding or reading a `package.json` file
-   * @returns {object} A parsed `package.json`
+   * @returns {import('read-pkg').NormalizedPackageJson} A parsed `package.json`
    */
   readPackageJsonFrom(dir, opts = {}) {
     const cwd = fs.findRoot(dir);
     try {
-      return readPkg.sync({...opts, cwd});
+      return readPkg.sync(
+        /** @type {import('read-pkg').NormalizeOptions} */ ({normalize: true, ...opts, cwd})
+      );
     } catch (err) {
       err.message = `Failed to read a \`package.json\` from dir \`${dir}\`:\n\n${err.message}`;
       throw err;


### PR DESCRIPTION
This adds up-front checking of user-provided custom paths to avoid doing a bunch of work and then
failing later ("fail fast").

For example, a user may provide a custom path to `mkdocs.yml` on the CLI:

```bash
appium-docs build --mkdocs-yml /some/bad/path/to/mkdocs.yml
```

In the above case, `appium-docs` will check if `/some/bad/path/to/mkdocs.yml` exists _before_ running
TypeDoc and MkDocs.

An alternative solution would be to just ignore it and use the default path.  This was _clearly_
not the user's intent (because they provided a custom path), so it's a poor solution.

