### PR TITLE
fix(typedoc-plugin-appium): allow ts v5 as peer dep

### DIFF
--- a/packages/typedoc-plugin-appium/package.json
+++ b/packages/typedoc-plugin-appium/package.json
@@ -57,7 +57,7 @@
     "typedoc": "^0.23.14",
     "typedoc-plugin-markdown": "^3.14.0",
     "typedoc-plugin-resolve-crossmodule-references": "~0.3.3",
-    "typescript": "^4.7.0"
+    "typescript": "^4.7.0 || ^5.0.0"
   },
   "dependencies": {
     "handlebars": "4.7.7",


### PR DESCRIPTION
Enables TS v5 as an allowed peer dep for `@appium/typedoc-plugin-appium`