### PR TITLE
feat(appium): show spinner during extension uninstall

### DIFF
--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -578,7 +578,9 @@ class ExtensionCliCommand {
       return this.config.installedExtensions;
     }
     const pkgName = extRecord.pkgName;
-    await npm.uninstallPackage(this.config.appiumHome, pkgName);
+    await spinWith(this.isJsonOutput, `Uninstalling ${this.type} '${installSpec}'`, async () => {
+      await npm.uninstallPackage(this.config.appiumHome, pkgName);
+    });
     await this.config.removeExtension(installSpec);
     this.log.ok(`Successfully uninstalled ${this.type} '${installSpec}'`.green);
     return this.config.installedExtensions;


### PR DESCRIPTION
## Proposed changes

The current process of uninstalling an extension doesn't give the user enough information. In my experience it always takes at least 10 seconds, during which the console does not show anything. This PR makes it so that a spinner is now shown during the uninstall operation.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
