### PR TITLE
fix(base-driver): Respect basic auth credentials if provided

### DIFF
--- a/packages/base-driver/lib/basedriver/helpers.js
+++ b/packages/base-driver/lib/basedriver/helpers.js
@@ -362,12 +362,19 @@ async function configureApp(
  * @returns {Promise<RemoteAppData>}
  */
 async function queryAppLink(appLink, reqHeaders) {
-  const {href} = url.parse(appLink);
+  const {href, auth} = url.parse(appLink);
+  const axiosUrl = auth ? href.replace(`${auth}@`, '') : href;
+  /** @type {import('axios').AxiosBasicCredentials|undefined} */
+  const axiosAuth = auth ? {
+    username: auth.substring(0, auth.indexOf(':')),
+    password: auth.substring(auth.indexOf(':') + 1),
+  } : undefined;
   /**
    * @type {import('axios').RawAxiosRequestConfig}
    */
   const requestOpts = {
-    url: href,
+    url: axiosUrl,
+    auth: axiosAuth,
     responseType: 'stream',
     timeout: APP_DOWNLOAD_TIMEOUT_MS,
     validateStatus: (status) =>
@@ -382,7 +389,7 @@ async function queryAppLink(appLink, reqHeaders) {
       status,
     };
   } catch (err) {
-    throw new Error(`Cannot download the app from ${href}: ${err.message}`);
+    throw new Error(`Cannot download the app from ${axiosUrl}: ${err.message}`);
   }
 }
 


### PR DESCRIPTION
## Proposed changes

axios does not support urls where basic auth creds are inlined

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
