### PR TITLE
fix(base-driver): add missing @types/lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4741,7 +4741,8 @@
     },
     "node_modules/@types/lodash": {
       "version": "4.14.194",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g=="
     },
     "node_modules/@types/method-override": {
       "version": "0.0.32",
@@ -22835,6 +22836,7 @@
         "@types/async-lock": "1.4.0",
         "@types/bluebird": "3.5.38",
         "@types/express": "4.17.17",
+        "@types/lodash": "4.14.194",
         "@types/method-override": "0.0.32",
         "@types/serve-favicon": "2.5.4",
         "async-lock": "1.4.0",
@@ -23639,6 +23641,7 @@
         "@types/async-lock": "1.4.0",
         "@types/bluebird": "3.5.38",
         "@types/express": "4.17.17",
+        "@types/lodash": "4.14.194",
         "@types/method-override": "0.0.32",
         "@types/serve-favicon": "2.5.4",
         "async-lock": "1.4.0",
@@ -27260,7 +27263,9 @@
       "version": "1.0.2"
     },
     "@types/lodash": {
-      "version": "4.14.194"
+      "version": "4.14.194",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+      "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g=="
     },
     "@types/method-override": {
       "version": "0.0.32",

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -50,6 +50,7 @@
     "@types/async-lock": "1.4.0",
     "@types/bluebird": "3.5.38",
     "@types/express": "4.17.17",
+    "@types/lodash": "4.14.194",
     "@types/method-override": "0.0.32",
     "@types/serve-favicon": "2.5.4",
     "async-lock": "1.4.0",


### PR DESCRIPTION
the lack of this module was causing base-driver to fail to compile when installed as a production module.  generally, nobody is going to do such a thing--consumers will use the generated `.d.ts` files--UNLESS they happen to be running typedoc against their extension.

will need to figure out a way to test this to make sure it doesn't happen again.
