### PR TITLE
chore(base-driver): remove mobileRotation as no references

### DIFF
--- a/packages/base-driver/docs/mjsonwp/protocol-methods.md
+++ b/packages/base-driver/docs/mjsonwp/protocol-methods.md
@@ -116,7 +116,6 @@ POST        | `session/{sessionId}/appium/getPerformanceData`				 | returns the 
 POST        | `session/{sessionId}/appium/device/press_keycode`              | Press a particular key code on the device.
 POST        | `session/{sessionId}/appium/device/long_press_keycode`         | Press and hold a particular key code on the device.
 POST        | `session/{sessionId}/appium/device/keyevent`                   | Send a key code to the device.
-POST        | `session/{sessionId}/appium/device/rotate`                     | Rotate the device in three dimensions.
 GET         | `session/{sessionId}/appium/device/current_activity`           | Retrieve the current activity running on the device.
 GET         | `session/{sessionId}/appium/device/current_package`            | Retrieve the current package running on the device.
 POST        | `session/{sessionId}/appium/device/install_app`                | Install the given app onto the device.

--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -568,16 +568,6 @@ const METHOD_MAP = /** @type {const} */ ({
       deprecated: true,
     },
   },
-  '/session/:sessionId/appium/device/rotate': {
-    POST: {
-      command: 'mobileRotation',
-      payloadParams: {
-        required: ['x', 'y', 'radius', 'rotation', 'touchCount', 'duration'],
-        optional: ['element'],
-      },
-      deprecated: true,
-    },
-  },
   '/session/:sessionId/appium/device/current_activity': {
     GET: {command: 'getCurrentActivity', deprecated: true},
   },

--- a/packages/base-driver/test/unit/protocol/routes.spec.js
+++ b/packages/base-driver/test/unit/protocol/routes.spec.js
@@ -35,7 +35,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('484810b0');
+      hash.should.equal('6e93ad90');
     });
   });
 

--- a/packages/fake-driver/lib/commands/index.ts
+++ b/packages/fake-driver/lib/commands/index.ts
@@ -71,7 +71,6 @@ import './general';
   //rest.post('/wd/hub/session/:sessionId?/appium/device/press_keycode', controller.pressKeyCode);
   //rest.post('/wd/hub/session/:sessionId?/appium/device/long_press_keycode', controller.longPressKeyCode);
   //rest.post('/wd/hub/session/:sessionId?/appium/device/keyevent', controller.keyevent);
-  //rest.post('/wd/hub/session/:sessionId?/appium/device/rotate', controller.mobileRotation);
   //rest.get('/wd/hub/session/:sessionId?/appium/device/current_activity', controller.getCurrentActivity);
   //rest.post('/wd/hub/session/:sessionId?/appium/device/install_app', controller.installApp);
   //rest.post('/wd/hub/session/:sessionId?/appium/device/remove_app', controller.removeApp);

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -1360,29 +1360,6 @@ export interface ExternalDriver<
   keyevent?(keycode: string | number, metastate?: string | number): Promise<void>;
 
   /**
-   * Construct a rotation gesture? Unclear what this command does and it does not appear to be used
-   *
-   * @param x - the x coordinate of the rotation center
-   * @param y - the y coordinate of the rotation center
-   * @param radius - the radius of the rotation circle
-   * @param rotation - the rotation angle? idk
-   * @param touchCount - how many fingers to rotate
-   * @param elementId - if we're rotating around an element
-   *
-   * @deprecated Use setRotation instead
-   * @privateRemarks Not implemented in `appium-xcuitest-driver`
-   */
-  mobileRotation?(
-    x: number,
-    y: number,
-    radius: number,
-    rotation: number,
-    touchCount: number,
-    duration: string,
-    elementId?: string
-  ): Promise<void>;
-
-  /**
    * Get the current activity name
    *
    * @returns The activity name


### PR DESCRIPTION
## Proposed changes

https://github.com/appium/appium/issues/19378

We no longer have `mobileRotation` references in our org => https://github.com/search?q=org%3Aappium%20mobileRotation&type=code
Our extension way is via `mobile:` stuff, so it is safe to remove `appium/device/rotate` endpoint as no usages.

Device orientation is by orientation endpoint. Element rotate is by https://appium.github.io/appium-xcuitest-driver/5.8/execute-methods/#mobile-rotateelement for example

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
