### PR TITLE
fix(appium): Do not crash the process if there was an exception in a winston transport

### DIFF
--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -228,7 +228,7 @@ async function init(args) {
     try {
       log[winstonLevel](msg);
     } catch (e) {
-      if (!reportedLoggerErrors.has(e.message)) {
+      if (!reportedLoggerErrors.has(e.message) && process.stderr.writable) {
         // eslint-disable-next-line no-console
         console.error(
           `The log message '${_.truncate(msg, {length: 30})}' cannot be written into ` +

--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -227,6 +227,9 @@ async function init(args) {
     }
     try {
       log[winstonLevel](msg);
+      if (_.isFunction(args.logHandler)) {
+        args.logHandler(level, msg);
+      }
     } catch (e) {
       if (!reportedLoggerErrors.has(e.message) && process.stderr.writable) {
         // eslint-disable-next-line no-console
@@ -236,9 +239,6 @@ async function init(args) {
         );
         reportedLoggerErrors.add(e.message);
       }
-    }
-    if (args.logHandler && _.isFunction(args.logHandler)) {
-      args.logHandler(level, msg);
     }
   });
 }


### PR DESCRIPTION
## Proposed changes

Sometimes winston may crash with EPIPE if the log output stream is not accessible anymore. We don't want to crash the whole process in such case because of an uncaught exception:

```
2024-05-03 09:10:08:373 uncaughtException: write EPIPE
Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:160:15)
    at writeGeneric (node:internal/stream_base_commons:151:3)
    at Socket._writeGeneric (node:net:952:11)
    at Socket._write (node:net:964:8)
    at writeOrBuffer (node:internal/streams/writable:447:12)
    at _write (node:internal/streams/writable:389:10)
    at Socket.Writable.write (node:internal/streams/writable:393:10)
    at Console.log (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/lib/winston/transports/console.js:51:25)
    at Console._write (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston-transport/modern.js:103:17)
    at doWrite (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston-transport/node_modules/readable-stream/lib/_stream_writable.js:390:139)
    at writeOrBuffer (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston-transport/node_modules/readable-stream/lib/_stream_writable.js:381:5)
    at Console.Writable.write (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston-transport/node_modules/readable-stream/lib/_stream_writable.js:302:11)
    at DerivedLogger.ondata (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_readable.js:629:20)
    at DerivedLogger.emit (node:events:526:35)
    at addChunk (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_readable.js:279:12)
    at readableAddChunk (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_readable.js:262:11)
    at DerivedLogger.Readable.push (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_readable.js:228:10)
    at DerivedLogger.Transform.push (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_transform.js:132:32)
    at DerivedLogger._transform (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/lib/winston/logger.js:313:12)
    at DerivedLogger.Transform._read (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_transform.js:166:10)
    at DerivedLogger.Transform._write (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_transform.js:155:83)
    at doWrite (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_writable.js:390:139)
    at writeOrBuffer (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_writable.js:381:5)
    at DerivedLogger.Writable.write (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/node_modules/readable-stream/lib/_stream_writable.js:302:11)
    at DerivedLogger.<computed> [as error] (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/winston/lib/winston/create-logger.js:81:14)
    at EventEmitter.<anonymous> (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/appium/lib/logsink.js:220:22)
    at EventEmitter.emit (node:events:514:28)
    at EventEmitter.<anonymous> (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/npmlog/lib/log.js:247:8)
    at EventEmitter.<anonymous> (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/npmlog/lib/log.js:377:23)
    at Object.wrappedLogger.<computed> [as error] (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/appium-xcuitest-driver/node_modules/@appium/support/lib/logging.js:106:24)
    at SubProcess.<anonymous> (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent/lib/xcodebuild.js:316:20)
    at SubProcess.emit (node:events:514:28)
    at handleOutput (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/appium-xcuitest-driver/node_modules/teen_process/lib/subprocess.js:172:14)
    at Socket.<anonymous> (/Users/jenkins/actions-runner/_at-tests/guacamole/guacamole/testing/app-at/node_modules/appium-xcuitest-driver/node_modules/teen_process/lib/subprocess.js:215:48)
    at Socket.emit (node:events:514:28)
    at addChunk (node:internal/streams/readable:376:12)
    at readableAddChunk (node:internal/streams/readable:345:11)
    at Socket.Readable.push (node:internal/streams/readable:286:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
