### PR TITLE
docs(appium): Added correct doc path for redirecting potentially insecure features with security.md file

### DIFF
--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -293,8 +293,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
         `Potentially insecure feature '${name}' has not been ` +
           `enabled. If you want to enable this feature and accept ` +
           `the security ramifications, please do so by following ` +
-          `the documented instructions at https://github.com/appium` +
-          `/appium/blob/master/docs/en/writing-running-appium/security.md`
+          `the documented instructions at http://appium.io/docs/en/2.0/guides/security/`
       );
     }
   }


### PR DESCRIPTION
## Proposed changes
Added correct doc path for redirecting potentially insecure features with security.md file for the below issue as reported,
```
org.openqa.selenium.WebDriverException: An unknown server-side error occurred while processing the command. Original error: Potentially insecure feature 'adb_shell' has not been enabled. If you want to enable this feature and accept the security ramifications, please do so by following the documented instructions at https://github.com/appium/appium/blob/master/docs/en/writing-running-appium/security.md
```

## Types of changes
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes

## Further comments

![Image 25-07-23 at 4 43 PM](https://github.com/appium/appium/assets/21119358/3d0aa3a8-a6cb-4cde-998b-bf3c2fb72bd8)


