### PR TITLE
feat(appium): make "ls" alias of "list"

### DIFF
--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -294,5 +294,5 @@ export {getServerArgs, getExtensionArgs};
 
 /**
  * A tuple of argument aliases and argument options
- * @typedef {Map<string[],import('argparse').ArgumentOptions>} ArgumentDefinitions
+ * @typedef {Map<[name: string]|[name: string, alias: string],import('argparse').ArgumentOptions>} ArgumentDefinitions
  */

--- a/packages/appium/lib/schema/cli-args.js
+++ b/packages/appium/lib/schema/cli-args.js
@@ -94,7 +94,7 @@ function makeDescription(schema) {
  * as understood by `argparse`.
  * @param {AppiumJSONSchema} subSchema - JSON schema for the option
  * @param {ArgSpec} argSpec - Argument spec tuple
- * @returns {[string[], import('argparse').ArgumentOptions]} Tuple of flag and options
+ * @returns {[[string]|[string, string], import('argparse').ArgumentOptions]} Tuple of flag and options
  */
 function subSchemaToArgDef(subSchema, argSpec) {
   let {type, appiumCliAliases, appiumCliTransformer, enum: enumValues} = subSchema;
@@ -207,7 +207,10 @@ function subSchemaToArgDef(subSchema, argSpec) {
     }
   }
 
-  return [aliases, argOpts];
+  // TODO: argparse only accepts the command name and a single alias; any extra aliases
+  // will be silently discarded.
+  const finalAliases = /** @type {[string]|[string, string]} */ (aliases);
+  return [finalAliases, argOpts];
 }
 
 /**

--- a/packages/appium/test/unit/parser.spec.js
+++ b/packages/appium/test/unit/parser.spec.js
@@ -264,6 +264,14 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'list', '--updates']);
         args.showUpdates.should.eql(true);
       });
+      it('should allow "ls" as an alias for "list"', function () {
+        const args = p.parseArgs([DRIVER_TYPE, 'ls']);
+        args.subcommand.should.eql(DRIVER_TYPE);
+        args.driverCommand.should.eql('list');
+        args.showInstalled.should.eql(false);
+        args.showUpdates.should.eql(false);
+        args.json.should.eql(false);
+      });
     });
     describe('install', function () {
       it('should not allow an empty argument list', function () {


### PR DESCRIPTION
This makes `ls` an alias of `list`; e.g., `appium driver ls`

While doing this I noticed a limitation of `argparser`, which is that an option (not a command) can only have a single (1) alias.  I have noted this behavior in a comment.

I also notice that we need to rewrite `ls` to be `list` ourselves, or we will have a bunch of conditionals checking for both values scattered around.

We need to use yargs...

* * *

Closes #18448