### PR TITLE
fix(support): prevent s3 presigned post request failing in http upload

### DIFF
--- a/packages/support/lib/net.js
+++ b/packages/support/lib/net.js
@@ -70,7 +70,6 @@ async function uploadFileToHttp(
   }
   if (fileFieldName) {
     const form = new FormData();
-    form.append(fileFieldName, localFileStream);
     if (formFields) {
       let pairs = [];
       if (_.isArray(formFields)) {
@@ -84,6 +83,7 @@ async function uploadFileToHttp(
         }
       }
     }
+    form.append(fileFieldName, localFileStream); // AWS S3 POST upload requires this to be the last field
     requestOpts.headers = {
       ...(_.isPlainObject(headers) ? headers : {}),
       ...form.getHeaders(),


### PR DESCRIPTION
## Proposed changes

AWS S3 expects the file field to be the last field in the POST request. Currently, it is the first field; that prevents AWS from parsing the other POST fields and the request gives a 400 error. The change makes it possible to provide formFields necessary for http upload to S3 from appium.

Use case:

mobile: stopMediaProjectionRecording can upload screen recordings to S3 for further processing

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

