### PR TITLE
chore: add a "release" script

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/lerna",
   "command": {
     "run": {
       "concurrency": 8
@@ -12,6 +13,9 @@
     },
     "add": {
       "exact": true
+    },
+    "publish": {
+      "message": "chore: publish"
     }
   },
   "ignoreChanges": ["**/test/**", "**/*.md"],

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "rebuild": "run-s clean build",
     "reinstall": "run-s clean clean:deps ci",
     "reinstall:angry": "npm run clean:dangerously && npm ci",
+    "release": "lerna publish",
     "stage-synced-pkgs": "git add -A packages/appium/README.md \"packages/*/package.json\"",
     "start": "appium",
     "sync-pkgs": "run-p sync-pkgs:*",


### PR DESCRIPTION
This script executes `lerna publish`.  The Lerna config has been changed so that the `publish` command uses a message of `chore: publish`.
