### PR TITLE
fix(typedoc-plugin-appium): don't prefix execute methods with "Script: "

### DIFF
--- a/packages/typedoc-plugin-appium/lib/theme/resources/partials/execute-method.hbs
+++ b/packages/typedoc-plugin-appium/lib/theme/resources/partials/execute-method.hbs
@@ -1,6 +1,6 @@
 {{#unless hasOwnDocument}}
 
-### {{#ifNamedAnchors}} <a id="{{anchor}}" name="{{this.anchor}}"></a> {{/ifNamedAnchors}}Script: `{{name}}`
+### {{#ifNamedAnchors}} <a id="{{anchor}}" name="{{this.anchor}}"></a> {{/ifNamedAnchors}}`{{name}}`
 
 {{#if hasComment}}
 {{> comment}}


### PR DESCRIPTION
When in the docs, it's clear that it's an execute method. This prefix adds a lot of extra noise to the commands list and I don't think we need it.