### PR TITLE
fix(appium): Update the GET /status response to be in sync with the standard

### DIFF
--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -440,10 +440,7 @@ async function main(args) {
     process.once(signal, async function onSignal() {
       logger.info(`Received ${signal} - shutting down`);
       try {
-        await appiumDriver.deleteAllSessions({
-          force: true,
-          reason: `The process has received ${signal} signal`,
-        });
+        await appiumDriver.shutdown(`The process has received ${signal} signal`);
         await server.close();
         process.exit(0);
       } catch (e) {


### PR DESCRIPTION
## Proposed changes

According to https://www.w3.org/TR/webdriver/#dfn-status the status response must contain `ready` and `message` fields

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
