### PR TITLE
chore(renovate,workflows): unpin GitHub Action digests

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -13,4 +13,4 @@ jobs:
     name: Auto-Label PRs
     runs-on: ubuntu-latest
     steps:
-      - uses: fuxingloh/multi-labeler@6704db0bcba106d07482efabbc79d3092af74fa2 # v2
+      - uses: fuxingloh/multi-labeler@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,14 +70,14 @@ jobs:
         # - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install dependencies
-        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+        uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
           install-command: npm ci --foreground-scripts
@@ -88,9 +88,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - name: Install dependencies
-        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+        uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
           install-command: npm ci

--- a/.github/workflows/clean-cache.yml
+++ b/.github/workflows/clean-cache.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        uses: actions/checkout@v4
 
       - name: Cleanup
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Appium

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,9 +37,9 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - name: Install dependencies (Node.js)
-        uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+        uses: bahmutov/npm-install@v1
         with:
           useRollingCache: true
           install-command: npm ci

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,11 +11,11 @@ jobs:
     name: Run FOSSA Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
         with:
           ref: master
       - name: Install dependencies
-        uses: bahmutov/npm-install@cb39a46f27f14697fec763d60fb23ad347e2befa # tag=v1
+        uses: bahmutov/npm-install@v1
       - name: Install fossa-cli
         run: ./scripts/install-fossa.sh -d
       - name: Run FOSSA analysis

--- a/.github/workflows/on-hold.yml
+++ b/.github/workflows/on-hold.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for "On Hold" label
-        uses: egmacke/action-check-label@0eb29f801fb482a95c9bd2dd22834ecc8f4e8af9 # v2
+        uses: egmacke/action-check-label@v2
         with:
           label: On Hold
           state: absent

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -17,7 +17,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+    - uses: actions/checkout@v4
     - run: |
         git config user.name github-actions
         git config user.email github-actions@github.com
@@ -26,7 +26,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install dependencies (Node.js)
-      uses: bahmutov/npm-install@1a235c31658a322a3b024444759650ee6345c26d # tag=v1
+      uses: bahmutov/npm-install@v1
       with:
         useRollingCache: true
         install-command: npm ci

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,6 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate Renovate Config
-        uses: rinchsan/renovate-config-validator@v0
+        uses: rinchsan/renovate-config-validator@v0.0.12
         with:
           pattern: '{.renovaterc.json,renovate/default.json}'

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,8 +23,8 @@ jobs:
     name: Check Renovate Configs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+      - uses: actions/checkout@v4
       - name: Validate Renovate Config
-        uses: rinchsan/renovate-config-validator@1ea1e8514f6a33fdd71c40b0a5fa3512b9e7b936 # tag=v0
+        uses: rinchsan/renovate-config-validator@v0
         with:
           pattern: '{.renovaterc.json,renovate/default.json}'

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -36,7 +36,6 @@ Appium extension authors--or anyone else--may use this config as well.
 
 - `config:js-app` - everything gets pinned except peer deps (plus a bunch of other reasonable defaults)
 - `group:definitelyTyped` - Groups all `@types/*` packages into one PR
-- `helpers:pinGitHubActionDigests` - Pins SHAs of GitHub Actions
 - `workarounds:typesNodeVersioning` - `@types/node` tracks Node.js versions instead
 - `:automergePatch` - Automatically merges "patch" and "pin" updates (assuming they pass CI)
 - `:automergeMinor` - Automatically merges "minor" updates (assuming they pass CI)

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -4,7 +4,6 @@
   "extends": [
     "config:js-app",
     "group:definitelyTyped",
-    "helpers:pinGitHubActionDigests",
     "workarounds:typesNodeVersioning",
     ":automergePatch",
     ":automergeMinor",


### PR DESCRIPTION
## Proposed changes

This PR removes the commit SHAs from all GitHub Actions, and changes the Renovate configuration to not pin them.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
