### PR TITLE
chore: Remove deprecated 'ANDROID_SDK_ROOT` 

### DIFF
--- a/packages/appium/docs/en/quickstart/uiauto2-driver.md
+++ b/packages/appium/docs/en/quickstart/uiauto2-driver.md
@@ -23,7 +23,7 @@ According to the driver, in addition to a working Appium server, we also need to
 - Set an environment variable pointing to the directory on disk where the Android tools are
 installed. You can usually find the path to this directory in the Android Studio SDK manager. It
 will contain the `platform-tools` and other directories. We need to define and persist the
-environment variable as `ANDROID_HOME` (or alternatively `ANDROID_SDK_ROOT`).
+environment variable as `ANDROID_HOME`.
 - Use the Android SDK manager to download whichever Android platform we want to automate (for
 example, API level 30)
 - Install the Java JDK (for the most recent Android API levels, JDK 9 is required, otherwise JDK

--- a/packages/doctor/lib/android.js
+++ b/packages/doctor/lib/android.js
@@ -52,7 +52,7 @@ class AndroidToolCheck extends DoctorCheck {
     const sdkRoot = getSdkRootFromEnv();
     if (!sdkRoot) {
       return nok(
-        `${listOfTools} could not be found because ANDROID_HOME or ANDROID_SDK_ROOT is NOT set!`
+        `${listOfTools} could not be found because ANDROID_HOME is NOT set!`
       );
     }
 

--- a/packages/doctor/test/unit/android.spec.js
+++ b/packages/doctor/test/unit/android.spec.js
@@ -88,11 +88,10 @@ describe('android', function () {
       });
       it('diagnose - failure - no ANDROID_HOME', async function () {
         delete process.env.ANDROID_HOME;
-        delete process.env.ANDROID_SDK_ROOT;
         (await check.diagnose()).should.deep.equal({
           ok: false,
           optional: false,
-          message: `adb, emulator, ${apkAnalyzerFilename} could not be found because ANDROID_HOME or ANDROID_SDK_ROOT is NOT set!`,
+          message: `adb, emulator, ${apkAnalyzerFilename} could not be found because ANDROID_HOME is NOT set!`,
         });
       });
       it('diagnose - failure - path not valid', async function () {

--- a/packages/doctor/test/unit/android.spec.js
+++ b/packages/doctor/test/unit/android.spec.js
@@ -88,6 +88,7 @@ describe('android', function () {
       });
       it('diagnose - failure - no ANDROID_HOME', async function () {
         delete process.env.ANDROID_HOME;
+        delete process.env.ANDROID_SDK_ROOT;
         (await check.diagnose()).should.deep.equal({
           ok: false,
           optional: false,


### PR DESCRIPTION
## Proposed changes

According to https://developer.android.com/tools/variables 'ANDROID_SDK_ROOT`  is deprecated, so no point in showing this Var in the error message for the users.
![image](https://github.com/appium/appium/assets/59066376/90a31585-38dd-4238-aaa7-6c6b67bf9061)

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
