### PR TITLE
fix(docutils): try python3 if python not in PATH

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,12 +11,6 @@
       "rules": {"func-names": "off"}
     },
     {
-      "files": ["packages/*/index.js", "packages/*/scripts/**/*.js", "test/*.js"],
-      "parserOptions": {
-        "sourceType": "script"
-      }
-    },
-    {
       "files": [
         "packages/appium/support.js",
         "packages/appium/driver.js",
@@ -27,9 +21,17 @@
       }
     },
     {
-      "files": ["./test/setup.js", "./**/scripts/**/*.js", "./packages/*/index.js"],
+      "files": [
+        "./test/setup.js",
+        "./**/scripts/**/*.js",
+        "./packages/*/index.js",
+        "./packages/docutils/bin/appium-docs.js"
+      ],
       "rules": {
         "@typescript-eslint/no-var-requires": "off"
+      },
+      "parserOptions": {
+        "sourceType": "script"
       }
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22922,6 +22922,7 @@
         "@appium/tsconfig": "^0.3.0",
         "@appium/typedoc-plugin-appium": "^0.6.4",
         "@sliphua/lilconfig-ts-loader": "3.2.2",
+        "@types/which": "3.0.0",
         "chalk": "4.1.2",
         "consola": "2.15.3",
         "diff": "5.1.0",
@@ -22952,6 +22953,11 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=8"
       }
+    },
+    "packages/docutils/node_modules/@types/which": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.0.tgz",
+      "integrity": "sha512-ASCxdbsrwNfSMXALlC3Decif9rwDMu+80KGp5zI2RLRotfMsTv7fHL8W8VDp24wymzDyIFudhUeSCugrgRFfHQ=="
     },
     "packages/docutils/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -23696,6 +23702,7 @@
         "@appium/tsconfig": "^0.3.0",
         "@appium/typedoc-plugin-appium": "^0.6.4",
         "@sliphua/lilconfig-ts-loader": "3.2.2",
+        "@types/which": "3.0.0",
         "chalk": "4.1.2",
         "consola": "2.15.3",
         "diff": "5.1.0",
@@ -23720,6 +23727,11 @@
         "yargs-parser": "21.1.1"
       },
       "dependencies": {
+        "@types/which": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.0.tgz",
+          "integrity": "sha512-ASCxdbsrwNfSMXALlC3Decif9rwDMu+80KGp5zI2RLRotfMsTv7fHL8W8VDp24wymzDyIFudhUeSCugrgRFfHQ=="
+        },
         "ansi-styles": {
           "version": "4.3.0",
           "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22946,7 +22946,7 @@
         "yargs-parser": "21.1.1"
       },
       "bin": {
-        "appium-docs": "build/lib/cli/index.js"
+        "appium-docs": "bin/appium-docs.js"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",

--- a/packages/docutils/bin/appium-docs.js
+++ b/packages/docutils/bin/appium-docs.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+'use strict';
+
+module.exports = require('../build/lib/cli');

--- a/packages/docutils/lib/builder/nav.ts
+++ b/packages/docutils/lib/builder/nav.ts
@@ -75,6 +75,7 @@ export function parseNav(nav: MkDocsYmlNav): ParsedNavData[] {
   const queue: QueueItem[] = [{entries, keypath: ''}];
 
   while (queue.length) {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const {entries, keypath} = queue.shift()!;
     for (const [key, item] of entries) {
       if (_.isString(item)) {
@@ -153,6 +154,7 @@ function getRootHeaderKeypath(headerItems: ParsedNavData[], header: string) {
   // these are the parts of the keypath of the first item, which will contain the header string. it
   // dosn't matter whether we pick the first one or any one; they will all contain the same root
   // keypath by definition.
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const rootHeaderKeypathParts = _.toPath(_.first(headerItems)!.keypath);
 
   // this is the keypath up to the header string, inclusive.

--- a/packages/docutils/lib/cli/command/validate.ts
+++ b/packages/docutils/lib/cli/command/validate.ts
@@ -50,7 +50,7 @@ const opts = {
   },
   'python-path': {
     defaultDescription: '(derived from shell)',
-    description: 'Path to python 3 executable',
+    description: 'Path to python3 executable',
     group: ValidateCommandGroup.Paths,
     nargs: 1,
     normalize: true,
@@ -75,6 +75,15 @@ const opts = {
   'typedoc-json': {
     defaultDescription: './typedoc.json',
     describe: 'Path to typedoc.json',
+    group: ValidateCommandGroup.Paths,
+    nargs: 1,
+    normalize: true,
+    requiresArg: true,
+    type: 'string',
+  },
+  'typedoc-path': {
+    defaultDescription: '(derived from shell)',
+    description: 'Path to typedoc executable',
     group: ValidateCommandGroup.Paths,
     nargs: 1,
     normalize: true,

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -225,6 +225,11 @@ export const whichNpm = _.partial(cachedWhich, NAME_NPM);
 export const whichPython = _.partial(cachedWhich, NAME_PYTHON);
 
 /**
+ * Finds `python3` executable
+ */
+export const whichPython3 = _.partial(cachedWhich, `${NAME_PYTHON}3`);
+
+/**
  * Finds `mike` executable
  */
 export const whichMike = _.partial(cachedWhich, NAME_MIKE);

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -3,28 +3,26 @@
  * @module
  */
 
-import findUp from 'find-up';
-import YAML from 'yaml';
-import readPkg, {NormalizedPackageJson, PackageJson} from 'read-pkg';
-import path from 'node:path';
-import {JsonValue} from 'type-fest';
 import {fs} from '@appium/support';
+import findUp from 'find-up';
 import * as JSON5 from 'json5';
 import _ from 'lodash';
+import path from 'node:path';
 import _pkgDir from 'pkg-dir';
-import {getLogger} from './logger';
+import readPkg, {NormalizedPackageJson, PackageJson} from 'read-pkg';
+import {JsonValue} from 'type-fest';
 import {Application, TypeDocReader} from 'typedoc';
+import YAML from 'yaml';
 import {
-  NAME_TYPEDOC_JSON,
   NAME_MKDOCS_YML,
-  NAME_PACKAGE_JSON,
-  NAME_MKDOCS,
   NAME_NPM,
+  NAME_PACKAGE_JSON,
   NAME_PYTHON,
-  NAME_MIKE,
   NAME_TYPEDOC,
+  NAME_TYPEDOC_JSON,
 } from './constants';
 import {DocutilsError} from './error';
+import {getLogger} from './logger';
 import {MkDocsYml} from './model';
 
 const log = getLogger('fs');

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -22,6 +22,7 @@ import {
   NAME_NPM,
   NAME_PYTHON,
   NAME_MIKE,
+  NAME_TYPEDOC,
 } from './constants';
 import {DocutilsError} from './error';
 import {MkDocsYml} from './model';
@@ -233,6 +234,21 @@ export const whichPython3 = _.partial(cachedWhich, `${NAME_PYTHON}3`);
  * Finds `mike` executable
  */
 export const whichMike = _.partial(cachedWhich, NAME_MIKE);
+
+/**
+ * Finds `typedoc` executable
+ */
+export const whichTypeDoc = _.partial(cachedWhich, NAME_TYPEDOC);
+
+export const findTypeDoc = _.memoize(async (cwd = process.cwd()): Promise<string | undefined> => {
+  const globResult =
+    (await fs.glob('node_modules/.bin/typedoc?(.cwd)', {cwd, nodir: true})) ??
+    (await fs.glob('node_modules/**/typedoc/bin/typedoc', {cwd, nodir: true, follow: true}));
+  if (globResult.length) {
+    return _.first(globResult);
+  }
+  return await whichTypeDoc({nothrow: true});
+});
 
 /**
  * Reads an `mkdocs.yml` file, merges inherited configs, and returns the result. The result is cached.

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -20,7 +20,7 @@ import {createScaffoldTask, ScaffoldTaskOptions} from './scaffold';
 import {getLogger} from './logger';
 import {MkDocsYml, TsConfigJson, TypeDocJson} from './model';
 import _ from 'lodash';
-import {stringifyJson5, stringifyYaml, whichPython, whichPython3} from './fs';
+import {findPython, stringifyJson5, stringifyYaml} from './fs';
 
 /**
  * Data for the base `mkdocs.yml` file
@@ -162,11 +162,8 @@ export async function initPython({
   dryRun = false,
   upgrade = false,
 }: InitPythonOptions = {}): Promise<void> {
-  pythonPath =
-    pythonPath ??
-    (await whichPython3({nothrow: true})) ??
-    (await whichPython({nothrow: true})) ??
-    NAME_PYTHON;
+  pythonPath = pythonPath ?? (await findPython()) ?? NAME_PYTHON;
+
   const args = ['-m', 'pip', 'install', '-r', REQUIREMENTS_TXT_PATH];
   if (upgrade) {
     args.push('--upgrade');

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -20,7 +20,7 @@ import {createScaffoldTask, ScaffoldTaskOptions} from './scaffold';
 import {getLogger} from './logger';
 import {MkDocsYml, TsConfigJson, TypeDocJson} from './model';
 import _ from 'lodash';
-import {stringifyJson5, stringifyYaml} from './fs';
+import {stringifyJson5, stringifyYaml, whichPython, whichPython3} from './fs';
 
 /**
  * Data for the base `mkdocs.yml` file
@@ -158,10 +158,15 @@ export const initMkDocs = createScaffoldTask<InitMkDocsOptions, MkDocsYml>(
  * @param opts Options
  */
 export async function initPython({
-  pythonPath = NAME_PYTHON,
+  pythonPath,
   dryRun = false,
   upgrade = false,
 }: InitPythonOptions = {}): Promise<void> {
+  pythonPath =
+    pythonPath ??
+    (await whichPython3({nothrow: true})) ??
+    (await whichPython({nothrow: true})) ??
+    NAME_PYTHON;
   const args = ['-m', 'pip', 'install', '-r', REQUIREMENTS_TXT_PATH];
   if (upgrade) {
     args.push('--upgrade');

--- a/packages/docutils/lib/logger.ts
+++ b/packages/docutils/lib/logger.ts
@@ -6,20 +6,19 @@
  * @module
  */
 
-import figures from 'figures';
-import logSymbols from 'log-symbols';
-import chalk, {ForegroundColor, BackgroundColor} from 'chalk';
+import chalk, {type BackgroundColor, type ForegroundColor} from 'chalk';
 import consola, {
-  logType as LogType,
-  ConsolaReporterLogObject,
+  type Consola,
+  type ConsolaReporterLogObject,
   FancyReporter,
-  FancyReporterOptions,
-  Consola,
-  ConsolaOptions,
-  LogLevel,
+  type FancyReporterOptions,
+  type LogLevel,
+  type logType as LogType,
 } from 'consola';
-import {DEFAULT_LOG_LEVEL, LogLevelMap} from './constants';
+import figures from 'figures';
 import _ from 'lodash';
+import logSymbols from 'log-symbols';
+import {DEFAULT_LOG_LEVEL, LogLevelMap} from './constants';
 
 /**
  * This is a reporter for `consola` which uses some extra/custom icons and colors.

--- a/packages/docutils/lib/util.ts
+++ b/packages/docutils/lib/util.ts
@@ -6,7 +6,6 @@
 import _ from 'lodash';
 import {SpawnOptions, spawn} from 'node:child_process';
 import path from 'node:path';
-import type {SubProcess} from 'teen_process';
 
 /**
  * Computes a relative path, prepending `./`
@@ -26,7 +25,7 @@ export function stopwatch(id: string) {
   const start = Date.now();
   stopwatch.cache.set(id, start);
   return () => {
-    const result = Date.now() - stopwatch.cache.get(id)!;
+    const result = Date.now() - (stopwatch.cache.get(id) ?? 0);
     stopwatch.cache.delete(id);
     return result;
   };

--- a/packages/docutils/lib/validate.ts
+++ b/packages/docutils/lib/validate.ts
@@ -38,6 +38,7 @@ import {
   whichMkDocs,
   whichNpm,
   whichPython,
+  whichPython3,
   readMkDocsYml,
 } from './fs';
 import {getLogger} from './logger';
@@ -423,7 +424,10 @@ export class DocutilsValidator extends EventEmitter {
    */
   protected async validatePythonDeps() {
     let pipListOutput: string;
-    const pythonPath = this.pythonPath ?? (await whichPython());
+    const pythonPath =
+      this.pythonPath ??
+      (await whichPython3({nothrow: true})) ??
+      (await whichPython({nothrow: true}));
     if (!pythonPath) {
       return this.fail(`Could not find ${NAME_PYTHON} in PATH. Is it installed?`);
     }

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -53,6 +53,7 @@
     "@appium/tsconfig": "^0.3.0",
     "@appium/typedoc-plugin-appium": "^0.6.4",
     "@sliphua/lilconfig-ts-loader": "3.2.2",
+    "@types/which": "3.0.0",
     "chalk": "4.1.2",
     "consola": "2.15.3",
     "diff": "5.1.0",

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -28,7 +28,7 @@
     "lib": "lib"
   },
   "bin": {
-    "appium-docs": "./build/lib/cli/index.js"
+    "appium-docs": "./bin/appium-docs.js"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
I discovered this while using WSL (Ubuntu).  `apt install python` installs `python2.7` (sigh..). To get v3 you need to `apt install python3` (and also `apt install python3-pip`).   The result is an executable named `python3`; not `python`.

This changes the `init` command to use `which` to find `python3`/`python`, as well as the validator.  `python3` is actually _preferred_, because while `python` could be python 2.x, `python3` is most certainly not.

**UPDATE**:

More changes here.

Instead of looking for `pip`, `mike` and `mkdocs` in the `PATH`, I've changed it to use `/path/to/python3 -m <module>` , because not all systems actually put these executables in the `PATH`.  If you're using, say, Homebrew on Mac, these _are_ automatically added to the `PATH`, but on e.g. Ubuntu they are not.

Furthermore, added the ability to provide a custom path to the `typedoc` executable.  This is unneeded in most cases, but can aid development at minimum.
  