### PR TITLE
refactor(support): Speed up findAppiumDependencyPackage API

### DIFF
--- a/packages/appium/test/e2e/local.e2e.spec.js
+++ b/packages/appium/test/e2e/local.e2e.spec.js
@@ -45,14 +45,6 @@ describe('when Appium is a dependency of the current project', function () {
   }
 
   /**
-   * Helper fn
-   * @returns {Promise<string>}
-   */
-  async function readHash() {
-    return await fs.readFile(hashPath, 'utf8');
-  }
-
-  /**
    * @template {CliExtensionSubcommand} ExtSubcommand
    * @type {import('lodash').CurriedFunction1<CliExtArgs<ExtSubcommand> | CliArgs, Promise<unknown>>}
    */
@@ -140,28 +132,15 @@ describe('when Appium is a dependency of the current project', function () {
           manifestParsed.should.have.nested.property('drivers.fake');
         });
 
-        it('should update the package hash', async function () {
-          (await fs.exists(hashPath)).should.be.true;
-        });
-
         describe('when a different driver is installed via "appium driver install"', function () {
-          /** @type {string} */
-          let oldHash;
-
           before(async function () {
             await runJson([DRIVER_TYPE, LIST]);
-            oldHash = await readHash();
             await installLocalExtension(appiumHome, DRIVER_TYPE, testDriverPath);
           });
 
           it('should update package.json', async function () {
             const newPkg = JSON.parse(await fs.readFile(appiumHomePkgPath, 'utf8'));
             expect(newPkg).to.have.nested.property('devDependencies.@appium/test-driver');
-          });
-
-          it('should update the hash', async function () {
-            const newHash = await readHash();
-            newHash.should.not.equal(oldHash);
           });
 
           it('should update the manifest with the new driver', async function () {

--- a/packages/support/lib/env.js
+++ b/packages/support/lib/env.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import {homedir} from 'os';
 import path from 'path';
 import readPkg from 'read-pkg';
-import fs from './fs';
+import { fs } from './fs';
 import semver from 'semver';
 
 /**

--- a/packages/support/lib/env.js
+++ b/packages/support/lib/env.js
@@ -63,7 +63,7 @@ export const findAppiumDependencyPackage = _.memoize(
           pkg?.devDependencies?.appium ??
           pkg?.peerDependencies?.appium
         ));
-        return version && semver.satisfies(version, '>=2.0.0', {includePrerelease: true})
+        return version && semver.satisfies(version, '>=2.0.0-beta', {includePrerelease: true})
           ? root
           : undefined;
       } catch {}

--- a/packages/support/lib/env.js
+++ b/packages/support/lib/env.js
@@ -3,7 +3,6 @@ import _ from 'lodash';
 import {homedir} from 'os';
 import path from 'path';
 import readPkg from 'read-pkg';
-import { fs } from './fs';
 import semver from 'semver';
 
 /**
@@ -73,12 +72,9 @@ export const findAppiumDependencyPackage = _.memoize(
     let currentDir = path.resolve(cwd);
     let isAtFsRoot = false;
     while (!isAtFsRoot) {
-      const manifestPath = path.join(currentDir, 'package.json');
-      if (await fs.exists(manifestPath)) {
-        const result = await readPkg(currentDir);
-        if (result) {
-          return result;
-        }
+      const result = await readPkg(currentDir);
+      if (result) {
+        return result;
       }
       currentDir = path.dirname(currentDir);
       isAtFsRoot = currentDir.length <= path.dirname(currentDir).length;

--- a/packages/support/lib/env.js
+++ b/packages/support/lib/env.js
@@ -3,7 +3,8 @@ import _ from 'lodash';
 import {homedir} from 'os';
 import path from 'path';
 import readPkg from 'read-pkg';
-import {npm} from './npm';
+import fs from './fs';
+import semver from 'semver';
 
 /**
  * Path to the default `APPIUM_HOME` dir (`~/.appium`).
@@ -28,8 +29,6 @@ export const MANIFEST_RELATIVE_PATH = path.join(
   MANIFEST_BASENAME
 );
 
-const OLD_VERSION_REGEX = /^[01]/;
-
 /**
  * Resolves `true` if an `appium` dependency can be found somewhere in the given `cwd`.
  *
@@ -52,39 +51,38 @@ export const findAppiumDependencyPackage = _.memoize(
    */
   async (cwd = process.cwd()) => {
     /**
-     * Tries to read `package.json` in `cwd` and resolves the identity if it depends on `appium`;
+     * Tries to read `package.json` in `root` and resolves the identity if it depends on `appium`;
      * otherwise resolves `undefined`.
-     * @param {string} cwd
+     * @param {string} root
      * @returns {Promise<string|undefined>}
      */
-    const readPkg = async (cwd) => {
-      /** @type {string|undefined} */
-      let pkgPath;
+    const readPkg = async (root) => {
       try {
-        const pkg = await readPackageInDir(cwd);
-        const version =
+        const pkg = await readPackageInDir(root);
+        const version = semver.clean(String(
           pkg?.dependencies?.appium ??
           pkg?.devDependencies?.appium ??
-          pkg?.peerDependencies?.appium;
-        pkgPath = version && !OLD_VERSION_REGEX.test(String(version)) ? cwd : undefined;
+          pkg?.peerDependencies?.appium
+        ));
+        return version && semver.satisfies(version, '>=2.0.0', {includePrerelease: true})
+          ? root
+          : undefined;
       } catch {}
-      return pkgPath;
     };
 
-    cwd = path.resolve(cwd);
-
-    /** @type {string} */
-    let pkgDir;
-    try {
-      const {json: list} = await npm.exec('list', ['--long', '--json'], {cwd});
-      ({path: pkgDir} = list);
-      if (pkgDir !== cwd) {
-        pkgDir = pkgDir ?? cwd;
+    let currentDir = path.resolve(cwd);
+    let isAtFsRoot = false;
+    while (!isAtFsRoot) {
+      const manifestPath = path.join(currentDir, 'package.json');
+      if (await fs.exists(manifestPath)) {
+        const result = await readPkg(currentDir);
+        if (result) {
+          return result;
+        }
       }
-    } catch {
-      pkgDir = cwd;
+      currentDir = path.dirname(currentDir);
+      isAtFsRoot = currentDir.length <= path.dirname(currentDir).length;
     }
-    return await readPkg(pkgDir);
   }
 );
 
@@ -124,11 +122,7 @@ export const resolveAppiumHome = _.memoize(
       return path.resolve(cwd, process.env.APPIUM_HOME);
     }
 
-    const pkgPath = await findAppiumDependencyPackage(cwd);
-    if (pkgPath) {
-      return pkgPath;
-    }
-    return DEFAULT_APPIUM_HOME;
+    return await findAppiumDependencyPackage(cwd) ?? DEFAULT_APPIUM_HOME;
   }
 );
 

--- a/packages/support/test/unit/env.spec.js
+++ b/packages/support/test/unit/env.spec.js
@@ -116,16 +116,6 @@ describe('env', function () {
         describe('when `appium` is a dependency of the package in the cwd', function () {
           const appiumHome = path.resolve(path.sep, 'somewhere');
 
-          describe('when the `appium` dependency spec begins with `file:`', function () {
-            beforeEach(function () {
-              MockReadPkg.resolves({devDependencies: {appium: 'file:../appium'}});
-            });
-
-            it('should resolve with the identity', async function () {
-              await expect(env.resolveAppiumHome(appiumHome)).to.eventually.equal(appiumHome);
-            });
-          });
-
           describe('when `appium` is a dependency which does not resolve to a file path`', function () {
             beforeEach(function () {
               MockReadPkg.resolves({devDependencies: {appium: '2.0.0-beta.25'}});
@@ -159,26 +149,6 @@ describe('env', function () {
             });
           });
         });
-
-        describe('when `appium` is a dependency of the workspace root of cwd', function () {
-          const appiumHome = path.resolve(path.sep, 'somewhere');
-
-          beforeEach(function () {
-            MockTeenProcess.exec.resolves({
-              stdout: JSON.stringify({
-                path: appiumHome,
-              }),
-            });
-            MockReadPkg.resolves({devDependencies: {appium: '2.x'}});
-          });
-
-          it('should resolve with the workspace root', async function () {
-            await expect(env.resolveAppiumHome(path.join(appiumHome, 'else'))).to.eventually.equal(
-              appiumHome
-            );
-          });
-        });
-      });
 
       describe('when reading `package.json` causes an exception', function () {
         beforeEach(function () {
@@ -261,18 +231,6 @@ describe('env', function () {
         describe('when `appium` is not yet actually installed', function () {
           beforeEach(function () {
             MockTeenProcess.exec.rejects();
-          });
-
-          describe('when the `appium` dependency spec begins with `file:`', function () {
-            beforeEach(function () {
-              MockReadPkg.resolves({
-                dependencies: {appium: 'file:packges/appium'},
-              });
-            });
-
-            it('should resolve `true`', async function () {
-              await expect(env.hasAppiumDependency('/somewhere')).to.eventually.equal(true);
-            });
           });
 
           describe('when `appium` dep is current`', function () {

--- a/packages/support/test/unit/env.spec.js
+++ b/packages/support/test/unit/env.spec.js
@@ -149,6 +149,7 @@ describe('env', function () {
             });
           });
         });
+      });
 
       describe('when reading `package.json` causes an exception', function () {
         beforeEach(function () {


### PR DESCRIPTION
The previous implementation used `npm list` call, which is super slow, because it reads all package dependencies
