### PR TITLE
feat(appium): Add a possibility to print logs in json format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22447,7 +22447,7 @@
     "packages/logger": {
       "name": "@appium/logger",
       "version": "1.3.0",
-      "license": "Apache-2.0",
+      "license": "ISC",
       "dependencies": {
         "console-control-strings": "1.1.0",
         "set-blocking": "2.0.0"

--- a/packages/appium/docs/en/cli/args.md
+++ b/packages/appium/docs/en/cli/args.md
@@ -38,6 +38,7 @@ below.
 |`--log`|Also send log output to this file|string||`-g`|
 |`--log-filters`|One or more log filtering rules|array|||
 |`--log-level`|Log level (console[:file]) (Value must be one of: `info`, `info:debug`, `info:info`, `info:warn`, `info:error`, `warn`, `warn:debug`, `warn:info`, `warn:warn`, `warn:error`, `error`, `error:debug`, `error:info`, `error:warn`, `error:error`, `debug`, `debug:debug`, `debug:info`, `debug:warn`, `debug:error`)|string|`debug`||
+|`--log-format`|Log format (Value must be to one of: `text`, `json`, `pretty_json`). If logs are printed as JSON then the text coloring is always disabled.|string|`text`||
 |`--log-no-colors`|Do not use color in console output|boolean|`false`||
 |`--log-timestamp`|Show timestamps in console output|boolean|`false`||
 |`--long-stacktrace`|Add long stack traces to log entries. Recommended for debugging only.|boolean|`false`||

--- a/packages/appium/test/fixtures/default-args.js
+++ b/packages/appium/test/fixtures/default-args.js
@@ -9,6 +9,7 @@ export default {
   driversImportChunkSize: 3,
   keepAliveTimeout: 600,
   localTimezone: false,
+  logFormat: 'text',
   loglevel: 'debug',
   logNoColors: false,
   logTimestamp: false,

--- a/packages/schema/lib/appium-config-schema.js
+++ b/packages/schema/lib/appium-config-schema.js
@@ -171,6 +171,18 @@ export const AppiumConfigJsonSchema = /** @type {const} */ ({
           title: 'log-level config',
           type: 'string',
         },
+        'log-format': {
+          appiumCliDest: 'logFormat',
+          default: 'text',
+          description: 'Log format (text|json|pretty_json)',
+          enum: [
+            'text',
+            'json',
+            'pretty_json',
+          ],
+          title: 'log-format config',
+          type: 'string',
+        },
         'log-no-colors': {
           default: false,
           description: 'Do not use color in console output',

--- a/packages/schema/lib/appium-config.schema.json
+++ b/packages/schema/lib/appium-config.schema.json
@@ -173,6 +173,18 @@
           "title": "log-level config",
           "type": "string"
         },
+        "log-format": {
+          "appiumCliDest": "logFormat",
+          "default": "text",
+          "description": "Log format (text|json|pretty_json)",
+          "enum": [
+            "text",
+            "json",
+            "pretty_json"
+          ],
+          "title": "log-format config",
+          "type": "string"
+        },
         "log-no-colors": {
           "default": false,
           "description": "Do not use color in console output",

--- a/packages/support/lib/logging.js
+++ b/packages/support/lib/logging.js
@@ -96,7 +96,7 @@ function getLogger(prefix = null) {
   wrappedLogger.errorWithException = function (/** @type {any[]} */ ...args) {
     this.error(...args);
     // make sure we have an `Error` object. Wrap if necessary
-    return _.isError(args[0]) ? args[0] : new Error(args.map(unleakString).join('\n'));
+    return _.isError(args[0]) ? args[0] : new Error(args.join('\n'));
   };
   /**
    * @deprecated Use {@link errorWithException} instead

--- a/packages/types/lib/appium-config.ts
+++ b/packages/types/lib/appium-config.ts
@@ -94,6 +94,10 @@ export type LogLevelConfig =
   | "debug:warn"
   | "debug:error";
 /**
+ * Log format (text|json|pretty_json)
+ */
+export type LogFormatConfig = "text" | "json" | "pretty_json";
+/**
  * Do not use color in console output
  */
 export type LogNoColorsConfig = boolean;
@@ -191,6 +195,7 @@ export interface ServerConfig {
   log?: LogConfig;
   "log-filters"?: LogFiltersConfig;
   "log-level"?: LogLevelConfig;
+  "log-format"?: LogFormatConfig;
   "log-no-colors"?: LogNoColorsConfig;
   "log-timestamp"?: LogTimestampConfig;
   "plugins-import-chunk-size"?: PluginsImportChunkSizeConfig;


### PR DESCRIPTION
## Proposed changes

Added a new CLI argument called log-format.
3 values are possible there:
- text (default)
- json
- pretty_json

If set to `json` then server logs look like:

```
{"message":"[Appium] Attempting to load driver chromium...","level":"info"}
```

`pretty_json ` looks like:

```
{
  "message": "[Appium] Attempting to load driver espresso...",
  "level": "info"
}
{
  "message": "[Appium] Attempting to load driver xcuitest...",
  "level": "info"
}
```

`pretty_json ` with `--log-timestamp`

```
{
  "message": "[Appium]   - devtools@0.0.1",
  "level": "info",
  "timestamp": "2024-06-07 19:46:21:287"
}
{
  "message": "[Appium] No plugins activated. Use the --use-plugins flag with names of plugins to activate",
  "level": "info",
  "timestamp": "2024-06-07 19:46:21:287"
}
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
