### PR TITLE
fix(appium): Load plugins in the same order that was used for the CLI command

### DIFF
--- a/packages/appium/lib/extension/index.js
+++ b/packages/appium/lib/extension/index.js
@@ -38,14 +38,26 @@ export async function loadExtensions(appiumHome) {
  * @returns {PluginNameMap} Mapping of PluginClass to name
  */
 export function getActivePlugins(pluginConfig, usePlugins = []) {
+  /** @type {string[]} */
+  let filteredPluginNames = [];
+  if (usePlugins.length === 1 && usePlugins[0] === USE_ALL_PLUGINS) {
+    filteredPluginNames = _.keys(pluginConfig.installedExtensions);
+  } else {
+    // It is important to load plugins in the same order that was used while enumerating them
+    for (const pluginName of usePlugins) {
+      if (pluginName in pluginConfig.installedExtensions) {
+        filteredPluginNames.push(pluginName);
+      } else {
+        throw new Error(
+          `Could not load the plugin '${pluginName}' because it is not installed. ` +
+          `Only the following plugins are available: ${_.keys(pluginConfig.installedExtensions)}`
+        );
+      }
+    }
+  }
   return new Map(
     _.compact(
-      Object.keys(pluginConfig.installedExtensions)
-        .filter(
-          (pluginName) =>
-            _.includes(usePlugins, pluginName) ||
-            (usePlugins.length === 1 && usePlugins[0] === USE_ALL_PLUGINS)
-        )
+      filteredPluginNames
         .map((pluginName) => {
           try {
             log.info(`Attempting to load plugin ${pluginName}...`);

--- a/packages/appium/lib/extension/index.js
+++ b/packages/appium/lib/extension/index.js
@@ -47,6 +47,10 @@ export function getActivePlugins(pluginConfig, usePlugins = []) {
     for (const pluginName of usePlugins) {
       if (pluginName in pluginConfig.installedExtensions) {
         filteredPluginNames.push(pluginName);
+      } else if (pluginName === USE_ALL_PLUGINS) {
+        throw new Error(
+          `The reserved plugin name '${pluginName}' cannot be combined with other names.`
+        );
       } else {
         throw new Error(
           `Could not load the plugin '${pluginName}' because it is not installed. ` +


### PR DESCRIPTION
## Proposed changes

Addresses https://discuss.appium.io/t/how-can-you-control-order-of-how-cmds-are-handled-by-appium-when-shared-by-multiple-plugins/40769

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
