### PR TITLE
chore(ci): attempt to avoid running trusted code on PRs from forks

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,7 +4,6 @@ on:
     types: [opened, synchronize]
 
 permissions:
-  # Setting up permissions in the workflow to limit the scope of what it can do. Optional!
   contents: read
   issues: read # change this if/when we want to label issues
   pull-requests: write
@@ -13,6 +12,7 @@ permissions:
 
 jobs:
   labeler:
+    if: ${{ github.repository == 'appium/appium' }}
     name: Labeler
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/on-hold.yml
+++ b/.github/workflows/on-hold.yml
@@ -5,10 +5,10 @@ on:
 
 jobs:
   label-check:
-    if: github.base_ref == 'master'
+    if: ${{ github.base_ref == 'master' && github.repository == 'appium/appium' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: danielchabr/pr-labels-checker@e1d7e79aa0933af1728011705a30528a279874fd
+      - uses: danielchabr/pr-labels-checker@e1d7e79aa0933af1728011705a30528a279874fd # v3.1
         with:
           id: check-labels
           hasNone: On Hold


### PR DESCRIPTION
The jobs which set labels can't run on PRs from forked repos because they don't have access to the `GITHUB_TOKEN` secret. 