### PR TITLE
feat(docutils): allow "%s" as version number in commit msg arg

### DIFF
--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -99,6 +99,10 @@ export async function deploy({
     );
   }
   version = version ?? (await findDeployVersion(packageJsonPath, cwd));
+
+  // substitute %s in message with version
+  message = message?.replace('%s', version);
+
   const mikeOpts = {
     'config-file': mkDocsYmlPath,
     push,
@@ -118,6 +122,7 @@ export async function deploy({
     if (alias) {
       mikeArgs.push(alias);
     }
+    stop(); // discard
     // unsure about how SIGHUP is handled here
     await doServe(mikeArgs, serveOpts);
   } else {

--- a/packages/docutils/lib/cli/command/build.ts
+++ b/packages/docutils/lib/cli/command/build.ts
@@ -127,7 +127,7 @@ const opts = Object.freeze({
   },
   message: {
     alias: 'm',
-    describe: 'Commit message',
+    describe: 'Commit message. Use "%s" for version placeholder',
     implies: 'deploy',
     group: NAME_GROUP_DEPLOY,
     type: 'string',


### PR DESCRIPTION
I noticed that the commit message for xcuitest defaults to include the version number, and there was no way to do this other than to specify the version number manually when using `--message`, so we can use a substitution. `npm publish` also does this