### PR TITLE
fix: add logger dependencies in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21672,6 +21672,7 @@
         "@appium/base-driver": "^9.8.0",
         "@appium/base-plugin": "^2.2.33",
         "@appium/docutils": "^1.0.9",
+        "@appium/logger": "^1.1.0",
         "@appium/schema": "~0.5.0",
         "@appium/support": "^4.3.0",
         "@appium/types": "^0.19.0",
@@ -22608,6 +22609,7 @@
       "version": "4.3.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@appium/logger": "^1.1.0",
         "@appium/tsconfig": "^0.3.3",
         "@appium/types": "^0.19.0",
         "@colors/colors": "1.6.0",
@@ -22912,6 +22914,7 @@
       "version": "0.19.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@appium/logger": "^1.1.0",
         "@appium/schema": "^0.5.0",
         "@appium/tsconfig": "^0.3.3",
         "@types/express": "4.17.21",
@@ -23520,6 +23523,7 @@
     "@appium/support": {
       "version": "file:packages/support",
       "requires": {
+        "@appium/logger": "^1.1.0",
         "@appium/tsconfig": "^0.3.3",
         "@appium/types": "^0.19.0",
         "@colors/colors": "1.6.0",
@@ -23733,6 +23737,7 @@
     "@appium/types": {
       "version": "file:packages/types",
       "requires": {
+        "@appium/logger": "^1.1.0",
         "@appium/schema": "^0.5.0",
         "@appium/tsconfig": "^0.3.3",
         "@types/express": "4.17.21",
@@ -26923,6 +26928,7 @@
         "@appium/base-driver": "^9.8.0",
         "@appium/base-plugin": "^2.2.33",
         "@appium/docutils": "^1.0.9",
+        "@appium/logger": "^1.1.0",
         "@appium/schema": "~0.5.0",
         "@appium/support": "^4.3.0",
         "@appium/types": "^0.19.0",

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -63,6 +63,7 @@
     "@appium/base-driver": "^9.8.0",
     "@appium/base-plugin": "^2.2.33",
     "@appium/docutils": "^1.0.9",
+    "@appium/logger": "^1.1.0",
     "@appium/schema": "~0.5.0",
     "@appium/support": "^4.3.0",
     "@appium/types": "^0.19.0",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -41,6 +41,7 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
+    "@appium/logger": "^1.1.0",
     "@appium/tsconfig": "^0.3.3",
     "@appium/types": "^0.19.0",
     "@colors/colors": "1.6.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -38,6 +38,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
+    "@appium/logger": "^1.1.0",
     "@appium/schema": "^0.5.0",
     "@appium/tsconfig": "^0.3.3",
     "@types/express": "4.17.21",


### PR DESCRIPTION
This adds missing imports for `@appium/logger`, which otherwise prevent launching the Appium process.

Fixes #20206 