### PR TITLE
fix(docutils): update dependency typescript to v5.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "through2": "4.0.2",
         "ts-node": "10.9.1",
         "tsd": "0.29.0",
-        "typescript": "5.3.2",
+        "typescript": "5.2.2",
         "validate.js": "0.13.1",
         "webdriverio": "8.24.1",
         "ws": "8.14.2",
@@ -20537,9 +20537,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22557,7 +22557,7 @@
         "source-map-support": "0.5.21",
         "teen_process": "2.0.101",
         "type-fest": "3.13.1",
-        "typescript": "5.3.2",
+        "typescript": "5.2.2",
         "yaml": "2.3.4",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
@@ -23320,7 +23320,7 @@
         "source-map-support": "0.5.21",
         "teen_process": "2.0.101",
         "type-fest": "3.13.1",
-        "typescript": "5.3.2",
+        "typescript": "5.2.2",
         "yaml": "2.3.4",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
@@ -37857,9 +37857,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
     },
     "ua-parser-js": {
       "version": "1.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
         "through2": "4.0.2",
         "ts-node": "10.9.1",
         "tsd": "0.29.0",
-        "typescript": "5.0.4",
+        "typescript": "5.3.2",
         "validate.js": "0.13.1",
         "webdriverio": "8.24.1",
         "ws": "8.14.2",
@@ -20537,15 +20537,15 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {
@@ -22557,7 +22557,7 @@
         "source-map-support": "0.5.21",
         "teen_process": "2.0.101",
         "type-fest": "3.13.1",
-        "typescript": "5.0.4",
+        "typescript": "5.3.2",
         "yaml": "2.3.4",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
@@ -23320,7 +23320,7 @@
         "source-map-support": "0.5.21",
         "teen_process": "2.0.101",
         "type-fest": "3.13.1",
-        "typescript": "5.0.4",
+        "typescript": "5.3.2",
         "yaml": "2.3.4",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
@@ -37857,9 +37857,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
-      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw=="
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ=="
     },
     "ua-parser-js": {
       "version": "1.0.33",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "through2": "4.0.2",
     "ts-node": "10.9.1",
     "tsd": "0.29.0",
-    "typescript": "5.3.2",
+    "typescript": "5.2.2",
     "validate.js": "0.13.1",
     "webdriverio": "8.24.1",
     "ws": "8.14.2",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "through2": "4.0.2",
     "ts-node": "10.9.1",
     "tsd": "0.29.0",
-    "typescript": "5.0.4",
+    "typescript": "5.3.2",
     "validate.js": "0.13.1",
     "webdriverio": "8.24.1",
     "ws": "8.14.2",

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -66,7 +66,7 @@
     "source-map-support": "0.5.21",
     "teen_process": "2.0.101",
     "type-fest": "3.13.1",
-    "typescript": "5.3.2",
+    "typescript": "5.2.2",
     "yaml": "2.3.4",
     "yargs": "17.7.2",
     "yargs-parser": "21.1.1"

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -66,7 +66,7 @@
     "source-map-support": "0.5.21",
     "teen_process": "2.0.101",
     "type-fest": "3.13.1",
-    "typescript": "5.0.4",
+    "typescript": "5.3.2",
     "yaml": "2.3.4",
     "yargs": "17.7.2",
     "yargs-parser": "21.1.1"

--- a/packages/execute-driver-plugin/tsconfig.json
+++ b/packages/execute-driver-plugin/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "outDir": "build",
     "checkJs": true,
+    "module": "commonjs",
     "moduleResolution": "node10"
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",


### PR DESCRIPTION
Replaces #19064 with an extra fix for `execute-driver-plugin`.