### PR TITLE
feat: Deny install/upgrade of packages which server dep does not meet the current Appium version

### DIFF
--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -42,11 +42,10 @@ function receiptToManifest(receipt) {
  * @returns {Promise<[string, string|null]>}
  */
 async function getRemoteExtensionVersionReq(installSpec) {
-  const currentVersion = npmPackage.version;
   const allDeps = await npm.getPackageInfo(installSpec, ['peerDependencies', 'dependencies']);
   const requiredVersionPair = _.flatMap(_.values(allDeps).map(_.toPairs))
     .find(([name]) => name === 'appium');
-  return [currentVersion, requiredVersionPair ? requiredVersionPair[1] : null];
+  return [npmPackage.version, requiredVersionPair ? requiredVersionPair[1] : null];
 }
 
 /**

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -43,7 +43,7 @@ function receiptToManifest(receipt) {
  */
 async function getRemoteExtensionVersionReq(installSpec) {
   const currentVersion = npmPackage.version;
-  const allDeps = await npm.showPackageDependencies(installSpec);
+  const allDeps = await npm.getPackageInfo(installSpec, ['peerDependencies', 'dependencies']);
   const requiredVersionPair = _.flatMap(_.values(allDeps).map(_.toPairs))
     .find(([name]) => name === 'appium');
   return [currentVersion, requiredVersionPair ? requiredVersionPair[1] : null];

--- a/packages/appium/lib/cli/utils.js
+++ b/packages/appium/lib/cli/utils.js
@@ -2,14 +2,14 @@
 
 import ora from 'ora';
 
-const JSON_SPACES = 4;
+export const JSON_SPACES = 4;
 
 /***
  * Log an error to the console and exit the process.
  * @param {boolean} json - whether we should log json or text
  * @param {any} msg - error message, object, Error instance, etc.
  */
-function errAndQuit(json, msg) {
+export function errAndQuit(json, msg) {
   if (json) {
     console.log(JSON.stringify({error: `${msg}`}, null, JSON_SPACES));
   } else {
@@ -26,7 +26,7 @@ function errAndQuit(json, msg) {
  * @param {boolean} json - whether we are in json mode (and should therefore not log)
  * @param {string} msg - string to log
  */
-function log(json, msg) {
+export function log(json, msg) {
   !json && console.log(msg);
 }
 
@@ -36,7 +36,7 @@ function log(json, msg) {
  * @param {string} msg - string to log
  * @param {function} fn - function to wrap with spinning
  */
-async function spinWith(json, msg, fn) {
+export async function spinWith(json, msg, fn) {
   if (json) {
     return await fn();
   }
@@ -52,7 +52,7 @@ async function spinWith(json, msg, fn) {
   }
 }
 
-class RingBuffer {
+export class RingBuffer {
   constructor(size = 50) {
     this.size = size;
     this.buffer = [];
@@ -70,5 +70,3 @@ class RingBuffer {
     this.buffer.push(item);
   }
 }
-
-export {errAndQuit, log, spinWith, JSON_SPACES, RingBuffer};

--- a/packages/appium/lib/config.js
+++ b/packages/appium/lib/config.js
@@ -5,11 +5,10 @@ import axios from 'axios';
 import {exec} from 'teen_process';
 import semver from 'semver';
 import os from 'node:os';
+import {npmPackage} from './utils';
 import {getDefaultsForSchema, getAllArgSpecs} from './schema/schema';
 
-const npmPackage = fs.readPackageJsonFrom(__dirname);
-
-const APPIUM_VER = npmPackage.version;
+export const APPIUM_VER = npmPackage.version;
 const ENGINES = /** @type {Record<string,string>} */ (npmPackage.engines);
 const MIN_NODE_VERSION = ENGINES.node;
 
@@ -317,7 +316,6 @@ export {
   showBuildInfo,
   getNonDefaultServerArgs,
   getGitRev,
-  APPIUM_VER,
   updateBuildInfo,
   showConfig,
   rootDir,

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import logger from './logger';
 import {processCapabilities, PROTOCOLS, STANDARD_CAPS, errors} from '@appium/base-driver';
 import {inspect as dump} from 'util';
-import {node} from '@appium/support';
+import {node, fs} from '@appium/support';
 import path from 'path';
 import {SERVER_SUBCOMMAND, DRIVER_TYPE, PLUGIN_TYPE} from './constants';
 import os from 'node:os';
@@ -11,6 +11,7 @@ const W3C_APPIUM_PREFIX = 'appium';
 const STANDARD_CAPS_LOWERCASE = new Set([...STANDARD_CAPS].map((cap) => cap.toLowerCase()));
 export const V4_BROADCAST_IP = '0.0.0.0';
 export const V6_BROADCAST_IP = '::';
+export const npmPackage = fs.readPackageJsonFrom(__dirname);
 
 
 /**

--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -264,17 +264,13 @@ export class NPM {
   }
 
   /**
-   * @typedef NpmDepsInfo
-   * @property {import('@appium/types').StringRecord} [peerDependencies]
-   * @property {import('@appium/types').StringRecord} [dependencies]
+   * @param {string} pkg Npm package spec to query
+   * @param {string[]} [entries=[]] Field names to be included into the
+   * resulting output. By default all fields are included.
+   * @returns {Promise<import('@appium/types').StringRecord>}
    */
-
-  /**
-   * @param {string} pkg
-   * @returns {Promise<NpmDepsInfo>}
-   */
-  async showPackageDependencies(pkg) {
-    return (await this.exec('info', [pkg, 'peerDependencies', 'dependencies'], {
+  async getPackageInfo(pkg, entries = []) {
+    return (await this.exec('info', [pkg, ...entries], {
       cwd: process.cwd(),
       json: true
     })).json;

--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -262,6 +262,23 @@ export class NPM {
       lockFile: this._getInstallLockfilePath(cwd),
     });
   }
+
+  /**
+   * @typedef NpmDepsInfo
+   * @property {import('@appium/types').StringRecord} [peerDependencies]
+   * @property {import('@appium/types').StringRecord} [dependencies]
+   */
+
+  /**
+   * @param {string} pkg
+   * @returns {Promise<NpmDepsInfo>}
+   */
+  async showPackageDependencies(pkg) {
+    return (await this.exec('info', [pkg, 'peerDependencies', 'dependencies'], {
+      cwd: process.cwd(),
+      json: true
+    })).json;
+  }
 }
 
 export const npm = new NPM();


### PR DESCRIPTION
## Proposed changes

We already have a similar check for locally installed extensions (that one only prints warnings). Although it does not seem logical to allow modules installation if these are not compatible.

The check is only applied to packages managed by NPM

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
