### PR TITLE
chore(ci): suppress warnings when linting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           useRollingCache: true
           install-command: npm ci
       - name: ESLint
-        run: npm run lint
+        run: npm run lint:ci
       - name: Validate Renovate Config
         uses: rinchsan/renovate-config-validator@1ea1e8514f6a33fdd71c40b0a5fa3512b9e7b936 # tag=v0
         with:

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "prepare": "run-p husky-install build:all",
     "lint": "eslint .",
     "lint:fix": "run-s \"lint -- --fix\"",
+    "lint:ci": "eslint --quiet .",
     "lint:commit": "commitlint",
     "lint:staged": "lint-staged",
     "prepublishOnly": "run-s rebuild",


### PR DESCRIPTION
This suppresses all warnings when running ESLint in CI (since they are noisy)

Local runs of `npm run lint` will still show all the warnings.