### PR TITLE
chore(renovate): ignore major releases of pkg 'conf'

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -19,6 +19,7 @@
       "matchPackageNames": [
         "@types/wrap-ansi",
         "chalk",
+        "conf",
         "del",
         "delay",
         "env-paths",


### PR DESCRIPTION
more esm-only nonsense
