### PR TITLE
fix(universal-xml-plugin): add checks to disable the plguin in webview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ certificate.key
 *.pdb
 .vs
 
+#vscode
+.history
+
 old
 .tern-project
 coverage
@@ -62,3 +65,4 @@ appium.zip
 packages/*/LICENSE
 local_appium_home
 *.tgz
+

--- a/packages/universal-xml-plugin/lib/plugin.js
+++ b/packages/universal-xml-plugin/lib/plugin.js
@@ -47,8 +47,7 @@ export default class UniversalXMLPlugin extends BasePlugin {
 
   async _find(multiple, next, driver, strategy, selector) {
     const {platformName} = driver.caps;
-    const currentContext = await driver.getCurrentContext();
-    if (strategy.toLowerCase() !== 'xpath' || currentContext !== 'NATIVE_APP') {
+    if (strategy.toLowerCase() !== 'xpath' || (await driver.getCurrentContext()) !== 'NATIVE_APP') {
       return await next();
     }
     const xml = await this.getPageSource(null, driver, null, true);

--- a/packages/universal-xml-plugin/lib/plugin.js
+++ b/packages/universal-xml-plugin/lib/plugin.js
@@ -23,7 +23,7 @@ export default class UniversalXMLPlugin extends BasePlugin {
         `The XML mapper found ${unknowns.nodes.length} node(s) / ` +
           `tag name(s) that it didn't know about. These should be ` +
           `reported to improve the quality of the plugin: ` +
-          unknowns.nodes.join(', ')
+          unknowns.nodes.join(', '),
       );
     }
     if (unknowns.attrs.length) {
@@ -31,7 +31,7 @@ export default class UniversalXMLPlugin extends BasePlugin {
         `The XML mapper found ${unknowns.attrs.length} attributes ` +
           `that it didn't know about. These should be reported to ` +
           `improve the quality of the plugin: ` +
-          unknowns.attrs.join(', ')
+          unknowns.attrs.join(', '),
       );
     }
     return xml;
@@ -47,7 +47,8 @@ export default class UniversalXMLPlugin extends BasePlugin {
 
   async _find(multiple, next, driver, strategy, selector) {
     const {platformName} = driver.caps;
-    if (strategy.toLowerCase() !== 'xpath') {
+    const currentContext = await driver.getCurrentContext();
+    if (strategy.toLowerCase() !== 'xpath' || currentContext !== 'NATIVE_APP') {
       return await next();
     }
     const xml = await this.getPageSource(null, driver, null, true);
@@ -58,7 +59,7 @@ export default class UniversalXMLPlugin extends BasePlugin {
     if (newSelector === null) {
       log.warn(
         `Selector was not able to be translated to underlying XML. Either the requested ` +
-          `element does not exist or there was an error in translation`
+          `element does not exist or there was an error in translation`,
       );
       if (multiple) {
         return [];

--- a/packages/universal-xml-plugin/test/fixtures/index.js
+++ b/packages/universal-xml-plugin/test/fixtures/index.js
@@ -9,6 +9,7 @@ const XML_IOS_EDGE_TRANSFORMED = fs.readFileSync(path.resolve(__dirname, 'ios-tr
 const XML_ANDROID = fs.readFileSync(path.resolve(__dirname, 'android.xml'), 'utf8').trim();
 const XML_ANDROID_TRANSFORMED = fs.readFileSync(path.resolve(__dirname, 'android-transformed.xml'), 'utf8').trim();
 const XML_ANDROID_TRANSFORMED_INDEX_PATH = fs.readFileSync(path.resolve(__dirname, 'android-transformed-path.xml'), 'utf8').trim();
+const XML_WEBVIEW = fs.readFileSync(path.resolve(__dirname, 'web-view.xml'), 'utf8').trim();
 
 export { XML_IOS, XML_ANDROID, XML_IOS_TRANSFORMED, XML_ANDROID_TRANSFORMED, XML_IOS_TRANSFORMED_INDEX_PATH,
-  XML_ANDROID_TRANSFORMED_INDEX_PATH, XML_IOS_EDGE, XML_IOS_EDGE_TRANSFORMED };
+  XML_ANDROID_TRANSFORMED_INDEX_PATH, XML_IOS_EDGE, XML_IOS_EDGE_TRANSFORMED, XML_WEBVIEW };

--- a/packages/universal-xml-plugin/test/fixtures/web-view.xml
+++ b/packages/universal-xml-plugin/test/fixtures/web-view.xml
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        <div id="section-1">Section 1</div>
+        <div id="section-2">Section  2</div>
+    </body>
+</html>

--- a/packages/universal-xml-plugin/test/unit/plugin.spec.js
+++ b/packages/universal-xml-plugin/test/unit/plugin.spec.js
@@ -1,6 +1,12 @@
 import {UniversalXMLPlugin} from '../..';
 import BaseDriver from 'appium/driver';
-import {XML_IOS, XML_ANDROID, XML_IOS_TRANSFORMED, XML_ANDROID_TRANSFORMED} from '../fixtures';
+import {
+  XML_IOS,
+  XML_ANDROID,
+  XML_IOS_TRANSFORMED,
+  XML_ANDROID_TRANSFORMED,
+  XML_WEBVIEW,
+} from '../fixtures';
 import {runQuery, getNodeAttrVal} from '../../lib/xpath';
 
 describe('UniversalXMLPlugin', function () {
@@ -9,11 +15,13 @@ describe('UniversalXMLPlugin', function () {
   describe('getPageSource', function () {
     const driver = new BaseDriver();
     it('should transform page source for ios', async function () {
+      driver.getCurrentContext = () => 'NATIVE_APP';
       next = driver.getPageSource = () => XML_IOS;
       driver.caps = {platformName: 'iOS'};
       await p.getPageSource(next, driver).should.eventually.eql(XML_IOS_TRANSFORMED);
     });
     it('should transform page source for android', async function () {
+      driver.getCurrentContext = () => 'NATIVE_APP';
       next = driver.getPageSource = () => XML_ANDROID;
       driver.caps = {platformName: 'Android'};
       driver.opts = {appPackage: 'io.cloudgrey.the_app'};
@@ -24,6 +32,7 @@ describe('UniversalXMLPlugin', function () {
   describe('findElement(s)', function () {
     const driver = new BaseDriver();
     it('should turn an xpath query into another query run on the original ios source', async function () {
+      driver.getCurrentContext = () => 'NATIVE_APP';
       next = driver.getPageSource = () => XML_IOS;
       driver.caps = {platformName: 'iOS'};
       // mock out the findElement function to just return an xml node from the fixture
@@ -37,6 +46,7 @@ describe('UniversalXMLPlugin', function () {
     });
 
     it('should turn an xpath query into another query run on the original android source', async function () {
+      driver.getCurrentContext = () => 'NATIVE_APP';
       next = driver.getPageSource = () => XML_ANDROID;
       driver.caps = {platformName: 'Android'};
       driver.opts = {appPackage: 'io.cloudgrey.the_app'};
@@ -47,6 +57,21 @@ describe('UniversalXMLPlugin', function () {
       const node = await p.findElement(next, driver, 'xpath', '//TextInput[@axId="username"]');
       getNodeAttrVal(node, 'content-desc').should.eql('username');
       node.nodeName.should.eql('android.widget.EditText');
+    });
+
+    it('should not modify the xpath query and proxy the call to underlying driver', async function () {
+      driver.getCurrentContext = () => 'WEB_VIEW';
+      driver.findElement = () => {};
+      driver.caps = {platformName: 'Android'};
+      driver.opts = {appPackage: 'io.cloudgrey.the_app'};
+      const selector = '//div[@id="section-1"]';
+      next = () => {
+        const nodes = runQuery(selector, XML_WEBVIEW);
+        return nodes[0];
+      };
+      const node = await p.findElement(next, driver, 'xpath', selector);
+      getNodeAttrVal(node, 'id').should.eql('section-1');
+      node.nodeName.should.eql('div');
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

Currently finding elements in webview is not working when the plugin is enabled. Added a check to make sure the plugin transforms the XML source only when the application context is set to `NATIVE_APP`.

Fixes https://github.com/appium/appium/issues/20060

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the CLA
- [X] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
