### PR TITLE
test(appium): add test to prove umbrella commands don't circumvent command timeouts

### DIFF
--- a/packages/appium/test/e2e/driver.e2e.spec.js
+++ b/packages/appium/test/e2e/driver.e2e.spec.js
@@ -244,6 +244,26 @@ describe('FakeDriver via HTTP', function () {
       await driver.getSessions().should.eventually.be.empty;
     });
 
+    it('should not allow umbrella commands to prevent newCommandTimeout on inner driver', async function () {
+      let localCaps = Object.assign(
+        {
+          'appium:newCommandTimeout': 0.25,
+        },
+        caps
+      );
+      let driver = await wdio({...wdOpts, capabilities: localCaps});
+      should.exist(driver.sessionId);
+
+      // get the session list 6 times over 300ms. each request will be below the new command
+      // timeout but since they are not received by the driver the session should still time out
+      for (let i = 0; i < 6; i++) {
+        await driver.getSessions();
+        await B.delay(50);
+      }
+      await driver.getPageSource().should.eventually.be.rejectedWith(/terminated/);
+      await driver.getSessions().should.eventually.be.empty;
+    });
+
     it('should accept valid W3C capabilities and start a W3C session', async function () {
       // Try with valid capabilities and check that it returns a session ID
       const w3cCaps = {


### PR DESCRIPTION
a test to help with the investigation of https://github.com/appium/appium/issues/18871