### PR TITLE
fix(support): Enable shell option for all npm-related commands on Windows

### DIFF
--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -44,11 +44,16 @@ export class NPM {
    * @param {Omit<TeenProcessExecOptions, 'cwd'>} [execOpts]
    */
   async exec(cmd, args, opts, execOpts = {}) {
-    let {cwd, json, lockFile} = opts;
+    const {cwd, json, lockFile} = opts;
 
     // make sure we perform the current operation in cwd
     /** @type {TeenProcessExecOptions} */
-    const teenProcessExecOpts = {...execOpts, cwd};
+    const teenProcessExecOpts = {
+      ...execOpts,
+      // https://github.com/nodejs/node/issues/52572
+      shell: system.isWindows(),
+      cwd,
+    };
 
     args.unshift(cmd);
     if (json) {
@@ -273,9 +278,6 @@ export class NPM {
     return (await this.exec('info', [pkg, ...entries], {
       cwd: process.cwd(),
       json: true,
-    }, {
-      // https://discuss.appium.io/t/appium-driver-install-fails-while-checking-drivers-compatibility/42209
-      shell: system.isWindows(),
     })).json;
   }
 }


### PR DESCRIPTION
## Proposed changes

Makes it work on Windows with newer node.js versions. Related to https://github.com/nodejs/node/issues/52572

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
