### PR TITLE
fix(typedoc-plugin-appium): restrict peer deps

### DIFF
--- a/packages/typedoc-plugin-appium/package.json
+++ b/packages/typedoc-plugin-appium/package.json
@@ -54,8 +54,8 @@
   },
   "peerDependencies": {
     "appium": "^2.0.0-beta.48",
-    "typedoc": "^0.23.14",
-    "typedoc-plugin-markdown": "^3.14.0",
+    "typedoc": "~0.23.14",
+    "typedoc-plugin-markdown": "3.14.0",
     "typedoc-plugin-resolve-crossmodule-references": "~0.3.3",
     "typescript": "^4.7.0 || ^5.0.0"
   },


### PR DESCRIPTION
This restricts peer deps to non-breaking versions. This is not a breaking change, because if newer versions are installed, they break anyway.

@mykola-mokhnach This should fix your failing smoke tests