### PR TITLE
fix: do not print deprecation message for caps that is not provided

### DIFF
--- a/packages/base-driver/lib/basedriver/desired-caps.js
+++ b/packages/base-driver/lib/basedriver/desired-caps.js
@@ -74,7 +74,8 @@ validator.validators.isArray = function isArray(value) {
   return 'must be of type array';
 };
 validator.validators.deprecated = function deprecated(value, options, key) {
-  if (options) {
+  // do not print caps that hasn't been provided.
+  if (typeof value !== 'undefined' && options) {
     log.warn(`${key} is a deprecated capability`);
   }
   return null;


### PR DESCRIPTION
## Proposed changes

https://github.com/appium/appium-xcuitest-driver/pull/2383#discussion_r1558901795 

`[BaseDriver] useSimpleBuildTest is a deprecated capability` message could print 3 times if the value was given. This PR fixes one reason.

With this pr, 

```
[XCUITestDriver@8e46] }
[BaseDriver] useSimpleBuildTest is a deprecated capability
[BaseDriver] useSimpleBuildTest is a deprecated capability
[BaseDriver] useSimpleBuildTest is a deprecated capability
[XCUITestDriver@8e46] The desired capabilities include neither an app nor a bundleId. WebDriverAgent will be started without the default app
[XCUITestDriver@8e46 (555c4c93)] Session created with session id: 555c4c93-b2d3-47b1-aaf4-a24783cb9ccc
```

with `useSimpleBuildTest` will be:

```
[XCUITestDriver@8e46] }
[BaseDriver] useSimpleBuildTest is a deprecated capability
[BaseDriver] useSimpleBuildTest is a deprecated capability
[XCUITestDriver@8e46] The desired capabilities include neither an app nor a bundleId. WebDriverAgent will be started without the default app
[XCUITestDriver@8e46 (555c4c93)] Session created with session id: 555c4c93-b2d3-47b1-aaf4-a24783cb9ccc
```

Another reason is `validateCaps`. `validateCaps` could be called multiple times in https://github.com/appium/appium/blob/4d48010a30339887f2138b3adbaf7dce7bb804a0/packages/base-driver/lib/basedriver/capabilities.ts and https://github.com/appium/appium/blob/4d48010a30339887f2138b3adbaf7dce7bb804a0/packages/base-driver/lib/basedriver/driver.ts in total. Ideally, we'd like to print once. This Pr does not include this.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
