### PR TITLE
fix(opencv): Do not apply additional checks to opencv objects

### DIFF
--- a/packages/opencv/lib/autorelease-pool.js
+++ b/packages/opencv/lib/autorelease-pool.js
@@ -1,5 +1,3 @@
-import _ from 'lodash';
-
 export class OpenCvAutoreleasePool {
   /**
    * @type {Set}
@@ -17,9 +15,7 @@ export class OpenCvAutoreleasePool {
    */
   add(...items) {
     for (const item of items) {
-      if (_.has(item, 'delete') && _.isFunction(item.delete)) {
-        this._items.add(item);
-      }
+      this._items.add(item);
     }
     return items.length === 1 ? items[0] : items;
   }


### PR DESCRIPTION
## Proposed changes

It seems like objects created by opencv wrapper have their properties being added dynamically (magic, magic everywhere), which prevents checks like `has` to detect them properly.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
