### PR TITLE
feat(appium): add easy management of Flutter driver

### DIFF
--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -28,7 +28,7 @@ These drivers are currently maintained by the Appium team:
 |[Safari](https://github.com/appium/appium-safari-driver)|`safari`|macOS, iOS|Web|
 |[UiAutomator2](https://github.com/appium/appium-uiautomator2-driver)|`uiautomator2`|Android|Native, Hybrid, Web|
 |[XCUITest](https://github.com/appium/appium-xcuitest-driver)|`xcuitest`|iOS|Native, Hybrid, Web|
-|[Flutter](https://github.com/appium/appium-flutter-driver)|`--source=npm appium-flutter-driver`|iOS, Android|Native|
+|[Flutter](https://github.com/appium/appium-flutter-driver)|`flutter`|iOS, Android|Native|
 
 ### Other Drivers
 

--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -23,12 +23,12 @@ These drivers are currently maintained by the Appium team:
 |--|--|--|--|
 |[Chromium](https://github.com/appium/appium-chromium-driver)|`chromium`|macOS, Windows, Linux|Web|
 |[Espresso](https://github.com/appium/appium-espresso-driver)|`espresso`|Android|Native|
+|[Flutter](https://github.com/appium/appium-flutter-driver)|`flutter`|iOS, Android|Native|
 |[Gecko](https://github.com/appium/appium-geckodriver)|`gecko`|macOS, Windows, Linux, Android|Web|
 |[Mac2](https://github.com/appium/appium-mac2-driver)|`mac2`|macOS|Native|
 |[Safari](https://github.com/appium/appium-safari-driver)|`safari`|macOS, iOS|Web|
 |[UiAutomator2](https://github.com/appium/appium-uiautomator2-driver)|`uiautomator2`|Android|Native, Hybrid, Web|
 |[XCUITest](https://github.com/appium/appium-xcuitest-driver)|`xcuitest`|iOS|Native, Hybrid, Web|
-|[Flutter](https://github.com/appium/appium-flutter-driver)|`flutter`|iOS, Android|Native|
 
 ### Other Drivers
 

--- a/packages/appium/lib/constants.js
+++ b/packages/appium/lib/constants.js
@@ -43,6 +43,7 @@ export const KNOWN_DRIVERS = Object.freeze(
     xcuitest: 'appium-xcuitest-driver',
     mac2: 'appium-mac2-driver',
     espresso: 'appium-espresso-driver',
+    flutter: 'appium-flutter-driver',
     safari: 'appium-safari-driver',
     gecko: 'appium-geckodriver',
     chromium: 'appium-chromium-driver',


### PR DESCRIPTION
## Proposed changes

Now that the Flutter driver is moved under the Appium repo, it only makes sense that the Appium CLI should reflect this. This PR allows the Flutter driver to be managed using just its automation name (e.g. `appium driver install flutter`)

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the CLA
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
