### PR TITLE
Fix quickstart for Appium-Python-Client 3.0.0

### DIFF
--- a/packages/appium/sample-code/quickstarts/py/test.py
+++ b/packages/appium/sample-code/quickstarts/py/test.py
@@ -1,5 +1,6 @@
 import unittest
 from appium import webdriver
+from appium.options.android import UiAutomator2Options
 from appium.webdriver.common.appiumby import AppiumBy
 
 capabilities = dict(
@@ -16,7 +17,7 @@ appium_server_url = 'http://localhost:4723'
 
 class TestAppium(unittest.TestCase):
     def setUp(self) -> None:
-        self.driver = webdriver.Remote(appium_server_url, capabilities)
+        self.driver = webdriver.Remote(appium_server_url, options=UiAutomator2Options().load_capabilities(capabilities))
 
     def tearDown(self) -> None:
         if self.driver:


### PR DESCRIPTION
## Proposed changes

Appium-Python-Client 3.0.0 was released on September 8. The quickstart test.py included in appium is not compatible with this new release as it uses a deprecated API which has been removed.

It is used as part of the following documentation which as it stands is out of date and results in a non-helpful error message if you try to follow the quickstart guide (AttributeError: 'NoneType' object has no attribute 'to_capabilities'):

http://appium.io/docs/en/2.1/quickstart/test-py/

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
