### PR TITLE
chore(base-driver,driver-test-support): do not run basedriver e2e tests in parallel

### DIFF
--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -38,7 +38,7 @@
   ],
   "scripts": {
     "test": "npm run test:unit",
-    "test:e2e": "mocha -p --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
+    "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
     "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\"",
     "test:types": "tsd"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -33,7 +33,7 @@
   ],
   "scripts": {
     "build": "node ./scripts/generate-schema-types.js",
-    "clean": "git checkout -- ./types/lib/appium-config.ts || true",
+    "clean": "git checkout -- ./lib/appium-config.ts || true",
     "test:smoke": "node ./index.js",
     "test:types": "tsd"
   },


### PR DESCRIPTION
also: rewrote event timings tests due to it being unclear which assertion actually failed. one assertion per test.
