### PR TITLE
chore(docs): updates the build-docs script to use docutils' logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "docs": "npm run -w packages/appium build:docs",
     "docs:preview": "npm run -w packages/appium build:docs:preview",
     "doctor": "node ./packages/doctor",
-    "generate-docs": "npm run --workspace=packages/appium generate-docs",
     "husky-install": "husky install",
     "lint": "eslint .",
     "lint:ci": "eslint --quiet .",

--- a/packages/appium/docs/scripts/build-docs.js
+++ b/packages/appium/docs/scripts/build-docs.js
@@ -50,7 +50,7 @@ async function main() {
   const majMinVer = `${semVersion.major}.${semVersion.minor}`;
 
   for (const lang of LANGS) {
-    log.info(`Building docs for language '${lang}' and version ${majMinVer}`);
+    log.info('Building docs for language `%s` and version %s', lang, majMinVer);
     const configFile = path.join(DOCS_DIR, `mkdocs-${lang}.yml`);
     if (preview) {
       await buildSite({
@@ -70,8 +70,9 @@ async function main() {
         message: `docs(appium): auto-build docs for appium@${majMinVer}, language ${lang}`,
       });
     }
-    log.info(`Docs built`);
+    log.success('Docs built for language `%s` and version %s', lang, majMinVer);
   }
+  log.success('Done!');
 }
 
 if (require.main === module) {

--- a/packages/appium/docs/scripts/utils.js
+++ b/packages/appium/docs/scripts/utils.js
@@ -2,10 +2,12 @@
 
 // for simplicity this file is not transpiled and is run directly via an npm script
 //
-const {logger} = require('@appium/support');
+const {initLogger, getLogger} = require('@appium/docutils');
 const path = require('path');
 
-const log = logger.getLogger('Docs');
+initLogger('info');
+
+const log = getLogger('build-docs');
 
 const DOCS_REMOTE = 'origin';
 const DOCS_BRANCH = 'gh-pages';


### PR DESCRIPTION
This makes the logging output more consistent (sans whatever warnings TypeDoc barfs out).

Removed an unused script (`generate-docs`).
