### PR TITLE
fix(appium): remove longjohn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12741,16 +12741,6 @@
       "version": "0.8.4",
       "license": "MIT"
     },
-    "node_modules/longjohn": {
-      "version": "0.2.12",
-      "license": "MIT",
-      "dependencies": {
-        "source-map-support": "0.3.2 - 1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.9.3"
-      }
-    },
     "node_modules/loud-rejection": {
       "version": "2.2.0",
       "license": "MIT",
@@ -19516,7 +19506,6 @@
         "glob": "8.1.0",
         "lilconfig": "2.1.0",
         "lodash": "4.17.21",
-        "longjohn": "0.2.12",
         "npmlog": "7.0.1",
         "ora": "5.4.1",
         "package-changed": "2.0.0",

--- a/packages/appium/lib/constants.js
+++ b/packages/appium/lib/constants.js
@@ -69,3 +69,11 @@ export const EXT_SUBCOMMAND_RUN = 'run';
  * Current revision of the manifest (`extensions.yaml`) schema
  */
 export const CURRENT_SCHEMA_REV = 4;
+
+/**
+ * The default number of stack frames to show in a "long" stack trace, when enabled via `--long-stacktrace`
+ * @remarks This value may be increased in the future.
+ * @privateRemarks A value like `Infinity` may provide to have deleterious effects on
+ * memory usage, perf, and/or log output, and higher limits may be difficult to scan.
+ */
+export const LONG_STACKTRACE_LIMIT = 100;

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -22,7 +22,7 @@ import {
 } from './config';
 import {readConfigFile} from './config-file';
 import {loadExtensions, getActivePlugins, getActiveDrivers} from './extension';
-import {SERVER_SUBCOMMAND} from './constants';
+import {SERVER_SUBCOMMAND, LONG_STACKTRACE_LIMIT} from './constants';
 import registerNode from './grid-register';
 import {getDefaultsForSchema, validate} from './schema/schema';
 import {
@@ -46,8 +46,7 @@ async function preflightChecks(args, throwInsteadOfExit = false) {
     checkNodeOk();
     await checkNpmOk();
     if (args.longStacktrace) {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      require('longjohn').async_trace_limit = -1;
+      Error.stackTraceLimit = LONG_STACKTRACE_LIMIT;
     }
     if (args.showBuildInfo) {
       await showBuildInfo();

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -85,7 +85,6 @@
     "glob": "8.1.0",
     "lilconfig": "2.1.0",
     "lodash": "4.17.21",
-    "longjohn": "0.2.12",
     "npmlog": "7.0.1",
     "ora": "5.4.1",
     "package-changed": "2.0.0",


### PR DESCRIPTION
This removes `longjohn` and replaces it with a statement which increases the stack trace limit from the default (10) to 100.

I believe setting this overrides whatever was passed to the runtime `--stack-trace-limit` option.  If someone complains, we can try a different strategy.

Closes [#18357](https://github.com/appium/appium/issues/18357)