### PR TITLE
chore(logger): tidy up logger integration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -48,16 +48,6 @@ labels:
     matcher:
       files: ['packages/base-driver/**']
 
-  - label: '@appium/eslint-config-appium'
-    sync: true
-    matcher:
-      files: ['packages/eslint-config-appium/**']
-
-  - label: '@appium/eslint-config-appium-ts'
-    sync: true
-    matcher:
-      files: ['packages/eslint-config-appium-ts/**']
-
   - label: '@appium/base-plugin'
     sync: true
     matcher:
@@ -78,6 +68,16 @@ labels:
     matcher:
       files: ['packages/driver-test-support/**']
 
+  - label: '@appium/eslint-config-appium'
+    sync: true
+    matcher:
+      files: ['packages/eslint-config-appium/**']
+
+  - label: '@appium/eslint-config-appium-ts'
+    sync: true
+    matcher:
+      files: ['packages/eslint-config-appium-ts/**']
+
   - label: '@appium/execute-driver-plugin'
     sync: true
     matcher:
@@ -97,6 +97,11 @@ labels:
     sync: true
     matcher:
       files: ['packages/images-plugin/**']
+
+  - label: '@appium/logger'
+    sync: true
+    matcher:
+      files: ['packages/logger/**']
 
   - label: '@appium/opencv'
     sync: true
@@ -123,6 +128,11 @@ labels:
     matcher:
       files: ['packages/support/**']
 
+  - label: '@appium/strongbox'
+    sync: true
+    matcher:
+      files: ['packages/strongbox/**']
+
   - label: '@appium/test-support'
     sync: true
     matcher:
@@ -142,8 +152,3 @@ labels:
     sync: true
     matcher:
       files: ['packages/universal-xml-plugin/**']
-  
-  - label: '@appium/strongbox'
-    sync: true
-    matcher:
-      files: ['packages/strongbox/**']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Appium contains many different modules and supports a variety of drivers, plugin
 
 ## Main Appium Module
 
-* ### [Appium 2.0 Changelog](packages/appium/CHANGELOG.md)
+* ### [Appium 2 Changelog](packages/appium/CHANGELOG.md)
 * [Appium 1.x Changelog](https://github.com/appium/appium/blob/1.x/CHANGELOG.md)
 
 ## Appium Drivers / Clients / Plugins
@@ -23,6 +23,7 @@ Appium contains many different modules and supports a variety of drivers, plugin
 * [fake-driver](packages/fake-driver/CHANGELOG.md)
 * [fake-plugin](packages/fake-plugin/CHANGELOG.md)
 * [images-plugin](packages/images-plugin/CHANGELOG.md)
+* [logger](packages/logger/CHANGELOG.md)
 * [opencv](packages/opencv/CHANGELOG.md)
 * [plugin-test-support](packages/plugin-test-support/CHANGELOG.md)
 * [relaxed-caps-plugin](packages/relaxed-caps-plugin/CHANGELOG.md)
@@ -31,6 +32,5 @@ Appium contains many different modules and supports a variety of drivers, plugin
 * [support](packages/support/CHANGELOG.md)
 * [test-support](packages/test-support/CHANGELOG.md)
 * [tsconfig](packages/tsconfig/CHANGELOG.md)
-* [typedoc-plugin-appium](packages/typedoc-plugin-appium/CHANGELOG.md)
 * [types](packages/types/CHANGELOG.md)
 * [universal-xml-plugin](packages/universal-xml-plugin/CHANGELOG.md)

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -1,14 +1,14 @@
-# Appium Logger
+# @appium/logger
 
-The logger util that Appium uses.
+> Appium's logging functionality
 
-# Installation
+## Installation
 
 ```console
 npm install @appium/logger --save
 ```
 
-# Basic Usage
+## Basic Usage
 
 ```js
 import log from '@appium/logger';
@@ -21,11 +21,11 @@ import log from '@appium/logger';
     log.info('fyi', 'I have a kitty cat: %j', myKittyCat);
 ```
 
-# History
+## History
 
 This module is forked from [npmlog](https://github.com/npm/npmlog) under ISC License because the original project has been archived.
 Please check [the npmlog changelog](https://github.com/npm/npmlog/blob/main/CHANGELOG.md) to see the list of former module updates before it was forked.
 
-# License
+## License
 
 ISC License


### PR DESCRIPTION
A few minor changes for a better integration of @appium/logger:

* Add labeler task
* Add link in aggregate changelog (also remove old typedoc plugin link)
* Align README with other module READMEs