### PR TITLE
chore(base-driver): Drop the obsolete es6-error import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8046,10 +8046,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "license": "MIT"
-    },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
       "dev": true,
@@ -21549,7 +21545,6 @@
         "axios": "1.6.8",
         "bluebird": "3.7.2",
         "body-parser": "1.20.2",
-        "es6-error": "4.1.1",
         "express": "4.19.2",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
@@ -22848,7 +22843,6 @@
         "axios": "1.6.8",
         "bluebird": "3.7.2",
         "body-parser": "1.20.2",
-        "es6-error": "4.1.1",
         "express": "4.19.2",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
@@ -29198,9 +29192,6 @@
         "es6-symbol": "^3.1.3",
         "next-tick": "^1.1.0"
       }
-    },
-    "es6-error": {
-      "version": "4.1.1"
     },
     "es6-iterator": {
       "version": "2.0.3",

--- a/packages/appium/test/unit/utils.spec.js
+++ b/packages/appium/test/unit/utils.spec.js
@@ -82,12 +82,10 @@ describe('utils', function () {
           'appium:foo2': 'bar2',
         }
       );
-      res.error.should.eql({
-        jsonwpCode: 61,
-        error: 'invalid argument',
-        w3cStatus: 400,
-        _stacktrace: null,
-      });
+      res.error.jsonwpCode.should.eql(61);
+      res.error.error.should.eql('invalid argument');
+      res.error.w3cStatus.should.eql(400);
+      _.isNull(res.error._stacktrace).should.be.true;
     });
     it('should reject if W3C caps are not passing constraints', function () {
       const err = parseCapsForInnerDriver(undefined, W3C_CAPS, {
@@ -101,14 +99,13 @@ describe('utils', function () {
         ...W3C_CAPS,
         firstMatch: [{foo: 'bar'}, {'appium:hello': 'world'}],
       };
-      parseCapsForInnerDriver(BASE_CAPS, w3cCaps, {
+      const error = parseCapsForInnerDriver(BASE_CAPS, w3cCaps, {
         hello: {presence: true},
-      }).error.should.eql({
-        jsonwpCode: 61,
-        error: 'invalid argument',
-        w3cStatus: 400,
-        _stacktrace: null,
-      });
+      }).error;
+      error.jsonwpCode.should.eql(61);
+      error.error.should.eql('invalid argument');
+      error.w3cStatus.should.eql(400);
+      _.isNull(error._stacktrace).should.be.true;
     });
     it('should add appium prefixes to W3C caps that are not standard in W3C', function () {
       parseCapsForInnerDriver(undefined, {

--- a/packages/base-driver/lib/protocol/errors.js
+++ b/packages/base-driver/lib/protocol/errors.js
@@ -18,6 +18,7 @@ export class ProtocolError extends Error {
     }
     this.w3cStatus = w3cStatus || HTTPStatusCodes.BAD_REQUEST;
     this._stacktrace = null;
+    this.name = this.constructor.name;
   }
 
   get stacktrace() {
@@ -906,6 +907,7 @@ export class BadParametersError extends Error {
         : generateBadParametersMessage(requiredParams, actualParams),
     );
     this.w3cStatus = HTTPStatusCodes.BAD_REQUEST;
+    this.name = this.constructor.name;
   }
 }
 
@@ -943,6 +945,7 @@ export class ProxyRequestError extends Error {
     } else {
       this.jsonwp = responseErrorObj;
     }
+    this.name = this.constructor.name;
   }
 
   getActualError() {

--- a/packages/base-driver/lib/protocol/errors.js
+++ b/packages/base-driver/lib/protocol/errors.js
@@ -1,4 +1,3 @@
-import ES6Error from 'es6-error';
 import _ from 'lodash';
 import {util, logger} from '@appium/support';
 import {StatusCodes as HTTPStatusCodes} from 'http-status-codes';
@@ -9,7 +8,7 @@ const w3cLog = logger.getLogger('W3C');
 const W3C_UNKNOWN_ERROR = 'unknown error';
 
 // base error class for all of our errors
-export class ProtocolError extends ES6Error {
+export class ProtocolError extends Error {
   constructor(msg, jsonwpCode, w3cStatus, error) {
     super(msg);
     this.jsonwpCode = jsonwpCode;
@@ -896,7 +895,7 @@ function generateBadParametersMessage(requiredParams, actualParams) {
 }
 
 // Equivalent to W3C InvalidArgumentError
-export class BadParametersError extends ES6Error {
+export class BadParametersError extends Error {
   static error() {
     return 'invalid argument';
   }
@@ -916,7 +915,7 @@ export class BadParametersError extends ES6Error {
  * In case of ProxyRequestError should fetch the actual error by calling `getActualError()`
  * for proxy failure to generate the client response.
  */
-export class ProxyRequestError extends ES6Error {
+export class ProxyRequestError extends Error {
   constructor(err, responseError, httpStatus) {
     let responseErrorObj = util.safeJsonParse(responseError);
     if (!_.isPlainObject(responseErrorObj)) {

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -58,7 +58,6 @@
     "axios": "1.6.8",
     "bluebird": "3.7.2",
     "body-parser": "1.20.2",
-    "es6-error": "4.1.1",
     "express": "4.19.2",
     "http-status-codes": "2.3.0",
     "lodash": "4.17.21",


### PR DESCRIPTION
## Proposed changes

I assume this import is obsolete now.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
