### PR TITLE
feat(appium): show extension update info message for newer major versions

### DIFF
--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -642,6 +642,7 @@ class ExtensionCliCommand {
           `Updating ${this.type} '${e}' from ${update.current} to ${updateVer}`,
           async () => await this.updateExtension(e, updateVer)
         );
+        // if we're doing a safe update, but an unsafe update is also available, let the user know
         if (!unsafe && update.unsafeUpdate) {
           const newMajorUpdateMsg = `A newer major version ${update.unsafeUpdate} ` +
             `is available for ${this.type} '${e}', which could include breaking changes. ` +

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -639,9 +639,15 @@ class ExtensionCliCommand {
         const updateVer = unsafe && update.unsafeUpdate ? update.unsafeUpdate : update.safeUpdate;
         await spinWith(
           this.isJsonOutput,
-          `Updating driver '${e}' from ${update.current} to ${updateVer}`,
+          `Updating ${this.type} '${e}' from ${update.current} to ${updateVer}`,
           async () => await this.updateExtension(e, updateVer)
         );
+        if (!unsafe && update.unsafeUpdate) {
+          const newMajorUpdateMsg = `A newer major version ${update.unsafeUpdate} ` +
+            `is available for ${this.type} '${e}', which could include breaking changes. ` +
+            `If you want to apply this update, re-run with --unsafe`;
+          this.log.info(newMajorUpdateMsg.yellow);
+        }
         updates[e] = {from: update.current, to: updateVer};
       } catch (err) {
         errors[e] = err;


### PR DESCRIPTION
## Proposed changes

If the user decides to update an extension using the standard command `appium <ext-type> update <ext-name>`, and a newer version does exist, the extension gets safely updated as expected. However, in case a newer _major_ version _also_ exists, the user is not informed about this right away. Currently this information is only shown if no newer minor or patch versions exist.
This PR adds an info message in such situations, so that the user is immediately informed of a newer major version.

I am also including a minor bugfix for the updating message, where it was always referring to drivers, even when a plugin was being updated.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [X] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
