### PR TITLE
chore(support): update dependency sharp to v0.33.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7665,14 +7665,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "license": "MIT"
@@ -9273,14 +9265,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "28.1.3",
       "dev": true,
@@ -10462,11 +10446,6 @@
       "version": "1.3.8",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -15434,11 +15413,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "license": "MIT"
@@ -15496,17 +15470,6 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.40.0",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-domexception": {
@@ -17796,31 +17759,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "license": "MIT",
@@ -18166,33 +18104,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/ini": {
-      "version": "1.3.8",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -19178,88 +19089,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/sharp": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14.15.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/sharp/node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "node_modules/sharp/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "optional": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/sharp/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "optional": true
-    },
-    "node_modules/sharp/node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "optional": true
-    },
-    "node_modules/sharp/node_modules/tar-fs": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
-      "optional": true,
-      "dependencies": {
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      }
-    },
-    "node_modules/sharp/node_modules/tar-stream": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
-      "optional": true,
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "license": "MIT",
@@ -19432,49 +19261,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/simple-swizzle": {
@@ -20319,6 +20105,7 @@
       "version": "2.1.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -20329,7 +20116,8 @@
     "node_modules/tar-fs/node_modules/chownr": {
       "version": "1.1.4",
       "license": "ISC",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
@@ -20939,17 +20727,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type": {
@@ -23795,7 +23572,7 @@
         "npm": ">=8"
       },
       "optionalDependencies": {
-        "sharp": "0.32.6"
+        "sharp": "0.33.0"
       }
     },
     "packages/support/node_modules/@types/which": {
@@ -23852,6 +23629,37 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
       }
+    },
+    "packages/support/node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "optional": true,
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "packages/support/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "optional": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "packages/support/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "optional": true
     },
     "packages/support/node_modules/gauge": {
       "version": "5.0.0",
@@ -23952,6 +23760,46 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "packages/support/node_modules/sharp": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.0.tgz",
+      "integrity": "sha512-99DZKudjm/Rmz+M0/26t4DKpXyywAOJaayGS9boEn7FvgtG0RYBi46uPE2c+obcJRtA3AZa0QwJot63gJQ1F0Q==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "libvips": ">=8.15.0",
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.0",
+        "@img/sharp-darwin-x64": "0.33.0",
+        "@img/sharp-libvips-darwin-arm64": "1.0.0",
+        "@img/sharp-libvips-darwin-x64": "1.0.0",
+        "@img/sharp-libvips-linux-arm": "1.0.0",
+        "@img/sharp-libvips-linux-arm64": "1.0.0",
+        "@img/sharp-libvips-linux-s390x": "1.0.0",
+        "@img/sharp-libvips-linux-x64": "1.0.0",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.0",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.0",
+        "@img/sharp-linux-arm": "0.33.0",
+        "@img/sharp-linux-arm64": "0.33.0",
+        "@img/sharp-linux-s390x": "0.33.0",
+        "@img/sharp-linux-x64": "0.33.0",
+        "@img/sharp-linuxmusl-arm64": "0.33.0",
+        "@img/sharp-linuxmusl-x64": "0.33.0",
+        "@img/sharp-wasm32": "0.33.0",
+        "@img/sharp-win32-ia32": "0.33.0",
+        "@img/sharp-win32-x64": "0.33.0"
       }
     },
     "packages/support/node_modules/string-width": {
@@ -24646,7 +24494,7 @@
         "resolve-from": "5.0.0",
         "sanitize-filename": "1.6.3",
         "semver": "7.5.4",
-        "sharp": "0.32.6",
+        "sharp": "0.33.0",
         "shell-quote": "1.8.1",
         "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
@@ -24691,6 +24539,31 @@
             "base64-js": "^1.3.1",
             "ieee754": "^1.2.1"
           }
+        },
+        "color": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+          "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1",
+            "color-string": "^1.9.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "optional": true
         },
         "gauge": {
           "version": "5.0.0",
@@ -24754,6 +24627,36 @@
             "buffer": "^6.0.3",
             "events": "^3.3.0",
             "process": "^0.11.10"
+          }
+        },
+        "sharp": {
+          "version": "0.33.0",
+          "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.0.tgz",
+          "integrity": "sha512-99DZKudjm/Rmz+M0/26t4DKpXyywAOJaayGS9boEn7FvgtG0RYBi46uPE2c+obcJRtA3AZa0QwJot63gJQ1F0Q==",
+          "optional": true,
+          "requires": {
+            "@img/sharp-darwin-arm64": "0.33.0",
+            "@img/sharp-darwin-x64": "0.33.0",
+            "@img/sharp-libvips-darwin-arm64": "1.0.0",
+            "@img/sharp-libvips-darwin-x64": "1.0.0",
+            "@img/sharp-libvips-linux-arm": "1.0.0",
+            "@img/sharp-libvips-linux-arm64": "1.0.0",
+            "@img/sharp-libvips-linux-s390x": "1.0.0",
+            "@img/sharp-libvips-linux-x64": "1.0.0",
+            "@img/sharp-libvips-linuxmusl-arm64": "1.0.0",
+            "@img/sharp-libvips-linuxmusl-x64": "1.0.0",
+            "@img/sharp-linux-arm": "0.33.0",
+            "@img/sharp-linux-arm64": "0.33.0",
+            "@img/sharp-linux-s390x": "0.33.0",
+            "@img/sharp-linux-x64": "0.33.0",
+            "@img/sharp-linuxmusl-arm64": "0.33.0",
+            "@img/sharp-linuxmusl-x64": "0.33.0",
+            "@img/sharp-wasm32": "0.33.0",
+            "@img/sharp-win32-ia32": "0.33.0",
+            "@img/sharp-win32-x64": "0.33.0",
+            "color": "^4.2.3",
+            "detect-libc": "^2.0.2",
+            "semver": "^7.5.4"
           }
         },
         "string-width": {
@@ -30092,10 +29995,6 @@
         "type-detect": "^4.0.0"
       }
     },
-    "deep-extend": {
-      "version": "0.6.0",
-      "optional": true
-    },
     "deep-is": {
       "version": "0.1.4"
     },
@@ -31200,10 +31099,6 @@
         "strip-final-newline": "^2.0.0"
       }
     },
-    "expand-template": {
-      "version": "2.0.3",
-      "optional": true
-    },
     "expect": {
       "version": "28.1.3",
       "dev": true,
@@ -32026,10 +31921,6 @@
           "dev": true
         }
       }
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "optional": true
     },
     "glob": {
       "version": "7.2.3",
@@ -35399,10 +35290,6 @@
     "nanoid": {
       "version": "3.3.3"
     },
-    "napi-build-utils": {
-      "version": "1.0.2",
-      "optional": true
-    },
     "natural-compare": {
       "version": "1.4.0"
     },
@@ -35445,13 +35332,6 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
-      }
-    },
-    "node-abi": {
-      "version": "3.40.0",
-      "optional": true,
-      "requires": {
-        "semver": "^7.3.5"
       }
     },
     "node-domexception": {
@@ -37024,24 +36904,6 @@
     "pluralize": {
       "version": "8.0.0"
     },
-    "prebuild-install": {
-      "version": "7.1.1",
-      "optional": true,
-      "requires": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.2.1"
     },
@@ -37267,26 +37129,6 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
-      }
-    },
-    "rc": {
-      "version": "1.2.8",
-      "optional": true,
-      "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "ini": {
-          "version": "1.3.8",
-          "optional": true
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "optional": true
-        }
       }
     },
     "react-is": {
@@ -37970,77 +37812,6 @@
         "kind-of": "^6.0.2"
       }
     },
-    "sharp": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
-      "optional": true,
-      "requires": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
-      },
-      "dependencies": {
-        "color": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-          "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1",
-            "color-string": "^1.9.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "optional": true
-        },
-        "node-addon-api": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-          "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-          "optional": true
-        },
-        "tar-fs": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-          "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
-          "optional": true,
-          "requires": {
-            "mkdirp-classic": "^0.5.2",
-            "pump": "^3.0.0",
-            "tar-stream": "^3.1.5"
-          }
-        },
-        "tar-stream": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
-          "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
-          "optional": true,
-          "requires": {
-            "b4a": "^1.6.4",
-            "fast-fifo": "^1.2.0",
-            "streamx": "^2.15.0"
-          }
-        }
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "requires": {
@@ -38157,19 +37928,6 @@
             "minipass": "^4.0.0"
           }
         }
-      }
-    },
-    "simple-concat": {
-      "version": "1.0.1",
-      "optional": true
-    },
-    "simple-get": {
-      "version": "4.0.1",
-      "optional": true,
-      "requires": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
       }
     },
     "simple-swizzle": {
@@ -38774,6 +38532,7 @@
     "tar-fs": {
       "version": "2.1.1",
       "optional": true,
+      "peer": true,
       "requires": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -38783,7 +38542,8 @@
       "dependencies": {
         "chownr": {
           "version": "1.1.4",
-          "optional": true
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -39208,13 +38968,6 @@
             "minipass": "^5.0.0"
           }
         }
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "optional": true,
-      "requires": {
-        "safe-buffer": "^5.0.1"
       }
     },
     "type": {

--- a/packages/support/README.md
+++ b/packages/support/README.md
@@ -56,6 +56,8 @@ Wrappers for the command line interface abstraction used by the Appium server.
 
 Utilities to work with images. Use [sharp](https://github.com/lovell/sharp) under the hood.
 
+:bangbang: Node >=18.17 is required to use these utilities
+
 #### log-internal
 
 Utilities needed for internal Appium log config assistance.

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -96,7 +96,7 @@
     "yauzl": "2.10.0"
   },
   "optionalDependencies": {
-    "sharp": "0.32.6"
+    "sharp": "0.33.0"
   },
   "engines": {
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0",


### PR DESCRIPTION
Bump `sharp` to `0.33.0` only for the `support` package, to align it with `opencv` and `images-plugin`. Might help with the situation in #19547. 
E2E tests for `support` were successful on my local Windows machine.