### PR TITLE
Updated logic to handle for W3C and avoid for MJSONWP

### DIFF
--- a/packages/base-driver/lib/jsonwp-proxy/proxy.js
+++ b/packages/base-driver/lib/jsonwp-proxy/proxy.js
@@ -249,7 +249,7 @@ class JWProxy {
         this.downstreamProtocol = this.getProtocolFromResBody(data);
         this.log.info(`Determined the downstream protocol as '${this.downstreamProtocol}'`);
       }
-      if (_.has(data, 'status') && parseInt(data.status, 10) !== 0) {
+      if (this.downstreamProtocol == W3C && _.has(data, 'status') && parseInt(data.status, 10) !== 0) {
         // Some servers, like chromedriver may return response code 200 for non-zero JSONWP statuses
         throwProxyError(data);
       }


### PR DESCRIPTION
## Proposed changes

Currently when using `MJSONWP` and when the status is a `7` it is getting caught in the following if statement in `appium/packages/base-driver/lib/jsonwp-proxy/proxy.js`
```
      if ( _.has(data, 'status') && parseInt(data.status, 10) !== 0) {
        // Some servers, like chromedriver may return response code 200 for non-zero JSONWP statuses
        throwProxyError(data);
      }
```
This throw proxy error is eating the commands and causing testing scripts to hang. Adding the `this.downstreamProtocol == W3C` still maintains the integrity of the check for W3C but prevents the script from hanging and allows the connection to continue.


## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ x ] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [ x ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] I have added the necessary documentation (if appropriate)
- [ x ] Any dependent changes have been merged and published in downstream modules

