### PR TITLE
fix(appium,fake-driver): expose child process when running an extension script

### DIFF
--- a/packages/appium/lib/cli/driver-command.js
+++ b/packages/appium/lib/cli/driver-command.js
@@ -58,7 +58,12 @@ export default class DriverCommand extends ExtensionCommand {
    * @return {Promise<import('./extension-command').RunOutput>}
    */
   async run({driver, scriptName, extraArgs}) {
-    return await super._run({installSpec: driver, scriptName, extraArgs});
+    return await super._run({
+      installSpec: driver,
+      scriptName,
+      extraArgs,
+      bufferOutput: this.isJsonOutput,
+    });
   }
 
   /**

--- a/packages/appium/lib/cli/plugin-command.js
+++ b/packages/appium/lib/cli/plugin-command.js
@@ -57,7 +57,12 @@ export default class PluginCommand extends ExtensionCommand {
    * @returns {Promise<import('./extension-command').RunOutput>}
    */
   async run({plugin, scriptName, extraArgs}) {
-    return await super._run({installSpec: plugin, scriptName, extraArgs});
+    return await super._run({
+      installSpec: plugin,
+      scriptName,
+      extraArgs,
+      bufferOutput: this.isJsonOutput,
+    });
   }
 
   /**

--- a/packages/appium/test/unit/extension/extension-command.spec.js
+++ b/packages/appium/test/unit/extension/extension-command.spec.js
@@ -1,0 +1,64 @@
+// @ts-check
+import {DriverConfig} from '../../../lib/extension/driver-config';
+import {ExtensionCommand} from '../../../lib/cli/extension-command';
+import sinon from 'sinon';
+import {FAKE_DRIVER_DIR} from '../../helpers';
+import {Manifest} from '../../../lib/extension/manifest';
+
+const {expect} = chai;
+
+/**
+ * Relative path from actual `package.json` of `FakeDriver` for the `fake-stdin` script
+ */
+const FAKE_STDIN_SCRIPT = require(`${FAKE_DRIVER_DIR}/package.json`).appium.scripts['fake-stdin'];
+
+describe('ExtensionCommand', function () {
+  describe('method', function () {
+    /** @type {ExtensionCommand} */
+    let ec;
+
+    /** @type {sinon.SinonSandbox} */
+    let sandbox;
+
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      const driverConfig = DriverConfig.create(sandbox.createStubInstance(Manifest));
+      ec = new ExtensionCommand({config: driverConfig, json: false});
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    describe('_runUnbuffered()', function () {
+      // this test is low value and mostly just asserts that `child_process.spawn()` works.
+      // the problem is that because `_run()` returns a `Promise`, a caller cannot reach the
+      // underlying `ChildProcess` instance.
+      // something like `execa` could work around this because it returns a frankenstein of a
+      // `Promise` + `ChildProcess`, but I didn't want to add the dep.
+      it('should respond to stdin', function (done) {
+        // we have to fake writing to STDIN because this is an automated test, after all.
+        const proc = ec
+          ._runUnbuffered(FAKE_DRIVER_DIR, FAKE_STDIN_SCRIPT, [], {
+            stdio: ['pipe', 'inherit', 'inherit'],
+          })
+          .once('exit', (code) => {
+            try {
+              expect(code).to.equal(0);
+              done();
+            } catch (err) {
+              done(err);
+            }
+          });
+
+        setTimeout(() => {
+          // TS does not understand that `proc.stdin` is not `null`, because it is only a `Writable`
+          // if STDIN is piped from the parent.
+          const stdin = /** @type {import('node:stream').Writable} */ (proc.stdin);
+          stdin.write('\n');
+          stdin.end();
+        }, 200);
+      });
+    });
+  });
+});

--- a/packages/fake-driver/lib/scripts/fake-error.js
+++ b/packages/fake-driver/lib/scripts/fake-error.js
@@ -1,1 +1,8 @@
-throw Error('Unsuccessfully ran the script');
+import ora from 'ora';
+
+const spinner = ora('Running fake-error...').start();
+
+setTimeout(() => {
+  spinner.fail('Oh nooooooo!');
+  throw Error('Unsuccessfully ran the script');
+}, 1000);

--- a/packages/fake-driver/lib/scripts/fake-stdin.js
+++ b/packages/fake-driver/lib/scripts/fake-stdin.js
@@ -1,0 +1,9 @@
+import readline from 'node:readline';
+
+const rl = readline.createInterface({input: process.stdin, output: process.stderr});
+
+rl.question('Press ENTER to continue: ', () => {
+  rl.close();
+  // eslint-disable-next-line no-console
+  console.error('You did it!');
+});

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -75,7 +75,8 @@
     "schema": "./build/lib/fake-driver-schema.js",
     "scripts": {
       "fake-error": "./build/lib/scripts/fake-error.js",
-      "fake-success": "./build/lib/scripts/fake-success.js"
+      "fake-success": "./build/lib/scripts/fake-success.js",
+      "fake-stdin": "./build/lib/scripts/fake-stdin.js"
     }
   },
   "typedoc": {


### PR DESCRIPTION
This change makes it so when running an extension script (e.g., `appium driver foo run some-script`), unless the `--json` flag is present, the child process will do no buffering whatsoever and will inherit `process.stdin`, `process.stdout` and `process.stderr` from Appium.

This means that extension scripts can do stuff like prompt the user for input.  It _also_ means they can do stuff like display progress bars and spinners.

If the user wants JSON data, we revert to the old behavior, which is to buffer the output and dump it once the script has completed.  I still don't understand why we need a `RingBuffer` there, since it seems like it could obliterate JSON output.  I didn't want to touch it though; Chesterton's fence & all that.

* * *

Note that given `teen_process`' `Promise`-based architecture--even using `teen_process.SubProcess`--there's still buffering and wrapping happening and I could not figure out how to make `teen_process` work the way I needed it to.  Maybe the lesson I've learned is that `teen_process` has a specific common use-case in mind--and it is not this one.