### PR TITLE
chore(github): add link to Appium forum when creating an issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: ❓ Question 
+    url: https://discuss.appium.io/
+    about: Please use the Appium forum for questions


### PR DESCRIPTION
This adds a link to the Appium forum in the issue type selector, when creating a new issue.
Just in case, creation of blank issues is intentionally left enabled.