### PR TITLE
docs(appium): Remove @next

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,9 +24,9 @@ jobs:
       - name: Install Appium
         run: |
           if [[ "$GITHUB_REF_TYPE" == tag ]]; then
-            npm i -g $GITHUB_REF_NAME
+            npm i --location=global $GITHUB_REF_NAME
           else
-            npm i -g appium@next
+            npm i --location=global appium
           fi
         shell: bash
       - name: Install drivers and plugins

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ These are only server requirements. Each driver might have its own requirements.
 To install Appium 2 server using Node Package Manager (npm) run the following command:
 
 ```bash
-npm install -g appium
+npm i --location=global appium
 ```
 
-:bangbang: Make sure Appium 1 is fully unistalled before upgrading it to Appium 2 (`npm uninstall -g appium`). Unexpected errors might appear if this has not been done.
+:bangbang: Make sure Appium 1 is fully unistalled before upgrading it to Appium 2 (`npm uninstall --location=global appium`). Unexpected errors might appear if this has not been done.
 
 ### Drivers
 

--- a/packages/appium/README.md
+++ b/packages/appium/README.md
@@ -37,10 +37,8 @@ These are only server requirements. Each driver might have its own requirements.
 To install Appium 2 server using Node Package Manager (npm) run the following command:
 
 ```bash
-npm install -g appium@next
+npm i --location=global appium
 ```
-
-:bangbang: Running `npm install -g appium` would still install Appium 1 because version 2 is in its late beta stage.
 
 ### Drivers
 

--- a/packages/appium/docs/en/guides/migrating-1-to-2.md
+++ b/packages/appium/docs/en/guides/migrating-1-to-2.md
@@ -31,7 +31,7 @@ You can also set server arguments as [Config file](./config.md) properties.
 
 ### :bangbang: Installing drivers during setup
 
-When you installed Appium 1.x, all available drivers would be installed at the same time as the main Appium server. This is no longer the case. Simply installing Appium 2.0 (e.g., by `npm install -g appium@next`), will install the Appium server only, but no drivers. To install drivers, you must instead use the new [Appium extension CLI](../cli/extensions.md). For example, to install the latest versions of the XCUITest and UiAutomator2 drivers, after installing Appium you would run the following commands:
+When you installed Appium 1.x, all available drivers would be installed at the same time as the main Appium server. This is no longer the case. Simply installing Appium 2.0 (e.g., by `npm install --location=global appium`), will install the Appium server only, but no drivers. To install drivers, you must instead use the new [Appium extension CLI](../cli/extensions.md). For example, to install the latest versions of the XCUITest and UiAutomator2 drivers, after installing Appium you would run the following commands:
 
 ```bash
 appium driver install uiautomator2     # installs the latest driver version
@@ -42,10 +42,10 @@ At this point, your drivers are installed and ready. There's a lot more you can 
 If you're running in a CI environment or want to install Appium along with some drivers all in one step, you can do so using some special flags during install, for example:
 
 ```bash
-npm install --global appium --drivers=xcuitest,uiautomator2
+npm install --location=global appium --drivers=xcuitest,uiautomator2
 ```
 
-This will install Appium and the two drivers for you in one go. Please uninstall any existing Appium 1.x npm packages (with `npm uninstall -g appium`) if you get an installation or startup error.
+This will install Appium and the two drivers for you in one go. Please uninstall any existing Appium 1.x npm packages (with `npm uninstall --location=global appium`) if you get an installation or startup error.
 
 ### :bangbang: Drivers installation path
 
@@ -122,7 +122,7 @@ appium driver update xcuitest
 (For a complete description of the update command, check out the [Extension
 CLI](../cli/extensions.md) doc)
 
-To update the Appium server itself, you do the same thing as in the past: `npm install -g appium`. Now, installing new versions of the Appium server will leave your drivers intact, so the whole process will be much more quick.
+To update the Appium server itself, you do the same thing as in the past: `npm install --location=global appium`. Now, installing new versions of the Appium server will leave your drivers intact, so the whole process will be much more quick.
 
 If you would like to update to a specific version, not the latest, please uninstall the driver and install the desired version using the `install` subcommand instead of `update`.
 

--- a/packages/appium/docs/en/quickstart/install.md
+++ b/packages/appium/docs/en/quickstart/install.md
@@ -5,13 +5,8 @@ title: Install Appium
 Installing Appium is as easy as running a single NPM command:
 
 ```bash
-npm i -g appium@next
+npm i --location=global appium
 ```
-
-!!! note
-
-    Currently, you must use `appium@next` instead of just `appium`. Once Appium 2.0 has been
-    officially published, you can simply use `appium`.
 
 This command installs Appium globally on your system so that you can access it from the command
 line simply by running the `appium` command. Go ahead and run it now:

--- a/packages/appium/docs/ja/guides/migrating-1-to-2.md
+++ b/packages/appium/docs/ja/guides/migrating-1-to-2.md
@@ -78,10 +78,10 @@ You can also set server arguments as [Config file](./config.md) properties.
 ### :bangbang: ドライバーのインストール
 
 <!---
-When you installed Appium 1.x, all available drivers would be installed at the same time as the main Appium server. This is no longer the case. Simply installing Appium 2.0 (e.g., by `npm install -g appium@next`), will install the Appium server only, but no drivers. To install drivers, you must instead use the new [Appium extension CLI](../cli/extensions.md). For example, to install the latest versions of the XCUITest and UiAutomator2 drivers, after installing Appium you would run the following commands:
+When you installed Appium 1.x, all available drivers would be installed at the same time as the main Appium server. This is no longer the case. Simply installing Appium 2.0 (e.g., by `npm install --location=global appium`), will install the Appium server only, but no drivers. To install drivers, you must instead use the new [Appium extension CLI](../cli/extensions.md). For example, to install the latest versions of the XCUITest and UiAutomator2 drivers, after installing Appium you would run the following commands:
 --->
 
-Appium 1.xをインストールしたとき、全ての入手可能なドライバーは主となるAppiumサーバーと合わせてインストールされていました。Appium 2.0ではそうではありません。Appium 2.0のインストール（例えば `npm install -g appium@next`）は単にAppiumサーバーのみをインストールし、ドライバーはインストールしません。ドライバーをインストールするためには新しい[Appium拡張コマンドラインインタフェース（Appium extension CLI）](../cli/extensions.md)を使わなければいけません。例えば、最新のXCUITestとUiAutomator2ドライバーをインストールする場合、Appiumをインストールしたのちに次のコマンドを実行する必要があります。
+Appium 1.xをインストールしたとき、全ての入手可能なドライバーは主となるAppiumサーバーと合わせてインストールされていました。Appium 2.0ではそうではありません。Appium 2.0のインストール（例えば `npm install --location=global appium`）は単にAppiumサーバーのみをインストールし、ドライバーはインストールしません。ドライバーをインストールするためには新しい[Appium拡張コマンドラインインタフェース（Appium extension CLI）](../cli/extensions.md)を使わなければいけません。例えば、最新のXCUITestとUiAutomator2ドライバーをインストールする場合、Appiumをインストールしたのちに次のコマンドを実行する必要があります。
 
 ```bash
 appium driver install uiautomator2     # installs the latest driver version
@@ -95,14 +95,14 @@ At this point, your drivers are installed and ready. There's a lot more you can 
 これにより、ドライバーはインストールされ、利用可能になります。このCLIはいろいろな機能を提供しているので、CLIのドキュメントを確認してみてください。もしCI上であったり、いくつかのドライバーをAppiumと一緒にインストールしたい場合、以下のようなフラグを利用することで実現可能です。
 
 ```bash
-npm install --global appium --drivers=xcuitest,uiautomator2
+npm install --location=global appium --drivers=xcuitest,uiautomator2
 ```
 
 <!---
-This will install Appium and the two drivers for you in one go. Please uninstall any existing Appium 1.x npm packages (with `npm uninstall -g appium`) if you get an installation or startup error. 
+This will install Appium and the two drivers for you in one go. Please uninstall any existing Appium 1.x npm packages (with `npm uninstall --location=global appium`) if you get an installation or startup error. 
 --->
 
-これはAppiumと2つのドライバーを一つのコマンドでインストールします。もしセットアップで何らかの問題が発生した場合、既存のAppium 1.xを`npm uninstall -g appium`で削除してみてください。
+これはAppiumと2つのドライバーを一つのコマンドでインストールします。もしセットアップで何らかの問題が発生した場合、既存のAppium 1.xを`npm uninstall --location=global appium`で削除してみてください。
 
 ### :bangbang: Drivers installation path
 
@@ -166,7 +166,7 @@ appium driver update xcuitest
 (For a complete description of the update command, check out the [Extension
 CLI](../cli/extensions.md) doc)
 
-To update the Appium server itself, you do the same thing as in the past: `npm install -g appium`. Now, installing new versions of the Appium server will leave your drivers intact, so the whole process will be much more quick.
+To update the Appium server itself, you do the same thing as in the past: `npm install --location=global appium`. Now, installing new versions of the Appium server will leave your drivers intact, so the whole process will be much more quick.
 
 If you would like to update to a specific version, not the latest, please uninstall the driver and install the desired version using the `install` subcommand instead of `update`.
 


### PR DESCRIPTION
## Proposed changes

Still we have `@next` installation command. We can remove them.
Also, `npm WARN config global `--global`, `--local` are deprecated. Use `--location=global` instead.` suggest to use `--location=global` instead of `-g`, so as documentation I have moved to the official nodejs suggestion way.

https://github.com/search?q=repo%3Aappium%2Fappium%20%22appium%40next%22&type=code

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
