### PR TITLE
fix(types): fix broken appium config schema types, temporarily

### DIFF
--- a/packages/appium/test/fixtures/flattened-schema.js
+++ b/packages/appium/test/fixtures/flattened-schema.js
@@ -11,14 +11,6 @@ export default [
       ref: 'appium.json#/properties/server/properties/address',
     },
     schema: {
-      anyOf: [
-        {
-          format: 'hostname'
-        },
-        {
-          format: 'ipv6'
-        }
-      ],
       appiumCliAliases: ['a'],
       default: '0.0.0.0',
       description: 'IPv4/IPv6 address or a hostname to listen on',

--- a/packages/schema/lib/appium-config-schema.js
+++ b/packages/schema/lib/appium-config-schema.js
@@ -24,12 +24,9 @@ export const AppiumConfigJsonSchema = /** @type {const} */ ({
           appiumCliAliases: ['a'],
           default: '0.0.0.0',
           description: 'IPv4/IPv6 address or a hostname to listen on',
-          anyOf: [
-            { format: 'hostname' },
-            { format: 'ipv6' }
-          ],
           title: 'address config',
           type: 'string',
+          // this should be anyOf [format: "hostname" or format: "ipv6"], but there seems to be a bug in json-schema-to-typescript preventing "ipv6" from converting to type "string"'
         },
         'allow-cors': {
           description:
@@ -340,7 +337,7 @@ export const AppiumConfigJsonSchema = /** @type {const} */ ({
           },
         },
         {
-          oneOf: [{$ref: '#/$defs/logFilterText'}, {$ref: '#/$defs/logFilterRegex'}],
+          anyOf: [{$ref: '#/$defs/logFilterText'}, {$ref: '#/$defs/logFilterRegex'}],
         },
       ],
     },

--- a/packages/schema/lib/appium-config.schema.json
+++ b/packages/schema/lib/appium-config.schema.json
@@ -19,14 +19,6 @@
           ],
           "default": "0.0.0.0",
           "description": "IPv4/IPv6 address or a hostname to listen on",
-          "anyOf": [
-            {
-              "format": "hostname"
-            },
-            {
-              "format": "ipv6"
-            }
-          ],
           "title": "address config",
           "type": "string"
         },
@@ -345,7 +337,7 @@
           }
         },
         {
-          "oneOf": [
+          "anyOf": [
             {
               "$ref": "#/$defs/logFilterText"
             },


### PR DESCRIPTION
This appears to be a bug in `json-schema-to-typescript`, where the `ipv6` type converts to `{[key: string]: unknown}` instead of `string`.

For now, we need to drop all formatting requirements from the `address` prop until this is fixed.

This did not break CI because the `build` script of `@appium/types` was run either _after_ building the rest of the project, or not at all, and the resulting change to `appium-config.ts` was not committed.
