### PR TITLE
chore(appium): Make sharp to an optional dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,9 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
         os:
         - ubuntu-latest
+        - windows-latest
         # TODO: Enable below envs after all tests have been verified green
         # - macos-latest
-        # - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,11 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 18.x, 20.x]
-        os: [ubuntu-latest, macos-latest]
+        os:
+        - ubuntu-latest
+        # TODO: Enable below envs after all tests have been verified green
+        # - macos-latest
+        # - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3

--- a/packages/support/lib/image-util.js
+++ b/packages/support/lib/image-util.js
@@ -1,14 +1,32 @@
-import sharp from 'sharp';
+let _sharp;
+
+/**
+ * @returns {import('sharp')}
+ */
+function requireSharp() {
+  if (!_sharp) {
+    try {
+      _sharp = require('sharp');
+    } catch (err) {
+      throw new Error(
+        `Cannot load the 'sharp' module needed for images processing. ` +
+        `Consider visiting https://sharp.pixelplumbing.com/install ` +
+        `for troubleshooting. Original error: ${err.message}`
+      );
+    }
+  }
+  return _sharp;
+}
 
 /**
  * Crop the image by given rectangle (use base64 string as input and output)
  *
  * @param {string} base64Image The string with base64 encoded image.
  * Supports all image formats natively supported by Sharp library.
- * @param {sharp.Region} rect The selected region of image
+ * @param {import('sharp').Region} rect The selected region of image
  * @return {Promise<string>} base64 encoded string of cropped image
  */
 export async function cropBase64Image(base64Image, rect) {
-  const buf = await sharp(Buffer.from(base64Image, 'base64')).extract(rect).toBuffer();
+  const buf = await requireSharp()(Buffer.from(base64Image, 'base64')).extract(rect).toBuffer();
   return buf.toString('base64');
 }

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -87,7 +87,6 @@
     "resolve-from": "5.0.0",
     "sanitize-filename": "1.6.3",
     "semver": "7.5.1",
-    "sharp": "0.32.1",
     "shell-quote": "1.8.1",
     "source-map-support": "0.5.21",
     "supports-color": "8.1.1",
@@ -96,6 +95,9 @@
     "uuid": "9.0.0",
     "which": "3.0.1",
     "yauzl": "2.10.0"
+  },
+  "optionalDependencies": {
+    "sharp": "0.32.1"
   },
   "engines": {
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0",


### PR DESCRIPTION
## Proposed changes

sharp is using native code. It is deployed in a form of downloadable precompiled binaries, but users may have issues fetching these because of possible networking or system issues. And since sharp module as a part of Appium server is only used rarely for various support calls it does not make sense to fail the whole server setup if it cannot be deployed.