### PR TITLE
fix(base-driver): Ignore unknown script arguments

### DIFF
--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -238,9 +238,7 @@ function validateExecuteMethodParams(params, paramSpec) {
   } else {
     paramSpec.required ??= [];
     paramSpec.optional ??= [];
-    const supportedParamNames = [...paramSpec.required, ...paramSpec.optional];
-    const argNames = _.keys(args);
-    const unknownNames = _.difference(argNames, supportedParamNames);
+    const unknownNames = _.difference(_.keys(args), paramSpec.required, paramSpec.optional);
     if (!_.isEmpty(unknownNames)) {
       log.info(`The following script arguments are not known and will be ignored: ${unknownNames}`);
       args = _.pickBy(args, (v, k) => !unknownNames.includes(k));

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -13,6 +13,7 @@ import B from 'bluebird';
 import {formatResponseValue, formatStatus} from './helpers';
 import {MAX_LOG_BODY_LENGTH, PROTOCOLS, DEFAULT_BASE_PATH} from '../constants';
 import {isW3cCaps} from '../helpers/capabilities';
+import log from '../basedriver/logger';
 
 const CREATE_SESSION_COMMAND = 'createSession';
 const DELETE_SESSION_COMMAND = 'deleteSession';
@@ -225,7 +226,7 @@ function validateExecuteMethodParams(params, paramSpec) {
         `arguments to execute script and instead received: ${JSON.stringify(params)}`
     );
   }
-  const args = params[0] ?? {};
+  let args = params[0] ?? {};
   if (!_.isPlainObject(args)) {
     throw new errors.InvalidArgumentError(
       `Did not receive an appropriate execute method parameters object. It needs to be ` +
@@ -237,6 +238,13 @@ function validateExecuteMethodParams(params, paramSpec) {
   } else {
     paramSpec.required ??= [];
     paramSpec.optional ??= [];
+    const supportedParamNames = [...paramSpec.required, ...paramSpec.optional];
+    const argNames = _.keys(args);
+    const unknownNames = _.difference(argNames, supportedParamNames);
+    if (!_.isEmpty(unknownNames)) {
+      log.info(`The following script arguments are not known and will be ignored: ${unknownNames}`);
+      args = _.pickBy(args, (v, k) => !unknownNames.includes(k));
+    }
     checkParams(paramSpec, args, null);
   }
   const argsToApply = makeArgs({}, args, paramSpec, null);


### PR DESCRIPTION
## Proposed changes

Sometimes we might pass extra arguments to executeScript command and this should not throw exceptions like in https://dev.azure.com/srinivasansekar/java-client/_build/results?buildId=1666&view=logs&j=61693eb6-c6c2-5404-693f-d0c9a515c613&t=2ca172d0-7775-512d-edc4-316d6d6b3014&l=3205

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
