### PR TITLE
chore: Tune elements caching logic

### DIFF
--- a/packages/images-plugin/lib/image-element.js
+++ b/packages/images-plugin/lib/image-element.js
@@ -22,26 +22,41 @@ const TAP_DURATION_MS = 125;
  */
 
 /**
+ * @typedef ImageElementOpts
+ * @property {string} b64Template - the base64-encoded image which was used to
+ *                               find this ImageElement
+ * @property {Rect} rect - bounds of matched image element
+ * @property {number} score The similarity score as a float number in range [0.0, 1.0].
+ * 1.0 is the highest score (means both images are totally equal).
+ * @property {string} sessionId - identifier of the corresponding driver session
+ * @property {string?} b64Result - the base64-encoded image which has matched marks.
+ *                              Defaults to null.
+ * @property {import('./finder').default?} finder - the finder we can use to re-check stale elements
+ * @property {import('@appium/types').Rect?} containerRect - The bounding
+ * rectangle to limit the search in
+ */
+
+/**
  * Representation of an "image element", which is simply a set of coordinates
  * and methods that can be used on that set of coordinates via the driver
  */
 export default class ImageElement {
   /**
-   * @param {string} b64Template - the base64-encoded image which was used to
-   *                               find this ImageElement
-   * @param {Rect} rect - bounds of matched image element
-   * @param {number} score The similarity score as a float number in range [0.0, 1.0].
-   * 1.0 is the highest score (means both images are totally equal).
-   * @param {string?} b64Result - the base64-encoded image which has matched marks.
-   *                              Defaults to null.
-   * @param {import('./finder').default?} finder - the finder we can use to re-check stale elements
-   * @param {import('@appium/types').Rect?} containerRect - The bounding
-   * rectangle to limit the search in
+   * @param {ImageElementOpts}
    */
-  constructor(b64Template, rect, score, b64Result = null, finder = null, containerRect = null) {
+  constructor({
+    b64Template,
+    rect,
+    score,
+    sessionId,
+    b64Result = null,
+    finder = null,
+    containerRect = null,
+  }) {
     this.template = b64Template;
     this.rect = rect;
     this.id = `${IMAGE_ELEMENT_PREFIX}${util.uuidV4()}`;
+    this.sessionId = sessionId;
     this.b64MatchedImage = b64Result;
     this.score = score;
     this.finder = finder;

--- a/packages/images-plugin/lib/plugin.js
+++ b/packages/images-plugin/lib/plugin.js
@@ -64,11 +64,15 @@ export default class ImageElementPlugin extends BasePlugin {
     // and execute the command on it
     const imgElId = getImgElFromArgs(args);
     if (imgElId) {
-      if (!this.finder.imgElCache.has(imgElId)) {
+      const imgEl = this.finder.getImageElement(imgElId);
+      if (!imgEl) {
         throw new errors.NoSuchElementError();
       }
-      const imgEl = this.finder.imgElCache.get(imgElId);
       return await ImageElement.execute(driver, imgEl, cmdName, ...args);
+    }
+
+    if (cmdName === 'deleteSession') {
+      this.finder.revokeObsoleteImageElements(driver.sessionId);
     }
 
     // otherwise just do the normal thing

--- a/packages/images-plugin/test/unit/finder.spec.js
+++ b/packages/images-plugin/test/unit/finder.spec.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {imageUtil} from 'appium/support';
+import {imageUtil, util} from 'appium/support';
 import {BaseDriver} from 'appium/driver';
 import {ImageElementPlugin} from '../../lib/plugin';
 import {IMAGE_STRATEGY} from '../../lib/constants';
@@ -77,9 +77,8 @@ describe('finding elements by image', function () {
     }
 
     function basicImgElVerify(imgElProto, finder) {
-      const imgElId = imgElProto.ELEMENT;
-      finder.imgElCache.has(imgElId).should.be.true;
-      const imgEl = finder.imgElCache.get(imgElId);
+      const imgElId = util.unwrapElement(imgElProto);
+      const imgEl = finder.getImageElement(imgElId);
       (imgEl instanceof ImageElement).should.be.true;
       imgEl.rect.should.eql(rect);
       imgEl.score.should.eql(score);
@@ -162,7 +161,7 @@ describe('finding elements by image', function () {
         shouldCheckStaleness: true,
       });
       (imgEl instanceof ImageElement).should.be.true;
-      f.imgElCache.has(imgEl.id).should.be.false;
+      _.isNil(f.getImageElement(imgEl.id)).should.be.true;
       imgEl.rect.should.eql(rect);
     });
   });

--- a/packages/images-plugin/test/unit/image-element.spec.js
+++ b/packages/images-plugin/test/unit/image-element.spec.js
@@ -233,7 +233,7 @@ describe('ImageElement', function () {
 
     before(function () {
       clickStub = sandbox.stub(imgEl, 'click');
-      f.registerImageElement(imgEl.id, imgEl);
+      f.registerImageElement(imgEl);
       clickStub.returns(true);
     });
 

--- a/packages/images-plugin/test/unit/image-element.spec.js
+++ b/packages/images-plugin/test/unit/image-element.spec.js
@@ -25,21 +25,30 @@ describe('ImageElement', function () {
 
   describe('.size', function () {
     it('should return the width and height of the image el', function () {
-      const el = new ImageElement(defTemplate, defRect);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       el.size.should.eql({width: defRect.width, height: defRect.height});
     });
   });
 
   describe('.location', function () {
     it('should return the location of the image el', function () {
-      const el = new ImageElement(defTemplate, defRect);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       el.location.should.eql({x: defRect.x, y: defRect.y});
     });
   });
 
   describe('.center', function () {
     it('should return the center location of the image el', function () {
-      const el = new ImageElement(defTemplate, defRect);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       el.center.should.eql({
         x: defRect.x + defRect.width / 2,
         y: defRect.y + defRect.height / 2,
@@ -49,21 +58,36 @@ describe('ImageElement', function () {
 
   describe('.asElement', function () {
     it('should get the webdriver object representation of the element', function () {
-      const el = new ImageElement(defTemplate, defRect);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       util.unwrapElement(el.asElement()).should.match(/^appium-image-el/);
     });
   });
 
   describe('.equals', function () {
     it('should say two image elements with same rect are equal', function () {
-      const el1 = new ImageElement('foo', defRect);
-      const el2 = new ImageElement('bar', defRect);
+      const el1 = new ImageElement({
+        b64Template: 'foo',
+        rect: defRect
+      });
+      const el2 = new ImageElement({
+        b64Template: 'bar',
+        rect: defRect
+      });
       el1.equals(el2).should.be.true;
       el2.equals(el1).should.be.true;
     });
     it('should say two image elements with different rect are not equal', function () {
-      const el1 = new ImageElement(defTemplate, {...defRect, x: 0});
-      const el2 = new ImageElement(defTemplate, defRect);
+      const el1 = new ImageElement({
+        b64Template: defTemplate,
+        rect: {...defRect, x: 0}
+      });
+      const el2 = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       el1.equals(el2).should.be.false;
       el2.equals(el1).should.be.false;
     });
@@ -72,7 +96,10 @@ describe('ImageElement', function () {
   describe('.click', function () {
     it('should reject an invalid tap strategy', async function () {
       const d = new BaseDriver();
-      const el = new ImageElement(defTemplate, defRect);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       await d.settings.update({imageElementTapStrategy: 'bad'});
       await el.click(d).should.be.rejectedWith(/Incorrect imageElementTapStrategy/);
     });
@@ -80,7 +107,11 @@ describe('ImageElement', function () {
       const d = new BaseDriver();
       const f = new ImageElementFinder();
       sandbox.stub(f, 'findByImage').throws();
-      const el = new ImageElement(defTemplate, defRect, null, null, f);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+        finder: f,
+      });
       // we need to check for staleness if explicitly requested to do so
       await d.settings.update({
         checkForImageElementStaleness: true,
@@ -100,9 +131,17 @@ describe('ImageElement', function () {
       d.performActions = _.noop;
       sandbox.stub(d, 'performActions');
       const f = new ImageElementFinder();
-      const el = new ImageElement(defTemplate, defRect, null, null, f);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+        finder: f,
+      });
       const newRect = {...defRect, x: defRect.x + 10, y: defRect.y + 5};
-      const elPos2 = new ImageElement(defTemplate, newRect, null, null, f);
+      const elPos2 = new ImageElement({
+        b64Template: defTemplate,
+        rect: newRect,
+        finder: f,
+      });
       sandbox.stub(f, 'findByImage').returns(elPos2);
       await d.settings.update({
         autoUpdateImageElementPosition: true,
@@ -115,7 +154,10 @@ describe('ImageElement', function () {
       const d = new BaseDriver();
       d.performActions = _.noop;
       const actionStub = sandbox.stub(d, 'performActions');
-      const el = new ImageElement(defTemplate, defRect);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       // skip the staleness check for this test
       await d.settings.update({
         checkForImageElementStaleness: false,
@@ -129,7 +171,10 @@ describe('ImageElement', function () {
       const d = new BaseDriver();
       d.performTouch = _.noop;
       const actionStub = sandbox.stub(d, 'performTouch');
-      const el = new ImageElement(defTemplate, defRect);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       // skip the staleness check for this test
       await d.settings.update({
         checkForImageElementStaleness: false,
@@ -145,7 +190,10 @@ describe('ImageElement', function () {
       const w3cStub = sandbox.stub(d, 'performActions');
       d.performTouch = _.noop;
       const touchStub = sandbox.stub(d, 'performTouch');
-      const el = new ImageElement(defTemplate, defRect);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       // skip the staleness check for this test
       await d.settings.update({
         checkForImageElementStaleness: false,
@@ -159,7 +207,10 @@ describe('ImageElement', function () {
     });
     it('should throw if driver does not implement any type of action', async function () {
       const d = new BaseDriver();
-      const el = new ImageElement(defTemplate, defRect);
+      const el = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       // skip the staleness check for this test
       await d.settings.update({
         checkForImageElementStaleness: false,
@@ -171,17 +222,19 @@ describe('ImageElement', function () {
   describe('#execute', function () {
     // aGFwcHkgdGVzdGluZw== is 'happy testing'
     const f = new ImageElementFinder();
-    const imgEl = new ImageElement(defTemplate, defRect, 0, 'aGFwcHkgdGVzdGluZw==', f);
+    const imgEl = new ImageElement({
+      b64Template: defTemplate,
+      rect: defRect,
+      score: 0,
+      b64Result: 'aGFwcHkgdGVzdGluZw==',
+      finder: f,
+    });
     let clickStub;
 
     before(function () {
       clickStub = sandbox.stub(imgEl, 'click');
-      f.imgElCache.set(imgEl.id, imgEl);
+      f.registerImageElement(imgEl.id, imgEl);
       clickStub.returns(true);
-    });
-
-    after(function () {
-      f.imgElCache.clear();
     });
 
     it('should reject executions for unsupported commands', async function () {
@@ -222,7 +275,10 @@ describe('ImageElement', function () {
       );
     });
     it('should get null as visual of element by default', async function () {
-      const imgElement = new ImageElement(defTemplate, defRect);
+      const imgElement = new ImageElement({
+        b64Template: defTemplate,
+        rect: defRect,
+      });
       await ImageElement.execute(
         driver,
         imgElement,
@@ -246,24 +302,34 @@ describe('ImageElement', function () {
 
 describe('image element LRU cache', function () {
   it('should accept and cache image elements', function () {
-    const el1 = new ImageElement(defTemplate, defRect);
-    const el2 = new ImageElement(defTemplate, defRect);
-    const cache = new ImageElementFinder().imgElCache;
-    cache.set(el1.id, el1);
-    el1.equals(cache.get(el1.id)).should.be.true;
-    _.isUndefined(cache.get(el2.id)).should.be.true;
-    cache.has(el1.id).should.be.true;
-    cache.has(el2.id).should.be.false;
+    const el1 = new ImageElement({
+      b64Template: defTemplate,
+      rect: defRect,
+    });
+    const el2 = new ImageElement({
+      b64Template: defTemplate,
+      rect: defRect,
+    });
+    const finder = new ImageElementFinder();
+    finder.registerImageElement(el1);
+    el1.equals(finder.getImageElement(el1.id)).should.be.true;
+    _.isUndefined(finder.getImageElement(el2.id)).should.be.true;
   });
   it('once cache reaches max size, should eject image elements', function () {
-    const el1 = new ImageElement(defTemplate, defRect);
-    const el2 = new ImageElement(defTemplate, defRect);
-    const cache = new ImageElementFinder(defTemplate.length + 1).imgElCache;
-    cache.set(el1.id, el1);
-    cache.has(el1.id).should.be.true;
-    cache.set(el2.id, el2);
-    cache.has(el2.id).should.be.true;
-    cache.has(el1.id).should.be.false;
+    const el1 = new ImageElement({
+      b64Template: defTemplate,
+      rect: defRect,
+    });
+    const el2 = new ImageElement({
+      b64Template: defTemplate,
+      rect: defRect,
+    });
+    const finder = new ImageElementFinder(defTemplate.length + 1);
+    finder.registerImageElement(el1);
+    _.isUndefined(finder.getImageElement(el1.id)).should.be.false;
+    finder.registerImageElement(el2);
+    _.isUndefined(finder.getImageElement(el1.id)).should.be.true;
+    _.isUndefined(finder.getImageElement(el2.id)).should.be.false;
   });
 });
 


### PR DESCRIPTION
## Proposed changes

This change ensures elements don't stay in the cache for too long (max 24 hours). Also, all obsolete elements now get deleted on session deletion to make sure the cache only contains actual ones.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
