### PR TITLE
ci: add back Node 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,9 +55,9 @@ jobs:
     outputs:
       versions: ${{ steps.generate-matrix.outputs.versions }}
     steps:
-    - name: Select 2 most recent LTS versions of Node.js
+    - name: Select 3 most recent LTS versions of Node.js
       id: generate-matrix
-      run: echo "versions=$(curl -s https://endoflife.date/api/nodejs.json | jq -c '[[.[] | select(.lts != false)][:2] | .[].cycle | tonumber]')" >> "$GITHUB_OUTPUT"
+      run: echo "versions=$(curl -s https://endoflife.date/api/nodejs.json | jq -c '[[.[] | select(.lts != false)][:3] | .[].cycle | tonumber]')" >> "$GITHUB_OUTPUT"
 
   test:
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,11 @@ jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.generate-matrix.outputs.versions }}
+      versions: ${{ steps.generate-matrix.outputs.lts }}
     steps:
-    - name: Select 3 most recent LTS versions of Node.js
+    - name: Select all active LTS versions of Node.js
       id: generate-matrix
-      run: echo "versions=$(curl -s https://endoflife.date/api/nodejs.json | jq -c '[[.[] | select(.lts != false)][:3] | .[].cycle | tonumber]')" >> "$GITHUB_OUTPUT"
+      uses: msimerson/node-lts-versions@v1
 
   test:
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.generate-matrix.outputs.lts }}
+      versions: ${{ steps.generate-matrix.outputs.active }}
     steps:
     - name: Select all active LTS versions of Node.js
       id: generate-matrix

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,9 @@ jobs:
     outputs:
       versions: ${{ steps.generate-matrix.outputs.versions }}
     steps:
-    - name: Select 2 most recent LTS versions of Node.js
+    - name: Select 3 most recent LTS versions of Node.js
       id: generate-matrix
-      run: echo "versions=$(curl -s https://endoflife.date/api/nodejs.json | jq -c '[[.[] | select(.lts != false)][:2] | .[].cycle | tonumber]')" >> "$GITHUB_OUTPUT"
+      run: echo "versions=$(curl -s https://endoflife.date/api/nodejs.json | jq -c '[[.[] | select(.lts != false)][:3] | .[].cycle | tonumber]')" >> "$GITHUB_OUTPUT"
 
   check:
     needs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.generate-matrix.outputs.lts }}
+      versions: ${{ steps.generate-matrix.outputs.active }}
     steps:
     - name: Select all active LTS versions of Node.js
       id: generate-matrix

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,11 +12,11 @@ jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
     outputs:
-      versions: ${{ steps.generate-matrix.outputs.versions }}
+      versions: ${{ steps.generate-matrix.outputs.lts }}
     steps:
-    - name: Select 3 most recent LTS versions of Node.js
+    - name: Select all active LTS versions of Node.js
       id: generate-matrix
-      run: echo "versions=$(curl -s https://endoflife.date/api/nodejs.json | jq -c '[[.[] | select(.lts != false)][:3] | .[].cycle | tonumber]')" >> "$GITHUB_OUTPUT"
+      uses: msimerson/node-lts-versions@v1
 
   check:
     needs:


### PR DESCRIPTION
Node.js 22 was recently released, and as a result, the current CI scripts are no longer running on Node.js 18 (which is still maintained). This PR adds it back.
