### PR TITLE
docs: update CLI and quickstart contents

### DIFF
--- a/packages/appium/docs/en/cli/args.md
+++ b/packages/appium/docs/en/cli/args.md
@@ -27,10 +27,12 @@ below.
 |`--base-path`|Base path to use as the prefix for all webdriver routes running on the server|string|`""`|`-pa`|
 |`--callback-address`|Callback IP address (default: same as `--address`)|string||`-ca`|
 |`--callback-port`|Callback port (default: same as `--port`) (Value must be between `1` and `65535`)|integer|`4723`|`-cp`|
+|`--config`|Path to an [Appium configuration JSON file](../guides/config.md)|string|||
 |`--debug-log-spacing`|Add exaggerated spacing in logs to help with visual inspection|boolean|`false`||
 |`--default-capabilities`|Set the default desired capabilities, which will be set on each session unless overridden by received capabilities. If a string, a path to a JSON file containing the capabilities, or raw JSON.|object||`-dc`|
 |`--deny-insecure`|Set which insecure features are not allowed to run in this server's sessions. Features are defined on a driver level; see documentation for more details. Features listed here will not be enabled even if also listed in `--allow-insecure`, and even if `--relaxed-security` is enabled. If string, a path to a text file containing policy or a comma-delimited list.|array<string>|`[]`||
 |`--driver`|Driver-specific configuration. Keys should correspond to driver package names|object|||
+|`--drivers-import-chunk-size`|The maximum amount of drivers that could be imported in parallel on server startup|number|`3`||
 |`--keep-alive-timeout`|Number of seconds the Appium server should apply as both the keep-alive timeout and the connection timeout for all requests. Setting this to `0` disables the timeout.|integer|`600`|`-ka`|
 |`--local-timezone`|Use local timezone for timestamps|boolean|`false`||
 |`--log`|Also send log output to this file|string||`-g`|
@@ -38,12 +40,11 @@ below.
 |`--log-level`|Log level (console[:file]) (Value must be one of: `info`, `info:debug`, `info:info`, `info:warn`, `info:error`, `warn`, `warn:debug`, `warn:info`, `warn:warn`, `warn:error`, `error`, `error:debug`, `error:info`, `error:warn`, `error:error`, `debug`, `debug:debug`, `debug:info`, `debug:warn`, `debug:error`)|string|`debug`||
 |`--log-no-colors`|Do not use color in console output|boolean|`false`||
 |`--log-timestamp`|Show timestamps in console output|boolean|`false`||
-|`--plugins-import-chunk-size`|The maximum amount of plugins that could be imported in parallel on server startup|number|`7`||
-|`--drivers-import-chunk-size`|The maximum amount of drivers that could be imported in parallel on server startup|number|`3`||
 |`--long-stacktrace`|Add long stack traces to log entries. Recommended for debugging only.|boolean|`false`||
-|`--no-perms-check`|Skip various permission checks on the server startup if set to true|boolean|`false`||
-|`--nodeconfig`|Path to configuration JSON file to register Appium as a node with Selenium Grid 3; otherwise the configuration itself|object|||
+|`--no-perms-check`|Skip various permission checks on the server startup|boolean|`false`||
+|`--nodeconfig`|Path to configuration JSON file to register Appium as a node with Selenium Grid 3; otherwise the configuration itself|string|||
 |`--plugin`|Plugin-specific configuration. Keys should correspond to plugin package names|object|||
+|`--plugins-import-chunk-size`|The maximum amount of plugins that could be imported in parallel on server startup|number|`7`||
 |`--port`|Port to listen on (Value must be between `1` and `65535`)|integer|`4723`|`-p`|
 |`--relaxed-security`|Disable additional security checks, so it is possible to use some advanced features, provided by drivers supporting this option. Only enable it if all the clients are in the trusted network and it's not the case if a client could potentially break out of the session sandbox. Specific features can be overridden by using `--deny-insecure`|boolean|`false`||
 |`--session-override`|Enables session override (clobbering)|boolean|`false`||
@@ -55,3 +56,13 @@ below.
 |`--use-drivers`|A list of drivers to activate. By default, all installed drivers will be activated.|array<string>|`[]`||
 |`--use-plugins`|A list of plugins to activate. To activate all plugins, the value should be an array with a single item `"all"`.|array<string>|`[]`||
 |`--webhook`|Also send log output to this http listener|string||`-G`|
+
+The following arguments are used for information retrieval, after which the server will automatically exit. They are therefore meant for reference or debug purposes.
+
+|<div style="width:10em">Argument</div>|Description|Alias|
+|--|--|--|
+|`--help`|Print instructions on using the Appium command-line. This argument can also be used for any Appium subcommands.|`-h`|
+|`--show-build-info`|Print detailed information on the Appium server version||
+|`--show-config`|Print the current Appium server configuration details||
+|`--show-debug-info`|Print information on the current environment: details about the operating system, Node.js, and Appium itself||
+|`--version`|Print the Appium server version|`-v`|

--- a/packages/appium/docs/en/cli/extensions.md
+++ b/packages/appium/docs/en/cli/extensions.md
@@ -30,27 +30,33 @@ All Extension CLI commands can take an optional `--json` argument, which will re
 the command as a machine-readable JSON string rather than the standard output, which is colourized
 and tuned for human consumption.
 
-### `list`
+### `doctor`
 
-List installed and available extensions. "Available" extensions include those which are officially
-recognized by the Appium team, but you are not limited to installing only the extensions displayed
-in this list.
+Run doctor checks for the given extension, which validate whether the extension has its prerequisites
+configured correctly. Note that not all extensions include doctor checks. See the
+[Building Doctor Checks](../developing/build-doctor-checks.md) tutorial for more details on
+how to create them.
 
 Usage:
 
 ```
-appium <ext-type> list [--installed] [--updates] [--json]
+appium <ext-type> doctor <ext-name>
 ```
 
 Required arguments:
 
 - `<ext-type>`: must be `driver` or `plugin`
+- `<ext-name>`: the name of the extension whose doctor checks you want to run
 
 Optional arguments:
 
-- `--installed`: show only installed extensions, not installed plus available extensions
-- `--updates`: for extensions installed via NPM, display a message if there are any updates
 - `--json`: return the result in JSON format
+
+Example (run doctor checks for the UiAutomator2 driver):
+
+```
+appium driver doctor uiautomator2
+```
 
 ### `install`
 
@@ -124,46 +130,26 @@ by `npm install`:
     appium plugin install --source=local /path/to/my/plugin
     ```
 
-### `update`
+### `list`
 
-Update one or more extensions that have been installed via NPM. By default, Appium will not
-automatically update any extension that has a revision in its major version, so as to prevent
-unintended breaking changes.
+List installed and available extensions. "Available" extensions include those which are officially
+recognized by the Appium team, but you are not limited to installing only the extensions displayed
+in this list.
 
 Usage:
 
 ```
-appium <ext-type> update <ext-name> [--unsafe] [--json]
+appium <ext-type> list [--installed] [--updates] [--json]
 ```
 
 Required arguments:
 
 - `<ext-type>`: must be `driver` or `plugin`
-- `<ext-name>`: the name of the extension to update, or the string `installed` (which will update
-  all installed extensions)
 
 Optional arguments:
 
-- `--unsafe`: direct Appium to go ahead and update passed a major version boundary
-- `--json`: return the result in JSON format
-
-### `uninstall`
-
-Remove an installed extension.
-
-Usage:
-
-```
-appium <ext-type> uninstall <ext-name> [--json]
-```
-
-Required arguments:
-
-- `<ext-type>`: must be `driver` or `plugin`
-- `<ext-name>`: the name of the extension to uninstall
-
-Optional arguments:
-
+- `--installed`: show only installed extensions, not installed plus available extensions
+- `--updates`: for extensions installed via NPM, display a message if there are any updates
 - `--json`: return the result in JSON format
 
 ### `run`
@@ -187,7 +173,7 @@ Required arguments:
 
 Optional arguments:
 
-* `script-args`: any arguments that Appium does not interpret as belonging to its own set of
+- `script-args`: any arguments that Appium does not interpret as belonging to its own set of
   arguments will be passed along to the extension script
 - `--json`: return the result in JSON format
 
@@ -197,23 +183,44 @@ Example (run the `reset` script included with the UiAutomator2 driver):
 appium driver run uiautomator2 reset
 ```
 
-### `doctor`
+### `update`
 
-Run doctor checks for the given extension if it has any. Extension authors can include
-runnable scripts that assist with driver or plugin preconditions validations. These scripts
-must be valid Node.js sources, must be listed in the package manifest, and must export
-class instances that comply to the particular requirements.
-See the [Building Doctor Checks](../developing/build-doctor-checks.md) tutorial for more
-details on these requirements.
+Update one or more extensions that have been installed via NPM. By default, Appium will not
+automatically update any extension past a major version boundary, so as to prevent
+unintended breaking changes.
 
 Usage:
 
 ```
-appium <ext-type> doctor <ext-name>
+appium <ext-type> update <ext-name> [--unsafe] [--json]
 ```
 
-Example (run doctor checks for the UiAutomator2 driver):
+Required arguments:
+
+- `<ext-type>`: must be `driver` or `plugin`
+- `<ext-name>`: the name of the extension to update, or the string `installed` (which will update
+  all installed extensions)
+
+Optional arguments:
+
+- `--unsafe`: direct Appium to go ahead and update past a major version boundary
+- `--json`: return the result in JSON format
+
+### `uninstall`
+
+Remove an installed extension.
+
+Usage:
 
 ```
-appium driver doctor uiautomator2
+appium <ext-type> uninstall <ext-name> [--json]
 ```
+
+Required arguments:
+
+- `<ext-type>`: must be `driver` or `plugin`
+- `<ext-name>`: the name of the extension to uninstall
+
+Optional arguments:
+
+- `--json`: return the result in JSON format

--- a/packages/appium/docs/en/cli/index.md
+++ b/packages/appium/docs/en/cli/index.md
@@ -11,14 +11,16 @@ the Appium server. This section of the Appium documentation describes how to use
 To start off, you can run `appium -v` or `appium --version` to return the installed version, 
 or run `appium -h` or `appium --help` to return the help message.
 
-The main `appium` executable provides 3 subcommands:
+The main `appium` executable provides the following subcommands:
 
 1. `appium server` (or simply `appium`) - launch an Appium server
     - [See here for accepted arguments](./args.md)
     - For advanced features, [see here for accepted environment variables](./env-vars.md)
 2. `appium driver` - manage Appium drivers
-    - [See here for accepted arguments](./extensions.md)
+    - [See here for details](./extensions.md)
 3. `appium plugin` - manage Appium plugins
-    - [See here for accepted arguments](./extensions.md)
+    - [See here for details](./extensions.md)
+4. `appium setup` - batch install a preset of drivers and plugins
+    - [See here for details](./setup.md)
 
 Like the main command, you can also run each subcommand with the `-h` or `--help` flag to learn more about it.

--- a/packages/appium/docs/en/cli/setup.md
+++ b/packages/appium/docs/en/cli/setup.md
@@ -1,0 +1,25 @@
+---
+hide:
+  - toc
+
+title: Setup Command-Line Usage
+---
+
+The `setup` command aims to simplify the initial procedure of setting up Appium. It allows to install
+multiple extensions (drivers/plugins) in one go, without the need to run
+`appium <extension> install <ext-name>` multiple times.
+
+The command has several presets that can be used to install different sets of extensions.
+The presets are as follows:
+
+|Preset|Installation Command|Included Drivers|Included Plugins|
+|--|--|--|--|
+|Mobile|`appium setup mobile` or `appium setup`|`uiautomator2`, `xcuitest`, `espresso`|`images`|
+|Desktop application|`appium setup desktop`|`mac2`|`images`|
+|Desktop browser|`appium setup browser`|`safari`, `gecko`, `chromium`|`images`|
+
+Attempting to install a preset while already having one or more of its included extensions installed
+will only install the missing extensions.
+
+Refer to the [Ecosystem documentation](../ecosystem/index.md) to learn more about the extensions
+listed above.

--- a/packages/appium/docs/en/cli/setup.md
+++ b/packages/appium/docs/en/cli/setup.md
@@ -14,12 +14,14 @@ The presets are as follows:
 
 |Preset|Installation Command|Included Drivers|Included Plugins|
 |--|--|--|--|
-|Mobile|`appium setup mobile` or `appium setup`|`uiautomator2`, `xcuitest`, `espresso`|`images`|
-|Desktop application|`appium setup desktop`|`mac2`|`images`|
-|Desktop browser|`appium setup browser`|`safari`, `gecko`, `chromium`|`images`|
+|Mobile|`appium setup mobile` or `appium setup`|`uiautomator2`, `xcuitest`[^1], `espresso`|`images`|
+|Desktop application|`appium setup desktop`|`mac2`[^1]|`images`|
+|Desktop browser|`appium setup browser`|`safari`[^1], `gecko`, `chromium`|`images`|
 
 Attempting to install a preset while already having one or more of its included extensions installed
 will only install the missing extensions.
 
 Refer to the [Ecosystem documentation](../ecosystem/index.md) to learn more about the extensions
 listed above.
+
+[^1]: Only installed if the host machine is running macOS.

--- a/packages/appium/docs/en/cli/setup.md
+++ b/packages/appium/docs/en/cli/setup.md
@@ -7,7 +7,7 @@ title: Setup Command-Line Usage
 
 The `setup` command aims to simplify the initial procedure of setting up Appium. It allows to install
 multiple extensions (drivers/plugins) in one go, without the need to run
-`appium <extension> install <ext-name>` multiple times.
+`appium <ext-name> install <ext-name>` multiple times.
 
 The command has several presets that can be used to install different sets of extensions.
 The presets are as follows:

--- a/packages/appium/docs/en/quickstart/index.md
+++ b/packages/appium/docs/en/quickstart/index.md
@@ -12,10 +12,10 @@ running Appium and writing Appium scripts.
 The basic plan for this quickstart is as follows:
 
 1. Install Appium
-1. Install an Appium driver and its dependencies (we'll be using the [UiAutomator2
-driver](https://github.com/appium/appium-uiautomator2-driver) for these examples)
-1. Install an Appium client library in your language of choice (this guide contains options for
-JavaScript, Python, Java, Ruby, and .NET).
+1. Install an Appium driver and its dependencies
+    - This guide provides instructions for the [UiAutomator2 driver](https://github.com/appium/appium-uiautomator2-driver)
+1. Install an Appium client library in your language of choice
+    - This guide contains options for JavaScript, Python, Java, Ruby, and .NET
 1. Write and run a simple Appium automation script using a sample application
 
 ### Requirements

--- a/packages/appium/docs/en/quickstart/install.md
+++ b/packages/appium/docs/en/quickstart/install.md
@@ -9,10 +9,10 @@ title: Install Appium
 
     Before installing, make sure to check the [System Requirements](./requirements.md).
 
-Appium can be installed using `npm`:
+Appium can be installed globally using `npm`:
 
 ```bash
-npm install appium
+npm install -g appium
 ```
 
 !!! note
@@ -28,11 +28,12 @@ appium
 ```
 
 This launches the Appium server process, which loads all the installed Appium drivers, and
-begins waiting for new session requests from client connections (such as test automation scripts). Since the server process is
-independent from its clients, it must always be explicitly
-launched before starting a new session.
+begins waiting for new session requests from client connections (such as test automation scripts).
+Since the server process is independent from its clients, it must be explicitly launched before
+attempting to start a new session.
 
-The console log will list all the valid URLs that clients can use to connect to this server:
+When the server is launched, the console log will list all the valid URLs that clients can use to
+connect to this server:
 
 ```
 [Appium] You can provide the following URLs in your client code to connect to this server:
@@ -44,6 +45,6 @@ Once a client requests a new session, the Appium server process will start loggi
 this session until its termination. Keep this in mind - if you ever encounter issues with Appium
 tests, you can always check the server log for more details.
 
-Now, even though Appium is installed and running, it does not come bundled with any drivers, meaning
-it cannot automate anything yet. We will set up automation for Android - continue to the next step:
-[Installing the UiAutomator2 Driver](./uiauto2-driver.md).
+So what's next? Even though Appium is installed and running, it does not come bundled with any
+drivers, which means it cannot automate anything yet. We will therefore set up automation for
+Android - continue to [Installing the UiAutomator2 Driver](./uiauto2-driver.md).

--- a/packages/appium/docs/en/quickstart/install.md
+++ b/packages/appium/docs/en/quickstart/install.md
@@ -9,33 +9,41 @@ title: Install Appium
 
     Before installing, make sure to check the [System Requirements](./requirements.md).
 
-You can install Appium globally using `npm`:
+Appium can be installed using `npm`:
 
 ```bash
-npm i -g appium
+npm install appium
 ```
 
 !!! note
 
     Other package managers are not currently supported.
 
-After installation, you should be able to run Appium from the command line:
+## Starting Appium
+
+Appium can be started [using the command line](../cli/index.md):
 
 ```
 appium
 ```
 
-You should see some output that starts with a line like this:
+This launches the Appium server process, which loads all the installed Appium drivers, and
+begins waiting for new session requests from client connections (such as test automation scripts). Since the server process is
+independent from its clients, it must always be explicitly
+launched before starting a new session.
+
+The console log will list all the valid URLs that clients can use to connect to this server:
 
 ```
-[Appium] Welcome to Appium v2.4.1
+[Appium] You can provide the following URLs in your client code to connect to this server:
+[Appium] 	http://127.0.0.1:4723/ (only accessible from the same host)
+(... any other URLs ...)
 ```
 
-In order to update Appium using `npm`:
+Once a client requests a new session, the Appium server process will start logging all details about
+this session until its termination. Keep this in mind - if you ever encounter issues with Appium
+tests, you can always check the server log for more details.
 
-```bash
-npm update -g appium
-```
-
-That's it! If you see this, the Appium server is up and running. Go ahead and quit
-it (Ctrl-C) and move on to the [next step](./uiauto2-driver.md), where we'll install a driver for automating Android apps.
+Now, even though Appium is installed and running, it does not come bundled with any drivers, meaning
+it cannot automate anything yet. We will set up automation for Android - continue to the next step:
+[Installing the UiAutomator2 Driver](./uiauto2-driver.md).

--- a/packages/appium/docs/en/quickstart/requirements.md
+++ b/packages/appium/docs/en/quickstart/requirements.md
@@ -9,7 +9,7 @@ The basic requirements for the Appium server are:
 
 * A macOS, Linux, or Windows operating system
 * [Node.js](https://nodejs.org) version in the [SemVer](https://semver.org) range `^14.17.0 || ^16.13.0 || >=18.0.0`
-   * LTS is recommended
+  * LTS is recommended
 * [`npm`](https://npmjs.com) version `>=8` (`npm` is usually bundled with Node.js, but can be upgraded
 independently)
 
@@ -24,6 +24,6 @@ documentation of the [Appium driver(s)](../ecosystem/drivers.md) for that platfo
 dependencies. It is almost universally the case that Appium drivers for a given platform will
 require the developer toolchain and SDKs for that platform to be installed.
 
-You may find it useful to use the `appium-doctor` tool for verifying if all driver requirements are
-installed. It can check the prerequisites for Android and iOS drivers.
-Learn more on its GitHub page: [Appium Doctor](https://github.com/appium/appium/tree/master/packages/doctor)
+In order to assist with driver requirements, each (official) driver comes with the Appium Doctor tool,
+which allows to verify if all requirements have been set up. Learn more about how to use this tool in
+the [Command-Line Usage documentation](../cli/extensions.md).

--- a/packages/appium/docs/en/quickstart/requirements.md
+++ b/packages/appium/docs/en/quickstart/requirements.md
@@ -26,4 +26,4 @@ require the developer toolchain and SDKs for that platform to be installed.
 
 In order to assist with driver requirements, each (official) driver comes with the Appium Doctor tool,
 which allows to verify if all requirements have been set up. Learn more about how to use this tool in
-the [Command-Line Usage documentation](../cli/extensions.md).
+the [Command-Line Usage documentation](../cli/extensions.md#doctor).

--- a/packages/appium/docs/en/quickstart/requirements.md
+++ b/packages/appium/docs/en/quickstart/requirements.md
@@ -9,7 +9,7 @@ The basic requirements for the Appium server are:
 
 * A macOS, Linux, or Windows operating system
 * [Node.js](https://nodejs.org) version in the [SemVer](https://semver.org) range `^14.17.0 || ^16.13.0 || >=18.0.0`
-  * LTS is recommended
+    * LTS is recommended
 * [`npm`](https://npmjs.com) version `>=8` (`npm` is usually bundled with Node.js, but can be upgraded
 independently)
 

--- a/packages/appium/docs/en/quickstart/uiauto2-driver.md
+++ b/packages/appium/docs/en/quickstart/uiauto2-driver.md
@@ -60,8 +60,12 @@ set up on your system, so you can get busy making Android apps if you want!
 
 ## Install the driver itself
 
-Since the UiAutomator2 driver is maintained by the core Appium team, it has an 'official' driver
-name that you can use to install it easily via the [Appium Extension CLI](../cli/extensions.md):
+Like all Appium drivers, the UiAutomator2 driver is installed via the [Appium Extension CLI](../cli/extensions.md).
+Since UiAutomator2 is maintained by the core Appium team, it has an 'official' driver name
+(`uiautomator2`), which makes the installation simpler.
+
+Before installing, make sure your Appium server is _not_ running (if it is, quit it with Ctrl-C).
+Then run the following command:
 
 ```bash
 appium driver install uiautomator2
@@ -77,11 +81,9 @@ Driver uiautomator2@2.0.5 successfully installed
 - platformNames: ["Android"]
 ```
 
-Running this command will locate and install the latest version of the UiAutomator2 driver, making
-it available for automation. Note that when it is installed it tells you what platforms it is valid
-for (in this case, `Android`), and what automation name (the `appium:automationName`
-[capability](../guides/caps.md)) must be used to select this driver for use during an Appium
-session (in this case, `UiAutomator2`).
+Note how the installation process specifies what platforms is the driver valid for (in this case,
+`Android`), and what automation name (the `appium:automationName` [capability](../guides/caps.md))
+must be used to select this driver for use during an Appium session (in this case, `UiAutomator2`).
 
 !!! note
 

--- a/packages/appium/docs/en/quickstart/uiauto2-driver.md
+++ b/packages/appium/docs/en/quickstart/uiauto2-driver.md
@@ -119,8 +119,8 @@ allows validating whether all prerequisites have been set up correctly:
 appium driver doctor uiautomator2
 ```
 
-This guide has focused on the essential requirements, so Appium Doctor may suggest one or more
-optional fixes. But if you see `0 required fixes needed`, that means everything is set up!
+This guide has focused on essential requirements, so Appium Doctor may suggest one or more optional
+fixes. But if you see `0 required fixes needed`, that means everything is set up!
 
 Now, start the Appium server again (run `appium`), and you should see that the newly-installed
 driver is listed as available:

--- a/packages/appium/docs/en/quickstart/uiauto2-driver.md
+++ b/packages/appium/docs/en/quickstart/uiauto2-driver.md
@@ -60,11 +60,13 @@ set up on your system, so you can get busy making Android apps if you want!
 
 ## Install the driver itself
 
+### Standard Install
+
 Like all Appium drivers, the UiAutomator2 driver is installed via the [Appium Extension CLI](../cli/extensions.md).
 Since UiAutomator2 is maintained by the core Appium team, it has an 'official' driver name
 (`uiautomator2`), which makes the installation simpler.
 
-Before installing, make sure your Appium server is _not_ running (if it is, quit it with Ctrl-C).
+Before installing, make sure your Appium server is _not_ running (if it is, quit it with _Ctrl-C_).
 Then run the following command:
 
 ```bash
@@ -91,6 +93,34 @@ must be used to select this driver for use during an Appium session (in this cas
     UiAutomator2 driver, but if you are incorporating Appium into a Node.js project, you might
     prefer to use `npm` to manage Appium and its connected drivers. To learn more about this
     technique, visit the guide on [managing Appium extensions](../guides/managing-exts.md).
+
+### Batch Install
+
+You may want to use Appium with more than one driver. One way to accomplish this is to run
+`appium driver install <driver-name>` for each individual driver, but you can also install multiple
+drivers in one go:
+
+```
+appium setup
+```
+
+Running this will install Appium's mobile-specific drivers: UiAutomator2, [XCUITest](https://appium.github.io/appium-xcuitest-driver/)
+(only if running macOS), and [Espresso](https://github.com/appium/appium-espresso-driver).
+
+You can also use this command to batch install drivers for desktop applications or desktop browsers.
+For more details on this, refer to the [Setup command documentation](../cli/setup.md).
+
+### Validating the Install
+
+The UiAutomator2 driver, like all official Appium drivers, comes with the Appium Doctor tool, which
+allows validating whether all prerequisites have been set up correctly:
+
+```
+appium driver doctor uiautomator2
+```
+
+This guide has focused on the essential requirements, so Appium Doctor may suggest one or more
+optional fixes. But if you see `0 required fixes needed`, that means everything is set up!
 
 Now, start the Appium server again (run `appium`), and you should see that the newly-installed
 driver is listed as available:

--- a/packages/appium/docs/mkdocs-en.yml
+++ b/packages/appium/docs/mkdocs-en.yml
@@ -39,6 +39,7 @@ nav:
       - cli/args.md
       - cli/env-vars.md
       - cli/extensions.md
+      - cli/setup.md
   - Command Reference:
       - commands/index.md
       - commands/base-driver.md


### PR DESCRIPTION
This is a documentation update prompted by the recent additions of the `--show-debug-info` flag and the `setup` subcommand.

* Update quickstart
  * Update install page with more information on the console log, and how the server must be launched separately from clients (fixes #19973)
  * Replace mention of standalone Appium Doctor in requirements with the extension subcommand
  * Add mention of `setup` and `doctor` commands in UiAutomator2 install page  (resolves #20118)
* Update CLI reference
  * Add page for `setup` CLI subcommand (resolves #20118)
  * Update list of server CLI arguments
    * Add `--config`
    * Reorder alphabetically
    * Add new section with flags that automatically exit (including `--show-debug-info`)
  * Update extension CLI usage page
    * Reorder alphabetically
    * Update `doctor` section with arguments
