### PR TITLE
chore(types): deprecate Element.ELEMENT

### DIFF
--- a/packages/types/lib/action.ts
+++ b/packages/types/lib/action.ts
@@ -4,13 +4,7 @@
  * @module
  */
 
-/**
- * A W3C or JSONWP element.
- */
-export interface Element<Id extends string = string> {
-  ELEMENT?: Id;
-  'element-6066-11e4-a52e-4f735466cecf': Id;
-}
+import {Element} from './util';
 
 /**
  * @group Actions

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -1,13 +1,13 @@
 import type {EventEmitter} from 'events';
 import {Entries} from 'type-fest';
-import {ActionSequence, Element} from './action';
+import {ActionSequence} from './action';
 import {Capabilities, DriverCaps, W3CCapabilities, W3CDriverCaps} from './capabilities';
 import {ExecuteMethodMap, MethodMap} from './command';
 import {ServerArgs} from './config';
 import {HTTPHeaders, HTTPMethod} from './http';
 import {AppiumLogger} from './logger';
 import {AppiumServer, UpdateServerCallback} from './server';
-import {Class, StringRecord} from './util';
+import {Class, StringRecord, Element} from './util';
 
 /**
  * Interface implemented by the `DeviceSettings` class in `@appium/base-driver`

--- a/packages/types/lib/util.ts
+++ b/packages/types/lib/util.ts
@@ -72,3 +72,20 @@ export type AnyCase<T extends string> = string extends T
   : T extends `${infer F}${infer R}`
   ? `${Uppercase<F> | Lowercase<F>}${AnyCase<R>}`
   : '';
+
+/**
+ * A W3C element.
+ * @see https://www.w3.org/TR/webdriver1/#elements
+ */
+export interface Element<Id extends string = string> {
+  /**
+   * For backwards compatibility with JSONWP only.
+   * @deprecated Use {@linkcode element-6066-11e4-a52e-4f735466cecf} instead.
+   */
+  ELEMENT?: Id;
+  /**
+   * This property name is the string constant W3C element identifier used to identify an object as
+   * a W3C element.
+   */
+  'element-6066-11e4-a52e-4f735466cecf': Id;
+}


### PR DESCRIPTION
- move `Element` into `util` since it isn't specific to action sequences
- add more docs for it
