### PR TITLE
fix(workflows): remove `tag=` prefix for action digest tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install dependencies
-        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # v1
         with:
           useRollingCache: true
           install-command: npm ci --foreground-scripts
@@ -90,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Install dependencies
-        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # v1
         with:
           useRollingCache: true
           install-command: npm ci

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Install dependencies (Node.js)
-        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # v1
         with:
           useRollingCache: true
           install-command: npm ci

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: master
       - name: Install dependencies
-        uses: bahmutov/npm-install@cb39a46f27f14697fec763d60fb23ad347e2befa # tag=v1
+        uses: bahmutov/npm-install@cb39a46f27f14697fec763d60fb23ad347e2befa # v1
       - name: Install fossa-cli
         run: ./scripts/install-fossa.sh -d
       - name: Run FOSSA analysis

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -26,7 +26,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies (Node.js)
-      uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+      uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # v1
       with:
         useRollingCache: true
         install-command: npm ci

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,6 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Validate Renovate Config
-        uses: rinchsan/renovate-config-validator@1ea1e8514f6a33fdd71c40b0a5fa3512b9e7b936 # tag=v0
+        uses: rinchsan/renovate-config-validator@1ea1e8514f6a33fdd71c40b0a5fa3512b9e7b936 # v0
         with:
           pattern: '{.renovaterc.json,renovate/default.json}'


### PR DESCRIPTION
## Proposed changes

Renovate appears to have forgotten how to parse GitHub Action digest tags with the `tag=` prefix. Given that tags without this prefix seem to be parsed just fine, let's see if removing the prefix fixes the problem.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
