### PR TITLE
feat(base-driver): Make it possible to provide settings as a map in session capabilities

### DIFF
--- a/packages/appium/docs/en/guides/settings.md
+++ b/packages/appium/docs/en/guides/settings.md
@@ -41,6 +41,18 @@ would construct a set of capabilities that includes the following in its JSON re
 }
 ```
 
+Also, since base-driver version 9.4.0, there is a possibility to provide multiple settings
+in a single `appium:settings` capability value:
+
+```json
+{
+    "appium:settings": {
+        "ignoreUnimportantViews": true,
+        "allowInvisibleElements": true
+    }
+}
+```
+
 Of course, initializing a setting via capabilities doesn't prevent you from changing it later on
 via the Settings API. To learn more about how to use the Settings API in the context of your
 specific client library, visit the documentation for that library.

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -278,10 +278,12 @@ function adjustNodePath() {
  * Each setting item must satisfy the following format:
  * `settings[setting_name]: setting_value`
  * or
- * `settings = {
+ * ```
+ * settings = {
  *   setting_name1: 'setting_value1',
  *   setting_name2: 'setting_value2',
- * }`
+ * }
+ * ```
  * The capabilities argument itself gets mutated, so it does not contain parsed
  * settings anymore to avoid further parsing issues.
  * Check

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -276,7 +276,12 @@ function adjustNodePath() {
 /**
  * Pulls the initial values of Appium settings from the given capabilities argument.
  * Each setting item must satisfy the following format:
- * `setting[setting_name]: setting_value`
+ * `settings[setting_name]: setting_value`
+ * or
+ * `settings = {
+ *   setting_name1: 'setting_value1',
+ *   setting_name2: 'setting_value2',
+ * }`
  * The capabilities argument itself gets mutated, so it does not contain parsed
  * settings anymore to avoid further parsing issues.
  * Check
@@ -295,14 +300,19 @@ function pullSettings(caps) {
   }
 
   const result = {};
+  const singleSettings = {};
   for (const [key, value] of _.toPairs(caps)) {
-    const match = /\bsettings\[(\S+)\]$/.exec(key);
-    if (!match) {
-      continue;
+    let match;
+    if (/^(s|appium:s)ettings$/.test(key) && _.isPlainObject(value)) {
+      Object.assign(result, value);
+      delete caps[key];
+    } else if ((match = /^(s|appium:s)ettings\[(\S+)\]$/.exec(key))) {
+      singleSettings[match[2]] = value;
+      delete caps[key];
     }
-
-    result[match[1]] = value;
-    delete caps[key];
+  }
+  if (!_.isEmpty(singleSettings)) {
+    Object.assign(result, singleSettings);
   }
   return result;
 }

--- a/packages/appium/test/unit/utils.spec.js
+++ b/packages/appium/test/unit/utils.spec.js
@@ -232,6 +232,26 @@ describe('utils', function () {
       settings.should.eql({});
       caps.should.eql({});
     });
+    it('should pull combined settings', function () {
+      const caps = {
+        platformName: 'foo',
+        browserName: 'bar',
+        'appium:settings[foo]': 'baz2',
+        'appium:settings': {
+          foo: 'baz',
+          yolo: 'bar',
+        },
+      };
+      const settings = pullSettings(caps);
+      settings.should.eql({
+        foo: 'baz2',
+        yolo: 'bar',
+      });
+      caps.should.eql({
+        platformName: 'foo',
+        browserName: 'bar',
+      });
+    });
   });
 
   describe('inspect()', function () {


### PR DESCRIPTION
## Proposed changes

Created in response to https://github.com/appium/appium/issues/18969
Although this might be a breaking change if any of existing drivers or plugins already defines a capability called `settings`.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
