### PR TITLE
fix(typedoc-plugin-appium): replace void responses with 'null'

### DIFF
--- a/packages/typedoc-plugin-appium/lib/converter/builtin-method-map.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/builtin-method-map.ts
@@ -78,6 +78,7 @@ export class BuiltinMethodMapConverter extends BaseConverter<BuiltinCommands> {
 
     const knownClassMethods = findCommandMethodsInReflection(baseDriverClassRefl);
     const baseDriverRoutes = convertMethodMap({
+      ctx: this.ctx,
       log: this.log,
       methodMapRefl: methodMap,
       parentRefl: baseDriverModuleRefl,

--- a/packages/typedoc-plugin-appium/lib/converter/exec-method-map.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/exec-method-map.ts
@@ -1,7 +1,6 @@
 import _ from 'lodash';
-import {DeclarationReflection, ReflectionKind} from 'typedoc';
+import {Context, DeclarationReflection, ReflectionKind} from 'typedoc';
 import {
-  isCommandMethodDeclarationReflection,
   isCommandPropDeclarationReflection,
   isExecMethodDefParamsPropDeclarationReflection,
 } from '../guards';
@@ -20,6 +19,7 @@ import {
  * Options for {@linkcode convertExecuteMethodMap}
  */
 export interface ConvertExecuteMethodMapOpts {
+  ctx: Context;
   /**
    * Logger
    */
@@ -52,6 +52,7 @@ export interface ConvertExecuteMethodMapOpts {
  * @returns List of "execute commands", if any
  */
 export function convertExecuteMethodMap({
+  ctx,
   log,
   parentRefl,
   execMethodMapRefl,
@@ -110,16 +111,15 @@ export function convertExecuteMethodMap({
 
     const commentData = deriveComment({refl: methodRefl, comment, knownMethods: knownMethods});
 
-    commandRefs.add(
-      new ExecMethodData(log, command, methodRefl, script, {
-        requiredParams,
-        optionalParams,
-        comment: commentData?.comment,
-        commentSource: commentData?.commentSource,
-        isPluginCommand,
-      })
-    );
+    const execMethodData = ExecMethodData.create(ctx, log, command, methodRefl, script, {
+      requiredParams,
+      optionalParams,
+      comment: commentData?.comment,
+      commentSource: commentData?.commentSource,
+      isPluginCommand,
+    });
 
+    commandRefs.add(execMethodData);
     log.verbose(
       'Added POST route %s for command "%s" from script "%s"',
       NAME_EXECUTE_ROUTE,

--- a/packages/typedoc-plugin-appium/lib/converter/external.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/external.ts
@@ -175,6 +175,7 @@ export class ExternalConverter extends BaseConverter<ProjectCommands> {
 
       const overriddenRouteMap: RouteMap = this.builtinCommands
         ? convertOverrides({
+            ctx: this.ctx,
             log,
             parentRefl: classRefl,
             classMethods,
@@ -217,6 +218,7 @@ export class ExternalConverter extends BaseConverter<ProjectCommands> {
       return new Set();
     }
     return convertExecuteMethodMap({
+      ctx: this.ctx,
       log,
       parentRefl,
       execMethodMapRefl,
@@ -250,6 +252,7 @@ export class ExternalConverter extends BaseConverter<ProjectCommands> {
       return new Map();
     }
     return convertMethodMap({
+      ctx: this.ctx,
       log,
       methodMapRefl: newMethodMapRefl,
       parentRefl,

--- a/packages/typedoc-plugin-appium/lib/converter/method-map.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/method-map.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {DeclarationReflection, ReflectionKind} from 'typedoc';
+import {Context, DeclarationReflection, ReflectionKind} from 'typedoc';
 import {
   isCommandPropDeclarationReflection,
   isExecMethodDefParamsPropDeclarationReflection,
@@ -22,6 +22,7 @@ import {
  * Options for {@linkcode convertMethodMap}
  */
 export interface ConvertMethodMapOpts {
+  ctx: Context;
   /**
    * All builtin methods from `@appium/types`
    */
@@ -59,6 +60,7 @@ export interface ConvertMethodMapOpts {
  * @returns Lookup of routes to {@linkcode CommandSet} objects
  */
 export function convertMethodMap({
+  ctx,
   log,
   methodMapRefl,
   parentRefl,
@@ -138,17 +140,17 @@ export function convertMethodMap({
 
       const commandSet: CommandSet = routes.get(route) ?? new Set();
 
-      commandSet.add(
-        new CommandData(log, command, method, httpMethod, route, {
-          requiredParams,
-          optionalParams,
-          comment,
-          commentSource,
-          parentRefl,
-          isPluginCommand,
-          knownBuiltinMethods,
-        })
-      );
+      const commandData = CommandData.create(ctx, log, command, method, httpMethod, route, {
+        requiredParams,
+        optionalParams,
+        comment,
+        commentSource,
+        parentRefl,
+        isPluginCommand,
+        knownBuiltinMethods,
+      });
+
+      commandSet.add(commandData);
 
       log.verbose('Registered route %s %s for command "%s"', httpMethod, route, command);
 

--- a/packages/typedoc-plugin-appium/lib/converter/overrides.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/overrides.ts
@@ -1,7 +1,7 @@
 import _ from 'lodash';
-import {DeclarationReflection} from 'typedoc';
+import {Context, DeclarationReflection} from 'typedoc';
 import {AppiumPluginLogger} from '../logger';
-import {CommandSet, ExecMethodDataSet, ModuleCommands, RouteMap} from '../model';
+import {CommandData, CommandSet, ExecMethodDataSet, ModuleCommands, RouteMap} from '../model';
 import {deriveComment} from './comment';
 import {KnownMethods} from './types';
 
@@ -16,6 +16,7 @@ import {KnownMethods} from './types';
  * @returns More routes pulled from `builtinCommands`, if the driver implements them
  */
 export function convertOverrides({
+  ctx,
   log,
   parentRefl,
   classMethods,
@@ -80,10 +81,13 @@ export function convertOverrides({
           refl: methodRefl,
           knownMethods: builtinMethods,
         });
-        const newCommandData = commandData.clone(methodRefl, {
+        const newCommandData = CommandData.clone(commandData, ctx, {
+          methodRefl,
           parentRefl,
           knownBuiltinMethods: builtinMethods,
-          ...commentData,
+          opts: {
+            comment: commentData?.comment,
+          },
         });
         log.verbose('Linked route %s %s for command "%s"', commandData.httpMethod, route, command);
         newCommandSet.add(newCommandData);
@@ -99,6 +103,7 @@ export function convertOverrides({
  * Options for {@link convertOverrides}
  */
 export interface ConvertOverridesOpts {
+  ctx: Context;
   /**
    * Logger
    */

--- a/packages/typedoc-plugin-appium/lib/guards.ts
+++ b/packages/typedoc-plugin-appium/lib/guards.ts
@@ -296,7 +296,7 @@ export function isCommandMethodDeclarationReflection(
     ? value.type.declaration.getAllSignatures()
     : value.getAllSignatures();
   return Boolean(
-    signatures?.find((sig) => isReferenceType(sig.type) && sig.type.name === 'Promise')
+    signatures?.find((sig) => sig.type instanceof ReferenceType && sig.type.name === 'Promise')
   );
 }
 
@@ -332,14 +332,6 @@ export function isCallSignatureReflectionWithArity(
 }
 
 /**
- * Guard for {@linkcode ReferenceType}
- * @param value any
- */
-export function isReferenceType(value: any): value is ReferenceType {
-  return value instanceof ReferenceType;
-}
-
-/**
  * Guard for {@linkcode ConstructorDeclarationReflection}
  * @param value any
  */
@@ -359,11 +351,12 @@ export function isBasePluginConstructorDeclarationReflection(
   if (!(isDeclarationReflection(value) && value.kindOf(ReflectionKind.Constructor))) {
     return false;
   }
-  const ref = isReferenceType(value.inheritedFrom)
-    ? value.inheritedFrom
-    : isReferenceType(value.overwrites)
-    ? value.overwrites
-    : undefined;
+  const ref =
+    value.inheritedFrom instanceof ReferenceType
+      ? value.inheritedFrom
+      : value.overwrites instanceof ReferenceType
+      ? value.overwrites
+      : undefined;
   return ref?.name === `${NAME_BASE_PLUGIN}.constructor`;
 }
 

--- a/packages/typedoc-plugin-appium/test/e2e/converter/builtin-method-map.e2e.spec.ts
+++ b/packages/typedoc-plugin-appium/test/e2e/converter/builtin-method-map.e2e.spec.ts
@@ -75,6 +75,7 @@ describe('@appium/typedoc-plugin-appium', function () {
               expect(
                 _.omit(
                   cmdData,
+                  'opts',
                   'methodRefl',
                   'parentRefl',
                   'knownBuiltinMethods',


### PR DESCRIPTION
The main thrust of this was to resolve #18269.

Implementation-wise, we have to modify an `IntrinsicType` of which both `void` and `undefined` become.  To make it `null`, we must create a new `LiteralType` (`null` is not an "intrinsic" type; I don't know why).  I would think that TypeDoc wouldn't go around creating new `LiteralType`s every time it sees `null`, but I don't see it doing anything else. Anyway, if there is a "type cache" somewhere, I'm not sure how to get at it.

Additionally, the new reflections created for parameters and the call signature were not being "registered" properly with TypeDoc.  So this adds a `static create` to both `CommandData` and `ExecMethodData` which wraps the constructor for each, respectively, then performs the registration.  This keeps a `Context` object _out_ of `CommandData`/`ExecMethodData` instances (it would only be used once at time of instantiation anyway).

Un-memoized a couple methods in `BaseCommandData` since not necessary
