### PR TITLE
many fixes to emit working declarations

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -33,7 +33,7 @@ const sessionsListGuard = new AsyncLock();
 const pendingDriversGuard = new AsyncLock();
 
 /**
- * @implements {AppiumSessionHandler}
+ * @extends {DriverCore<AppiumDriverConstraints>}
  */
 class AppiumDriver extends DriverCore {
   /**
@@ -160,11 +160,10 @@ class AppiumDriver extends DriverCore {
     };
   }
 
-  // eslint-disable-next-line require-await
   async getSessions() {
     return _.toPairs(this.sessions).map(([id, driver]) => ({
       id,
-      capabilities: driver.caps,
+      capabilities: /** @type {import('@appium/types').DriverCaps} */ (driver.caps),
     }));
   }
 
@@ -852,7 +851,7 @@ export {AppiumDriver};
  * @typedef {import('@appium/types').ExternalDriver} ExternalDriver
  * @typedef {import('@appium/types').PluginClass} PluginClass
  * @typedef {import('@appium/types').Plugin} Plugin
- * @typedef {import('@appium/types').DriverClass<Constraints>} DriverClass
+ * @typedef {import('@appium/types').DriverClass<import('@appium/types').Driver>} DriverClass
  */
 
 /**
@@ -863,6 +862,11 @@ export {AppiumDriver};
 /**
  * @typedef {SessionHandlerResult<[innerSessionId: string, caps:
  * import('@appium/types').DriverCaps<Constraints>, protocol: string|undefined]>} SessionHandlerCreateResult
+ */
+
+/**
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').Core<C>} Core
  */
 
 /**

--- a/packages/appium/lib/extension/driver-config.js
+++ b/packages/appium/lib/extension/driver-config.js
@@ -244,7 +244,3 @@ export class DriverConfig extends ExtensionConfig {
  * @property {string} version
  * @property {string} driverName
  */
-
-/**
- * @typedef {import('@appium/types').Capabilities} Capabilities
- */

--- a/packages/appium/lib/extension/driver-config.js
+++ b/packages/appium/lib/extension/driver-config.js
@@ -212,28 +212,29 @@ export class DriverConfig extends ExtensionConfig {
 }
 
 /**
- * @template T
+ * @template {ExtensionType} T
  * @typedef {import('appium/types').ExtMetadata<T>} ExtMetadata
  */
 
 /**
- * @template T
+ * @template {ExtensionType} T
  * @typedef {import('appium/types').ExtManifest<T>} ExtManifest
  */
 
 /**
+ * @typedef {import('@appium/types').ExtensionType} ExtensionType
  * @typedef {import('appium/types').ManifestData} ManifestData
  * @typedef {import('@appium/types').DriverType} DriverType
  * @typedef {import('./manifest').Manifest} Manifest
  */
 
 /**
- * @template T
+ * @template {ExtensionType} T
  * @typedef {import('appium/types').ExtRecord<T>} ExtRecord
  */
 
 /**
- * @template T
+ * @template {ExtensionType} T
  * @typedef {import('appium/types').ExtName<T>} ExtName
  */
 

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -244,7 +244,11 @@ async function init(args) {
       }
     }
 
-    const appiumDriver = new AppiumDriver(serverArgs);
+    const appiumDriver = new AppiumDriver(
+      /** @type {import('@appium/types').DriverOpts<import('./appium').AppiumDriverConstraints>} */ (
+        serverArgs
+      )
+    );
     // set the config on the umbrella driver so it can match drivers to caps
     appiumDriver.driverConfig = driverConfig;
     await preflightChecks(serverArgs, throwInsteadOfExit);

--- a/packages/appium/lib/schema/cli-args.js
+++ b/packages/appium/lib/schema/cli-args.js
@@ -224,7 +224,7 @@ export function toParserArgs() {
 }
 
 /**
- * @template T
+ * @template {string|number} T
  * @typedef {import('ajv/dist/types').FormatValidator<T>} FormatValidator<T>
  */
 

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -369,21 +369,18 @@ export {
  */
 
 /**
- * @template {Constraints} [C=BaseDriverCapConstraints]
- * @template {StringRecord|void} [Extra=void]
- * @typedef {import('@appium/types').Capabilities<C, Extra>} Capabilities
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').Capabilities<C>} Capabilities
  */
 
 /**
- * @template {Constraints} [C=BaseDriverCapConstraints]
- * @template {StringRecord|void} [Extra=void]
- * @typedef {import('@appium/types').W3CCapabilities<C, Extra>} W3CCapabilities
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').W3CCapabilities<C>} W3CCapabilities
  */
 
 /**
- * @template {Constraints} [C=BaseDriverCapConstraints]
- * @template {StringRecord|void} [Extra=void]
- * @typedef {import('@appium/types').NSCapabilities<C, Extra>} NSCapabilities
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').NSCapabilities<C>} NSCapabilities
  */
 
 /**

--- a/packages/base-driver/lib/basedriver/commands/event.ts
+++ b/packages/base-driver/lib/basedriver/commands/event.ts
@@ -1,9 +1,10 @@
-import _ from 'lodash';
 import {Constraints, IEventCommands} from '@appium/types';
-import {mixin} from './mixin';
+import _ from 'lodash';
 import {BaseDriver} from '../driver';
+import {mixin} from './mixin';
 
 declare module '../driver' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface BaseDriver<C extends Constraints> extends IEventCommands {}
 }
 

--- a/packages/base-driver/lib/basedriver/commands/find.ts
+++ b/packages/base-driver/lib/basedriver/commands/find.ts
@@ -4,6 +4,7 @@ import {BaseDriver} from '../driver';
 import {mixin} from './mixin';
 
 declare module '../driver' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface BaseDriver<C extends Constraints> extends IFindCommands {}
 }
 

--- a/packages/base-driver/lib/basedriver/commands/log.ts
+++ b/packages/base-driver/lib/basedriver/commands/log.ts
@@ -4,6 +4,7 @@ import {BaseDriver} from '../driver';
 import {mixin} from './mixin';
 
 declare module '../driver' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface BaseDriver<C extends Constraints> extends ILogCommands {}
 }
 
@@ -15,10 +16,7 @@ const LogCommands: ILogCommands = {
     return Object.keys(this.supportedLogTypes);
   },
 
-  async getLog<C extends Constraints>(
-    this: Driver<C>,
-    logType: keyof ILogCommands['supportedLogTypes']
-  ) {
+  async getLog<C extends Constraints>(this: Driver<C>, logType: string) {
     this.log.debug(`Retrieving '${String(logType)}' logs`);
 
     if (!(logType in this.supportedLogTypes)) {

--- a/packages/base-driver/lib/basedriver/commands/session.ts
+++ b/packages/base-driver/lib/basedriver/commands/session.ts
@@ -1,14 +1,17 @@
-import {Constraints, ISessionCommands, MultiSessionData} from '@appium/types';
+import {Constraints, ISessionCommands, MultiSessionData, SingularSessionData} from '@appium/types';
 import {BaseDriver} from '../driver';
 import {mixin} from './mixin';
 
 declare module '../driver' {
-  interface BaseDriver<C extends Constraints> extends ISessionCommands {}
+  interface BaseDriver<
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    C extends Constraints
+  > extends ISessionCommands {}
 }
 
 const SessionCommands: ISessionCommands = {
   async getSessions<C extends Constraints>(this: BaseDriver<C>) {
-    const ret: MultiSessionData[] = [];
+    const ret: MultiSessionData<C>[] = [];
 
     if (this.sessionId) {
       ret.push({
@@ -24,10 +27,9 @@ const SessionCommands: ISessionCommands = {
    * Returns capabilities for the session and event history (if applicable)
    */
   async getSession<C extends Constraints>(this: BaseDriver<C>) {
-    if (this.caps.eventTimings) {
-      return {...this.caps, events: this.eventHistory};
-    }
-    return this.caps;
+    return <SingularSessionData<C>>(
+      (this.caps.eventTimings ? {...this.caps, events: this.eventHistory} : this.caps)
+    );
   },
 };
 

--- a/packages/base-driver/lib/basedriver/commands/settings.ts
+++ b/packages/base-driver/lib/basedriver/commands/settings.ts
@@ -3,6 +3,7 @@ import {Constraints, ISettingsCommands, StringRecord} from '@appium/types';
 import {mixin} from './mixin';
 
 declare module '../driver' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface BaseDriver<C extends Constraints> extends ISettingsCommands {}
 }
 

--- a/packages/base-driver/lib/basedriver/core.js
+++ b/packages/base-driver/lib/basedriver/core.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable require-await */
 
-import {fs, logger} from '@appium/support';
+import {logger} from '@appium/support';
 import AsyncLock from 'async-lock';
 import {EventEmitter} from 'events';
 import _ from 'lodash';
@@ -16,8 +16,9 @@ const NEW_COMMAND_TIMEOUT_MS = 60 * 1000;
 const ON_UNEXPECTED_SHUTDOWN_EVENT = 'onUnexpectedShutdown';
 
 /**
- * @template {Constraints} [C=BaseDriverCapConstraints]
- * @implements {Core<C>}
+ * @template {Constraints} C
+ * @template {StringRecord} [Settings=StringRecord]
+ * @implements {Core<C, Settings>}
  */
 class DriverCore {
   /**
@@ -37,7 +38,7 @@ class DriverCore {
   opts;
 
   /**
-   * @type {ServerArgs}
+   * @type {import('@appium/types').DriverOpts<C>}
    */
   initialOpts;
 
@@ -115,7 +116,7 @@ class DriverCore {
    * we set it to an empty DeviceSettings instance here to make sure that the
    * default settings are applied even if an extending driver doesn't utilize
    * the settings functionality itself
-   * @type {DeviceSettings}
+   * @type {DeviceSettings<Settings>}
    */
   settings;
 
@@ -180,11 +181,9 @@ class DriverCore {
    * specific driver sessions. This data can be later used to adjust
    * properties for driver instances running in parallel.
    * Override it in inherited driver classes if necessary.
-   *
-   * @return {Record<string,unknown>} Driver properties mapping
    */
   get driverData() {
-    return {};
+    return /** @type {import('@appium/types').DriverData} */ ({});
   }
 
   /**
@@ -256,7 +255,7 @@ class DriverCore {
    * @returns {Core<C> | null}
    */
   driverForSession(sessionId) {
-    return this;
+    return /** @type {Core<C> | null} */ (this);
   }
 
   isMjsonwpProtocol() {
@@ -445,18 +444,9 @@ export {DriverCore};
  */
 
 /**
- * @template {Constraints} [C=BaseDriverCapConstraints]
- * @template {StringRecord|void} [Extra=void]
- * @typedef {import('@appium/types').Capabilities<C, Extra>} Capabilities
- */
-/**
- * @template {StringRecord} [T={}]
- * @typedef {import('@appium/types').W3CCapabilities<T>} W3CCapabilities
- */
-
-/**
  * @template {Constraints} C
- * @typedef {import('@appium/types').Core<C>} Core
+ * @template {StringRecord} [S=StringRecord]
+ * @typedef {import('@appium/types').Core<C, S>} Core
  */
 
 /**

--- a/packages/base-driver/lib/basedriver/device-settings.js
+++ b/packages/base-driver/lib/basedriver/device-settings.js
@@ -9,13 +9,13 @@ import {errors} from '../protocol/errors';
 export const MAX_SETTINGS_SIZE = 20 * 1024 * 1024; // 20 MB
 
 /**
- * @template T
+ * @template {import('@appium/types').StringRecord} T
  * @implements {IDeviceSettings<T>}
  */
-class DeviceSettings {
+export class DeviceSettings {
   /**
    * @protected
-   * @type {Record<string,T>}
+   * @type {T}
    */
   _settings;
 
@@ -27,17 +27,17 @@ class DeviceSettings {
 
   /**
    * Creates a _shallow copy_ of the `defaultSettings` parameter!
-   * @param {Record<string,T>} [defaultSettings]
+   * @param {T} [defaultSettings]
    * @param {import('@appium/types').SettingsUpdateListener<T>} [onSettingsUpdate]
    */
-  constructor(defaultSettings = {}, onSettingsUpdate = async () => {}) {
+  constructor(defaultSettings = /** @type {T} */ ({}), onSettingsUpdate = async () => {}) {
     this._settings = {...defaultSettings};
     this._onSettingsUpdate = onSettingsUpdate;
   }
 
   /**
    * calls updateSettings from implementing driver every time a setting is changed.
-   * @param {Record<string,T>} newSettings
+   * @param {T} newSettings
    */
   async update(newSettings) {
     if (!_.isPlainObject(newSettings)) {
@@ -54,8 +54,7 @@ class DeviceSettings {
       );
     }
 
-    const props = /** @type {(keyof T & string)[]} */ (_.keys(newSettings));
-    for (const prop of props) {
+    for (const prop in newSettings) {
       if (!_.isUndefined(this._settings[prop])) {
         if (this._settings[prop] === newSettings[prop]) {
           log.debug(`The value of '${prop}' setting did not change. Skipping the update for it`);
@@ -73,9 +72,8 @@ class DeviceSettings {
 }
 
 export default DeviceSettings;
-export {DeviceSettings};
 
 /**
- * @template T
- * @typedef {import('@appium/types').DeviceSettings<T>} IDeviceSettings
+ * @template {import('@appium/types').StringRecord} [T=import('@appium/types').StringRecord]
+ * @typedef {import('@appium/types').IDeviceSettings<T>} IDeviceSettings
  */

--- a/packages/base-driver/lib/helpers/capabilities.js
+++ b/packages/base-driver/lib/helpers/capabilities.js
@@ -83,7 +83,6 @@ export {isW3cCaps, fixCaps};
  */
 
 /**
- * @template {Constraints} [C=BaseDriverCapConstraints]
- * @template {StringRecord|void} [Extra=void]
- * @typedef {import('@appium/types').Capabilities<C, Extra>} Capabilities
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').Capabilities<C>} Capabilities
  */

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -277,7 +277,7 @@ function routeConfiguringFunction(driver) {
           `${basePath}${path}`,
           spec,
           driver,
-          isSessionCommand(spec.command)
+          isSessionCommand(/** @type {import('@appium/types').DriverMethodDef} */ (spec).command)
         );
       }
     }
@@ -455,12 +455,12 @@ function buildHandler(app, method, path, spec, driver, isSessCmd) {
       // if anything goes wrong, figure out what our response should be
       // based on the type of error that we encountered
       let actualErr;
-      if ((err instanceof Error) || (_.has(err, 'stack') && _.has(err, 'message'))) {
+      if (err instanceof Error || (_.has(err, 'stack') && _.has(err, 'message'))) {
         actualErr = err;
       } else {
         getLogger(driver, req.params.sessionId || newSessionId).warn(
           'The thrown error object does not seem to be a valid instance of the Error class. This ' +
-          'might be a genuine bug of a driver or a plugin.'
+            'might be a genuine bug of a driver or a plugin.'
         );
         actualErr = new Error(`${err ?? 'unknown'}`);
       }

--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -18,6 +18,7 @@ const SET_ALERT_TEXT_PAYLOAD_PARAMS = {
  * define the routes, mapping of HTTP methods to particular driver commands, and
  * any parameters that are expected in a request parameters can be `required` or
  * `optional`
+ * @satisfies {import('@appium/types').MethodMap<import('../basedriver/driver').BaseDriver>}
  */
 const METHOD_MAP = /** @type {const} */ ({
   '/status': {
@@ -129,7 +130,11 @@ const METHOD_MAP = /** @type {const} */ ({
     POST: {command: 'deactivateIMEEngine', deprecated: true},
   },
   '/session/:sessionId/ime/activate': {
-    POST: {command: 'activateIMEEngine', payloadParams: {required: ['engine']}, deprecated: true},
+    POST: {
+      command: 'activateIMEEngine',
+      payloadParams: {required: ['engine']},
+      deprecated: true,
+    },
   },
   '/session/:sessionId/frame': {
     POST: {command: 'setFrame', payloadParams: {required: ['id']}},
@@ -356,7 +361,11 @@ const METHOD_MAP = /** @type {const} */ ({
     DELETE: {command: 'releaseActions'},
   },
   '/session/:sessionId/touch/longclick': {
-    POST: {command: 'touchLongClick', payloadParams: {required: ['elements']}, deprecated: true},
+    POST: {
+      command: 'touchLongClick',
+      payloadParams: {required: ['elements']},
+      deprecated: true,
+    },
   },
   '/session/:sessionId/touch/flick': {
     POST: {
@@ -922,7 +931,7 @@ const METHOD_MAP = /** @type {const} */ ({
 let ALL_COMMANDS = [];
 for (let v of _.values(METHOD_MAP)) {
   for (let m of _.values(v)) {
-    if (m.command) {
+    if ('command' in m && m.command) {
       ALL_COMMANDS.push(m.command);
     }
   }
@@ -1006,13 +1015,3 @@ function routeToCommandName(endpoint, method, basePath = DEFAULT_BASE_PATH) {
 const NO_SESSION_ID_COMMANDS = ['createSession', 'getStatus', 'getSessions'];
 
 export {METHOD_MAP, ALL_COMMANDS, NO_SESSION_ID_COMMANDS, routeToCommandName};
-
-/**
- * This checks compat with the `MethodMap` interface.
- * @ignore
- */
-// eslint-disable-next-line no-unused-vars
-const _validMethodMap =
-  /** @type {import('@appium/types').MethodMap<import('@appium/types').ExternalDriver<import('@appium/types').BaseDriverCapConstraints>>} */ (
-    METHOD_MAP
-  );

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -40,7 +40,8 @@
     "test": "npm run test:unit",
     "test:e2e": "mocha -p --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
     "test:smoke": "node ./index.js",
-    "test:unit": "mocha \"./test/unit/**/*.spec.js\""
+    "test:unit": "mocha \"./test/unit/**/*.spec.js\"",
+    "test:types": "tsd"
   },
   "dependencies": {
     "@appium/support": "^3.1.7",
@@ -78,5 +79,8 @@
   "gitHead": "84b211330dc84849af9cc1f3a5c5ad32e15b2e72",
   "typedoc": {
     "entryPoint": "./lib/index.js"
+  },
+  "tsd": {
+    "directory": "test/types"
   }
 }

--- a/packages/base-driver/test/types/basedriver/driver.test-d.ts
+++ b/packages/base-driver/test/types/basedriver/driver.test-d.ts
@@ -1,5 +1,11 @@
-import {expectType} from 'tsd';
-import {BaseDriver} from '.../../../build/lib/basedriver/driver';
-import {BaseDriverCapConstraints, Driver} from '@appium/types';
+import {expectAssignable} from 'tsd';
+// NOTE: this pulls in the distfiles
+import {BaseDriver} from '.../../..';
+import {BaseDriverCapConstraints, ExternalDriver, Driver, DriverOpts} from '@appium/types';
 
-expectType<Driver<BaseDriverCapConstraints>>(new BaseDriver());
+expectAssignable<Driver<BaseDriverCapConstraints>>(
+  new BaseDriver({} as DriverOpts<BaseDriverCapConstraints>)
+);
+expectAssignable<ExternalDriver<BaseDriverCapConstraints>>(
+  new BaseDriver({} as DriverOpts<BaseDriverCapConstraints>)
+);

--- a/packages/base-driver/test/types/basedriver/driver.test-d.ts
+++ b/packages/base-driver/test/types/basedriver/driver.test-d.ts
@@ -1,0 +1,5 @@
+import {expectType} from 'tsd';
+import {BaseDriver} from '.../../../build/lib/basedriver/driver';
+import {BaseDriverCapConstraints, Driver} from '@appium/types';
+
+expectType<Driver<BaseDriverCapConstraints>>(new BaseDriver());

--- a/packages/docutils/lib/logger.ts
+++ b/packages/docutils/lib/logger.ts
@@ -134,7 +134,7 @@ class DocutilsReporter extends FancyReporter {
  *
  * "Global" inasmuch as any logger created from the root logger will use this level.
  */
-let globalLevel = LogLevelMap[DEFAULT_LOG_LEVEL];
+let globalLevel: LogLevel = LogLevelMap[DEFAULT_LOG_LEVEL];
 
 /**
  * The logger from which all loggers are created.  This one uses a unique tag and our custom reporter.

--- a/packages/driver-test-support/lib/e2e-suite.js
+++ b/packages/driver-test-support/lib/e2e-suite.js
@@ -425,7 +425,12 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
  * @typedef {import('@appium/types').BaseDriverCapConstraints} BaseDriverCapConstraints
  * @typedef {import('@appium/types').BaseNSCapabilities} BaseNSCapabilities
  * @typedef {import('axios').RawAxiosRequestConfig} RawAxiosRequestConfig
- * @typedef {import('@appium/types').SingularSessionData} SingularSessionData
+ */
+
+/**
+ * `Constraints` is purposefully loose here
+ * @template {Constraints} [C=Constraints]
+ * @typedef {import('@appium/types').SingularSessionData<C>} SingularSessionData
  */
 
 /**
@@ -434,18 +439,18 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
  */
 
 /**
- * @template {Constraints} [C=BaseDriverCapConstraints]
- * @template {StringRecord|void} [Extra=void]
+ * `Constraints` is purposefully loose here
+ * @template {Constraints} [C=Constraints]
  * @typedef NewSessionData
- * @property {import('type-fest').RequireAtLeastOne<import('@appium/types').W3CCapabilities<C, Extra>, 'firstMatch'|'alwaysMatch'>} capabilities
+ * @property {import('type-fest').RequireAtLeastOne<import('@appium/types').W3CCapabilities<C>, 'firstMatch'|'alwaysMatch'>} capabilities
  */
 
 /**
- * @template {Constraints} [C=BaseDriverCapConstraints]
- * @template {StringRecord|void} [Extra=void]
+ * `Constraints` is purposefully loose here
+ * @template {Constraints} [C=Constraints]
  * @typedef NewSessionResponse
  * @property {string} sessionId,
- * @property {import('@appium/types').Capabilities<C, Extra>} capabilities
+ * @property {import('@appium/types').Capabilities<C>} capabilities
  */
 
 /**

--- a/packages/driver-test-support/lib/index.js
+++ b/packages/driver-test-support/lib/index.js
@@ -11,7 +11,6 @@ export * from './stoppable';
  */
 
 /**
- * @template {import('@appium/types').Constraints} [C=import('@appium/types').BaseDriverCapConstraints]
- * @template {import('@appium/types').StringRecord|void} [Extra=void]
- * @typedef {import('@appium/types').W3CCapabilities<C, Extra>} W3CCapabilities
+ * @template {import('@appium/types').Constraints} C
+ * @typedef {import('@appium/types').W3CCapabilities<C>} W3CCapabilities
  */

--- a/packages/driver-test-support/lib/unit-suite.js
+++ b/packages/driver-test-support/lib/unit-suite.js
@@ -12,18 +12,22 @@ const {expect} = chai;
 
 /**
  * Creates unit test suites for a driver.
- * @param {DriverClass} DriverClass
- * @param {Partial<BaseNSCapabilities>} [defaultCaps]
+ * @template {Constraints} C
+ * @param {DriverClass<C>} DriverClass
+ * @param {import('@appium/types').NSDriverCaps<C>} [defaultCaps]
  */
 
-export function driverUnitTestSuite(DriverClass, defaultCaps = {}) {
+export function driverUnitTestSuite(
+  DriverClass,
+  defaultCaps = /** @type {import('@appium/types').NSDriverCaps<C>} */ ({})
+) {
   // to display the driver under test in report
   const className = DriverClass.name ?? '(unknown driver)';
 
   describe(`BaseDriver unit suite (as ${className})`, function () {
     /** @type {InstanceType<typeof DriverClass>} */
     let d;
-    /** @type {W3CCapabilities} */
+    /** @type {import('@appium/types').W3CDriverCaps<C>} */
     let w3cCaps;
     /** @type {import('sinon').SinonSandbox} */
     let sandbox;
@@ -229,7 +233,7 @@ export function driverUnitTestSuite(DriverClass, defaultCaps = {}) {
     });
 
     describe('command queue', function () {
-      /** @type {InstanceType<DriverClass>} */
+      /** @type {InstanceType<DriverClass<Constraints>>} */
       let d;
       let waitMs = 10;
 
@@ -531,11 +535,11 @@ export function driverUnitTestSuite(DriverClass, defaultCaps = {}) {
             d.logEvent('commands');
           }).should.throw();
           (() => {
-            // @ts-expect-error
+            // @ts-expect-error - bad type
             d.logEvent(1);
           }).should.throw();
           (() => {
-            // @ts-expect-error
+            // @ts-expect-error - bad type
             d.logEvent({});
           }).should.throw();
         });
@@ -631,7 +635,7 @@ export function driverUnitTestSuite(DriverClass, defaultCaps = {}) {
  */
 
 /**
- * @template {Constraints} [C=import('@appium/types').BaseDriverCapConstraints]
+ * @template {Constraints} C
  * @typedef {import('@appium/types').DriverClass<Driver<C>>} DriverClass
  */
 
@@ -641,7 +645,6 @@ export function driverUnitTestSuite(DriverClass, defaultCaps = {}) {
  */
 
 /**
- * @template {Constraints} [C=import('@appium/types').BaseDriverCapConstraints]
- * @template {import('@appium/types').StringRecord|void} [Extra=void]
- * @typedef {import('@appium/types').W3CCapabilities<C, Extra>} W3CCapabilities
+ * @template {Constraints} C
+ * @typedef {import('@appium/types').W3CCapabilities<C>} W3CCapabilities
  */

--- a/packages/execute-driver-plugin/lib/plugin.js
+++ b/packages/execute-driver-plugin/lib/plugin.js
@@ -32,7 +32,7 @@ export default class ExecuteDriverPlugin extends BasePlugin {
    *
    * @returns {Promise<any>} - a JSONifiable object representing the return value of
    * the script
-   * @type {import('@appium/types').PluginCommand<[script: string, scriptType: string?, timeoutMs: number?], any>}
+   * @type {import('@appium/types').PluginCommand<import('@appium/types').ExternalDriver, [script: string, scriptType: string?, timeoutMs: number?]>}
    * @throws {Error}
    */
   async executeDriverScript(

--- a/packages/fake-driver/lib/commands/general.ts
+++ b/packages/fake-driver/lib/commands/general.ts
@@ -22,7 +22,7 @@ interface FakeDriverGeneralMixin {
   doubleClick(): Promise<void>;
   execute(script: string, args: any[]): Promise<any>;
   fakeAddition(a: number, b: number, c?: number): Promise<number>;
-  getLog(type: string): Promise<any[]>;
+  getLog(type: string): Promise<unknown[]>;
 }
 
 declare module '../driver' {

--- a/packages/types/lib/capabilities.ts
+++ b/packages/types/lib/capabilities.ts
@@ -141,7 +141,7 @@ export type NSCapabilities<C extends Constraints, NS extends string = W3C_APPIUM
  * Normalized capabilities for drivers extending `BaseDriver`.
  * Includes {@linkcode BaseCapabilities}.
  */
-export type DriverCaps<C extends Constraints> = BaseCapabilities & Capabilities<C>;
+export type DriverCaps<C extends Constraints = Constraints> = BaseCapabilities & Capabilities<C>;
 
 /**
  * W3C-style capabilities for drivers extending `BaseDriver`.
@@ -157,11 +157,13 @@ export type DriverCaps<C extends Constraints> = BaseCapabilities & Capabilities<
  * }
  * ```
  */
-export type W3CDriverCaps<C extends Constraints> = BaseW3CCapabilities & W3CCapabilities<C>;
+export type W3CDriverCaps<C extends Constraints = Constraints> = BaseW3CCapabilities &
+  W3CCapabilities<C>;
 
 /**
  * Namespaced capabilities for drivers extending `BaseDriver`.
  *
  * Includes {@linkcode BaseNSCapabilities}.
  */
-export type NSDriverCaps<C extends Constraints> = BaseNSCapabilities & NSCapabilities<C>;
+export type NSDriverCaps<C extends Constraints = Constraints> = BaseNSCapabilities &
+  NSCapabilities<C>;

--- a/packages/types/lib/capabilities.ts
+++ b/packages/types/lib/capabilities.ts
@@ -1,6 +1,6 @@
-import {StandardCapabilities} from './standard-caps';
 import {BaseDriverCapConstraints} from './constraints';
 import {Constraint, Constraints} from './driver';
+import {StandardCapabilities} from './standard-caps';
 import {AnyCase, StringRecord} from './util';
 
 export {StandardCapabilities};
@@ -10,20 +10,23 @@ export type W3C_APPIUM_PREFIX = 'appium';
 /**
  * Base capabilities as derived from {@linkcode BaseDriverCapConstraints}.
  */
-export type BaseCapabilities = ConstraintsToCaps<BaseDriverCapConstraints>;
+export type BaseCapabilities = Capabilities<BaseDriverCapConstraints>;
 
 /**
  * Like {@linkcode BaseCapabilities}, except all Appium-specific keys are namespaced.
  */
-export type BaseNSCapabilities = CapsToNSCaps<ConstraintsToCaps<BaseDriverCapConstraints>>;
+export type BaseNSCapabilities = NSCapabilities<BaseDriverCapConstraints>;
+
+/**
+ * Like {@linkcode NSBaseCapabilities}, except W3C-style.
+ * @see {@linkcode W3CCapabilities}
+ */
+export type BaseW3CCapabilities = W3CCapabilities<BaseDriverCapConstraints>;
 
 /**
  * Given a {@linkcode Constraint} `C` and a type `T`, see if `inclusion`/`inclusionCaseInsensitive` is present, and create a union of its allowed literals; otherwise just use `T`.
  */
-type ConstraintChoice<
-  C extends Constraint,
-  T
-> = C['inclusionCaseInsensitive'] extends ReadonlyArray<T>
+export type ConstraintChoice<C extends Constraint, T> = C['inclusionCaseInsensitive'] extends T[]
   ? AnyCase<C['inclusionCaseInsensitive'][number]>
   : C['inclusion'] extends ReadonlyArray<T>
   ? C['inclusion'][number]
@@ -38,7 +41,7 @@ type ConstraintChoice<
  * - If `isArray` is `true`, the type is always of type `string[]`. If this is incorrect, then it will be `any[]`.
  * - There is no way to express the shape of an object if `ifObject` is `true`.
  */
-type ConstraintToCapKind<C extends Constraint> = C['isString'] extends true
+export type ConstraintToCapKind<C extends Constraint> = C['isString'] extends true
   ? ConstraintChoice<C, string>
   : C['isNumber'] extends true
   ? ConstraintChoice<C, number>
@@ -48,7 +51,7 @@ type ConstraintToCapKind<C extends Constraint> = C['isString'] extends true
   ? string[]
   : C['isObject'] extends true
   ? object
-  : any;
+  : unknown;
 
 /**
  * Given {@linkcode Constraint} `C`, determine if it is required or optional.
@@ -72,6 +75,10 @@ export type CapsToNSCaps<T extends StringRecord, NS extends string = W3C_APPIUM_
     : NamespacedString<K & string, NS>]: T[K];
 };
 
+/**
+ * A namespaced string of the format `<NS>:<S>` where `NS` defaults to the value of
+ * {@linkcode W3C_APPIUM_PREFIX} and `S` is a string.
+ */
 export type NamespacedString<
   S extends string,
   NS extends string = W3C_APPIUM_PREFIX
@@ -79,6 +86,7 @@ export type NamespacedString<
 
 /**
  * Converts {@linkcode Constraint} `C` to a {@linkcode Capabilities} object.
+ * @privateRemarks I would like to figure out how to simplify this type
  */
 export type ConstraintsToCaps<C extends Constraints> = {
   -readonly [K in keyof C]: ConstraintToCap<C[K]>;
@@ -89,34 +97,26 @@ export type ConstraintsToCaps<C extends Constraints> = {
  *
  * Does not contain {@linkcode BaseCapabilities}; see {@linkcode DriverCaps}.
  */
-export type Capabilities<
-  C extends Constraints = BaseDriverCapConstraints,
-  Extra extends StringRecord | void = void
-> = Partial<ConstraintsToCaps<C> & Extra>;
+export type Capabilities<C extends Constraints> = ConstraintsToCaps<C>;
 
 /**
  * Like {@linkcode Capabilities}, except W3C-style.
  *
  * Does not contain {@linkcode BaseCapabilities}; see {@linkcode W3CDriverCaps}.
  */
-export type W3CCapabilities<
-  C extends Constraints = BaseDriverCapConstraints,
-  Extra extends StringRecord | void = void
-> = {
-  alwaysMatch: NSCapabilities<C, Extra>;
-  firstMatch: NSCapabilities<C, Extra>[];
-};
+export interface W3CCapabilities<C extends Constraints> {
+  alwaysMatch: NSCapabilities<C>;
+  firstMatch: NSCapabilities<C>[];
+}
 
 /**
  * Namespaced caps (where appropriate).
  *
  * Does not contain {@linkcode BaseCapabilities}; see {@linkcode NSDriverCaps}.
  */
-export type NSCapabilities<
-  C extends Constraints = BaseDriverCapConstraints,
-  Extra extends StringRecord | void = void,
-  NS extends string = W3C_APPIUM_PREFIX
-> = Partial<CapsToNSCaps<ConstraintsToCaps<C> & Extra, NS>>;
+export type NSCapabilities<C extends Constraints, NS extends string = W3C_APPIUM_PREFIX> = Partial<
+  CapsToNSCaps<ConstraintsToCaps<C>, NS>
+>;
 
 /**
  * Capabilities for drivers extending `BaseDriver`.
@@ -125,7 +125,7 @@ export type NSCapabilities<
  *
  * @example
  * ```ts
- * class MyDriver extends BaseDriver {
+ * class MyDriver extends BaseDriver<MyDriverConstraints> {
  *   async createSession (w3ccaps: W3CDriverCaps<MyDriverConstraints>, ...args: any[]) {
  *     const [
  *       sessionId: string,
@@ -137,36 +137,31 @@ export type NSCapabilities<
  * ```
  */
 
-export type DriverCaps<
-  C extends Constraints,
-  Extra extends StringRecord | void = void
-> = Capabilities<BaseDriverCapConstraints & C, Extra>;
+/**
+ * Normalized capabilities for drivers extending `BaseDriver`.
+ * Includes {@linkcode BaseCapabilities}.
+ */
+export type DriverCaps<C extends Constraints> = BaseCapabilities & Capabilities<C>;
 
 /**
  * W3C-style capabilities for drivers extending `BaseDriver`.
  *
- * Includes {@linkcode BaseCapabilities}.
+ * Includes {@linkcode BaseW3CCapabilities}.
  *
  * @example
  * ```ts
- * class MyDriver extends BaseDriver {
+ * class MyDriver extends BaseDriver<MyDriverConstraints> {
  *   async createSession (w3ccaps: W3CDriverCaps<MyDriverConstraints>, ...args: any[]) {
  *     // ...
  *   }
  * }
  * ```
  */
-export type W3CDriverCaps<
-  C extends Constraints,
-  Extra extends StringRecord | void = void
-> = W3CCapabilities<BaseDriverCapConstraints & C, Extra>;
+export type W3CDriverCaps<C extends Constraints> = BaseW3CCapabilities & W3CCapabilities<C>;
 
 /**
  * Namespaced capabilities for drivers extending `BaseDriver`.
  *
- * Includes {@linkcode BaseCapabilities}.
+ * Includes {@linkcode BaseNSCapabilities}.
  */
-export type NSDriverCaps<
-  C extends Constraints,
-  Extra extends StringRecord | void = void
-> = NSCapabilities<BaseDriverCapConstraints & C, Extra>;
+export type NSDriverCaps<C extends Constraints> = BaseNSCapabilities & NSCapabilities<C>;

--- a/packages/types/lib/command.ts
+++ b/packages/types/lib/command.ts
@@ -16,6 +16,19 @@ export interface PayloadParams {
 }
 /**
  * A mapping of URL paths to HTTP methods to either a {@linkcode DriverMethodDef} or {@linkcode PluginMethodDef}.
+ *
+ * Extensions can define new methods for the Appium server to map to command names, of the same
+ * format as used in Appium's `routes.js`.
+ *
+ * @example
+ * ```js
+ * {
+ *   '/session/:sessionId/new_method': {
+ *     GET: {command: 'getNewThing'},
+ *     POST: {command: 'setNewThing', payloadParams: {required: ['someParam']}}
+ *   }
+ * }
+ * ```
  */
 export type MethodMap<T extends Plugin | Driver> = T extends Plugin
   ? Readonly<PluginMethodMap<T>>

--- a/packages/types/lib/command.ts
+++ b/packages/types/lib/command.ts
@@ -30,16 +30,16 @@ export interface PayloadParams {
  * }
  * ```
  */
-export type MethodMap<T extends Plugin | Driver> = T extends Plugin
+export type MethodMap<T extends Plugin | Driver<any>> = T extends Plugin
   ? Readonly<PluginMethodMap<T>>
-  : T extends Driver
+  : T extends Driver<any>
   ? Readonly<DriverMethodMap<T>>
   : never;
 
 /**
  * A {@linkcode MethodMap} for a {@linkcode Driver}.
  */
-export interface DriverMethodMap<T extends Driver> {
+export interface DriverMethodMap<T extends Driver<any>> {
   [key: string]: {
     GET?: DriverMethodDef<T>;
     POST?: DriverMethodDef<T>;
@@ -118,7 +118,7 @@ export interface BaseExecuteMethodDef {
 /**
  * A definition of an execute method in a {@linkcode Driver}.
  */
-export interface DriverExecuteMethodDef<T extends Driver> extends BaseExecuteMethodDef {
+export interface DriverExecuteMethodDef<T extends Driver<any>> extends BaseExecuteMethodDef {
   command: keyof ConditionalPick<T, DriverCommand>;
 }
 
@@ -132,8 +132,8 @@ export interface PluginExecuteMethodDef<T extends Plugin> extends BaseExecuteMet
 /**
  * Definition of an execute method (which overloads the behavior of the `execute` command) in a {@linkcode Driver} or {@linkcode Plugin}.
  */
-export type ExecuteMethodMap<T extends Plugin | Driver> = T extends Plugin
+export type ExecuteMethodMap<T extends Plugin | Driver<any>> = T extends Plugin
   ? Readonly<StringRecord<PluginExecuteMethodDef<T>>>
-  : T extends Driver
+  : T extends Driver<any>
   ? Readonly<StringRecord<DriverExecuteMethodDef<T>>>
   : never;

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -163,7 +163,7 @@ export interface ISessionCommands {
    *
    * @returns A list of session data objects
    */
-  getSessions<C extends Constraints>(): Promise<MultiSessionData<C>[]>;
+  getSessions(): Promise<MultiSessionData[]>;
 
   /**
    * Get the data for the current session
@@ -192,12 +192,12 @@ export interface IExecuteCommands {
   ): Promise<TReturn>;
 }
 
-export interface MultiSessionData<C extends Constraints> {
+export interface MultiSessionData<C extends Constraints = Constraints> {
   id: string;
   capabilities: DriverCaps<C>;
 }
 
-export type SingularSessionData<C extends Constraints> = DriverCaps<C> & {
+export type SingularSessionData<C extends Constraints = Constraints> = DriverCaps<C> & {
   events?: EventHistory;
   error?: string;
 };


### PR DESCRIPTION
This fixes the invalid declarations generated by TypeScript by rewriting `@appium/base-driver`'s
`lib/basedriver/driver.js` (containing the `BaseDriver` class) in TypeScript.

It also addresses a host of issues found when doing so, particularly around the use of the
`*Capabilities` and `*DriverCaps` types.  The question of which of these an external driver should
use is much less murky (e.g., you want to use `createSession(caps: W3CDriverCaps<MyConstraints>)`).
See the detailed commit message for more information.

It builds upon the structure added in #18390 by adding handful of simple checks for `BaseDriver`.

Closes #18379
