### PR TITLE
feat(types,base-driver): allow declaration of extra props to "opts" prop of driver

### DIFF
--- a/packages/base-driver/lib/basedriver/core.js
+++ b/packages/base-driver/lib/basedriver/core.js
@@ -20,6 +20,7 @@ const ON_UNEXPECTED_SHUTDOWN_EVENT = 'onUnexpectedShutdown';
 
 /**
  * @template {Constraints} [C=BaseDriverCapConstraints]
+ * @template {import('@appium/types').StringRecord} [ExtraOpts=import('type-fest').EmptyObject]
  * @implements {Core<C>}
  */
 class DriverCore {
@@ -35,7 +36,7 @@ class DriverCore {
   sessionId;
 
   /**
-   * @type {import('@appium/types').DriverOpts<C>}
+   * @type {import('@appium/types').DriverOpts<C, ExtraOpts>}
    */
   opts;
 
@@ -124,10 +125,13 @@ class DriverCore {
   settings;
 
   /**
-   * @param {DriverOpts<C>} opts
+   * @param {import('@appium/types').DriverOpts<C, ExtraOpts>} opts
    * @param {boolean} [shouldValidateCaps]
    */
-  constructor(opts = /** @type {DriverOpts<C>} */ ({}), shouldValidateCaps = true) {
+  constructor(
+    opts = /** @type {import('@appium/types').DriverOpts<C, ExtraOpts>} */ ({}),
+    shouldValidateCaps = true
+  ) {
     this._log = logger.getLogger(helpers.generateDriverLogPrefix(this));
 
     // setup state

--- a/packages/base-driver/lib/basedriver/driver.js
+++ b/packages/base-driver/lib/basedriver/driver.js
@@ -1,15 +1,15 @@
 /* eslint-disable require-await */
 /* eslint-disable no-unused-vars */
 
-import {validateCaps, processCapabilities} from './capabilities';
-import {DriverCore} from './core';
 import {util} from '@appium/support';
+import {BASE_DESIRED_CAP_CONSTRAINTS} from '@appium/types';
 import B from 'bluebird';
 import _ from 'lodash';
 import {fixCaps, isW3cCaps} from '../helpers/capabilities';
 import {DELETE_SESSION_COMMAND, determineProtocol, errors} from '../protocol';
+import {processCapabilities, validateCaps} from './capabilities';
+import {DriverCore} from './core';
 import helpers from './helpers';
-import {BASE_DESIRED_CAP_CONSTRAINTS} from '@appium/types';
 
 const EVENT_SESSION_INIT = 'newSessionRequested';
 const EVENT_SESSION_START = 'newSessionStarted';
@@ -21,8 +21,9 @@ const ON_UNEXPECTED_SHUTDOWN_EVENT = 'onUnexpectedShutdown';
  * @implements {SessionHandler<C>}
  * @template {Constraints} C
  * @template {StringRecord} [CArgs=StringRecord]
+ * @template {StringRecord} [ExtraOpts=import('type-fest').EmptyObject]
  * @implements {Driver<C, CArgs>}
- * @extends {DriverCore<C>}
+ * @extends {DriverCore<C, ExtraOpts>}
  */
 export class BaseDriver extends DriverCore {
   /**
@@ -46,16 +47,19 @@ export class BaseDriver extends DriverCore {
   desiredCapConstraints;
 
   /**
-   * @type {DriverOpts<C> & DriverOpts<BaseDriverCapConstraints>}
+   * @type {import('@appium/types').DriverOpts<C, ExtraOpts> & import('@appium/types').DriverOpts<BaseDriverCapConstraints>}
    */
   opts;
 
   /**
    *
-   * @param {DriverOpts<C>} opts
+   * @param {import('@appium/types').DriverOpts<C, ExtraOpts>} opts
    * @param {boolean} shouldValidateCaps
    */
-  constructor(opts = /** @type {DriverOpts<C>} */ ({}), shouldValidateCaps = true) {
+  constructor(
+    opts = /** @type {import('@appium/types').DriverOpts<C, ExtraOpts>} */ ({}),
+    shouldValidateCaps = true
+  ) {
     super(opts, shouldValidateCaps);
 
     /**
@@ -307,7 +311,11 @@ export class BaseDriver extends DriverCore {
     this.sessionId = util.uuidV4();
     this.caps = caps;
     // merge caps onto opts so we don't need to worry about what's where
-    this.opts = {..._.cloneDeep(this.initialOpts), ...this.caps};
+    this.opts =
+      /** @type {import('@appium/types').DriverOpts<C, ExtraOpts> & import('@appium/types').DriverOpts<BaseDriverCapConstraints>} */ ({
+        ..._.cloneDeep(this.initialOpts),
+        ...this.caps,
+      });
 
     // deal with resets
     // some people like to do weird things by setting noReset and fullReset
@@ -463,9 +471,4 @@ export default BaseDriver;
 /**
  * @template {Constraints} C
  * @typedef {import('@appium/types').ExternalDriver<C>} ExternalDriver
- */
-
-/**
- * @template {Constraints} C
- * @typedef {import('@appium/types').DriverOpts<C>} DriverOpts
  */

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -1,20 +1,20 @@
 import type {EventEmitter} from 'events';
-import {Element, ActionSequence} from './action';
+import {EmptyObject, Entries} from 'type-fest';
 import {
-  HTTPMethod,
-  AppiumServer,
-  UpdateServerCallback,
-  Class,
   AppiumLogger,
-  StringRecord,
-  ConstraintsToCaps,
+  AppiumServer,
   BaseDriverCapConstraints,
-  W3CCapabilities,
   Capabilities,
+  Class,
+  ConstraintsToCaps,
+  HTTPMethod,
+  StringRecord,
+  UpdateServerCallback,
+  W3CCapabilities,
 } from '.';
+import {ActionSequence, Element} from './action';
+import {ExecuteMethodMap, MethodMap} from './command';
 import {ServerArgs} from './config';
-import {AsyncReturnType, Entries} from 'type-fest';
-import {MethodMap, ExecuteMethodMap} from './command';
 
 export interface ITimeoutCommands {
   /**
@@ -2224,10 +2224,18 @@ export interface ExtraDriverOpts {
  * Options as passed into a driver constructor, which is just a union of {@linkcode ServerArgs} and {@linkcode Capabilities}.
  *
  * The combination happens within Appium prior to calling the constructor.
+ *
+ * @example
+ * ```ts
+ * class MyDriver extends BaseDriver<MyConstraints> {
+ *   constructor(opts: DriverOpts<MyConstraints, {foo: string}>) {}
+ * }
+ * ```
  */
-export type DriverOpts<C extends Constraints = BaseDriverCapConstraints> = ServerArgs &
-  ExtraDriverOpts &
-  Partial<ConstraintsToCaps<C>>;
+export type DriverOpts<
+  C extends Constraints = BaseDriverCapConstraints,
+  ExtraOpts extends StringRecord = EmptyObject
+> = ServerArgs & ExtraDriverOpts & Partial<ConstraintsToCaps<C>> & Partial<ExtraOpts>;
 
 /**
  * An instance method of a driver class, whose name may be referenced by {@linkcode MethodDef.command}, and serves as an Appium command.


### PR DESCRIPTION
Some drivers (e.g., XCUITest), for better or worse, put arbitrary data in "opts". This adds a type arg which allows a driver to define what that arbitrary data is. However, we cannot guarantee that the data is present at time of instantiation (unless the driver impl makes the assignment in the constructor, which may not be desirable), so even if defined, it will always be considered a "partial" type.

* * *

FWIW I'm not sure I really _agree_ with this--_why_ does a driver need to put data there?--but in the name of retrofitting types to our codebases, it's either this or refactors.  I don't know how prevalent this strategy is.
