### PR TITLE
chore: run eslint --fix on ts files before commit

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,6 +1,5 @@
 module.exports = {
-  '*.js': ['eslint --fix', 'prettier --write'],
-  '*.ts': ['prettier --write'],
+  '*.(js|ts)': ['eslint --fix', 'prettier --write'],
   'appium-config-schema.js': () => [
     'npm run --workspace=./packages/schema build',
     'git add -A packages/schema/lib/appium-config.schema.json',


### PR DESCRIPTION
ensures `eslint --fix` gets run on `.ts` files in precommit hook