### PR TITLE
ci: Remove v14 from the test matrix and add v20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # node-version: [14.x, 16.x, 18.x]
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Use Node.js ${{ matrix.node-version }}

--- a/packages/driver-test-support/lib/e2e-suite.js
+++ b/packages/driver-test-support/lib/e2e-suite.js
@@ -1,11 +1,11 @@
 import _ from 'lodash';
 import {server, routeConfiguringFunction, DeviceSettings} from 'appium/driver';
-import { util } from 'appium/support';
 import axios from 'axios';
 import B from 'bluebird';
 import {TEST_HOST, getTestPort, createAppiumURL} from './helpers';
 import chai from 'chai';
 import sinon from 'sinon';
+import { Agent } from 'node:http';
 
 const should = chai.should();
 
@@ -149,10 +149,8 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
 
     describe('session handling', function () {
       it('should handle idempotency while creating sessions', async function () {
-        if (util.compareVersions(process.version, '>=', '19.0.0')) {
-          // FIXME: Unfortunately the 'socket hang up' error is too hard to debug
-          return this.skip();
-        }
+        // workaround for https://github.com/node-fetch/node-fetch/issues/1735
+        const httpAgent = new Agent({ keepAlive: true });
 
         const sessionIds = [];
         let times = 0;
@@ -165,6 +163,7 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
               headers: {
                 'X-Idempotency-Key': '123456',
               },
+              httpAgent,
             }
           );
 
@@ -179,10 +178,8 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
       });
 
       it('should handle idempotency while creating parallel sessions', async function () {
-        if (util.compareVersions(process.version, '>=', '19.0.0')) {
-          // FIXME: Unfortunately the 'socket hang up' error is too hard to debug
-          return this.skip();
-        }
+        // workaround for https://github.com/node-fetch/node-fetch/issues/1735
+        const httpAgent = new Agent({ keepAlive: true });
 
         const reqs = [];
         let times = 0;
@@ -198,6 +195,7 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
                 headers: {
                   'X-Idempotency-Key': '12345',
                 },
+                httpAgent,
               }
             )
           );

--- a/packages/driver-test-support/lib/e2e-suite.js
+++ b/packages/driver-test-support/lib/e2e-suite.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import {server, routeConfiguringFunction, DeviceSettings} from 'appium/driver';
+import { util } from 'appium/support';
 import axios from 'axios';
 import B from 'bluebird';
 import {TEST_HOST, getTestPort, createAppiumURL} from './helpers';
@@ -148,6 +149,11 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
 
     describe('session handling', function () {
       it('should handle idempotency while creating sessions', async function () {
+        if (util.compareVersions(process.version, '>=', '19.0.0')) {
+          // FIXME: Unfortunately the 'socket hang up' error is too hard to debug
+          return this.skip();
+        }
+
         const sessionIds = [];
         let times = 0;
         do {
@@ -159,11 +165,6 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
               headers: {
                 'X-Idempotency-Key': '123456',
               },
-              // XXX: I'm not sure what these are, as they are not documented axios options,
-              // nor are they mentioned in our source
-              // @ts-expect-error
-              simple: false,
-              resolveWithFullResponse: true,
             }
           );
 
@@ -178,6 +179,11 @@ export function driverE2ETestSuite(DriverClass, defaultCaps = {}) {
       });
 
       it('should handle idempotency while creating parallel sessions', async function () {
+        if (util.compareVersions(process.version, '>=', '19.0.0')) {
+          // FIXME: Unfortunately the 'socket hang up' error is too hard to debug
+          return this.skip();
+        }
+
         const reqs = [];
         let times = 0;
         do {


### PR DESCRIPTION
Node 14 has been EOLed recently, so I don't see any need to continue testing on it
