### PR TITLE
fix(types): make getContext & getContexts generic

### DIFF
--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -780,7 +780,8 @@ export interface Driver<
  * External drivers must subclass `BaseDriver`, and can implement any of these methods.
  * None of these are implemented within Appium itself.
  */
-export interface ExternalDriver<C extends Constraints = Constraints> extends Driver<C> {
+export interface ExternalDriver<C extends Constraints = Constraints, Ctx = string>
+  extends Driver<C> {
   // WebDriver spec commands
 
   /**
@@ -1826,7 +1827,7 @@ export interface ExternalDriver<C extends Constraints = Constraints> extends Dri
    *
    * @returns The context name
    */
-  getCurrentContext?(): Promise<string | null>;
+  getCurrentContext?(): Promise<Ctx | null>;
 
   /**
    * Switch to a context by name
@@ -1842,7 +1843,7 @@ export interface ExternalDriver<C extends Constraints = Constraints> extends Dri
    *
    * @returns The list of context names
    */
-  getContexts?(): Promise<string[]>;
+  getContexts?(): Promise<Ctx[]>;
 
   /**
    * Get the index of an element on the page


### PR DESCRIPTION
These can now return `T` and `T[]`, respectively.  `T` defaults to `string`, but in `appium-xcuitest-driver`, `T` is either `string` or an object, depending on the settings.  This makes the types more in-line with reality (again).

* * *

_Note_: the type arg must be defined on the _interface_ (`ExternalDriver`), not the function. When the function has a type argument: 

1. it is unrelated to any other type argument (`T` should be the same for both `getContext()` and `getContexts()`)
2. the _implementation_ must also be generic (e.g., `T` is what the _caller_ thinks it is; not the interface).  

Here's another example illustrating the difference ([playground link](https://www.typescriptlang.org/play?#code/PTAEEYDoChoSwHYBcCmAnAZgQwMYtAMoD2AtikgBaIDmoA3tKKAM6koBiArgjgDwAqAPgAUGIkQBcofgEopANyJwAJgG5oAX1g4iCZklBEARgCspxMpRqgAvPUYs2XHgJFjJ0uaEUr7TJiCgykSOllQItADucJSg7g5aWtDGJpCsZM44wgDk6SgESGg02TKggVbMoHCVGIgosIEATDDwyOjYeIRsVhEAogA2zCiufqEc3FnuUrIKSmqa2rr6hqaN5t3h1ANDvAicJEbograjeZmi4qUM-mVgwWM9UTEUceIJC8mraU4TOXkFRQiJVuoHQaCIaFU0iqlSw-UiWAAnpU9gd0EA)):

```ts
// 1.

interface Something {
  someFunc<T>(foo: T): void;
}

const obj: Something = {
  someFunc<T>(foo: T): void {
    // do something with foo
  }
}

obj.someFunc('someString') // this is fine

// 2.

interface SomethingElse<T> {
  someFunc(foo: T): void;
}

const obj2: SomethingElse<number> = {
  someFunc(foo) {
    // do something with foo
  }
}

obj2.someFunc('someString') // error; T is always number

```

