### PR TITLE
feat(typedoc-plugin-appium): enable comment derivation via reflection types

### DIFF
--- a/packages/typedoc-plugin-appium/lib/converter/comment/finder.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/comment/finder.ts
@@ -8,7 +8,7 @@ import {CommentSource} from '../types';
 const nullFinder: CommentFinder = {
   /**
    *
-   * @returns A comment probably from the method map itself
+   * @returns A comment which was directly provided
    */
   getter: ({comment}) => comment,
   commentSource: CommentSource.OtherComment,

--- a/packages/typedoc-plugin-appium/lib/converter/comment/index.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/comment/index.ts
@@ -75,7 +75,7 @@ export function deriveComment(opts: DeriveCommentOptions = {}): CommentData | un
   const finalBlockTags: CommentTag[] = [];
   for (const tags of Object.values(tagsByTag)) {
     if (tags.length === 1) {
-      finalBlockTags.push(_.first(tags)!);
+      finalBlockTags.push(tags[0]);
     } else if (tags.length > 1) {
       // prefer a tag with content
       const tag = tags.find((t) => t.content.length) ?? tags[0];

--- a/packages/typedoc-plugin-appium/lib/converter/comment/method.ts
+++ b/packages/typedoc-plugin-appium/lib/converter/comment/method.ts
@@ -1,5 +1,5 @@
 import {Comment} from 'typedoc';
-import {isDeclarationReflection} from '../../guards';
+import {isDeclarationReflection, isReflectionType} from '../../guards';
 import {CommentSource} from '../types';
 import {CommentFinder} from './types';
 
@@ -24,11 +24,20 @@ const MethodCommentFinders: Readonly<CommentFinder[]> = [
   },
   {
     /**
-     * @returns The comment from the method's signature (may be inherited)
+     * @returns The comment from the method's signature (may be inherited or from a `ReflectionType`'s declaration)
      */
     getter: ({refl}) => {
       if (isDeclarationReflection(refl)) {
-        return refl.getAllSignatures().find((sig) => sig.comment?.summary)?.comment;
+        let comment = refl.getAllSignatures().find((sig) => sig.comment?.summary)?.comment;
+        if (comment) {
+          return comment;
+        }
+        if (isReflectionType(refl.type)) {
+          comment = refl.type.declaration
+            .getAllSignatures()
+            .find((sig) => sig.comment?.summary)?.comment;
+        }
+        return comment;
       }
     },
     commentSource: CommentSource.MethodSignature,


### PR DESCRIPTION
In the case of `appium-xcuitest-driver`, each command (or execute) method is declared like so:

```ts
import {someMixin} from './some-mixins';

class XCUITestDriver {
  foo = someMixin.foo;
}
```

The docstring exists on `someMixin.foo`, but not on the `foo` prop of an `XCUITestDriver` instance.

This change makes `@appium/typedoc-plugin-appium` dig into such references and derive the comments.
