### PR TITLE
fix(logger): Print an empty message if no arguments are provided

### DIFF
--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -221,7 +221,9 @@ export class Log extends EventEmitter implements Logger {
     if (stack) {
       messageArguments.unshift(`${stack}\n`);
     }
-    const formattedMessage: string = util.format(...messageArguments);
+    const formattedMessage: string = messageArguments.length
+      ? util.format(...messageArguments)
+      : '';
 
     const m: MessageObject = {
       id: this._id++,


### PR DESCRIPTION
## Proposed changes

Currently for calls like `log.debug()` it prints `undefined`

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
