### PR TITLE
blast docs PR preview

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Build Docs
 
 on:
-  pull_request_target:
+  pull_request:
     paths:
       - '**/typedoc.json'
       - '**/tsconfig*.json'
@@ -15,10 +15,20 @@ on:
       - '.github/workflows/docs.yml' # this file
       - '!**/test/**'
       - '!**/sample-code/**'
-
-    branches: [master]
-
-concurrency: preview-${{ github.ref }}
+  push:
+    paths:
+      - '**/typedoc.json'
+      - '**/tsconfig*.json'
+      - '**/package*.json'
+      - '**/*mkdocs*.ya?ml'
+      - 'packages/docutils/requirements.txt'
+      - 'packages/*/README.md'
+      - 'packages/*/docs/**'
+      - 'packages/*/**/*.ts'
+      - 'packages/*/**/*.js'
+      - '.github/workflows/docs.yml' # this file
+      - '!**/test/**'
+      - '!**/sample-code/**'
 
 jobs:
   docs:
@@ -39,8 +49,3 @@ jobs:
           git config --local user.name "github-actions[bot]"
       - name: Build Docs
         run: npm run docs:preview
-      - name: Deploy Preview
-        uses: rossjrw/pr-preview-action@2a652922e9b9c53e7e5ea62fa38da744de09043c # v1
-        with:
-          source-dir: ./packages/appium/docs/site
-          custom-url: 'appium.github.io/appium'


### PR DESCRIPTION
~~The PR docs preview was pointing to a directory which contains `en`, `ja`, and `zh`, but no `index.html`.~~

~~This changes the `build-docs` script, when run as a PR preview, to copy a `preview-index.html` file into the `site` dir, which will perform the redirect to `en`.~~

~~Unfortunately, there's no way to tell the action to deploy the `x` dir, but actually append e.g., `en/index.html` to the URL.  As it stands, the alternative is deploying `en` only.~~

Update: this disables the PR preview entirely, since there's [no feasible way to run it for forks](https://github.com/appium/appium/pull/18525#issuecomment-1511913195) given our current configuration.