### PR TITLE
fix: Revert "chore(deps): update dependency conventional-changelog-conventionalcommits to v8"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "chai": "4.4.1",
         "chai-as-promised": "7.1.1",
         "chai-webdriverio-async": "3.0.0",
-        "conventional-changelog-conventionalcommits": "8.0.0",
+        "conventional-changelog-conventionalcommits": "7.0.2",
         "cpy-cli": "5.0.0",
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
@@ -6481,15 +6481,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-core": {
@@ -28074,9 +28074,9 @@
       }
     },
     "conventional-changelog-conventionalcommits": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "chai": "4.4.1",
     "chai-as-promised": "7.1.1",
     "chai-webdriverio-async": "3.0.0",
-    "conventional-changelog-conventionalcommits": "8.0.0",
+    "conventional-changelog-conventionalcommits": "7.0.2",
     "cpy-cli": "5.0.0",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",


### PR DESCRIPTION
https://github.com/semantic-release/release-notes-generator/issues/633