### PR TITLE
docs(appium): fix incorrect filetype in Ruby quickstart example

### DIFF
--- a/packages/appium/docs/en/quickstart/test-rb.md
+++ b/packages/appium/docs/en/quickstart/test-rb.md
@@ -9,9 +9,10 @@ title: Write a Test (Ruby)
 The [AppiumLib](https://github.com/appium/ruby_lib) and the [AppiumLibCore](https://github.com/appium/ruby_lib_core) (**recommended**) are official Appium client libraries in Ruby, which are available via gem under the [appium_lib](https://rubygems.org/gems/appium_lib) and the [appium_lib_core](https://rubygems.org/gems/appium_lib_core) package names. The appium_lib_core inherits from the Selenium Ruby Binding, and the appium_lib inherits from the appium_lib_core, so installing these libraries include the selenium binding. We recommend `appium_lib_core` if you need a less complex client-side solution. The `appium_lib` has some useful methods the core does not have, but for the cost of greater complexity.
 
 ```bash
-gem install appium_lib
+bundle init
+bundle add appium_lib
 # or
-gem install appium_lib_core
+bundle add appium_lib_core
 ```
 
 The `appium_lib_core` is the main part as an Appium client.
@@ -21,7 +22,7 @@ The `appium_lib_core` is the main part as an Appium client.
 This example is by the `appium_lib_core` with `test-unit` gem module.
 Tes code in `appium_lib` should be similar.
 
-```python title="test.rb"
+```ruby title="test.rb"
 --8<-- "./sample-code/quickstarts/rb/test.rb"
 ```
 
@@ -49,7 +50,6 @@ running in another terminal session, otherwise you'll get an error about not bei
 to one. Then, you can execute the script:
 
 ```bash
-bundle install
 bundle exec ruby test.rb
 ```
 

--- a/packages/appium/docs/en/quickstart/test-rb.md
+++ b/packages/appium/docs/en/quickstart/test-rb.md
@@ -21,7 +21,7 @@ The `appium_lib_core` is the main part as an Appium client.
 This example is by the `appium_lib_core` with `test-unit` gem module.
 Tes code in `appium_lib` should be similar.
 
-```python title="test.py"
+```python title="test.rb"
 --8<-- "./sample-code/quickstarts/rb/test.rb"
 ```
 


### PR DESCRIPTION
## Proposed changes

The file extension was .py should be .rb for the ruby example.

It took me some time to actually find where to change this. Would be great to have a deeplink into the underlying documentation to help first time contributors like me.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
