### PR TITLE
fix(docutils): inherit stdio in long-running processes

### DIFF
--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -5,8 +5,8 @@
  */
 
 import _ from 'lodash';
-import {exec, SubProcess, SubProcessOptions, TeenProcessExecOptions} from 'teen_process';
 import path from 'node:path';
+import {exec, TeenProcessExecOptions} from 'teen_process';
 import {
   DEFAULT_DEPLOY_BRANCH,
   DEFAULT_DEPLOY_REMOTE,
@@ -18,7 +18,7 @@ import {
 import {DocutilsError} from '../error';
 import {findMkDocsYml, readPackageJson, whichMike} from '../fs';
 import logger from '../logger';
-import {argify, stopwatch, TeenProcessSubprocessStartOpts} from '../util';
+import {argify, spawnBackgroundProcess, SpawnBackgroundProcessOpts, stopwatch} from '../util';
 
 const log = logger.withTag('builder:deploy');
 
@@ -30,15 +30,12 @@ const log = logger.withTag('builder:deploy');
  */
 async function doServe(
   args: string[] = [],
-  {startDetector, detach, timeoutMs}: TeenProcessSubprocessStartOpts = {},
+  opts: SpawnBackgroundProcessOpts = {},
   mikePath?: string
 ) {
   mikePath = mikePath ?? (await whichMike());
   const finalArgs = ['serve', ...args];
-  const opts: SubProcessOptions = {stdio: 'inherit'};
-  log.debug('Launching %s with args: %s', mikePath, finalArgs);
-  const proc = new SubProcess(mikePath, finalArgs, opts);
-  return await proc.start(startDetector, detach, timeoutMs);
+  return spawnBackgroundProcess(mikePath, finalArgs, opts);
 }
 
 /**
@@ -223,7 +220,7 @@ export interface DeployOpts {
   execOpts?: TeenProcessExecOptions;
 
   /**
-   * Extra options for {@linkcode teen_process.Subprocess.start}
+   * Extra options for {@linkcode spawnBackgroundProcess}
    */
-  serveOpts?: TeenProcessSubprocessStartOpts;
+  serveOpts?: SpawnBackgroundProcessOpts;
 }

--- a/packages/docutils/lib/builder/site.ts
+++ b/packages/docutils/lib/builder/site.ts
@@ -5,13 +5,14 @@
  * @module
  */
 
+import {spawn, SpawnOptions} from 'node:child_process';
 import path from 'node:path';
-import {exec, SubProcess, SubProcessOptions, TeenProcessExecOptions} from 'teen_process';
-import {NAME_BIN, NAME_THEME, NAME_MKDOCS_YML} from '../constants';
+import {exec, TeenProcessExecOptions} from 'teen_process';
+import {NAME_BIN, NAME_MKDOCS, NAME_MKDOCS_YML, NAME_THEME} from '../constants';
 import {DocutilsError} from '../error';
 import {findMkDocsYml, readMkDocsYml, whichMkDocs} from '../fs';
 import logger from '../logger';
-import {relative, stopwatch, TeenProcessSubprocessStartOpts} from '../util';
+import {relative, spawnBackgroundProcess, SpawnBackgroundProcessOpts, stopwatch} from '../util';
 
 const log = logger.withTag('mkdocs');
 
@@ -23,15 +24,14 @@ const log = logger.withTag('mkdocs');
  */
 async function doServe(
   args: string[] = [],
-  {startDetector, detach, timeoutMs}: TeenProcessSubprocessStartOpts = {},
+  opts: SpawnBackgroundProcessOpts = {},
   mkDocsPath?: string
 ) {
   mkDocsPath = mkDocsPath ?? (await whichMkDocs());
   const finalArgs = ['serve', ...args];
-  const opts: SubProcessOptions = {stdio: 'inherit'};
+
   log.debug('Launching %s with args: %s', mkDocsPath, finalArgs);
-  const proc = new SubProcess(mkDocsPath, finalArgs, opts);
-  return await proc.start(startDetector, detach, timeoutMs);
+  return spawnBackgroundProcess(mkDocsPath, finalArgs, opts);
 }
 
 /**
@@ -138,7 +138,7 @@ export interface BuildMkDocsOpts {
   execOpts?: TeenProcessExecOptions;
 
   /**
-   * Extra options for {@linkcode teen_process.Subprocess.start}
+   * Extra options for {@linkcode spawnBackgroundProcess}
    */
-  serveOpts?: TeenProcessSubprocessStartOpts;
+  serveOpts?: SpawnBackgroundProcessOpts;
 }


### PR DESCRIPTION
This change ensures when running `mkdocs` or `mike` with the `--serve` flag, the output is unbuffered and stdio is inherited from the parent process.

This will show helpful things like _the URL at which the development server is running_.
