### PR TITLE
fix(appium): restrict address to ipv6/hostname

### DIFF
--- a/packages/appium/test/fixtures/flattened-schema.js
+++ b/packages/appium/test/fixtures/flattened-schema.js
@@ -16,6 +16,10 @@ export default [
       description: 'IPv4/IPv6 address or a hostname to listen on',
       title: 'address config',
       type: 'string',
+      anyOf: [
+        {format: 'hostname', type: 'string'},
+        {format: 'ipv6', type: 'string'}
+      ]
     },
   },
   {

--- a/packages/schema/lib/appium-config-schema.js
+++ b/packages/schema/lib/appium-config-schema.js
@@ -26,7 +26,16 @@ export const AppiumConfigJsonSchema = /** @type {const} */ ({
           description: 'IPv4/IPv6 address or a hostname to listen on',
           title: 'address config',
           type: 'string',
-          // this should be anyOf [format: "hostname" or format: "ipv6"], but there seems to be a bug in json-schema-to-typescript preventing "ipv6" from converting to type "string"'
+          anyOf: [
+            {
+              type: 'string',
+              format: 'hostname',
+            },
+            {
+              type: 'string',
+              format: 'ipv6',
+            },
+          ],
         },
         'allow-cors': {
           description:

--- a/packages/schema/lib/appium-config.schema.json
+++ b/packages/schema/lib/appium-config.schema.json
@@ -20,7 +20,17 @@
           "default": "0.0.0.0",
           "description": "IPv4/IPv6 address or a hostname to listen on",
           "title": "address config",
-          "type": "string"
+          "type": "string",
+          "anyOf": [
+            {
+              "type": "string",
+              "format": "hostname"
+            },
+            {
+              "type": "string",
+              "format": "ipv6"
+            }
+          ]
         },
         "allow-cors": {
           "description": "Whether the Appium server should allow web browser connections from any host",

--- a/packages/types/lib/appium-config.ts
+++ b/packages/types/lib/appium-config.ts
@@ -8,7 +8,9 @@
 /**
  * IPv4/IPv6 address or a hostname to listen on
  */
-export type AddressConfig = string;
+export type AddressConfig = AddressConfig1 & AddressConfig2;
+export type AddressConfig1 = string;
+export type AddressConfig2 = string;
 /**
  * Whether the Appium server should allow web browser connections from any host
  */


### PR DESCRIPTION
This resolves #18716.

For whatever reason, `json-schema-to-typescript` needed `"type": "string"` in there.  See https://github.com/bcherny/json-schema-to-typescript/issues/528 for further discussion

cc @mykola-mokhnach 