### PR TITLE
docs(appium): add blog system to docs

### DIFF
--- a/packages/appium/docs/base-mkdocs.yml
+++ b/packages/appium/docs/base-mkdocs.yml
@@ -10,6 +10,9 @@ theme:
   favicon: assets/images/appium-logo.png
 
 plugins:
+  blog:
+    enabled: true
+    post_excerpt: required
   redirects:
     redirect_maps:
       'intro/requirements.md': 'quickstart/requirements.md'
@@ -34,7 +37,7 @@ extra:
       link: https://twitter.com/AppiumDevs
   alternate:
     - name: English
-      link: /docs/en/ 
+      link: /docs/en/
       lang: en
     - name: 日本
       link: /docs/ja/

--- a/packages/appium/docs/en/blog/.authors.yml
+++ b/packages/appium/docs/en/blog/.authors.yml
@@ -1,0 +1,8 @@
+authors:
+  jlipps:
+    name: "Jonathan Lipps"
+    description: "Appium project lead. Learn more about Jonathan at https://jlipps.com"
+    avatar: "https://gravatar.com/avatar/fdaadd825d92709bcf7fe76dffa12c40681c6108c67bcddf19478b2d00e3794b.jpg"
+    slug: "jlipps"
+    url: "https://jlipps.com"
+

--- a/packages/appium/docs/en/blog/index.md
+++ b/packages/appium/docs/en/blog/index.md
@@ -1,0 +1,2 @@
+# Appium Blog
+

--- a/packages/appium/docs/en/blog/posts/hello-world.md
+++ b/packages/appium/docs/en/blog/posts/hello-world.md
@@ -1,0 +1,15 @@
+---
+authors:
+  - jlipps
+date: 2024-03-07
+---
+
+# Hello World!
+
+This is the first post in the Appium blog. There's not much to see here yet. We're creating this
+space so we can make announcements or post other news, or information about events, that don't
+really fit inside the documentation itself.
+
+<!-- more -->
+
+Stay tuned for more!

--- a/packages/appium/docs/mkdocs-en.yml
+++ b/packages/appium/docs/mkdocs-en.yml
@@ -8,6 +8,7 @@ theme:
   language: en
 nav:
   - Welcome: index.md
+  - Blog: blog/index.md
   - Introduction:
       - intro/index.md
       - Background:


### PR DESCRIPTION
This way we can add persistent new/announcement/info posts when necessary.

![Screenshot 2024-03-07 at 14 00 22](https://github.com/appium/appium/assets/605053/d9b3f3ee-23ca-4f61-be0f-20cc73392d01)
