### PR TITLE
sundry type fixes

### DIFF
--- a/packages/base-driver/lib/basedriver/commands/find.ts
+++ b/packages/base-driver/lib/basedriver/commands/find.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import {Constraints, Element, IFindCommands} from '@appium/types';
 import {errors} from '../../protocol';
 import {BaseDriver} from '../driver';
@@ -8,50 +9,50 @@ declare module '../driver' {
   interface BaseDriver<C extends Constraints> extends IFindCommands {}
 }
 
-async function findElOrEls<C extends Constraints, Ctx = any>(
+async function findElOrEls<C extends Constraints>(
   this: BaseDriver<C>,
   strategy: string,
   selector: string,
   mult: true,
-  context?: Ctx
+  context?: any
 ): Promise<Element[]>;
-async function findElOrEls<C extends Constraints, Ctx = any>(
+async function findElOrEls<C extends Constraints>(
   this: BaseDriver<C>,
   strategy: string,
   selector: string,
   mult: false,
-  context?: Ctx
+  context?: any
 ): Promise<Element>;
-async function findElOrEls<C extends Constraints, Ctx = any>(
+async function findElOrEls<C extends Constraints>(
   this: BaseDriver<C>,
   strategy: string,
   selector: string,
   mult: boolean,
-  context?: Ctx
+  context?: any
 ): Promise<Element[] | Element> {
   throw new errors.NotImplementedError('Not implemented yet for find.');
 }
 
-async function findElOrElsWithProcessing<C extends Constraints, Ctx = any>(
+async function findElOrElsWithProcessing<C extends Constraints>(
   this: BaseDriver<C>,
   strategy: string,
   selector: string,
   mult: true,
-  context?: Ctx
+  context?: any
 ): Promise<Element[]>;
-async function findElOrElsWithProcessing<C extends Constraints, Ctx = any>(
+async function findElOrElsWithProcessing<C extends Constraints>(
   this: BaseDriver<C>,
   strategy: string,
   selector: string,
   mult: false,
-  context?: Ctx
+  context?: any
 ): Promise<Element>;
-async function findElOrElsWithProcessing<C extends Constraints, Ctx = any>(
+async function findElOrElsWithProcessing<C extends Constraints>(
   this: BaseDriver<C>,
   strategy: string,
   selector: string,
   mult: boolean,
-  context?: Ctx
+  context?: any
 ): Promise<Element[] | Element> {
   this.validateLocatorStrategy(strategy);
   try {

--- a/packages/base-driver/lib/basedriver/commands/find.ts
+++ b/packages/base-driver/lib/basedriver/commands/find.ts
@@ -1,4 +1,4 @@
-import {Constraints, IFindCommands} from '@appium/types';
+import {Constraints, Element, IFindCommands} from '@appium/types';
 import {errors} from '../../protocol';
 import {BaseDriver} from '../driver';
 import {mixin} from './mixin';
@@ -6,6 +6,67 @@ import {mixin} from './mixin';
 declare module '../driver' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface BaseDriver<C extends Constraints> extends IFindCommands {}
+}
+
+async function findElOrEls<C extends Constraints, Ctx = any>(
+  this: BaseDriver<C>,
+  strategy: string,
+  selector: string,
+  mult: true,
+  context?: Ctx
+): Promise<Element[]>;
+async function findElOrEls<C extends Constraints, Ctx = any>(
+  this: BaseDriver<C>,
+  strategy: string,
+  selector: string,
+  mult: false,
+  context?: Ctx
+): Promise<Element>;
+async function findElOrEls<C extends Constraints, Ctx = any>(
+  this: BaseDriver<C>,
+  strategy: string,
+  selector: string,
+  mult: boolean,
+  context?: Ctx
+): Promise<Element[] | Element> {
+  throw new errors.NotImplementedError('Not implemented yet for find.');
+}
+
+async function findElOrElsWithProcessing<C extends Constraints, Ctx = any>(
+  this: BaseDriver<C>,
+  strategy: string,
+  selector: string,
+  mult: true,
+  context?: Ctx
+): Promise<Element[]>;
+async function findElOrElsWithProcessing<C extends Constraints, Ctx = any>(
+  this: BaseDriver<C>,
+  strategy: string,
+  selector: string,
+  mult: false,
+  context?: Ctx
+): Promise<Element>;
+async function findElOrElsWithProcessing<C extends Constraints, Ctx = any>(
+  this: BaseDriver<C>,
+  strategy: string,
+  selector: string,
+  mult: boolean,
+  context?: Ctx
+): Promise<Element[] | Element> {
+  this.validateLocatorStrategy(strategy);
+  try {
+    // @ts-expect-error TS does not understand how to deal with the overload here
+    return await this.findElOrEls(strategy, selector, mult, context);
+  } catch (err) {
+    if (this.opts.printPageSourceOnFindFailure) {
+      const src = await this.getPageSource();
+      this.log.debug(`Error finding element${mult ? 's' : ''}: ${err.message}`);
+      this.log.debug(`Page source requested through 'printPageSourceOnFindFailure':`);
+      this.log.debug(src);
+    }
+    // still want the error to occur
+    throw err;
+  }
 }
 
 const FindCommands: IFindCommands = {
@@ -35,46 +96,13 @@ const FindCommands: IFindCommands = {
     return await this.findElOrElsWithProcessing(strategy, selector, true, elementId);
   },
 
-  /**
-   * Returns an object which adheres to the way the JSON Wire Protocol represents elements:
-   *
-   * Override this for your own driver!
-   */
-  async findElOrEls<C extends Constraints, Mult extends boolean, Ctx = any>(
-    this: BaseDriver<C>,
-    strategy: string,
-    selector: string,
-    mult: Mult,
-    context: Ctx
-  ) {
-    throw new errors.NotImplementedError('Not implemented yet for find.');
-  },
+  findElOrEls,
 
   async getPageSource<C extends Constraints>(this: BaseDriver<C>) {
     throw new errors.NotImplementedError('Not implemented yet for find.');
   },
 
-  async findElOrElsWithProcessing<C extends Constraints, Mult extends boolean, Ctx = any>(
-    this: BaseDriver<C>,
-    strategy: string,
-    selector: string,
-    mult: Mult,
-    context?: Ctx
-  ) {
-    this.validateLocatorStrategy(strategy);
-    try {
-      return await this.findElOrEls(strategy, selector, mult, context);
-    } catch (err) {
-      if (this.opts.printPageSourceOnFindFailure) {
-        const src = await this.getPageSource();
-        this.log.debug(`Error finding element${mult ? 's' : ''}: ${err.message}`);
-        this.log.debug(`Page source requested through 'printPageSourceOnFindFailure':`);
-        this.log.debug(src);
-      }
-      // still want the error to occur
-      throw err;
-    }
-  },
+  findElOrElsWithProcessing,
 };
 
 mixin(FindCommands);

--- a/packages/base-driver/lib/jsonwp-proxy/proxy.js
+++ b/packages/base-driver/lib/jsonwp-proxy/proxy.js
@@ -320,6 +320,12 @@ class JWProxy {
     return commandName;
   }
 
+  /**
+   *
+   * @param {string} url
+   * @param {import('@appium/types').HTTPMethod} method
+   * @param {any?} body
+   */
   async proxyCommand(url, method, body = null) {
     const commandName = this.requestToCommandName(url, method);
     if (!commandName) {
@@ -330,6 +336,12 @@ class JWProxy {
     return await this.protocolConverter.convertAndProxy(commandName, url, method, body);
   }
 
+  /**
+   *
+   * @param {string} url
+   * @param {import('@appium/types').HTTPMethod} method
+   * @param {any?} body
+   */
   async command(url, method, body = null) {
     let response;
     let resBodyObj;

--- a/packages/base-driver/lib/protocol/errors.js
+++ b/packages/base-driver/lib/protocol/errors.js
@@ -982,7 +982,13 @@ function isUnknownError(err) {
     })
   );
 }
-
+/**
+ * Type guard to check if an Error is of a specific type
+ * @template {Error} T
+ * @param {any} err
+ * @param {import('@appium/types').Class<T>} type
+ * @returns {err is T}
+ */
 function isErrorType(err, type) {
   // `name` property is the constructor name
   if (type.name === ProtocolError.name) {

--- a/packages/fake-driver/lib/commands/find.ts
+++ b/packages/fake-driver/lib/commands/find.ts
@@ -69,19 +69,19 @@ interface FakeDriverFindMixin {
   getExistingElementForNode(node: FakeElement): string | null;
   wrapNewEl(obj: FakeElement): Element;
 
-  findElOrEls<Ctx = any>(
+  findElOrEls(
     this: FakeDriver,
     strategy: string,
     selector: string,
     mult: true,
-    context?: Ctx
+    context?: any
   ): Promise<Element[]>;
-  findElOrEls<Ctx = any>(
+  findElOrEls(
     this: FakeDriver,
     strategy: string,
     selector: string,
     mult: false,
-    context?: Ctx
+    context?: any
   ): Promise<Element>;
   findElement(strategy: string, selector: string): Promise<Element>;
   findElements(strategy: string, selector: string): Promise<Element[]>;

--- a/packages/fake-driver/lib/commands/general.ts
+++ b/packages/fake-driver/lib/commands/general.ts
@@ -8,7 +8,7 @@ const ORIENTATIONS = new Set(['LANDSCAPE', 'PORTRAIT']);
 interface FakeDriverGeneralMixin {
   title(): Promise<string>;
   keys(value: string | string[]): Promise<void>;
-  setGeoLocation(location: Location): Promise<void>;
+  setGeoLocation(location: Location): Promise<Location>;
   getGeoLocation(): Promise<Location>;
   getPageSource(): Promise<string>;
   getOrientation(): Promise<string>;
@@ -22,7 +22,7 @@ interface FakeDriverGeneralMixin {
   doubleClick(): Promise<void>;
   execute(script: string, args: any[]): Promise<any>;
   fakeAddition(a: number, b: number, c?: number): Promise<number>;
-  getLog(type: string): Promise<unknown>;
+  getLog(type: string): Promise<any>;
 }
 
 declare module '../driver' {
@@ -46,6 +46,7 @@ const GeneralMixin: FakeDriverGeneralMixin = {
     // TODO test this adequately once WD bug is fixed
     this.appModel.lat = location.latitude;
     this.appModel.long = location.longitude;
+    return location;
   },
 
   async getGeoLocation(this: FakeDriver) {

--- a/packages/fake-driver/lib/commands/general.ts
+++ b/packages/fake-driver/lib/commands/general.ts
@@ -22,7 +22,7 @@ interface FakeDriverGeneralMixin {
   doubleClick(): Promise<void>;
   execute(script: string, args: any[]): Promise<any>;
   fakeAddition(a: number, b: number, c?: number): Promise<number>;
-  getLog(type: string): Promise<unknown[]>;
+  getLog(type: string): Promise<unknown>;
 }
 
 declare module '../driver' {

--- a/packages/support/lib/index.ts
+++ b/packages/support/lib/index.ts
@@ -57,3 +57,24 @@ export default {
   env,
   console,
 };
+
+export type {ConsoleOpts} from './console';
+export type {ReadFn, WalkDirCallback} from './fs';
+export type {
+  NetOptions,
+  DownloadOptions,
+  AuthCredentials,
+  NotHttpUploadOptions,
+  HttpUploadOptions,
+} from './net';
+export type {InstallPackageOpts, ExecOpts, NpmInstallReceipt} from './npm';
+export type {Affixes, OpenedAffixes} from './tempdir';
+export type {PluralizeOptions, EncodingOptions, LockFileOptions, NonEmptyString} from './util';
+export type {
+  ExtractAllOptions,
+  ZipEntry,
+  ZipOptions,
+  ZipCompressionOptions,
+  ZipSourceOptions,
+} from './zip';
+export type {SecureValuePreprocessingRule} from './log-internal';

--- a/packages/support/test/unit/index.spec.js
+++ b/packages/support/test/unit/index.spec.js
@@ -1,4 +1,4 @@
-import AppiumSupport from '../../lib/index.js';
+import AppiumSupport from '../../lib/';
 
 let {system, tempDir, util} = AppiumSupport;
 

--- a/packages/support/test/unit/plist.spec.js
+++ b/packages/support/test/unit/plist.spec.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import {plist, tempDir, fs} from '../../lib/index.js';
+import {plist, tempDir, fs} from '../../lib';
 
 const binaryPlistPath = path.join(__dirname, 'assets', 'sample_binary.plist');
 const textPlistPath = path.join(__dirname, 'assets', 'sample_text.plist');

--- a/packages/support/test/unit/system.spec.js
+++ b/packages/support/test/unit/system.spec.js
@@ -1,4 +1,4 @@
-import {system} from '../../lib/index.js';
+import {system} from '../../lib';
 import os from 'os';
 import {createSandbox} from 'sinon';
 import * as teen_process from 'teen_process';

--- a/packages/support/test/unit/tempdir.spec.js
+++ b/packages/support/test/unit/tempdir.spec.js
@@ -1,4 +1,4 @@
-import {tempDir, fs} from '../../lib/index.js';
+import {tempDir, fs} from '../../lib';
 
 describe('tempdir', function () {
   afterEach(function () {

--- a/packages/typedoc-plugin-appium/test/e2e/theme/__snapshots__/output.e2e.spec.ts.snap
+++ b/packages/typedoc-plugin-appium/test/e2e/theme/__snapshots__/output.e2e.spec.ts.snap
@@ -264,7 +264,7 @@ Get the log for a given log type.
 
 #### Response
 
-\`unknown\`[]
+\`any\`
 
 ### \`getLog\`
 
@@ -282,7 +282,7 @@ Get the log for a given log type.
 
 #### Response
 
-\`unknown\`[]
+\`any\`
 
 ### \`getLogEvents\`
 
@@ -852,7 +852,7 @@ Get the log for a given log type.
 
 #### Response
 
-\`unknown\`[]
+\`any\`
 
 ### \`getLog\`
 
@@ -870,7 +870,7 @@ Get the log for a given log type.
 
 #### Response
 
-\`unknown\`[]
+\`any\`
 
 ### \`getLogEvents\`
 

--- a/packages/types/lib/capabilities.ts
+++ b/packages/types/lib/capabilities.ts
@@ -50,7 +50,7 @@ export type ConstraintToCapKind<C extends Constraint> = C['isString'] extends tr
   : C['isArray'] extends true
   ? string[]
   : C['isObject'] extends true
-  ? object
+  ? StringRecord
   : unknown;
 
 /**

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -536,36 +536,7 @@ export interface Cookie {
   sameSite?: 'Lax' | 'Strict';
 }
 
-// Appium W3C WebDriver Extension
-
-export interface StartScreenRecordOptions {
-  remotePath?: string;
-  username?: string;
-  password?: string;
-  method?: string;
-  forceRestart?: boolean;
-  timeLimit?: string;
-  videoType?: string;
-  videoQuality?: string;
-  videoFps?: string;
-  videoScale?: string;
-  bitRate?: string;
-  videoSize?: string;
-  bugReport?: string;
-}
-
-export interface StopScreenRecordOptions {
-  remotePath?: string;
-  user?: string;
-  pass?: string;
-  method?: string;
-  headers?: Record<string, string>;
-  fileFieldName?: string;
-  formFields: Record<string, string> | Entries<Record<string, string>>;
-}
-
 // JSONWP
-
 export type Size = Pick<Rect, 'width' | 'height'>;
 
 export type Position = Pick<Rect, 'x' | 'y'>;

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -353,7 +353,7 @@ export interface ILogCommands {
    *
    * @param logType - Name/key of log type as defined in {@linkcode ILogCommands.supportedLogTypes}.
    */
-  getLog(logType: string): Promise<unknown[]>;
+  getLog(logType: string): Promise<unknown>;
 }
 
 /**
@@ -378,7 +378,7 @@ export interface LogDef {
    *
    * This implementation *should* drain, truncate or otherwise reset the log buffer.
    */
-  getter: (driver: any) => Promise<unknown[]> | unknown[];
+  getter: (driver: any) => Promise<unknown> | unknown;
 }
 
 export interface ISettingsCommands<T extends StringRecord = StringRecord> {

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -291,18 +291,8 @@ export interface IFindCommands {
    *
    * @returns A single element or list of elements
    */
-  findElOrEls<Ctx = any>(
-    strategy: string,
-    selector: string,
-    mult: true,
-    context?: Ctx
-  ): Promise<Element[]>;
-  findElOrEls<Ctx = any>(
-    strategy: string,
-    selector: string,
-    mult: false,
-    context?: Ctx
-  ): Promise<Element>;
+  findElOrEls(strategy: string, selector: string, mult: true, context?: any): Promise<Element[]>;
+  findElOrEls(strategy: string, selector: string, mult: false, context?: any): Promise<Element>;
 
   /**
    * This is a wrapper for {@linkcode findElOrEls} that validates locator strategies
@@ -315,17 +305,17 @@ export interface IFindCommands {
    *
    * @returns A single element or list of elements
    */
-  findElOrElsWithProcessing<Ctx = any>(
+  findElOrElsWithProcessing(
     strategy: string,
     selector: string,
     mult: true,
-    context?: Ctx
+    context?: any
   ): Promise<Element[]>;
-  findElOrElsWithProcessing<Ctx = any>(
+  findElOrElsWithProcessing(
     strategy: string,
     selector: string,
     mult: false,
-    context?: Ctx
+    context?: any
   ): Promise<Element>;
 
   /**
@@ -353,7 +343,7 @@ export interface ILogCommands {
    *
    * @param logType - Name/key of log type as defined in {@linkcode ILogCommands.supportedLogTypes}.
    */
-  getLog(logType: string): Promise<unknown>;
+  getLog(logType: string): Promise<any>;
 }
 
 /**
@@ -1230,7 +1220,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @returns The list of types
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   getPerformanceDataTypes?(): Promise<string[]>;
 
@@ -1245,13 +1234,12 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @returns A list of performance data strings
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   getPerformanceData?(
     packageName: string,
     dataType: string,
     dataReadTimeout?: number
-  ): Promise<string[]>;
+  ): Promise<any>;
 
   /**
    * Press a device hardware key by its code for the default duration
@@ -1426,8 +1414,10 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    *
    * @param appId - the package or bundle ID of the application
    * @param options - driver-specific launch options
+   *
+   * @returns `true` if successful
    */
-  removeApp?(appId: string, options?: unknown): Promise<void>;
+  removeApp?(appId: string, options?: unknown): Promise<boolean>;
 
   /**
    * Quit / terminate / stop a running application
@@ -1462,8 +1452,15 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param key - the text of a key to use to hide the keyboard
    * @param keyCode - a key code to trigger to hide the keyboard
    * @param keyName - the name of a key to use to hide the keyboard
+   *
+   * @returns Whether the keyboard was successfully hidden. May never return `false` on some platforms
    */
-  hideKeyboard?(strategy?: string, key?: string, keyCode?: string, keyName?: string): Promise<void>;
+  hideKeyboard?(
+    strategy?: string,
+    key?: string,
+    keyCode?: string,
+    keyName?: string
+  ): Promise<boolean>;
 
   /**
    * Determine whether the keyboard is shown
@@ -1574,9 +1571,8 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @returns An array of information objects of driver-specific shape
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
-  getSystemBars?(): Promise<unknown[]>;
+  getSystemBars?(): Promise<unknown>;
 
   /**
    * Get the display's pixel density
@@ -1639,7 +1635,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @returns The name of the active engine
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   getActiveIMEEngine?(): Promise<string>;
 
@@ -1649,7 +1644,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @returns True if the IME is activated
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   isIMEActivated?(): Promise<boolean>;
 
@@ -1657,7 +1651,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * Deactivate an IME engine
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   deactivateIMEEngine?(): Promise<void>;
 
@@ -1667,7 +1660,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param engine - the name of the engine
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   activateIMEEngine?(engine: string): Promise<void>;
 
@@ -1730,9 +1722,8 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param y - the y coordinate
    *
    * @deprecated Use the Actions API instead
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
-  touchDown?(x: number, y: number): Promise<void>;
+  touchDown?(element: string, x: number, y: number): Promise<void>;
 
   /**
    * Perform a touch up event at the location specified
@@ -1741,9 +1732,8 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param y - the y coordinate
    *
    * @deprecated Use the Actions API instead
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
-  touchUp?(x: number, y: number): Promise<void>;
+  touchUp?(element: string, x: number, y: number): Promise<void>;
 
   /**
    * Perform a touch move event at the location specified
@@ -1752,9 +1742,8 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param y - the y coordinate
    *
    * @deprecated Use the Actions API instead
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
-  touchMove?(x: number, y: number): Promise<void>;
+  touchMove?(element: string, x: number, y: number): Promise<void>;
 
   /**
    * Perform a long touch down event at the location specified
@@ -1762,9 +1751,8 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param elementId - the id of the element to long touch
    *
    * @deprecated Use the Actions API instead
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
-  touchLongClick?(elementId: string): Promise<void>;
+  touchLongClick?(element: string, x: number, y: number, duration: number): Promise<void>;
 
   /**
    * Perform a flick event at the location specified
@@ -1799,8 +1787,9 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * Set the virtual geographical location of a device
    *
    * @param location - the location including latitude and longitude
+   * @returns The complete location
    */
-  setGeoLocation?(location: Partial<Location>): Promise<void>;
+  setGeoLocation?(location: Partial<Location>): Promise<Location>;
 
   // MJSONWIRE
 
@@ -1854,8 +1843,10 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @see {@link https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#device-modes}
    *
    * @param type - the bitmask representing network state
+   * @returns A number which is a bitmask representing categories like Data, Wifi, and Airplane
+   * mode status
    */
-  setNetworkConnection?(type: number): Promise<void>;
+  setNetworkConnection?(type: number): Promise<number>;
 
   /**
    * Get the current rotation state of the device

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -291,15 +291,21 @@ export interface IFindCommands {
    *
    * @returns A single element or list of elements
    */
-  findElOrEls<Mult extends boolean, Ctx = any>(
+  findElOrEls<Ctx = any>(
     strategy: string,
     selector: string,
-    mult: Mult,
+    mult: true,
     context?: Ctx
-  ): Promise<Mult extends true ? Element[] : Element>;
+  ): Promise<Element[]>;
+  findElOrEls<Ctx = any>(
+    strategy: string,
+    selector: string,
+    mult: false,
+    context?: Ctx
+  ): Promise<Element>;
 
   /**
-   * This is a wrapper for {@linkcode IFindCommands.findElOrEls} that validates locator strategies
+   * This is a wrapper for {@linkcode findElOrEls} that validates locator strategies
    * and implements the `appium:printPageSourceOnFindFailure` capability
    *
    * @param strategy - the locator strategy
@@ -309,12 +315,18 @@ export interface IFindCommands {
    *
    * @returns A single element or list of elements
    */
-  findElOrElsWithProcessing<Mult extends boolean, Ctx = any>(
+  findElOrElsWithProcessing<Ctx = any>(
     strategy: string,
     selector: string,
-    mult: Mult,
+    mult: true,
     context?: Ctx
-  ): Promise<Mult extends true ? Element[] : Element>;
+  ): Promise<Element[]>;
+  findElOrElsWithProcessing<Ctx = any>(
+    strategy: string,
+    selector: string,
+    mult: false,
+    context?: Ctx
+  ): Promise<Element>;
 
   /**
    * Get the current page/app source as HTML/XML
@@ -1278,7 +1290,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param flags - the code denoting the combination of extra flags
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   pressKeyCode?(keycode: number, metastate?: number, flags?: number): Promise<void>;
 
@@ -1290,7 +1301,7 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param flags - the code denoting the combination of extra flags
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
+   *
    */
   longPressKeyCode?(keycode: number, metastate?: number, flags?: number): Promise<void>;
 
@@ -1300,7 +1311,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param fingerprintId - the numeric ID of the fingerprint to use
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   fingerprint?(fingerprintId: number): Promise<void>;
 
@@ -1311,7 +1321,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param message - the SMS text
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   sendSMS?(phoneNumber: string, message: string): Promise<void>;
 
@@ -1323,7 +1332,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param action - the action to take in response (accept, reject, etc...)
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   gsmCall?(phoneNumber: string, action: string): Promise<void>;
 
@@ -1333,9 +1341,8 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param singalStrength - the strength in a driver-appropriate string
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
-  gsmSignal?(signalStrength: string): Promise<void>;
+  gsmSignal?(signalStrength: string | number): Promise<void>;
 
   /**
    * Do something with GSM voice (unclear; this should not be implemented anywhere)
@@ -1353,7 +1360,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param percent - how full the battery should become
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   powerCapacity?(percent: number): Promise<void>;
 
@@ -1363,7 +1369,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param state - whether the device is connected to power or not
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   powerAC?(state: string): Promise<void>;
 
@@ -1373,7 +1378,6 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param netspeed - the speed as a string, like '3G'
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
   networkSpeed?(netspeed: string): Promise<void>;
 
@@ -1384,9 +1388,8 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param metastate - the combination of meta startUnexpectedShutdown
    *
    * @deprecated
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
    */
-  keyevent?(keycode: string, metastate?: string): Promise<void>;
+  keyevent?(keycode: string | number, metastate?: string | number): Promise<void>;
 
   /**
    * Construct a rotation gesture? Unclear what this command does and it does not appear to be used
@@ -1461,7 +1464,7 @@ export interface ExternalDriver<C extends Constraints = Constraints, Ctx = strin
    * @param appId - the package or bundle ID of the application
    * @param options - driver-specific launch options
    */
-  terminateApp?(appId: string, options?: unknown): Promise<void>;
+  terminateApp?(appId: string, options?: unknown): Promise<boolean>;
 
   /**
    * Determine whether an app is installed


### PR DESCRIPTION
Mainly:

**BREAKING CHANGE: This changes the def of `findElOrEls` and `findElOrElsWithProcessing` in `ExternalDriver` in a breaking manner.**

So conditional types don't work like how I was using them.  They work in capital-T-types (`type`), but they don't work as return values.  Instead, what we should have is an overload.  in this case, the function can be called one of two ways, and it returns a different thing depending on those values.  _unfortunately_ this is a little hinky to implement, given that overloads are unsupported in _object literals_.  they are supported in function statements or expressions, and they are supported in class definitions, but not object literals.  you'll see what needs to happen to make this work in `FakeDriver` and `BaseDriver` in subsequent changesets; essentially the function must be defined outside of the object literal and then stuffed in there.

The other change here changes an `object` type (which does not allow arbitrary properties) to a `StringRecord` type within the type which converts `Constraints` to `Capabilities`.  This affects caps for some drivers such as `chromedriverArgs` in `appium-android-driver`; anywhere where the constraint has `isObject: true`.
