### PR TITLE
chore: add auto-labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,143 @@
+version: v1
+
+labels:
+  - label: 'Enhancement'
+    sync: true
+    matcher:
+      commits: '^feat.*?:'
+      title: '^feat.*?:'
+
+  - label: 'Bug'
+    sync: true
+    matcher:
+      commits: '^fix.*?:'
+      title: '^fix.*?:'
+
+  - label: 'Documentation'
+    sync: true
+    matcher:
+      commits: '^docs.*?:'
+      title: '^docs.*?:'
+      files: ['packages/docutils/**', 'packages/appium/docs/**', '**/*.md']
+
+  - label: 'chore'
+    sync: true
+    matcher:
+      commits: '^chore.*?:'
+      title: '^chore.*?:'
+
+  - label: 'SemVer:Breaking'
+    sync: true
+    matcher:
+      commits: '(^(.+?)!:)|(BREAKING CHANGE:)'
+
+  - label: 'Dependencies'
+    sync: true
+    matcher:
+      files: ['**/package.json', '**/package-lock.json', '**/requirements.txt']
+      author: 'renovate'
+
+  - label: 'appium core'
+    sync: true
+    matcher:
+      files: ['packages/appium/**']
+
+  - label: '@appium/base-driver'
+    sync: true
+    matcher:
+      files: ['packages/base-driver/**']
+
+  - label: '@appium/eslint-config-appium'
+    sync: true
+    matcher:
+      files: ['packages/eslint-config-appium/**']
+
+  - label: '@appium/base-plugin'
+    sync: true
+    matcher:
+      files: ['packages/base-plugin/**']
+
+  - label: '@appium/doctor'
+    sync: true
+    matcher:
+      files: ['packages/doctor/**']
+
+  - label: '@appium/docutils'
+    sync: true
+    matcher:
+      files: ['packages/docutils/**']
+
+  - label: '@appium/driver-test-support'
+    sync: true
+    matcher:
+      files: ['packages/driver-test-support/**']
+
+  - label: '@appium/execute-driver-plugin'
+    sync: true
+    matcher:
+      files: ['packages/execute-driver-plugin/**']
+
+  - label: '@appium/fake-driver'
+    sync: true
+    matcher:
+      files: ['packages/fake-driver/**']
+
+  - label: '@appium/fake-plugin'
+    sync: true
+    matcher:
+      files: ['packages/fake-plugin/**']
+
+  - label: '@appium/images-plugin'
+    sync: true
+    matcher:
+      files: ['packages/images-plugin/**']
+
+  - label: '@appium/opencv'
+    sync: true
+    matcher:
+      files: ['packages/opencv/**']
+
+  - label: '@appium/plugin-test-support'
+    sync: true
+    matcher:
+      files: ['packages/plugin-test-support/**']
+
+  - label: '@appium/relaxed-caps-plugin'
+    sync: true
+    matcher:
+      files: ['packages/relaxed-caps-plugin/**']
+
+  - label: '@appium/schema'
+    sync: true
+    matcher:
+      files: ['packages/schema/**']
+
+  - label: '@appium/support'
+    sync: true
+    matcher:
+      files: ['packages/support/**']
+
+  - label: '@appium/test-support'
+    sync: true
+    matcher:
+      files: ['packages/test-support/**']
+
+  - label: '@appium/tsconfig'
+    sync: true
+    matcher:
+      files: ['packages/tsconfig/**']
+
+  - label: '@appium/typedoc-plugin-appium'
+    sync: true
+    matcher:
+      files: ['packages/typedoc-plugin-appium/**']
+
+  - label: '@appium/types'
+    sync: true
+    matcher:
+      files: ['packages/types/**']
+
+  - label: '@appium/universal-xml-plugin'
+    sync: true
+    matcher:
+      files: ['packages/universal-xml-plugin/**']

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,22 @@
+name: 'Labeler'
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  # Setting up permissions in the workflow to limit the scope of what it can do. Optional!
+  contents: read
+  issues: read # change this if/when we want to label issues
+  pull-requests: write
+  statuses: read
+  checks: read
+
+jobs:
+  labeler:
+    name: Labeler
+    runs-on: ubuntu-latest
+    steps:
+      # follows semantic versioning. Lock to different version: v1, v1.5, v1.5.0 or use a commit hash.
+      - uses: fuxingloh/multi-labeler@6704db0bcba106d07482efabbc79d3092af74fa2 # v2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}} # optional, default to '${{ github.token }}'


### PR DESCRIPTION
This will automatically label PRs. We can update it to further automatically label issues at a later time, if necessary.

I have added labels for each package.

Roughly, what this ~~will~~ should do is:

- Check commits in any PR (or PR title) based on conventional commits and assign labels `Bug`, `chore`, `Enhancement`, `Documentation` and `SemVer:Breaking` (`SemVer:Breaking` is not assigned via PR title)
- Check filepath changes in commit and add a label corresponding to each package.
- Add `Dependencies` label if author is Renovate or lockfiles get touched
