### PR TITLE
fix(eslint-config-appium-ts): disable brace-style rule

### DIFF
--- a/packages/eslint-config-appium-ts/index.js
+++ b/packages/eslint-config-appium-ts/index.js
@@ -72,6 +72,13 @@ module.exports = {
      * `return await somePromise` have their own use-cases.
      */
     'require-await': 'off',
+
+    /**
+     * Disables the `brace-style` rule.
+     * @remarks Due to the way `prettier` sometimes formats extremely verbose types, sometimes it is necessary
+     * to indent in a way that is not allowed by the default `brace-style` rule.
+     */
+    'brace-style': 'off',
   },
   /**
    * This stuff enables `eslint-plugin-import` to resolve TS modules.


### PR DESCRIPTION
In certain situations in `.ts` sources, class definition lines can get very long.  Prettier will
split these into multiple lines, and add a final line with `{` at position 0.  This conflicts with
the `brace-style` rule in ESLint.  I am not sure why the ESLint prettier config doesn't already
handle this, but I am going to guess it's because that config doesn't work on `.ts` sources.
