### PR TITLE
plugin command fixes

### DIFF
--- a/packages/appium/lib/cli/driver-command.js
+++ b/packages/appium/lib/cli/driver-command.js
@@ -1,15 +1,15 @@
 import _ from 'lodash';
-import ExtensionCommand from './extension-command';
+import ExtensionCliCommand from './extension-command';
 import {KNOWN_DRIVERS} from '../constants';
 import '@colors/colors';
 
 const REQ_DRIVER_FIELDS = ['driverName', 'automationName', 'platformNames', 'mainClass'];
 
 /**
- * @extends {ExtensionCommand<DriverType>}
+ * @extends {ExtensionCliCommand<DriverType>}
  */
 
-export default class DriverCommand extends ExtensionCommand {
+export default class DriverCliCommand extends ExtensionCliCommand {
   /**
    * @param {import('./extension-command').ExtensionCommandOptions<DriverType>} opts
    */
@@ -120,7 +120,7 @@ export default class DriverCommand extends ExtensionCommand {
  */
 
 /**
- * Options for {@linkcode DriverCommand.install}
+ * Options for {@linkcode DriverCliCommand.install}
  * @typedef DriverInstallOpts
  * @property {string} driver - the name or spec of a driver to install
  * @property {InstallType} installType - how to install this driver. One of the INSTALL_TYPES
@@ -132,20 +132,20 @@ export default class DriverCommand extends ExtensionCommand {
  */
 
 /**
- * Options for {@linkcode DriverCommand.uninstall}
+ * Options for {@linkcode DriverCliCommand.uninstall}
  * @typedef DriverUninstallOpts
  * @property {string} driver - the name or spec of a driver to uninstall
  */
 
 /**
- * Options for {@linkcode DriverCommand.update}
+ * Options for {@linkcode DriverCliCommand.update}
  * @typedef DriverUpdateOpts
  * @property {string} driver - the name of the driver to update
  * @property {boolean} unsafe - if true, will perform unsafe updates past major revision boundaries
  */
 
 /**
- * Options for {@linkcode DriverCommand.run}.
+ * Options for {@linkcode DriverCliCommand.run}.
  * @typedef DriverRunOptions
  * @property {string} driver - name of the driver to run a script from
  * @property {string} scriptName - name of the script to run

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -34,7 +34,7 @@ function receiptToManifest(receipt) {
 /**
  * @template {ExtensionType} ExtType
  */
-class ExtensionCommand {
+class ExtensionCliCommand {
   /**
    * This is the `DriverConfig` or `PluginConfig`, depending on `ExtType`.
    * @type {ExtensionConfig<ExtType>}
@@ -789,11 +789,11 @@ class ExtensionCommand {
   }
 }
 
-export default ExtensionCommand;
-export {ExtensionCommand};
+export default ExtensionCliCommand;
+export {ExtensionCliCommand as ExtensionCommand};
 
 /**
- * Options for the {@linkcode ExtensionCommand} constructor
+ * Options for the {@linkcode ExtensionCliCommand} constructor
  * @template {ExtensionType} ExtType
  * @typedef ExtensionCommandOptions
  * @property {ExtensionConfig<ExtType>} config - the `DriverConfig` or `PluginConfig` instance used for this command
@@ -801,7 +801,7 @@ export {ExtensionCommand};
  */
 
 /**
- * Extra stuff about extensions; used indirectly by {@linkcode ExtensionCommand.list}.
+ * Extra stuff about extensions; used indirectly by {@linkcode ExtensionCliCommand.list}.
  *
  * @typedef ExtensionListMetadata
  * @property {boolean} installed - If `true`, the extension is installed
@@ -849,7 +849,7 @@ export {ExtensionCommand};
  */
 
 /**
- * Possible return value for {@linkcode ExtensionCommand.list}
+ * Possible return value for {@linkcode ExtensionCliCommand.list}
  * @template {ExtensionType} ExtType
  * @typedef {Partial<ExtManifest<ExtType>> & Partial<ExtensionListMetadata>} ExtensionListData
  */
@@ -860,13 +860,13 @@ export {ExtensionCommand};
  */
 
 /**
- * Return value of {@linkcode ExtensionCommand.list}.
+ * Return value of {@linkcode ExtensionCliCommand.list}.
  * @template {ExtensionType} ExtType
  * @typedef {Record<string,ExtensionListData<ExtType>>} ExtensionList
  */
 
 /**
- * Options for {@linkcode ExtensionCommand._run}.
+ * Options for {@linkcode ExtensionCliCommand._run}.
  * @typedef RunOptions
  * @property {string} installSpec - name of the extension to run a script from
  * @property {string} scriptName - name of the script to run
@@ -875,7 +875,7 @@ export {ExtensionCommand};
  */
 
 /**
- * Return value of {@linkcode ExtensionCommand._run}
+ * Return value of {@linkcode ExtensionCliCommand._run}
  *
  * @typedef RunOutput
  * @property {string} [error] - error message if script ran unsuccessfully, otherwise undefined
@@ -883,41 +883,41 @@ export {ExtensionCommand};
  */
 
 /**
- * Options for {@linkcode ExtensionCommand._update}.
+ * Options for {@linkcode ExtensionCliCommand._update}.
  * @typedef ExtensionUpdateOpts
  * @property {string} installSpec - the name of the extension to update
  * @property {boolean} unsafe - if true, will perform unsafe updates past major revision boundaries
  */
 
 /**
- * Return value of {@linkcode ExtensionCommand._update}.
+ * Return value of {@linkcode ExtensionCliCommand._update}.
  * @typedef ExtensionUpdateResult
  * @property {Record<string,Error>} errors - map of ext names to error objects
  * @property {Record<string,UpdateReport>} updates - map of ext names to {@linkcode UpdateReport}s
  */
 
 /**
- * Part of result of {@linkcode ExtensionCommand._update}.
+ * Part of result of {@linkcode ExtensionCliCommand._update}.
  * @typedef UpdateReport
  * @property {string} from - version the extension was updated from
  * @property {string} to - version the extension was updated to
  */
 
 /**
- * Options for {@linkcode ExtensionCommand._uninstall}.
+ * Options for {@linkcode ExtensionCliCommand._uninstall}.
  * @typedef UninstallOpts
  * @property {string} installSpec - the name or spec of an extension to uninstall
  */
 
 /**
- * Used by {@linkcode ExtensionCommand.getPostInstallText}
+ * Used by {@linkcode ExtensionCliCommand.getPostInstallText}
  * @typedef ExtensionArgs
  * @property {string} extName - the name of an extension
  * @property {object} extData - the data for an installed extension
  */
 
 /**
- * Options for {@linkcode ExtensionCommand.installViaNpm}
+ * Options for {@linkcode ExtensionCliCommand.installViaNpm}
  * @typedef InstallViaNpmArgs
  * @property {string} installSpec - the name or spec of an extension to install
  * @property {string} pkgName - the NPM package name of the extension
@@ -926,7 +926,7 @@ export {ExtensionCommand};
  */
 
 /**
- * Object returned by {@linkcode ExtensionCommand.checkForExtensionUpdate}
+ * Object returned by {@linkcode ExtensionCliCommand.checkForExtensionUpdate}
  * @typedef PossibleUpdates
  * @property {string} current - current version
  * @property {string?} safeUpdate - version we can safely update to if it exists, or null
@@ -934,7 +934,7 @@ export {ExtensionCommand};
  */
 
 /**
- * Options for {@linkcode ExtensionCommand._install}
+ * Options for {@linkcode ExtensionCliCommand._install}
  * @typedef InstallOpts
  * @property {string} installSpec - the name or spec of an extension to install
  * @property {InstallType} installType - how to install this extension. One of the INSTALL_TYPES
@@ -954,7 +954,7 @@ export {ExtensionCommand};
  */
 
 /**
- * Opts for {@linkcode ExtensionCommand.getInstallationReceipt}
+ * Opts for {@linkcode ExtensionCliCommand.getInstallationReceipt}
  * @template {ExtensionType} ExtType
  * @typedef GetInstallationReceiptOpts
  * @property {string} installPath

--- a/packages/appium/lib/cli/extension.js
+++ b/packages/appium/lib/cli/extension.js
@@ -1,14 +1,14 @@
 /* eslint-disable no-console */
 import {DRIVER_TYPE, PLUGIN_TYPE} from '../constants';
 import {isExtensionCommandArgs} from '../utils';
-import DriverCommand from './driver-command';
-import PluginCommand from './plugin-command';
+import DriverCliCommand from './driver-command';
+import PluginCliCommand from './plugin-command';
 import {errAndQuit, JSON_SPACES} from './utils';
 
 export const commandClasses = Object.freeze(
   /** @type {const} */ ({
-    [DRIVER_TYPE]: DriverCommand,
-    [PLUGIN_TYPE]: PluginCommand,
+    [DRIVER_TYPE]: DriverCliCommand,
+    [PLUGIN_TYPE]: PluginCliCommand,
   })
 );
 
@@ -59,7 +59,7 @@ export {runExtensionCommand};
 
 /**
  * @template {ExtensionType} ExtType
- * @typedef {ExtType extends DriverType ? Class<DriverCommand> : ExtType extends PluginType ? Class<PluginCommand> : never} ExtCommand
+ * @typedef {ExtType extends DriverType ? Class<DriverCliCommand> : ExtType extends PluginType ? Class<PluginCliCommand> : never} ExtCommand
  */
 
 /**

--- a/packages/appium/lib/cli/plugin-command.js
+++ b/packages/appium/lib/cli/plugin-command.js
@@ -1,13 +1,13 @@
 import _ from 'lodash';
-import ExtensionCommand from './extension-command';
+import ExtensionCliCommand from './extension-command';
 import {KNOWN_PLUGINS} from '../constants';
 
 const REQ_PLUGIN_FIELDS = ['pluginName', 'mainClass'];
 
 /**
- * @extends {ExtensionCommand<PluginType>}
+ * @extends {ExtensionCliCommand<PluginType>}
  */
-export default class PluginCommand extends ExtensionCommand {
+export default class PluginCliCommand extends ExtensionCliCommand {
   /**
    *
    * @param {import('./extension-command').ExtensionCommandOptions<PluginType>} opts
@@ -110,7 +110,7 @@ export default class PluginCommand extends ExtensionCommand {
  */
 
 /**
- * Options for {@linkcode PluginCommand.install}
+ * Options for {@linkcode PluginCliCommand.install}
  * @typedef PluginInstallOpts
  * @property {string} plugin - the name or spec of a plugin to install
  * @property {InstallType} installType - how to install this plugin. One of the INSTALL_TYPES
@@ -122,20 +122,20 @@ export default class PluginCommand extends ExtensionCommand {
  */
 
 /**
- * Options for {@linkcode PluginCommand.uninstall}
+ * Options for {@linkcode PluginCliCommand.uninstall}
  * @typedef PluginUninstallOpts
  * @property {string} plugin - the name or spec of a plugin to uninstall
  */
 
 /**
- * Options for {@linkcode PluginCommand.update}
+ * Options for {@linkcode PluginCliCommand.update}
  * @typedef PluginUpdateOpts
  * @property {string} plugin - the name of the plugin to update
  * @property {boolean} unsafe - if true, will perform unsafe updates past major revision boundaries
  */
 
 /**
- * Options for {@linkcode PluginCommand.run}.
+ * Options for {@linkcode PluginCliCommand.run}.
  * @typedef PluginRunOptions
  * @property {string} plugin - name of the plugin to run a script from
  * @property {string} scriptName - name of the script to run

--- a/packages/base-driver/lib/basedriver/commands/execute.ts
+++ b/packages/base-driver/lib/basedriver/commands/execute.ts
@@ -20,7 +20,7 @@ const ExecuteCommands: IExecuteCommands = {
   async executeMethod<C extends Constraints>(
     this: BaseDriver<C>,
     script: string,
-    protoArgs: [StringRecord] | any[]
+    protoArgs: readonly [StringRecord<unknown>] | readonly unknown[]
   ) {
     const Driver = this.constructor as DriverClass<Driver<C>>;
     const commandMetadata = {...Driver.executeMethodMap?.[script]};

--- a/packages/base-plugin/lib/plugin.js
+++ b/packages/base-plugin/lib/plugin.js
@@ -60,7 +60,7 @@ class BasePlugin {
    * @param {NextPluginCallback} next
    * @param {Driver<C>} driver
    * @param {string} script
-   * @param {[Record<string, any>]|[]} protoArgs
+   * @param {readonly [import('@appium/types').StringRecord<unknown>] | readonly any[]} protoArgs
    */
   async executeMethod(next, driver, script, protoArgs) {
     const Plugin = /** @type {import('@appium/types').PluginClass<Plugin>} */ (this.constructor);

--- a/packages/types/lib/command.ts
+++ b/packages/types/lib/command.ts
@@ -1,6 +1,7 @@
 import {ConditionalPick, MultidimensionalReadonlyArray} from 'type-fest';
 import {Driver, DriverCommand} from './driver';
 import {Plugin, PluginCommand} from './plugin';
+import {StringRecord} from './util';
 
 /**
  * Defines the shape of a payload for a {@linkcode MethodDef}.
@@ -119,7 +120,7 @@ export interface PluginExecuteMethodDef<T extends Plugin> extends BaseExecuteMet
  * Definition of an execute method (which overloads the behavior of the `execute` command) in a {@linkcode Driver} or {@linkcode Plugin}.
  */
 export type ExecuteMethodMap<T extends Plugin | Driver> = T extends Plugin
-  ? Readonly<Record<string, PluginExecuteMethodDef<T>>>
+  ? Readonly<StringRecord<PluginExecuteMethodDef<T>>>
   : T extends Driver
-  ? Readonly<Record<string, DriverExecuteMethodDef<T>>>
+  ? Readonly<StringRecord<DriverExecuteMethodDef<T>>>
   : never;

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -177,7 +177,13 @@ export interface IExecuteCommands {
    *
    * @returns The result of calling the Execute Method
    */
-  executeMethod<TReturn = any>(script: string, args: [StringRecord] | any[]): Promise<TReturn>;
+  executeMethod<
+    TArgs extends readonly any[] | readonly [StringRecord<unknown>] = unknown[],
+    TReturn = unknown
+  >(
+    script: string,
+    args: TArgs
+  ): Promise<TReturn>;
 }
 
 export interface MultiSessionData<
@@ -2028,12 +2034,9 @@ export type DriverOpts<C extends Constraints = BaseDriverCapConstraints> = Serve
  *
  * Note that this signature differs from a `PluginCommand`.
  */
-export type DriverCommand<TArgs = any, TRetval = unknown> = (...args: TArgs[]) => Promise<TRetval>;
-
-export type DriverCommands<TArgs = any, TReturn = unknown> = Record<
-  string,
-  DriverCommand<TArgs, TReturn>
->;
+export type DriverCommand<TArgs extends readonly any[] = any[], TRetval = unknown> = (
+  ...args: TArgs
+) => Promise<TRetval>;
 
 /**
  * Tuple of an HTTP method with a regex matching a request path

--- a/packages/types/lib/plugin.ts
+++ b/packages/types/lib/plugin.ts
@@ -36,7 +36,7 @@ export interface PluginStatic<P extends Plugin> {
  * @example
  *
  * class MyPlugin extends BasePlugin implements Plugin {
- *   public getPageSource: OverrideDriverCommand<
+ *   public getPageSource: DriverCommandToPluginCommand<
  *     ExternalDriver['getPageSource'], // method to override
  *     [flag: boolean], // new arguments; defaults to the args of the method
  *     string|Buffer, // new return type; defaults to the async return type of the method

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -34,7 +34,8 @@
   "scripts": {
     "build": "node ./scripts/generate-schema-types.js",
     "clean": "git checkout -- ./types/lib/appium-config.ts || true",
-    "test:smoke": "node ./index.js"
+    "test:smoke": "node ./index.js",
+    "test:types": "tsd"
   },
   "dependencies": {
     "@appium/schema": "^0.2.6",

--- a/packages/types/test-d/plugin.test.ts
+++ b/packages/types/test-d/plugin.test.ts
@@ -1,0 +1,59 @@
+import {expectAssignable, expectNotAssignable} from 'tsd';
+import {
+  AppiumLogger,
+  DriverCommandToPluginCommand,
+  ExternalDriver,
+  Plugin,
+  StringRecord,
+  ExecuteMethodMap,
+  PluginClass,
+  PluginExecuteMethodDef,
+  PluginStatic,
+  NextPluginCallback,
+  PluginCommand,
+  DriverCommand,
+} from '..';
+class TestPlugin implements Plugin {
+  public logger: AppiumLogger = {} as AppiumLogger;
+
+  constructor(public readonly name: string, public readonly cliArgs: StringRecord<unknown> = {}) {}
+
+  static executeMethodMap = {
+    'test: method': {
+      command: 'testMethod',
+    },
+  } as const satisfies ExecuteMethodMap<TestPlugin>;
+
+  public getPageSource: DriverCommandToPluginCommand<
+    ExternalDriver['getPageSource'],
+    [flag: boolean],
+    string | Buffer
+  > = async function (next, driver, flag) {
+    const source = await next();
+    if (typeof source === 'string') {
+      return flag ? source : Buffer.from(source);
+    }
+    return '';
+  };
+
+  public async testMethod(next: NextPluginCallback, driver: ExternalDriver) {
+    return driver ? await next() : '';
+  }
+}
+
+const instance = new TestPlugin('test-plugin');
+
+expectAssignable<Plugin>(instance);
+expectAssignable<PluginExecuteMethodDef<TestPlugin>>(TestPlugin.executeMethodMap['test: method']);
+expectAssignable<ExecuteMethodMap<TestPlugin>>(TestPlugin.executeMethodMap);
+expectAssignable<PluginStatic<TestPlugin>>(TestPlugin);
+expectAssignable<PluginClass<TestPlugin>>(TestPlugin);
+expectNotAssignable<PluginClass>(TestPlugin);
+expectAssignable<PluginCommand>(instance.testMethod);
+expectAssignable<PluginCommand>(instance.getPageSource);
+// DriverCommand does not know anything about the driver in which it lives, so `getPageSource` looks
+// like any other `DriverCommand`; it returns a `Promise`!
+expectAssignable<DriverCommand>(instance.getPageSource);
+expectAssignable<PluginCommand<ExternalDriver, [flag: boolean], string | Buffer>>(
+  TestPlugin.prototype.getPageSource
+);


### PR DESCRIPTION
- Renamed classes `ExtensionCommand`, `DriverCommand` and `PluginCommand` in `appium` to
  `ExtensionCliCommand`, `DriverCliCommand` and `PluginCliCommand`, respectively to avoid naming
  conflicts and confusion w/ `DriverCommand` and `PluginCommand` from `@appium/types`, which have no relation.
- Updated the above two types:
    The first arg of `PluginCommand` is a `NextPluginCallback` which now returns `Promise<unknown>` instead of `Promise<void>`, which was incorrect.

    We use `unknown` rather than `any` because it forces us to be explicit about the return value of `await next()` if we are to call it.

    Added a type `DriverCommandToPluginCommand` which essentially converts a `DriverCommand` to a `PluginCommand`.  It's probably best used as a type guard or decorator, but it can "fill in the blanks" when overloading commands in a plugin.

    Also normalized some of the `TArgs`/`TReturn` stuff.
- Wrote some type tests for plugins.
