### PR TITLE
docs(appium): add helper tools section in the ecosystem doc

### DIFF
--- a/packages/appium/docs/en/ecosystem/index.md
+++ b/packages/appium/docs/en/ecosystem/index.md
@@ -99,9 +99,9 @@ are currently maintained by the Appium Team:
 
 ## Helper tools
 
-These tools are to help Appium as part of Appium ecosystem.
+The following tools might also be useful for Appium users:
 
 |Name|Description|Supported By|
 |---|---|---|
-|[appium-installer](https://github.com/AppiumTestDistribution/appium-installer)|Help setting up Appium running environment for Android and iOS|`@AppiumTestDistribution`|
+|[appium-installer](https://github.com/AppiumTestDistribution/appium-installer)|Help set up an Appium environment for Android and iOS|`@AppiumTestDistribution`|
 

--- a/packages/appium/docs/en/ecosystem/index.md
+++ b/packages/appium/docs/en/ecosystem/index.md
@@ -97,3 +97,10 @@ are currently maintained by the Appium Team:
     If you maintain an Appium plugin that you would like to be listed in the Appium docs, feel free
     to make a PR to add it to this section with a link to the documentation for the plugin.
 
+## Helper tools
+
+These tools are to help Appium as part of Appium ecosystem.
+
+|Name|Description|Supported By|
+|[appium-installer](https://github.com/AppiumTestDistribution/appium-installer)|Help setting up Appium running environment for Android and iOS|`@AppiumTestDistribution`|
+

--- a/packages/appium/docs/en/ecosystem/index.md
+++ b/packages/appium/docs/en/ecosystem/index.md
@@ -102,5 +102,6 @@ are currently maintained by the Appium Team:
 These tools are to help Appium as part of Appium ecosystem.
 
 |Name|Description|Supported By|
+|---|---|---|
 |[appium-installer](https://github.com/AppiumTestDistribution/appium-installer)|Help setting up Appium running environment for Android and iOS|`@AppiumTestDistribution`|
 


### PR DESCRIPTION
## Proposed changes

Maybe it would be nice to have a section that allows developers to share their tools to help Appium ecosystem, but not only driver and plugins but also help these configuration etc.

The installer apps is by @saikrishna321 @SrinivasanTarget . They help especially beginners to configure Android/iOS automation environment for Appium. It has appium/docstor dependency. In addition to the doctor, the installer helps users to prepare Android/iOS env with nightwatch. 

What do you think?

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
