### PR TITLE
feat: add webdriver bidi support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ examples/javascript-wd
 sample-code
 **/build-fixtures/**
 packages/appium/docs/**/assets/**
+packages/appium/docs/**/js/**

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ build/
 .idea
 *DerivedData
 __pycache__
+certificate.cert
+certificate.key
 
 # csharp
 *.pyc

--- a/package-lock.json
+++ b/package-lock.json
@@ -22818,6 +22818,7 @@
         "type-fest": "4.8.3",
         "winston": "3.11.0",
         "wrap-ansi": "7.0.0",
+        "ws": "8.14.2",
         "yaml": "2.3.4"
       },
       "bin": {
@@ -22941,6 +22942,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/appium/node_modules/ws": {
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "packages/base-driver": {
@@ -28401,6 +28422,7 @@
         "type-fest": "4.8.3",
         "winston": "3.11.0",
         "wrap-ansi": "7.0.0",
+        "ws": "8.14.2",
         "yaml": "2.3.4"
       },
       "dependencies": {
@@ -28472,6 +28494,12 @@
           "version": "4.8.3",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.8.3.tgz",
           "integrity": "sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw=="
+        },
+        "ws": {
+          "version": "8.14.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+          "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+          "requires": {}
         }
       }
     },

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 import _ from 'lodash';
+import B from 'bluebird';
 import {getBuildInfo, updateBuildInfo, APPIUM_VER} from './config';
 import {
   BaseDriver,
@@ -9,6 +10,7 @@ import {
   CREATE_SESSION_COMMAND,
   DELETE_SESSION_COMMAND,
   GET_STATUS_COMMAND,
+  MAX_LOG_BODY_LENGTH,
   promoteAppiumOptions,
   promoteAppiumOptionsForObject,
 } from '@appium/base-driver';
@@ -16,7 +18,8 @@ import AsyncLock from 'async-lock';
 import {parseCapsForInnerDriver, pullSettings, makeNonW3cCapsError} from './utils';
 import {util, node, logger} from '@appium/support';
 import {getDefaultsForExtension} from './schema';
-import {DRIVER_TYPE} from './constants';
+import {DRIVER_TYPE, BIDI_BASE_PATH, BIDI_EVENT_NAME} from './constants';
+import WebSocket from 'ws';
 
 const desiredCapabilityConstraints = /** @type {const} */ ({
   automationName: {
@@ -83,6 +86,12 @@ class AppiumDriver extends DriverCore {
   /** @type {AppiumServer} */
   server;
 
+  /** @type {Record<string, import('ws').WebSocket[]>} */
+  bidiSockets;
+
+  /** @type {Record<string, import('ws').WebSocket>} */
+  bidiProxyClients;
+
   /**
    * @type {AppiumDriverConstraints}
    * @readonly
@@ -113,6 +122,8 @@ class AppiumDriver extends DriverCore {
     this.pluginClasses = new Map();
     this.sessionPlugins = {};
     this.sessionlessPlugins = [];
+    this.bidiSockets = {};
+    this.bidiProxyClients = {};
     this.desiredCapConstraints = desiredCapabilityConstraints;
     this._isShuttingDown = false;
 
@@ -239,6 +250,337 @@ class AppiumDriver extends DriverCore {
         return cliArgs;
       }
     }
+  }
+
+  /**
+   * Initialize a new bidi connection and set up handlers
+   * @param {import('ws').WebSocket} ws The websocket connection object
+   * @param {import('http').IncomingMessage} req The connection pathname, which might include the session id
+   */
+  onBidiConnection(ws, req) {
+    // TODO put bidi-related functionality into a mixin/helper class
+    // wrap all of the handler logic with exception handling so if something blows up we can log
+    // and close the websocket
+    try {
+      const {bidiHandlerDriver, proxyClient, send, sendToProxy, logSocketErr} = this.initBidiSocket(
+        ws,
+        req,
+      );
+
+      this.initBidiSocketHandlers(
+        ws,
+        proxyClient,
+        send,
+        sendToProxy,
+        bidiHandlerDriver,
+        logSocketErr,
+      );
+      this.initBidiProxyHandlers(proxyClient, ws, send);
+      this.initBidiEventListeners(ws, bidiHandlerDriver, send);
+    } catch (err) {
+      this.log.error(err);
+      try {
+        ws.close();
+      } catch (ign) {}
+    }
+  }
+
+  /**
+   * Initialize a new bidi connection
+   * @param {import('ws').WebSocket} ws The websocket connection object
+   * @param {import('http').IncomingMessage} req The connection pathname, which might include the session id
+   */
+  initBidiSocket(ws, req) {
+    let outOfBandErrorPrefix = '';
+    const pathname = req.url;
+    if (!pathname) {
+      throw new Error('Invalid connection request: pathname missing from request');
+    }
+    const bidiSessionRe = new RegExp(`${BIDI_BASE_PATH}/([^/]+)$`);
+    const bidiNoSessionRe = new RegExp(`${BIDI_BASE_PATH}/?$`);
+    const sessionMatch = bidiSessionRe.exec(pathname);
+    const noSessionMatch = bidiNoSessionRe.exec(pathname);
+
+    if (!sessionMatch && !noSessionMatch) {
+      throw new Error(
+        `Got websocket connection for path ${pathname} but didn't know what to do with it. ` +
+          `Ignoring and will close the connection`,
+      );
+    }
+
+    // Let's figure out which driver is going to handle this socket connection. It's either going
+    // to be a driver matching a session id appended to the bidi base path, or this umbrella driver
+    // (if no session id is included in the bidi connection request)
+
+    /** @type {import('@appium/types').ExternalDriver | AppiumDriver} */
+    let bidiHandlerDriver;
+
+    /** @type {import('ws').WebSocket | null} */
+    let proxyClient = null;
+
+    if (sessionMatch) {
+      // If we found a session id, see if it matches an active session
+      const sessionId = sessionMatch[1];
+      bidiHandlerDriver = this.sessions[sessionId];
+      if (!bidiHandlerDriver) {
+        // The session ID sent in doesn't match an active session; just ignore this socket
+        // connection in that case
+        throw new Error(
+          `Got bidi connection request for session with id ${sessionId} which is closed ` +
+            `or does not exist. Closing the socket connection.`,
+        );
+      }
+      const driverName = bidiHandlerDriver.constructor.name;
+      outOfBandErrorPrefix = `[session ${sessionId}] `;
+      this.log.info(`Bidi websocket connection made for session ${sessionId}`);
+      // store this socket connection for later removal on session deletion. theoretically there
+      // can be multiple sockets per session
+      if (!this.bidiSockets[sessionId]) {
+        this.bidiSockets[sessionId] = [];
+      }
+      this.bidiSockets[sessionId].push(ws);
+
+      const bidiProxyUrl = bidiHandlerDriver.bidiProxyUrl;
+      if (bidiProxyUrl) {
+        try {
+          new URL(bidiProxyUrl);
+        } catch (ign) {
+          throw new Error(
+            `Got request for ${driverName} to proxy bidi connections to upstream socket with ` +
+              `url ${bidiProxyUrl}, but this was not a valid url`,
+          );
+        }
+        this.log.info(`Bidi connection for ${driverName} will be proxied to ${bidiProxyUrl}`);
+        proxyClient = new WebSocket(bidiProxyUrl);
+        this.bidiProxyClients[sessionId] = proxyClient;
+      }
+    } else {
+      this.log.info('Bidi websocket connection made to main server');
+      // no need to store the socket connection if it's to the main server since it will just
+      // stay open as long as the server itself is and will close when the server closes.
+      bidiHandlerDriver = this; // eslint-disable-line @typescript-eslint/no-this-alias
+    }
+
+    const logSocketErr = (/** @type {Error} */ err) =>
+      this.log.error(`${outOfBandErrorPrefix}${err}`);
+
+    // This is a function which wraps the 'send' method on a web socket for two reasons:
+    // 1. Make it async-await friendly
+    // 2. Do some logging if there's a send error
+    const sendFactory = (/** @type {import('ws').WebSocket} */ socket) => {
+      const socketSend = B.promisify(socket.send, {context: socket});
+      return async (/** @type {string|Buffer} */ data) => {
+        try {
+          await socketSend(data);
+        } catch (err) {
+          logSocketErr(err);
+        }
+      };
+    };
+
+    // Construct our send method for sending messages to the client
+    const send = sendFactory(ws);
+
+    // Construct a conditional send method for proxying messages from the client to an upstream
+    // bidi socket server (e.g. on a browser)
+    const sendToProxy = proxyClient ? sendFactory(proxyClient) : null;
+
+    return {bidiHandlerDriver, proxyClient, send, sendToProxy, logSocketErr};
+  }
+
+  /**
+   * Set up handlers on upstream bidi socket we are proxying to/from
+   *
+   * @param {import('ws').WebSocket | null} proxyClient - the websocket connection to/from the
+   * upstream socket (the one we're proxying to/from)
+   * @param {import('ws').WebSocket} ws - the websocket connection to/from the client
+   * @param {(data: string | Buffer) => Promise<void>} send - a method used to send data to the
+   * client
+   */
+  initBidiProxyHandlers(proxyClient, ws, send) {
+    // Set up handlers for events that might come from the upstream bidi socket connection if
+    // we're in proxy mode
+    if (proxyClient) {
+      // Here we're receiving a message from the upstream socket server. We want to pass it on to
+      // the client
+      proxyClient.on('message', async (/** @type {Buffer|string} */ data) => {
+        const logData = _.truncate(data.toString('utf8'), {length: MAX_LOG_BODY_LENGTH});
+        this.log.debug(
+          `<-- BIDI Received data from proxied bidi socket, sending to client. Data: ${logData}`,
+        );
+        await send(data);
+      });
+
+      // If the upstream socket server closes the connection, should close the connection to the
+      // client as well
+      proxyClient.on('close', (code, reason) => {
+        this.log.debug(
+          `Upstream bidi socket closed connection (code ${code}, reason: '${reason}'). ` +
+            `Closing proxy connection to client`,
+        );
+        ws.close(code, reason);
+      });
+
+      proxyClient.on('error', (err) => {
+        this.log.error(`Got error on upstream bidi socket connection: ${err}`);
+      });
+    }
+  }
+
+  /**
+   * Set up handlers on the bidi socket connection to the client
+   *
+   * @param {import('ws').WebSocket} ws - the websocket connection to/from the client
+   * @param {import('ws').WebSocket | null} proxyClient - the websocket connection to/from the
+   * upstream socket (the one we're proxying to/from, if we're proxying)
+   * @param {(data: string | Buffer) => Promise<void>} send - a method used to send data to the
+   * client
+   * @param {((data: string | Buffer) => Promise<void>) | null} sendToProxy - a method used to send data to the
+   * upstream socket
+   * @param {import('@appium/types').ExternalDriver | AppiumDriver} bidiHandlerDriver - the driver
+   * handling the bidi commands
+   * @param {(err: Error) => void} logSocketErr - a special prefixed logger
+   */
+  initBidiSocketHandlers(ws, proxyClient, send, sendToProxy, bidiHandlerDriver, logSocketErr) {
+    ws.on('error', (err) => {
+      // Can't do much with random errors on the connection other than log them
+      logSocketErr(err);
+    });
+
+    ws.on('open', () => {
+      this.log.info('Bidi websocket connection is now open');
+    });
+
+    // Now set up handlers for the various events that might happen on the websocket connection
+    // coming from the client
+    // First is incoming messages from the client
+    ws.on('message', async (/** @type {Buffer} */ data) => {
+      if (proxyClient) {
+        const logData = _.truncate(data.toString('utf8'), {length: MAX_LOG_BODY_LENGTH});
+        this.log.debug(
+          `--> BIDI Received data from client, sending to upstream bidi socket. Data: ${logData}`,
+        );
+        // if we're meant to proxy to an upstream bidi socket, just do that
+        // @ts-ignore sendToProxy is never null if proxyClient is truthy, but ts doesn't know
+        // that
+        await sendToProxy(data.toString('utf8'));
+      } else {
+        const res = await this.onBidiMessage(data, bidiHandlerDriver);
+        await send(JSON.stringify(res));
+      }
+    });
+
+    // Next consider if the client closes the socket connection on us
+    ws.on('close', (code, reason) => {
+      // Not sure if we need to do anything here if the client closes the websocket connection.
+      // Probably if a session was started via the socket, and the socket closes, we should end the
+      // associated session to free up resources. But otherwise, for sockets attached to existing
+      // sessions, doing nothing is probably right.
+      this.log.debug(`Bidi socket connection closed (code ${code}, reason: '${reason}')`);
+
+      // If we're proxying, might as well close the upstream connection and clean it up
+      if (proxyClient) {
+        this.log.debug('Also closing bidi proxy socket connection');
+        proxyClient.close(code, reason);
+      }
+    });
+  }
+
+  /**
+   * Set up bidi event listeners
+   *
+   * @param {import('ws').WebSocket} ws - the websocket connection to/from the client
+   * @param {import('@appium/types').ExternalDriver | AppiumDriver} bidiHandlerDriver - the driver
+   * handling the bidi commands
+   * @param {(data: string | Buffer) => Promise<void>} send - a method used to send data to the
+   * client
+   */
+  initBidiEventListeners(ws, bidiHandlerDriver, send) {
+    // If the driver emits a bidi event that should maybe get sent to the client, check to make
+    // sure the client is subscribed and then pass it on
+    let eventListener = async ({context, method, params}) => {
+      // if the driver didn't specify a context, use the empty context
+      if (!context) {
+        context = '';
+      }
+      if (!method || !params) {
+        throw new Error(
+          `Driver emitted a bidi event that was malformed. Require method and params keys ` +
+            `(with optional context). But instead received: ${JSON.stringify({
+              context,
+              method,
+              params,
+            })}`,
+        );
+      }
+      if (ws.readyState !== WebSocket.OPEN) {
+        // if the websocket is not still 'open', then we can ignore sending these events
+        if (ws.readyState > WebSocket.OPEN) {
+          // if the websocket is closed or closing, we can remove this listener as well to avoid
+          // leaks
+          bidiHandlerDriver.eventEmitter.removeListener(BIDI_EVENT_NAME, eventListener);
+        }
+        return;
+      }
+
+      if (bidiHandlerDriver.bidiEventSubs[method]?.includes(context)) {
+        this.log.info(
+          `<-- BIDI EVENT ${method} (context: '${context}', params: ${JSON.stringify(params)})`,
+        );
+        // now we can send the event onto the socket
+        const ev = {type: 'event', context, method, params};
+        await send(JSON.stringify(ev));
+      }
+    };
+    bidiHandlerDriver.eventEmitter.on(BIDI_EVENT_NAME, eventListener);
+  }
+
+  /**
+   * @param {Buffer} data
+   * @param {ExternalDriver | AppiumDriver} driver
+   */
+  async onBidiMessage(data, driver) {
+    let resMessage, id, method, params;
+    const dataTruncated = _.truncate(data.toString(), {length: 100});
+    try {
+      try {
+        ({id, method, params} = JSON.parse(data.toString('utf8')));
+      } catch (err) {
+        throw new errors.InvalidArgumentError(
+          `Could not parse Bidi command '${dataTruncated}': ${err.message}`,
+        );
+      }
+      driver.log.info(`--> BIDI message #${id}`);
+      if (!method) {
+        throw new errors.InvalidArgumentError(
+          `Missing method for BiDi operation in '${dataTruncated}'`,
+        );
+      }
+      if (!params) {
+        throw new errors.InvalidArgumentError(
+          `Missing params for BiDi operation in '${dataTruncated}`,
+        );
+      }
+      const result = await driver.executeBidiCommand(method, params);
+      // https://w3c.github.io/webdriver-bidi/#protocol-definition
+      resMessage = {
+        id,
+        type: 'success',
+        result,
+      };
+    } catch (err) {
+      resMessage = err.bidiErrObject(id);
+    }
+    driver.log.info(`<-- BIDI message #${id}`);
+    return resMessage;
+  }
+
+  /**
+   * Log a bidi server error
+   * @param {Error} err
+   */
+  onBidiServerError(err) {
+    this.log.error(`Error from bidi websocket server: ${err}`);
   }
 
   /**
@@ -410,6 +752,21 @@ class AppiumDriver extends DriverCore {
         );
         await driverInstance.updateSettings(jwpSettings);
       }
+
+      // if the user has asked for bidi support, and the driver says that it supports bidi,
+      // send our bidi url back to the user. The inner driver will need to have already saved any
+      // internal bidi urls it might want to proxy to, cause we are going to overwrite that
+      // information here!
+      if (dCaps.webSocketUrl && driverInstance.doesSupportBidi) {
+        const {address, port, basePath} = this.args;
+        const isUsingSsl = this.args.sslCertificatePath && this.args.sslKeyPath;
+        const scheme = isUsingSsl ? 'wss' : 'ws';
+        const bidiUrl = `${scheme}://${address}:${port}${basePath}${BIDI_BASE_PATH}/${innerSessionId}`;
+        // @ts-ignore webSocketUrl gets sent by the client as a boolean, but then it is supposed
+        // to come back from the server as a string. TODO figure out how to express this in our
+        // capability constraint system
+        dCaps.webSocketUrl = bidiUrl;
+      }
     } catch (error) {
       return {
         protocol,
@@ -515,6 +872,9 @@ class AppiumDriver extends DriverCore {
         // be in otherwise
         delete this.sessions[sessionId];
         delete this.sessionPlugins[sessionId];
+
+        this.cleanupBidiSockets(sessionId);
+
         return dstSession;
       });
       // this may not be correct, but if `dstSession` was falsy, the call to `deleteSession()` would
@@ -532,6 +892,32 @@ class AppiumDriver extends DriverCore {
         protocol,
         error: e,
       };
+    }
+  }
+
+  /**
+   * @param {string} sessionId
+   */
+  cleanupBidiSockets(sessionId) {
+    // clean up any bidi sockets associated with session
+    if (this.bidiSockets[sessionId]) {
+      try {
+        this.log.debug(`Closing bidi socket(s) associated with session ${sessionId}`);
+        for (const ws of this.bidiSockets[sessionId]) {
+          // 1001 means server is going away
+          ws.close(1001, 'Appium session is closing');
+        }
+      } catch {}
+      delete this.bidiSockets[sessionId];
+      const proxyClient = this.bidiProxyClients[sessionId];
+      if (proxyClient) {
+        this.log.debug(`Also closing proxy connection to upstream bidi server`);
+        try {
+          // 1000 means normal closure, which seems correct when Appium is acting as the client
+          proxyClient.close(1000);
+        } catch {}
+        delete this.bidiProxyClients[sessionId];
+      }
     }
   }
 

--- a/packages/appium/lib/constants.js
+++ b/packages/appium/lib/constants.js
@@ -78,3 +78,14 @@ export const CURRENT_SCHEMA_REV = 4;
  * memory usage, perf, and/or log output, and higher limits may be difficult to scan.
  */
 export const LONG_STACKTRACE_LIMIT = 100;
+
+/**
+ * Where should the bidi websocket handler live on the server?
+ */
+export const BIDI_BASE_PATH = '/bidi';
+
+/**
+ * The name of the event for drivers to emit when they want to send bidi events to a client over
+ * a bidi socket
+ */
+export const BIDI_EVENT_NAME = 'bidiEvent';

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -94,6 +94,7 @@
     "type-fest": "4.8.3",
     "winston": "3.11.0",
     "wrap-ansi": "7.0.0",
+    "ws": "8.14.2",
     "yaml": "2.3.4"
   },
   "engines": {

--- a/packages/base-driver/lib/basedriver/commands/bidi.ts
+++ b/packages/base-driver/lib/basedriver/commands/bidi.ts
@@ -1,0 +1,37 @@
+import type {Constraints, Driver, IBidiCommands} from '@appium/types';
+import type {BaseDriver} from '../driver';
+import {mixin} from './mixin';
+
+declare module '../driver' {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface BaseDriver<C extends Constraints> extends IBidiCommands {}
+}
+
+const BidiCommands: IBidiCommands = {
+  async bidiSubscribe<C extends Constraints>(
+    this: BaseDriver<C>,
+    events: string[],
+    contexts: string[] = [''],
+  ) {
+    for (const event of events) {
+      this.bidiEventSubs[event] = contexts;
+    }
+  },
+
+  async bidiUnsubscribe<C extends Constraints>(
+    this: BaseDriver<C>,
+    events: string[],
+    contexts: string[] = [''],
+  ) {
+    for (const event of events) {
+      if (this.bidiEventSubs[event]) {
+        this.bidiEventSubs[event] = this.bidiEventSubs[event].filter((c) => !contexts.includes(c));
+      }
+      if (this.bidiEventSubs[event].length === 0) {
+        delete this.bidiEventSubs[event];
+      }
+    }
+  },
+};
+
+mixin(BidiCommands);

--- a/packages/base-driver/lib/basedriver/commands/index.ts
+++ b/packages/base-driver/lib/basedriver/commands/index.ts
@@ -3,3 +3,4 @@ import './find';
 import './log';
 import './timeout';
 import './execute';
+import './bidi';

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -14,15 +14,17 @@ import type {
   Protocol,
   RouteMatcher,
   StringRecord,
+  BidiMethodDef,
 } from '@appium/types';
 import AsyncLock from 'async-lock';
 import _ from 'lodash';
 import {EventEmitter} from 'node:events';
 import os from 'node:os';
-import {DEFAULT_BASE_PATH, PROTOCOLS} from '../constants';
+import {DEFAULT_BASE_PATH, PROTOCOLS, MAX_LOG_BODY_LENGTH} from '../constants';
 import {errors} from '../protocol';
 import DeviceSettings from './device-settings';
 import helpers, {BASEDRIVER_VER} from './helpers';
+import {BIDI_COMMANDS} from '../protocol/bidi-commands';
 
 const NEW_COMMAND_TIMEOUT_MS = 60 * 1000;
 
@@ -99,6 +101,10 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
 
   protocol?: Protocol;
 
+  bidiEventSubs: Record<string, string[]>;
+
+  doesSupportBidi: boolean;
+
   constructor(opts: InitialOpts = <InitialOpts>{}, shouldValidateCaps = true) {
     this._log = logger.getLogger(helpers.generateDriverLogPrefix(this as Core<C>));
 
@@ -132,6 +138,8 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
     this.shutdownUnexpectedly = false;
     this.commandsQueueGuard = new AsyncLock();
     this.settings = new DeviceSettings();
+    this.bidiEventSubs = {};
+    this.doesSupportBidi = false;
   }
 
   get log() {
@@ -293,7 +301,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
         `Potentially insecure feature '${name}' has not been ` +
           `enabled. If you want to enable this feature and accept ` +
           `the security ramifications, please do so by following ` +
-          `the documented instructions at http://appium.io/docs/en/2.0/guides/security/`
+          `the documented instructions at http://appium.io/docs/en/2.0/guides/security/`,
       );
     }
   }
@@ -308,9 +316,21 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
 
     if (!_.includes(validStrategies, strategy)) {
       throw new errors.InvalidSelectorError(
-        `Locator Strategy '${strategy}' is not supported for this session`
+        `Locator Strategy '${strategy}' is not supported for this session`,
       );
     }
+  }
+
+  /**
+   * If this driver has requested proxying of bidi connections to an upstream bidi endpoint, this
+   * method should be overridden to return the URL of that websocket, to indicate that bidi
+   * proxying is enabled. Otherwise, a null return will indicate that bidi proxying should not be
+   * active and bidi commands will be handled by this driver.
+   *
+   * @returns {string | null}
+   */
+  get bidiProxyUrl(): string | null {
+    return null;
   }
 
   proxyActive(sessionId: string): boolean {
@@ -375,5 +395,61 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
       clearTimeout(this.noCommandTimer);
       this.noCommandTimer = null;
     }
+  }
+
+  async executeBidiCommand(bidiCmd: string, bidiParams: StringRecord): Promise<any> {
+    const [moduleName, methodName] = bidiCmd.split('.');
+
+    // if we don't get a valid format for bidi command name, reject
+    if (!moduleName || !methodName) {
+      throw new errors.UnknownCommandError(
+        `Did not receive a valid BiDi module and method name ` +
+          `of the form moduleName.methodName. Instead received ` +
+          `'${moduleName}.${methodName}'`,
+      );
+    }
+
+    // if the command module isn't part of our spec, reject
+    if (!BIDI_COMMANDS[moduleName]) {
+      throw new errors.UnknownCommandError();
+    }
+
+    const {command, params} = BIDI_COMMANDS[moduleName][methodName] as BidiMethodDef;
+    // if the command method isn't part of our spec, also reject
+    if (!command) {
+      throw new errors.UnknownCommandError();
+    }
+
+    // If the driver doesn't have this command, it must not be implemented
+    if (!this[command]) {
+      throw new errors.NotYetImplementedError();
+    }
+
+    // TODO improve param parsing and error messages along the lines of what we have in the http
+    // handlers
+    const args: any[] = [];
+    if (params?.required?.length) {
+      for (const requiredParam of params.required) {
+        if (_.isUndefined(bidiParams[requiredParam])) {
+          throw new errors.InvalidArgumentError(
+            `The ${requiredParam} parameter was required but you omitted it`,
+          );
+        }
+        args.push(bidiParams[requiredParam]);
+      }
+    }
+    if (params?.optional?.length) {
+      for (const optionalParam of params.optional) {
+        args.push(bidiParams[optionalParam]);
+      }
+    }
+    const logParams = _.truncate(JSON.stringify(bidiParams), {length: MAX_LOG_BODY_LENGTH});
+    this.log.debug(
+      `Executing bidi command '${bidiCmd}' with params ${logParams} by passing to driver ` +
+        `method '${command}'`,
+    );
+    const res = (await this[command](...args)) ?? null;
+    this.log.debug(`Responding to bidi command '${bidiCmd}' with ${JSON.stringify(res)}`);
+    return res;
   }
 }

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -37,7 +37,7 @@ export class BaseDriver<
     Settings extends StringRecord = StringRecord,
     CreateResult = DefaultCreateSessionResult<C>,
     DeleteResult = DefaultDeleteSessionResult,
-    SessionData extends StringRecord = StringRecord
+    SessionData extends StringRecord = StringRecord,
   >
   extends DriverCore<C, Settings>
   implements Driver<C, CArgs, Settings, CreateResult, DeleteResult, SessionData>
@@ -55,7 +55,6 @@ export class BaseDriver<
     super(opts, shouldValidateCaps);
 
     this.caps = {} as DriverCaps<C>;
-
     this.cliArgs = {} as CArgs & ServerArgs;
   }
 
@@ -114,7 +113,7 @@ export class BaseDriver<
           // This is needed to prevent memory leaks
           this.eventEmitter.removeListener(
             ON_UNEXPECTED_SHUTDOWN_EVENT,
-            unexpectedShutdownListener
+            unexpectedShutdownListener,
           );
           unexpectedShutdownListener = null;
         }
@@ -147,7 +146,7 @@ export class BaseDriver<
   }
 
   async startUnexpectedShutdown(
-    err: Error = new errors.NoSuchDriverError('The driver was unexpectedly shut down!')
+    err: Error = new errors.NoSuchDriverError('The driver was unexpectedly shut down!'),
   ) {
     this.eventEmitter.emit(ON_UNEXPECTED_SHUTDOWN_EVENT, err); // allow others to listen for this
     this.shutdownUnexpectedly = true;
@@ -170,7 +169,7 @@ export class BaseDriver<
     this.noCommandTimer = setTimeout(async () => {
       this.log.warn(
         `Shutting down because we waited ` +
-          `${this.newCommandTimeoutMs / 1000.0} seconds for a command`
+          `${this.newCommandTimeoutMs / 1000.0} seconds for a command`,
       );
       const errorMessage =
         `New Command Timeout of ` +
@@ -234,23 +233,23 @@ export class BaseDriver<
     w3cCapabilities2?: W3CDriverCaps<C>,
     w3cCapabilities?: W3CDriverCaps<C>,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    driverData?: DriverData[]
+    driverData?: DriverData[],
   ): Promise<CreateResult> {
     if (this.sessionId !== null) {
       throw new errors.SessionNotCreatedError(
-        'Cannot create a new session while one is in progress'
+        'Cannot create a new session while one is in progress',
       );
     }
 
     this.log.debug();
 
     const originalCaps = _.cloneDeep(
-      [w3cCapabilities, w3cCapabilities1, w3cCapabilities2].find(isW3cCaps)
+      [w3cCapabilities, w3cCapabilities1, w3cCapabilities2].find(isW3cCaps),
     );
     if (!originalCaps) {
       throw new errors.SessionNotCreatedError(
         'Appium only supports W3C-style capability objects. ' +
-          'Your client is sending an older capabilities format. Please update your client library.'
+          'Your client is sending an older capabilities format. Please update your client library.',
       );
     }
 
@@ -258,7 +257,7 @@ export class BaseDriver<
 
     this.originalCaps = originalCaps;
     this.log.debug(
-      `Creating session with W3C capabilities: ${JSON.stringify(originalCaps, null, 2)}`
+      `Creating session with W3C capabilities: ${JSON.stringify(originalCaps, null, 2)}`,
     );
 
     let caps: DriverCaps<C>;
@@ -266,7 +265,7 @@ export class BaseDriver<
       caps = processCapabilities(
         originalCaps,
         this._desiredCapConstraints,
-        this.shouldValidateCaps
+        this.shouldValidateCaps,
       ) as DriverCaps<C>;
       caps = fixCaps(caps, this._desiredCapConstraints, this.log) as DriverCaps<C>;
     } catch (e) {
@@ -287,7 +286,7 @@ export class BaseDriver<
       throw new Error(
         "The 'noReset' and 'fullReset' capabilities are mutually " +
           'exclusive and should not both be set to true. You ' +
-          "probably meant to just use 'fullReset' on its own"
+          "probably meant to just use 'fullReset' on its own",
       );
     }
     if (this.opts.noReset === true) {
@@ -354,9 +353,7 @@ export class BaseDriver<
   logExtraCaps(caps: Capabilities<C>) {
     const extraCaps = _.difference(_.keys(caps), _.keys(this._desiredCapConstraints));
     if (extraCaps.length) {
-      this.log.warn(
-        `The following provided capabilities were not recognized by this driver:`
-      );
+      this.log.warn(`The following provided capabilities were not recognized by this driver:`);
       for (const cap of extraCaps) {
         this.log.warn(`  ${cap}`);
       }
@@ -374,8 +371,8 @@ export class BaseDriver<
       this.log.errorAndThrow(
         new errors.SessionNotCreatedError(
           `The desiredCapabilities object was not valid for the ` +
-            `following reason(s): ${e.message}`
-        )
+            `following reason(s): ${e.message}`,
+        ),
       );
     }
 

--- a/packages/base-driver/lib/index.js
+++ b/packages/base-driver/lib/index.js
@@ -1,8 +1,13 @@
 import B from 'bluebird';
 
-B.config({
-  cancellation: true,
-});
+try {
+  B.config({
+    cancellation: true,
+  });
+} catch (ign) {
+  // sometimes during testing this somehow gets required twice and results in an error about
+  // cancellation not being able to be enabled after promise has been configured
+}
 
 // BaseDriver exports
 import {BaseDriver} from './basedriver/driver';

--- a/packages/base-driver/lib/index.js
+++ b/packages/base-driver/lib/index.js
@@ -11,11 +11,11 @@ export {DeviceSettings} from './basedriver/device-settings';
 
 export {BaseDriver};
 export default BaseDriver;
+export {MAX_LOG_BODY_LENGTH, DEFAULT_BASE_PATH, PROTOCOLS, W3C_ELEMENT_KEY} from './constants';
 
 // MJSONWP exports
 export * from './protocol';
 export {errorFromMJSONWPStatusCode as errorFromCode} from './protocol';
-export {DEFAULT_BASE_PATH, PROTOCOLS, W3C_ELEMENT_KEY} from './constants';
 
 // Express exports
 export {STATIC_DIR} from './express/static';

--- a/packages/base-driver/lib/protocol/bidi-commands.js
+++ b/packages/base-driver/lib/protocol/bidi-commands.js
@@ -1,0 +1,31 @@
+const SUBSCRIPTION_REQUEST_PARAMS = /** @type {const} */ ({
+  required: ['events'],
+  optional: ['contexts'],
+});
+
+const BIDI_COMMANDS = /** @type {const} */ ({
+  session: {
+    subscribe: {
+      command: 'bidiSubscribe',
+      params: SUBSCRIPTION_REQUEST_PARAMS,
+    },
+    unsubscribe: {
+      command: 'bidiUnsubscribe',
+      params: SUBSCRIPTION_REQUEST_PARAMS,
+    },
+  },
+  browsingContext: {
+    navigate: {
+      command: 'bidiNavigate',
+      params: {
+        required: ['context', 'url'],
+        optional: ['wait'],
+      },
+    },
+  },
+});
+
+// TODO add definitions for all bidi commands.
+// spec link: https://w3c.github.io/webdriver-bidi/
+
+export {BIDI_COMMANDS};

--- a/packages/base-driver/lib/protocol/errors.js
+++ b/packages/base-driver/lib/protocol/errors.js
@@ -28,6 +28,27 @@ export class ProtocolError extends ES6Error {
   set stacktrace(value) {
     this._stacktrace = value;
   }
+
+  /**
+   * Get the Bidi protocol version of an error
+   * @param {string|number} id - the id used in the request for which this error forms the response
+   * @see https://w3c.github.io/webdriver-bidi/#protocol-definition
+   * @returns The object conforming to the shape of a BiDi error response
+   */
+  bidiErrObject(id) {
+    // if we don't have an id, the client didn't send one, so we have nothing to send back.
+    // send back an empty string rather than making something up
+    if (_.isNil(id)) {
+      id = '';
+    }
+    return {
+      id,
+      type: 'error',
+      error: this.error,
+      stacktrace: this.stacktrace,
+      message: this.message,
+    };
+  }
 }
 
 // https://github.com/SeleniumHQ/selenium/blob/176b4a9e3082ac1926f2a436eb346760c37a5998/java/client/src/org/openqa/selenium/remote/ErrorCodes.java#L215

--- a/packages/fake-driver/lib/commands/general.ts
+++ b/packages/fake-driver/lib/commands/general.ts
@@ -23,6 +23,9 @@ interface FakeDriverGeneralMixin {
   execute(script: string, args: any[]): Promise<any>;
   fakeAddition(a: number, b: number, c?: number): Promise<number>;
   getLog(type: string): Promise<any>;
+  getUrl(): Promise<string>;
+
+  bidiNavigate(context: string, url: string): Promise<void>;
 }
 
 declare module '../driver' {
@@ -110,6 +113,14 @@ const GeneralMixin: FakeDriverGeneralMixin = {
    */
   async fakeAddition(this: FakeDriver, num1: number, num2: number, num3 = 0) {
     return num1 + num2 + (num3 ?? 0);
+  },
+
+  async getUrl() {
+    return this.url;
+  },
+
+  async bidiNavigate(context: string, url: string) {
+    this.url = url;
   },
 };
 

--- a/packages/types/lib/command.ts
+++ b/packages/types/lib/command.ts
@@ -137,3 +137,15 @@ export type ExecuteMethodMap<T extends Plugin | Driver> = T extends Plugin
   : T extends Driver
   ? Readonly<StringRecord<DriverExecuteMethodDef<T>>>
   : never;
+
+export interface BidiMethodDef extends BaseExecuteMethodDef {
+  command: string;
+}
+
+export interface BidiMethodMap {
+  [k: string]: BidiMethodDef;
+}
+
+export interface BidiModuleMap {
+  [k: string]: BidiMethodMap;
+}

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -32,7 +32,7 @@ export interface ITimeoutCommands {
     ms: number | string,
     script?: number,
     pageLoad?: number,
-    implicit?: number | string
+    implicit?: number | string,
   ): Promise<void>;
 
   /**
@@ -169,10 +169,10 @@ export interface IExecuteCommands {
    */
   executeMethod<
     TArgs extends readonly any[] | readonly [StringRecord<unknown>] = unknown[],
-    TReturn = unknown
+    TReturn = unknown,
   >(
     script: string,
-    args: TArgs
+    args: TArgs,
   ): Promise<TReturn>;
 }
 
@@ -190,7 +190,7 @@ export interface MultiSessionData<C extends Constraints = Constraints> {
  */
 export type SingularSessionData<
   C extends Constraints = Constraints,
-  T extends StringRecord = StringRecord
+  T extends StringRecord = StringRecord,
 > = DriverCaps<C> & {
   events?: EventHistory;
   error?: string;
@@ -248,7 +248,7 @@ export interface IFindCommands {
   findElementsFromElement(
     strategy: string,
     selector: string,
-    elementId: string
+    elementId: string,
   ): Promise<Element[]>;
 
   /**
@@ -263,7 +263,7 @@ export interface IFindCommands {
   findElementFromShadowRoot?(
     strategy: string,
     selector: string,
-    shadowId: string
+    shadowId: string,
   ): Promise<Element>;
 
   /**
@@ -278,7 +278,7 @@ export interface IFindCommands {
   findElementsFromShadowRoot?(
     strategy: string,
     selector: string,
-    shadowId: string
+    shadowId: string,
   ): Promise<Element[]>;
 
   /**
@@ -309,13 +309,13 @@ export interface IFindCommands {
     strategy: string,
     selector: string,
     mult: true,
-    context?: any
+    context?: any,
   ): Promise<Element[]>;
   findElOrElsWithProcessing(
     strategy: string,
     selector: string,
     mult: false,
-    context?: any
+    context?: any,
   ): Promise<Element>;
 
   /**
@@ -344,6 +344,11 @@ export interface ILogCommands {
    * @param logType - Name/key of log type as defined in {@linkcode ILogCommands.supportedLogTypes}.
    */
   getLog(logType: string): Promise<any>;
+}
+
+export interface IBidiCommands {
+  bidiSubscribe(events: string[], contexts: string[]): Promise<void>;
+  bidiUnsubscribe(events: string[], contexts: string[]): Promise<void>;
 }
 
 /**
@@ -393,7 +398,7 @@ export interface ISettingsCommands<T extends object = object> {
  */
 export type DefaultCreateSessionResult<C extends Constraints> = [
   sessionId: string,
-  capabilities: DriverCaps<C>
+  capabilities: DriverCaps<C>,
 ];
 
 /**
@@ -408,7 +413,7 @@ export interface ISessionHandler<
   C extends Constraints = Constraints,
   CreateResult = DefaultCreateSessionResult<C>,
   DeleteResult = DefaultDeleteSessionResult,
-  SessionData extends StringRecord = StringRecord
+  SessionData extends StringRecord = StringRecord,
 > {
   /**
    * Start a new automation session
@@ -431,7 +436,7 @@ export interface ISessionHandler<
     w3cCaps1: W3CDriverCaps<C>,
     w3cCaps2?: W3CDriverCaps<C>,
     w3cCaps3?: W3CDriverCaps<C>,
-    driverData?: DriverData[]
+    driverData?: DriverData[],
   ): Promise<CreateResult>;
 
   /**
@@ -485,7 +490,7 @@ export type Constraints = {
 export interface DriverHelpers {
   configureApp: (
     app: string,
-    supportedAppExtensions?: string | string[] | ConfigureAppOptions
+    supportedAppExtensions?: string | string[] | ConfigureAppOptions,
   ) => Promise<string>;
   isPackageOrBundle: (app: string) => boolean;
   duplicateKeys: <T>(input: T, firstKey: string, secondKey: string) => T;
@@ -496,7 +501,7 @@ export interface DriverHelpers {
 export type SettingsUpdateListener<T extends Record<string, unknown> = Record<string, unknown>> = (
   prop: keyof T,
   newValue: unknown,
-  curValue: unknown
+  curValue: unknown,
 ) => Promise<void>;
 
 // WebDriver
@@ -596,6 +601,8 @@ export interface Core<C extends Constraints, Settings extends StringRecord = Str
   driverData: DriverData;
   isCommandsQueueEnabled: boolean;
   eventHistory: EventHistory;
+  bidiEventSubs: Record<string, string[]>;
+  doesSupportBidi: boolean;
   onUnexpectedShutdown(handler: () => any): void;
   /**
    * @summary Retrieve the server's current status.
@@ -636,6 +643,7 @@ export interface Core<C extends Constraints, Settings extends StringRecord = Str
   assertFeatureEnabled(name: string): void;
   validateLocatorStrategy(strategy: string, webContext?: boolean): void;
   proxyActive(sessionId?: string): boolean;
+  get bidiProxyUrl(): string | null;
   getProxyAvoidList(sessionId?: string): RouteMatcher[];
   canProxy(sessionId?: string): boolean;
   proxyRouteIsAvoided(sessionId: string, method: string, url: string, body?: any): boolean;
@@ -660,7 +668,7 @@ export interface Driver<
   Settings extends StringRecord = StringRecord,
   CreateResult = DefaultCreateSessionResult<C>,
   DeleteResult = DefaultDeleteSessionResult,
-  SessionData extends StringRecord = StringRecord
+  SessionData extends StringRecord = StringRecord,
 > extends ILogCommands,
     IFindCommands,
     ISettingsCommands<Settings>,
@@ -690,6 +698,12 @@ export interface Driver<
    * @returns The result of running the command
    */
   executeCommand(cmd: string, ...args: any[]): Promise<any>;
+
+  /** Execute a driver (WebDriver Bidi protocol) command by its name as defined in the bidi commands file
+   * @param bidiCmd - the name of the command in the bidi spec
+   * @param args - arguments to pass to the command
+   */
+  executeBidiCommand(bidiCmd: string, ...args: any[]): Promise<any>;
 
   /**
    * Signify to any owning processes that this driver encountered an error which should cause the
@@ -771,7 +785,7 @@ export interface ExternalDriver<
   Settings extends StringRecord = StringRecord,
   CreateResult = DefaultCreateSessionResult<C>,
   DeleteResult = DefaultDeleteSessionResult,
-  SessionData extends StringRecord = StringRecord
+  SessionData extends StringRecord = StringRecord,
 > extends Driver<C, CArgs, Settings, CreateResult, DeleteResult, SessionData> {
   // WebDriver spec commands
 
@@ -1247,7 +1261,7 @@ export interface ExternalDriver<
   getPerformanceData?(
     packageName: string,
     dataType: string,
-    dataReadTimeout?: number
+    dataReadTimeout?: number,
   ): Promise<any>;
 
   /**
@@ -1445,7 +1459,7 @@ export interface ExternalDriver<
     strategy?: string,
     key?: string,
     keyCode?: string,
-    keyName?: string
+    keyName?: string,
   ): Promise<boolean>;
 
   /**
@@ -1548,7 +1562,7 @@ export interface ExternalDriver<
     intentCategory?: string,
     intentFlags?: string,
     optionalIntentArguments?: string,
-    dontStopAppOnReset?: boolean
+    dontStopAppOnReset?: boolean,
   ): Promise<void>;
 
   /**
@@ -1759,7 +1773,7 @@ export interface ExternalDriver<
     ySpeed?: number,
     xOffset?: number,
     yOffset?: number,
-    speed?: number
+    speed?: number,
   ): Promise<void>;
 
   /**
@@ -1885,7 +1899,7 @@ export interface ExternalDriver<
     hasResidentKey?: boolean,
     hasUserVerification?: boolean,
     isUserConsenting?: boolean,
-    isUserVerified?: boolean
+    isUserVerified?: boolean,
   ): Promise<string>;
 
   /**
@@ -1915,7 +1929,7 @@ export interface ExternalDriver<
     privateKey: string,
     userHandle: string,
     signCount: number,
-    authenticatorId: string
+    authenticatorId: string,
   ): Promise<void>;
 
   /**
@@ -1963,7 +1977,7 @@ export interface ExternalDriver<
   proxyCommand?<TReq = any, TRes = unknown>(
     url: string,
     method: HTTPMethod,
-    body?: TReq
+    body?: TReq,
   ): Promise<TRes>;
 }
 
@@ -2108,7 +2122,7 @@ export interface ConfigureAppOptions {
    * @returns
    */
   onPostProcess?: (
-    obj: PostProcessOptions
+    obj: PostProcessOptions,
   ) => Promise<PostProcessResult | undefined> | PostProcessResult | undefined;
   supportedExtensions: string[];
 }


### PR DESCRIPTION
This is a major new feature for Appium, enabling [WebDriver BiDi](https://w3c.github.io/webdriver-bidi) support for Appium drivers. The main idea:

- Add websocket handlers for routes to the main appium server
- Define a set of bidi commands which drivers can implement the same way they implement webdriver classic commands
- Allow drivers to declare whether they support bidi
- If a driver supports bidi, then clients can make bidi connections, and commands/params will be unwrapped and applied to the methods implemented by drivers. I.e., the main Appium server will handle all aspects of the BiDi protocol, and drivers don't need to worry about it.
- Default implementation for subscription/unsubscription to bidi events
- Allow drivers to emit bidi events which will be pushed to the client if the client is subscribed
- Add bidi support for FakeDriver (a simple bidi command and a simple bidi event) for testing
- Allow bidi proxying. If a driver sets a bidi proxy url for an upstream socket server (e.g., appium-chromium-driver wanting to proxy bidi connections to chromedriver), then Appium will transparently pass all socket communication back and forth instead of handling 

TODO:
- [ ] allow drivers to define custom bidi commands (similar to how they can define custom webdriver commands) (separate PR)
- [ ] add lots more tests (separate PR)
- [x] add documentation for driver authors on what they need to do to implement bidi support in their drivers
- [ ] fill out the bidi command list with all the currently supported commands from the spec (separate PR)
- [ ] on the current implementation, proxying is single-shot; you can turn it on but you can't toggle it on and off. Unclear if this is desirable but it's how our current webdriver proxying works (separate PR)
- [ ] evaluate whether we want "bidi proxy avoid" commands like we have "webdriver proxy avoid" routes (separate PR)
- [ ] allow create/delete session to work from the 'global' / 'sessionless' bidi connection (unclear if desirable, but it's part of the spec, kinda) (separate PR)