### PR TITLE
chore: use conventionalcommit changelog

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/lerna",
+  "changelogPreset": "conventional-changelog-conventionalcommits",
   "command": {
+    "add": {
+      "exact": true
+    },
+    "publish": {
+      "message": "chore: publish"
+    },
     "run": {
       "concurrency": 8
     },
@@ -10,16 +17,10 @@
       "version": {
         "allowBranch": "master"
       }
-    },
-    "add": {
-      "exact": true
-    },
-    "publish": {
-      "message": "chore: publish"
     }
   },
   "ignoreChanges": ["**/test/**", "**/*.md"],
-  "version": "independent",
+  "useNx": false,
   "useWorkspaces": true,
-  "useNx": false
+  "version": "independent"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "chai": "4.3.7",
         "chai-as-promised": "7.1.1",
         "chai-webdriverio-async": "2.7.0",
+        "conventional-changelog-conventionalcommits": "5.0.0",
         "cpy-cli": "4.2.0",
         "eslint": "8.38.0",
         "eslint-config-prettier": "8.8.0",
@@ -6731,8 +6732,9 @@
     },
     "node_modules/conventional-changelog-conventionalcommits": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
+      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0",
         "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
     "chai-webdriverio-async": "2.7.0",
+    "conventional-changelog-conventionalcommits": "5.0.0",
     "cpy-cli": "4.2.0",
     "eslint": "8.38.0",
     "eslint-config-prettier": "8.8.0",


### PR DESCRIPTION
This changes Lerna's changelog preset from "angular" to "conventionalcommits" which should be more appropriate for our workflow.  

I'm unsure if the changelogs will be completely rewritten or not.  The changelog format looks like it is probably the same.  At minimum, this will no worse than our current setup -- and somewhat more accurate in the best case.
