### PR TITLE
refactor(appium): Remove npm version check from preflight checks

### DIFF
--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -12,7 +12,6 @@ const npmPackage = fs.readPackageJsonFrom(__dirname);
 const APPIUM_VER = npmPackage.version;
 const ENGINES = /** @type {Record<string,string>} */ (npmPackage.engines);
 const MIN_NODE_VERSION = ENGINES.node;
-const MIN_NPM_VERSION = ENGINES.npm;
 
 const GIT_META_ROOT = '.git';
 const GIT_BINARY = `git${system.isWindows() ? '.exe' : ''}`;
@@ -27,15 +26,6 @@ const BUILD_INFO = {
 
 function getNodeVersion() {
   return /** @type {import('semver').SemVer} */ (semver.coerce(process.version));
-}
-
-/**
- * Returns version of `npm`
- * @returns {Promise<string>}
- */
-async function getNpmVersion() {
-  const {stdout} = await exec(system.isWindows() ? 'npm.cmd' : 'npm', ['--version']);
-  return stdout.trim();
 }
 
 /**
@@ -147,28 +137,6 @@ function checkNodeOk() {
       `Node version must be at least ${MIN_NODE_VERSION}; current is ${version.version}`
     );
   }
-}
-
-export async function checkNpmOk() {
-  const npmVersion = await getNpmVersion();
-  if (!semver.satisfies(npmVersion, MIN_NPM_VERSION)) {
-    throw new Error(
-      `npm version must be at least ${MIN_NPM_VERSION}; current is ${npmVersion}. Run "npm install -g npm" to upgrade.`
-    );
-  }
-}
-
-function warnNodeDeprecations() {
-  /**
-   * Uncomment this section to get node version deprecation warnings
-   * Also add test cases to config-specs.js to cover the cases added
-   **/
-  // const version = getNodeVersion();
-  // if (version.major < 8) {
-  //   logger.warn(`Appium support for versions of node < ${version.major} has been ` +
-  //               'deprecated and will be removed in a future version. Please ' +
-  //               'upgrade!');
-  // }
 }
 
 async function showBuildInfo() {
@@ -330,7 +298,6 @@ export {
   getBuildInfo,
   checkNodeOk,
   showBuildInfo,
-  warnNodeDeprecations,
   validateTmpDir,
   getNonDefaultServerArgs,
   getGitRev,

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -21,8 +21,6 @@ import {
   showConfig,
   showBuildInfo,
   validateTmpDir,
-  warnNodeDeprecations,
-  checkNpmOk,
 } from './config';
 import {readConfigFile} from './config-file';
 import {loadExtensions, getActivePlugins, getActiveDrivers} from './extension';
@@ -53,7 +51,6 @@ const {resolveAppiumHome} = env;
 async function preflightChecks(args, throwInsteadOfExit = false) {
   try {
     checkNodeOk();
-    await checkNpmOk();
     if (args.longStacktrace) {
       Error.stackTraceLimit = LONG_STACKTRACE_LIMIT;
     }
@@ -61,7 +58,6 @@ async function preflightChecks(args, throwInsteadOfExit = false) {
       await showBuildInfo();
       process.exit(0);
     }
-    warnNodeDeprecations();
 
     validate(args);
 

--- a/packages/appium/test/unit/config.spec.js
+++ b/packages/appium/test/unit/config.spec.js
@@ -10,10 +10,8 @@ import {
   showBuildInfo,
   showConfig,
   validateTmpDir,
-  warnNodeDeprecations,
 } from '../../lib/config';
 import {PLUGIN_TYPE} from '../../lib/constants';
-import logger from '../../lib/logger';
 import {
   finalizeSchema,
   getDefaultsForSchema,
@@ -159,28 +157,6 @@ describe('Config', function () {
           process.version = 'v18.0.0';
           checkNodeOk.should.not.throw();
         });
-      });
-    });
-
-    describe('warnNodeDeprecations', function () {
-      let spy;
-      before(function () {
-        spy = sandbox.spy(logger, 'warn');
-      });
-      beforeEach(function () {
-        spy.resetHistory();
-      });
-      it('should not log a warning if node is 8+', function () {
-        // @ts-expect-error
-        process.version = 'v8.0.0';
-        warnNodeDeprecations();
-        logger.warn.should.not.be.called;
-      });
-      it('should not log a warning if node is 9+', function () {
-        // @ts-expect-error
-        process.version = 'v9.0.0';
-        warnNodeDeprecations();
-        logger.warn.should.not.be.called;
       });
     });
   });


### PR DESCRIPTION
npm startup is slow as it is still a vanilla nodejs package and must be interpreted before load together with all its dependencies even to just show a version number.

This optimization cuts off about 1 second from the server startup