### PR TITLE
feat(logger,support): Add the 'debug' level to the default logger (#20203)

### DIFF
--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -1,11 +1,10 @@
 import globalLog from '@appium/logger';
 import {createLogger, format, transports} from 'winston';
-import {fs, logger} from '@appium/support';
+import {fs} from '@appium/support';
 import { APPIUM_LOGGER_NAME } from './logger';
 import _ from 'lodash';
 
 // set up distributed logging before everything else
-logger.patchLogger(globalLog);
 global._global_npmlog = globalLog;
 
 // npmlog is used only for emitting, we use winston for output

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -6,10 +6,12 @@ import consoleControl from 'console-control-strings';
 import * as util from 'node:util';
 import type {MessageObject, StyleObject, Logger, LogLevel} from './types';
 import type {Writable} from 'node:stream';
+import { unleakString } from './utils';
 
 const DEFAULT_LOG_LEVELS: any[][] = [
   ['silly', -Infinity, {inverse: true}, 'sill'],
   ['verbose', 1000, {fg: 'cyan', bg: 'black'}, 'verb'],
+  ['debug', 1500, {fg: 'cyan', bg: 'black'}, 'dbug'],
   ['info', 2000, {fg: 'green'}],
   ['timing', 2500, {fg: 'green', bg: 'black'}],
   ['http', 3000, {fg: 'green', bg: 'black'}],
@@ -114,6 +116,10 @@ export class Log extends EventEmitter implements Logger {
     this.log('verbose', prefix, message, ...args);
   }
 
+  debug(prefix: string, message: any, ...args: any[]): void {
+    this.log('debug', prefix, message, ...args);
+  }
+
   info(prefix: string, message: any, ...args: any[]): void {
     this.log('info', prefix, message, ...args);
   }
@@ -190,8 +196,8 @@ export class Log extends EventEmitter implements Logger {
       id: this._id++,
       timestamp: Date.now(),
       level,
-      prefix: String(prefix || ''),
-      message: formattedMessage,
+      prefix: unleakString(prefix || ''),
+      message: unleakString(formattedMessage),
     };
 
     this.emit('log', m);

--- a/packages/logger/lib/types.ts
+++ b/packages/logger/lib/types.ts
@@ -25,6 +25,7 @@ export interface Logger extends EventEmitter {
    */
   silly(prefix: string, message: any, ...args: any[]): void;
   verbose(prefix: string, message: any, ...args: any[]): void;
+  debug(prefix: string, message: any, ...args: any[]): void;
   info(prefix: string, message: any, ...args: any[]): void;
   timing(prefix: string, message: any, ...args: any[]): void;
   http(prefix: string, message: any, ...args: any[]): void;
@@ -57,6 +58,7 @@ export interface Logger extends EventEmitter {
 export type LogLevel =
   | 'silly'
   | 'verbose'
+  | 'debug'
   | 'info'
   | 'timing'
   | 'http'

--- a/packages/logger/lib/utils.ts
+++ b/packages/logger/lib/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * This function is necessary to workaround unexpected memory leaks
+ * caused by NodeJS string interning
+ * behavior described in https://bugs.chromium.org/p/v8/issues/detail?id=2869
+ *
+ * @param {any} s - The string to unleak
+ * @return {string} Either the unleaked string or the original object converted to string
+ */
+export function unleakString(s: any): string {
+  return ` ${s}`.substring(1);
+}

--- a/packages/support/lib/logging.js
+++ b/packages/support/lib/logging.js
@@ -2,7 +2,6 @@
 
 import globalLog from '@appium/logger';
 import _ from 'lodash';
-import {unleakString} from './util';
 import moment from 'moment';
 import SECURE_VALUES_PREPROCESSOR from './log-internal';
 
@@ -16,16 +15,6 @@ const PREFIX_TIMESTAMP_FORMAT = 'HH-mm-ss:SSS';
 let mockLog = {};
 for (let level of LEVELS) {
   mockLog[level] = () => {};
-}
-
-/**
- *
- * @param {import('@appium/logger').Logger} logger
- */
-function patchLogger(logger) {
-  if (!logger.debug) {
-    logger.addLevel('debug', 1000, {fg: 'blue', bg: 'black'}, 'dbug');
-  }
 }
 
 /**
@@ -50,7 +39,6 @@ function _getLogger() {
     // The default value is 10000, which causes excessive memory usage
     logger.maxRecordSize = MAX_LOG_RECORDS_COUNT;
   }
-  patchLogger(logger);
   return [logger, usingGlobalLog];
 }
 
@@ -100,10 +88,7 @@ function getLogger(prefix = null) {
       for (const arg of args) {
         const out = _.isError(arg) && arg.stack ? arg.stack : `${arg}`;
         for (const line of out.split('\n')) {
-          // it is necessary to unleak each line because `split` call
-          // creates "views" to the original string as well as the `substring` one
-          const unleakedLine = unleakString(line);
-          logger[level](actualPrefix, SECURE_VALUES_PREPROCESSOR.preprocess(unleakedLine));
+          logger[level](actualPrefix, SECURE_VALUES_PREPROCESSOR.preprocess(line));
         }
       }
     };
@@ -111,7 +96,7 @@ function getLogger(prefix = null) {
   wrappedLogger.errorWithException = function (/** @type {any[]} */ ...args) {
     this.error(...args);
     // make sure we have an `Error` object. Wrap if necessary
-    return _.isError(args[0]) ? args[0] : new Error(args.map(unleakString).join('\n'));
+    return _.isError(args[0]) ? args[0] : new Error(args.join('\n'));
   };
   /**
    * @deprecated Use {@link errorWithException} instead
@@ -159,7 +144,7 @@ async function loadSecureValuesPreprocessingRules(rulesJsonPath) {
 // export a default logger with no prefix
 const log = getLogger();
 
-export {log, patchLogger, getLogger, loadSecureValuesPreprocessingRules};
+export {log, getLogger, loadSecureValuesPreprocessingRules};
 export default log;
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: Remove `patchLogger` exported method from `logger` in @appium/support

Add the 'debug' level to the default logger


---

Can we put `logger` and `support` in the `feat` prefix...?

This is the same of https://github.com/appium/appium/pull/20203 to bump support's major version.