### PR TITLE
feat(strongbox): export BaseItem

### DIFF
--- a/packages/strongbox/lib/index.ts
+++ b/packages/strongbox/lib/index.ts
@@ -138,7 +138,11 @@ export class Strongbox {
    */
   protected constructor(
     public readonly name: string,
-    {container, suffix = DEFAULT_SUFFIX, defaultItemCtor: defaultCtor = BaseItem}: StrongboxOpts = {}
+    {
+      container,
+      suffix = DEFAULT_SUFFIX,
+      defaultItemCtor: defaultCtor = BaseItem,
+    }: StrongboxOpts = {}
   ) {
     this.id = slugify(name);
     this.defaultItemCtor = defaultCtor;
@@ -282,3 +286,8 @@ export interface StrongboxOpts {
  * {@inheritdoc Strongbox.create}
  */
 export const strongbox = Strongbox.create;
+
+/**
+ * This can be subclassed if needed.
+ */
+export {BaseItem};

--- a/packages/strongbox/package.json
+++ b/packages/strongbox/package.json
@@ -34,9 +34,10 @@
     "tsconfig.json"
   ],
   "scripts": {
-    "test": "npm run test:unit",
+    "test": "run-p test:unit test:types",
     "test:smoke": "node .",
-    "test:unit": "mocha \"test/unit/**/*.spec.ts\""
+    "test:unit": "mocha \"test/unit/**/*.spec.ts\"",
+    "test:types": "tsd"
   },
   "dependencies": {
     "env-paths": "2.2.1",
@@ -48,5 +49,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "tsd": {
+    "directory": "test/types"
   }
 }

--- a/packages/strongbox/test/types/strongbox.test-d.ts
+++ b/packages/strongbox/test/types/strongbox.test-d.ts
@@ -1,0 +1,10 @@
+import {expectAssignable, expectNotAssignable} from 'tsd';
+import {Item, BaseItem, Value} from '../..';
+
+expectAssignable<Item<string>>(new BaseItem('foo', 'some-container'));
+
+expectNotAssignable<Value>(1);
+expectAssignable<Value>('foo');
+expectNotAssignable<Value>(true);
+expectAssignable<Value>(Buffer.from('foo'));
+expectNotAssignable<Value>({});

--- a/packages/strongbox/tsconfig.json
+++ b/packages/strongbox/tsconfig.json
@@ -6,5 +6,6 @@
     "strict": true,
     "types": ["node", "mocha", "chai", "chai-as-promised", "sinon-chai"]
   },
-  "include": ["lib", "test"]
+  "include": ["lib", "test"],
+  "exclude": ["**/*.test-d.ts"]
 }


### PR DESCRIPTION
This exports `BaseItem`, the builtin implementation of `Item`.

Also adds some type tests.