### PR TITLE
fix(appium): Tune warning messages about installed extensions

### DIFF
--- a/packages/appium/lib/extension/extension-config.js
+++ b/packages/appium/lib/extension/extension-config.js
@@ -311,7 +311,9 @@ export class ExtensionConfig {
       const invalidFieldsText = invalidFields.map((field) => `"${field}"`).join(', ');
 
       warnings.push(
-        `${extTypeText} "${extName}" (package \`${pkgName}\`) has ${invalidFieldsEnumerationText} (${invalidFieldsText}) in \`extensions.yaml\`; this may cause upgrades done via the \`appium\` CLI tool to fail. Please reinstall with \`appium ${this.extensionType} uninstall ${extName}\` and \`appium ${this.extensionType} install ${extName}\` to attempt a fix.`
+        `${extTypeText} "${extName}" (package \`${pkgName}\`) has ${invalidFieldsEnumerationText} (${invalidFieldsText}) in \`extensions.yaml\`; ` +
+        `this may cause upgrades done via the \`appium\` CLI tool to fail. Please reinstall with \`appium ${this.extensionType} uninstall ` +
+        `${extName}\` and \`appium ${this.extensionType} install ${extName}\` to attempt a fix.`
       );
     }
 
@@ -331,16 +333,16 @@ export class ExtensionConfig {
         );
       if (extListData?.installed) {
         const {updateVersion, upToDate} = extListData;
-        if (!upToDate) {
+        if (!upToDate && updateVersion) {
           warnings.push(
             createPeerWarning(
-              `its peer dependency on older Appium v${appiumVersion}. Please upgrade \`${pkgName}\` to v${updateVersion} or newer.`
+              `its peer dependency on Appium ${appiumVersion}. Try to upgrade \`${pkgName}\` to v${updateVersion} or newer.`
             )
           );
         } else {
           warnings.push(
             createPeerWarning(
-              `its peer dependency on older Appium v${appiumVersion}. Please ask the developer of \`${pkgName}\` to update the peer dependency on Appium to v${APPIUM_VER}.`
+              `its peer dependency on Appium ${appiumVersion}. Please install a compatible version of the ${_.toLower(extTypeText)}.`
             )
           );
         }
@@ -354,13 +356,15 @@ export class ExtensionConfig {
       if (!extListData?.upToDate && extListData?.updateVersion) {
         warnings.push(
           createPeerWarning(
-            `an invalid or missing peer dependency on Appium. A newer version of \`${pkgName}\` is available; please attempt to upgrade "${extName}" to v${extListData.updateVersion} or newer.`
+            `an invalid or missing peer dependency on Appium. A newer version of \`${pkgName}\` is available; ` +
+            `please attempt to upgrade "${extName}" to v${extListData.updateVersion} or newer.`
           )
         );
       } else {
         warnings.push(
           createPeerWarning(
-            `an invalid or missing peer dependency on Appium. Please ask the developer of \`${pkgName}\` to add a peer dependency on \`^appium@${APPIUM_VER}\`.`
+            `an invalid or missing peer dependency on Appium. ` +
+            `Please ask the developer of \`${pkgName}\` to add a peer dependency on \`^appium@${APPIUM_VER}\`.`
           )
         );
       }

--- a/packages/appium/test/unit/extension/extension-config.spec.js
+++ b/packages/appium/test/unit/extension/extension-config.spec.js
@@ -239,7 +239,7 @@ describe('ExtensionConfig', function () {
             await expect(
               config.getGenericConfigWarnings(extData, extData.pkgName)
             ).to.eventually.eql([
-              `Driver "${extData.pkgName}" (package \`${extData.pkgName}\`) may be incompatible with the current version of Appium (v${APPIUM_VER}) due to its peer dependency on older Appium v${extData.appiumVersion}. Please upgrade \`${extData.pkgName}\` to v${updateVersion} or newer.`,
+              `Driver "${extData.pkgName}" (package \`${extData.pkgName}\`) may be incompatible with the current version of Appium (v${APPIUM_VER}) due to its peer dependency on Appium ${extData.appiumVersion}. Try to upgrade \`${extData.pkgName}\` to v${updateVersion} or newer.`,
             ]);
           });
         });
@@ -254,7 +254,7 @@ describe('ExtensionConfig', function () {
             await expect(
               config.getGenericConfigWarnings(extData, extData.pkgName)
             ).to.eventually.eql([
-              `Driver "${extData.pkgName}" (package \`${extData.pkgName}\`) may be incompatible with the current version of Appium (v${APPIUM_VER}) due to its peer dependency on older Appium v${extData.appiumVersion}. Please ask the developer of \`${extData.pkgName}\` to update the peer dependency on Appium to v${APPIUM_VER}.`,
+              `Driver "${extData.pkgName}" (package \`${extData.pkgName}\`) may be incompatible with the current version of Appium (v${APPIUM_VER}) due to its peer dependency on Appium ${extData.appiumVersion}. Please install a compatible version of the driver.`,
             ]);
           });
         });


### PR DESCRIPTION
## Proposed changes

Got the following warning with the current server version (the package has been installed locally):

```
WARN Appium   - Driver "uiautomator2" (package `appium-uiautomator2-driver`) may be incompatible with the current version of Appium (v2.2.1) due to its peer dependency on older Appium v^2.4.1. Please upgrade `appium-uiautomator2-driver` to vundefined or newer.
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
