### PR TITLE
fix(docutils): change default alias type to `symlink`

### DIFF
--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -139,12 +139,6 @@ export async function deploy({
     const mikeArgs = [
       ...argify(_.pickBy(mikeOpts, (value) => _.isNumber(value) || Boolean(value))),
     ];
-    if (alias) {
-      mikeArgs.push('--update-aliases', version, alias);
-      mikeArgs.push('--alias-type', aliasType);
-    } else {
-      mikeArgs.push(version);
-    }
     stop(); // discard
     // unsure about how SIGHUP is handled here
     await doServe(mikePath, mikeArgs, serveOpts);
@@ -159,8 +153,8 @@ export async function deploy({
       ),
     ];
     if (alias) {
-      mikeArgs.push('--update-aliases', version, alias);
-      mikeArgs.push('--alias-type', aliasType);
+      mikeArgs.push('--update-aliases', '--alias-type', aliasType);
+      mikeArgs.push(version, alias);
     } else {
       mikeArgs.push(version);
     }

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -108,7 +108,7 @@ export const REQUIREMENTS_TXT_PATH = path.join(PKG_ROOT_DIR, NAME_REQUIREMENTS_T
  * The default alias creation strategy to pass to `mike` when deploying
  * (`symlink`, `redirect` or `copy`)
  */
-export const DEFAULT_DEPLOY_ALIAS_TYPE = 'redirect';
+export const DEFAULT_DEPLOY_ALIAS_TYPE = 'symlink';
 
 /**
  * The default branch to deploy to


### PR DESCRIPTION
Two `mike`-related fixes for `docutils`:

* Fix argument order. `--alias-type` was being passed after the version and alias names, which should be the last arguments. Also removed the equivalent code for `mike serve` because it does not accept these arguments anyway.
* Change the default alias type to `symlink`:
  * Current behavior
    * I go to `appium.io`
    * This redirects to `http://appium.io/docs/en/latest/`
    * The alias type is `redirect`, so this further redirects to `http://appium.io/docs/en/2.4/`
  * New behavior (at least, how I _assume_ it will work)
    * I go to `appium.io`
    * This redirects to `http://appium.io/docs/en/latest/`
    * The alias type is `symlink`, so the page contents are loaded from `http://appium.io/docs/en/2.4/`, but the URL stays as `http://appium.io/docs/en/latest/`

  In theory this is a breaking change, however, I would argue that:
    * the old URL is still accessible by using the version switcher (change to another version and back)
    * the new behavior is more desirable anyway, as it prevents unwanted sharing of version-specific links