### PR TITLE
chore(renovate): move renovate check into its own workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,3 @@ jobs:
           install-command: npm ci
       - name: ESLint
         run: npm run lint:ci
-      - name: Validate Renovate Config
-        uses: rinchsan/renovate-config-validator@1ea1e8514f6a33fdd71c40b0a5fa3512b9e7b936 # tag=v0
-        with:
-          pattern: '{.renovaterc.json,renovate/default.json}'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,26 @@
+name: Validate Renovate Configs
+on:
+  push:
+    paths:
+      - '.github/workflows/renovate.yml' # this file
+      - '.renovaterc.json'
+      - 'renovate/default.json'
+  pull_request:
+    paths:
+      - '.github/workflows/renovate.yml' # this file
+      - '.renovaterc.json'
+      - 'renovate/default.json'
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    name: Check Renovate Configs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
+      - name: Validate Renovate Config
+        uses: rinchsan/renovate-config-validator@1ea1e8514f6a33fdd71c40b0a5fa3512b9e7b936 # tag=v0
+        with:
+          pattern: '{.renovaterc.json,renovate/default.json}'


### PR DESCRIPTION
This was causing checks to not happen because of the path filter.
