### PR TITLE
feat(appium): improvements to ext commands when running extension in dev mode

### DIFF
--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -84,6 +84,16 @@ function makeListArgs(type) {
         dest: 'showUpdates',
       },
     ],
+    [
+      ['--verbose'],
+      {
+        required: false,
+        default: false,
+        action: 'store_true',
+        help: 'Show more information about each extension',
+        dest: 'verbose',
+      },
+    ],
   ]);
 }
 

--- a/packages/appium/lib/constants.js
+++ b/packages/appium/lib/constants.js
@@ -68,4 +68,4 @@ export const EXT_SUBCOMMAND_RUN = 'run';
 /**
  * Current revision of the manifest (`extensions.yaml`) schema
  */
-export const CURRENT_SCHEMA_REV = 3;
+export const CURRENT_SCHEMA_REV = 4;

--- a/packages/appium/lib/extension/manifest-migrations.js
+++ b/packages/appium/lib/extension/manifest-migrations.js
@@ -102,7 +102,7 @@ export async function migrate(manifest) {
   didChange = setSchemaRev(manifest, CURRENT_SCHEMA_REV) || didChange;
   if (didChange) {
     // this is not _technically_ true, since we don't actually write the file here.
-    log.info(`Upgraded extension manifest to schema v${manifest.schemaRev}`);
+    log.debug(`Upgraded extension manifest to schema v${manifest.schemaRev}`);
   }
 
   return didChange;

--- a/packages/appium/lib/extension/manifest-migrations.js
+++ b/packages/appium/lib/extension/manifest-migrations.js
@@ -1,4 +1,4 @@
-import {DRIVER_TYPE, PLUGIN_TYPE} from '../constants';
+import {CURRENT_SCHEMA_REV, DRIVER_TYPE, PLUGIN_TYPE} from '../constants';
 import log from '../logger';
 
 /**
@@ -13,6 +13,11 @@ import log from '../logger';
 const SCHEMA_REV_3 = 3;
 
 /**
+ * Constant for v4 of the schema rev.
+ */
+const SCHEMA_REV_4 = 4;
+
+/**
  * Collection of functions to migrate from one version to another.
  *
  * These functions _should not actually perform the migration_; rather, they
@@ -20,7 +25,7 @@ const SCHEMA_REV_3 = 3;
  * itself will happen within {@linkcode Manifest.syncWithInstalledExtensions}; the extensions
  * will be checked and the manifest file updated per the state of the filesystem.
  *
- * @type {{[P in keyof ManifestDataVersions]?: Migration}}
+ * @type { {[P in keyof ManifestDataVersions]?: Migration} }
  */
 const Migrations = {
   /**
@@ -32,19 +37,32 @@ const Migrations = {
    * @type {Migration}
    */
   [SCHEMA_REV_3]: (manifest) => {
-    let shouldSync = false;
     /** @type {Array<ExtManifest<PluginType>|ExtManifest<DriverType>>} */
     const allExtData = [
       ...Object.values(manifest.getExtensionData(DRIVER_TYPE)),
       ...Object.values(manifest.getExtensionData(PLUGIN_TYPE)),
     ];
-    for (const metadata of allExtData) {
-      if (!('installPath' in metadata)) {
-        shouldSync = true;
-        break;
-      }
+    return allExtData.some((metadata) => !('installPath' in metadata));
+  },
+  /**
+   * Updates installed extensions to use `InstallType` of `dev` if appropriate.
+   *
+   * Previously, these types of extensions (automatically discovered) would use the default `InstallType` of `npm`, so we need
+   * to refresh any with this install type.
+   *
+   * This should only happen once; we do not want to re-check everything with `npm` install type
+   * every time.
+   * @type {Migration}
+   */
+  [SCHEMA_REV_4]: (manifest) => {
+    if (manifest.schemaRev < SCHEMA_REV_4) {
+      const allExtData = [
+        ...Object.values(manifest.getExtensionData(DRIVER_TYPE)),
+        ...Object.values(manifest.getExtensionData(PLUGIN_TYPE)),
+      ];
+      return allExtData.some((metadata) => metadata.installType === 'npm');
     }
-    return shouldSync;
+    return false;
   },
 };
 
@@ -61,7 +79,7 @@ const Migrations = {
  * @returns {boolean} Whether the data was modified
  */
 function setSchemaRev(manifest, version) {
-  if (manifest.schemaRev ?? 0 < version) {
+  if ((manifest.schemaRev ?? 0) < version) {
     manifest.setSchemaRev(version);
     return true;
   }
@@ -78,12 +96,10 @@ function setSchemaRev(manifest, version) {
  */
 export async function migrate(manifest) {
   let didChange = false;
-  for await (const [v, migration] of Object.entries(Migrations)) {
-    const version = /** @type {keyof ManifestDataVersions} */ (Number(v));
+  for await (const migration of Object.values(Migrations)) {
     didChange = (await migration(manifest)) || didChange;
-    didChange = setSchemaRev(manifest, version) || didChange;
   }
-
+  didChange = setSchemaRev(manifest, CURRENT_SCHEMA_REV) || didChange;
   if (didChange) {
     // this is not _technically_ true, since we don't actually write the file here.
     log.info(`Upgraded extension manifest to schema v${manifest.schemaRev}`);

--- a/packages/appium/test/e2e/cli-plugin.e2e.spec.js
+++ b/packages/appium/test/e2e/cli-plugin.e2e.spec.js
@@ -63,7 +63,7 @@ describe('Plugin CLI', function () {
  * @typedef {import('appium/types').ManifestData} ManifestData
  * @typedef {import('@appium/types').DriverType} DriverType
  * @typedef {import('@appium/types').PluginType} PluginType
- * @typedef {import('appium/lib/cli/extension-command').ExtensionListData} ExtensionListData
+ * @typedef {import('appium/lib/cli/extension-command').ExtensionList} ExtensionListData
  * @typedef {import('./e2e-helpers').CliArgs} CliArgs
  * @typedef {import('appium/types').CliExtensionSubcommand} CliExtensionSubcommand
  */

--- a/packages/appium/test/e2e/e2e-helpers.js
+++ b/packages/appium/test/e2e/e2e-helpers.js
@@ -182,7 +182,7 @@ export function formatAppiumArgErrorOutput(stderr) {
 
 /**
  * @typedef {import('@appium/types').ExtensionType} ExtensionType
- * @typedef {import('appium/lib/cli/extension-command').ExtensionListData} ExtensionListData
+ * @typedef {import('appium/lib/cli/extension-command').ExtensionList} ExtensionListData
  * @typedef {import('teen_process').ExecError} ExecError
  * @typedef {import('teen_process').TeenProcessExecOptions} TeenProcessExecOptions
  * @typedef {import('teen_process').TeenProcessExecResult<string>} TeenProcessExecResult

--- a/packages/appium/test/e2e/manifest.e2e.spec.js
+++ b/packages/appium/test/e2e/manifest.e2e.spec.js
@@ -99,7 +99,7 @@ describe('manifest handling', function () {
       });
 
       it('should update the manifest file to the latest schema revision', function () {
-        expect(manifest.schemaRev).to.equal(3);
+        expect(manifest.schemaRev).to.equal(CURRENT_SCHEMA_REV);
       });
     });
   });

--- a/packages/appium/test/unit/extension/manifest-migrations.spec.js
+++ b/packages/appium/test/unit/extension/manifest-migrations.spec.js
@@ -1,0 +1,91 @@
+import {Manifest} from '../../../lib/extension/manifest';
+import {migrate} from '../../../lib/extension/manifest-migrations';
+import {DRIVER_TYPE} from '../../../lib/constants';
+
+const {expect} = chai;
+
+describe('manifest-migrations', function () {
+  describe('when no installPath property present in manifest', function () {
+    it('should trigger refresh', async function () {
+      const manifest = Manifest.getInstance(process.cwd());
+      // do not explicitly set the schema rev lower here, since that will trigger
+      manifest.setExtension(
+        DRIVER_TYPE,
+        'derp',
+        // @ts-expect-error - old manifest version
+        {
+          version: '1.0.0',
+          automationName: 'Derp',
+          mainClass: 'SomeClass',
+          pkgName: 'derp',
+          platformNames: ['dogs', 'cats'],
+          installSpec: 'derp',
+          installType: 'local',
+          appiumVersion: '2.0.0',
+        }
+      );
+
+      await expect(migrate(manifest)).to.eventually.be.true;
+    });
+  });
+
+  describe('when installPath property present in manifest', function () {
+    it('should not trigger refresh', async function () {
+      const manifest = Manifest.getInstance(process.cwd());
+      // do not explicitly set the schema rev lower here, since that will trigger
+      manifest.setExtension(DRIVER_TYPE, 'derp', {
+        version: '1.0.0',
+        automationName: 'Derp',
+        mainClass: 'SomeClass',
+        pkgName: 'derp',
+        platformNames: ['dogs', 'cats'],
+        installPath: '/path/to/thing',
+        installType: 'local',
+        installSpec: 'derp',
+        appiumVersion: '2.0.0',
+      });
+
+      await expect(migrate(manifest)).to.eventually.be.false;
+    });
+  });
+
+  describe('when an installType is "npm" and the rev is old', function () {
+    it('should trigger refresh', async function () {
+      const manifest = Manifest.getInstance(process.cwd());
+      manifest.setSchemaRev(3); // this will trigger a refresh, but there's no way to tell _why_, which may be bad. YAGNI?
+      manifest.setExtension(DRIVER_TYPE, 'derp', {
+        version: '1.0.0',
+        automationName: 'Derp',
+        mainClass: 'SomeClass',
+        pkgName: 'derp',
+        platformNames: ['dogs', 'cats'],
+        installType: 'npm',
+        installPath: '/path/to/thing',
+        installSpec: 'derp',
+        appiumVersion: '2.0.0',
+      });
+
+      await expect(migrate(manifest)).to.eventually.be.true;
+    });
+  });
+
+  describe('when no installType is "npm"', function () {
+    it('should not trigger refresh', async function () {
+      const manifest = Manifest.getInstance(process.cwd());
+      // do not explicitly set the schema rev lower here, since that will trigger
+      manifest.setExtension(DRIVER_TYPE, 'derp', {
+        version: '1.0.0',
+        automationName: 'Derp',
+        mainClass: 'SomeClass',
+        pkgName: 'derp',
+        platformNames: ['dogs', 'cats'],
+        installType: 'local',
+        installPath: '/path/to/thing',
+        installSpec: 'derp',
+        appiumVersion: '2.0.0',
+      });
+
+      await expect(migrate(manifest)).to.eventually.be.false;
+    });
+  });
+});

--- a/packages/appium/test/unit/extension/manifest.spec.js
+++ b/packages/appium/test/unit/extension/manifest.spec.js
@@ -40,7 +40,10 @@ describe('Manifest', function () {
     let overrides;
     ({MockPackageChanged, MockAppiumSupport, MockGlob, overrides, sandbox} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
-    ({Manifest} = rewiremock.proxy(() => require('../../../lib/extension/manifest'), overrides));
+    ({Manifest} = rewiremock.proxy(() => require('../../../lib/extension/manifest'), {
+      ...overrides,
+      '../../../lib/extension/manifest-migrations.js': {migrate: sandbox.stub().resolves()},
+    }));
 
     Manifest.getInstance.cache = new Map();
   });

--- a/packages/appium/types/manifest/index.ts
+++ b/packages/appium/types/manifest/index.ts
@@ -5,17 +5,18 @@
 
 import * as ManifestV2 from './base';
 import * as ManifestV3 from './v3';
-
+import * as ManifestV4 from './v4';
 // add `import * as ManifestV<new-version> from './v<new-version>';` above
 
-export * from './v3';
+export * from './v4';
 // replace above line with `export * from './v<new-version>';`
 
-export {ManifestV2, ManifestV3};
+export {ManifestV2, ManifestV3, ManifestV4};
 
 export interface ManifestDataVersions {
   2: ManifestV2.ManifestData;
   3: ManifestV3.ManifestData;
+  4: ManifestV4.ManifestData;
 }
 // append to this interface your new version of `ManifestData`
 

--- a/packages/appium/types/manifest/v4.ts
+++ b/packages/appium/types/manifest/v4.ts
@@ -1,0 +1,161 @@
+import {DriverType, ExtensionType, PluginType} from '@appium/types';
+import {SchemaObject} from 'ajv';
+import {PackageJson, SetRequired} from 'type-fest';
+
+/**
+ * One of the possible extension installation stratgies
+ */
+export type InstallType = 'npm' | 'git' | 'local' | 'github' | 'dev';
+
+export interface InternalMetadata {
+  /**
+   * Package name of extension
+   *
+   * `name` from its `package.json`
+   */
+  pkgName: string;
+  /**
+   * Version of extension
+   *
+   * `version` from its `package.json`
+   */
+  version: string;
+  /**
+   * The method in which the user installed the extension (the `source` CLI arg)
+   */
+  installType: InstallType;
+  /**
+   * Whatever the user typed as the extension to install. May be derived from `package.json`
+   */
+  installSpec: string;
+  /**
+   * Maximum version of Appium that this extension is compatible with.
+   *
+   * If `undefined`, we'll try anyway.
+   */
+  appiumVersion?: string;
+  /**
+   * Path to the extension's root directory
+   */
+  installPath: string;
+}
+
+/**
+ * Shape of the `appium.schema` property in an extension's `package.json` (if it exists)
+ */
+export type ExtSchemaMetadata = string | (SchemaObject & {[key: number]: never});
+
+/**
+ * Manifest data shared by all extensions, as contained in `package.json`
+ */
+export interface CommonExtMetadata {
+  /**
+   * The main class of the extension.
+   *
+   * The extension must export this class by name.
+   */
+  mainClass: string;
+
+  /**
+   * Lookup table of scripts to run via `appium <driver|plugin> run <script>` keyed by name.
+   */
+  scripts?: Record<string, string>;
+
+  /**
+   * Schema describing configuration options (and CLI args) for the extension.
+   *
+   * Can also just be a path (relative to the extension root) to an external JSON schema file.
+   */
+  schema?: ExtSchemaMetadata;
+}
+
+/**
+ * Driver-specific manifest data as stored in a driver's `package.json`
+ */
+export interface DriverMetadata {
+  /**
+   * Automation name of the driver
+   */
+  automationName: string;
+  /**
+   * Platforms the driver supports
+   */
+  platformNames: string[];
+  /**
+   * Short name of the driver (displayed in `appium list`, etc.)
+   */
+  driverName: string;
+}
+
+/**
+ * Plugin-specific manifest data as stored in a plugin's `package.json`
+ */
+export interface PluginMetadata {
+  /**
+   * Short name of the plugin (displayed in `appium list`, etc.)
+   */
+  pluginName: string;
+}
+
+/**
+ * Generic extension metadata as stored in the `appium` prop of an extension's `package.json`.
+ */
+export type ExtMetadata<ExtType extends ExtensionType> = (ExtType extends DriverType
+  ? DriverMetadata
+  : ExtType extends PluginType
+  ? PluginMetadata
+  : never) &
+  CommonExtMetadata;
+
+/**
+ * Combination of external + internal extension data with `driverName`/`pluginName` removed (it becomes a key in an {@linkcode ExtRecord} object).
+ * Part of `extensions.yaml`.
+ */
+export type ExtManifest<ExtType extends ExtensionType> = Omit<
+  ExtMetadata<ExtType>,
+  'driverName' | 'pluginName'
+> &
+  InternalMetadata;
+
+/**
+ * Lookup of extension name to {@linkcode ExtManifest}.
+ * @see {ManifestData}
+ */
+export type ExtRecord<ExtType extends ExtensionType> = Record<string, ExtManifest<ExtType>>;
+
+/**
+ * The shape of the `extensions.yaml` file
+ */
+export interface ManifestData {
+  drivers: ExtRecord<DriverType>;
+  plugins: ExtRecord<PluginType>;
+  schemaRev: number;
+}
+
+/**
+ * The name of an installed extension, as it appears in `extensions.yaml`
+ * (as a property name under `drivers` or `plugins`)
+ */
+export type ExtName<ExtType extends ExtensionType> = keyof ExtRecord<ExtType>;
+
+/**
+ * A `package.json` containing extension metadata.
+ * Must have the following properties:
+ * - `name`: the name of the extension
+ * - `version`: the version of the extension
+ * - `appium`: the metadata for the extension
+ * - `peerDependencies.appium`: the maximum compatible version of Appium
+ */
+export type ExtPackageJson<ExtType extends ExtensionType> = SetRequired<
+  PackageJson,
+  'name' | 'version'
+> & {
+  appium: ExtMetadata<ExtType>;
+  peerDependencies: {appium: string; [key: string]: string};
+};
+
+/**
+ * A transient format between installation and insertion of extension metadata into the manifest.
+ */
+export type ExtInstallReceipt<ExtType extends ExtensionType> = ExtMetadata<ExtType> &
+  InternalMetadata;


### PR DESCRIPTION

This PR does a handful of things:

1. It adds a `--verbose` flag to `appium <driver|plugin> list` which just dumps a big object (via Node's `util.inspect()`), which contains the underlying manifest file data
2. It creates a new manifest schema revision where the "install type" can be `dev`. Added a migration.
3. Displays a warning if trying to uninstall an extension in dev mode
4. Displays `[installed (dev mode)]` instead of `[installed (npm)]` when running `appium <driver|plugin> list` w/o `--verbose` flag
5. Attempted to simplify the return type of `ExtensionCommand.list()`

Closes #18277
