### PR TITLE
fix(support): add ? in casae it does not have updateAsyncStorage function deps

### DIFF
--- a/packages/support/lib/logging.js
+++ b/packages/support/lib/logging.js
@@ -47,6 +47,7 @@ export function getLogger(prefix = null) {
       /** @type {import('@appium/types').AppiumLoggerContext} */ contextInfo,
       replace = false,
     ) {
+      // Older Appium dependencies may not have 'updateAsyncStorage'
       this.unwrap().updateAsyncStorage?.(contextInfo, replace);
     },
   };

--- a/packages/support/lib/logging.js
+++ b/packages/support/lib/logging.js
@@ -47,7 +47,7 @@ export function getLogger(prefix = null) {
       /** @type {import('@appium/types').AppiumLoggerContext} */ contextInfo,
       replace = false,
     ) {
-      this.unwrap().updateAsyncStorage(contextInfo, replace);
+      this.unwrap().updateAsyncStorage?.(contextInfo, replace);
     },
   };
   // allow access to the level of the underlying logger


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/appium/appium/issues/20303

Then, older appium cannot use https://github.com/appium/appium/pull/20250 feature, but can avoid:

```
info Appium No plugins have been installed. Use the "appium plugin" command to install the one(s) you want to use.
[HTTP] Uncaught error: this.unwrap(...).updateAsyncStorage is not a function
[HTTP] Sending generic error response
[HTTP] TypeError: this.unwrap(...).updateAsyncStorage is not a function
    at Object.updateAsyncContext (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/@appium/base-driver/node_modules/@appium/support/lib/logging.js:50:12)
    at handleLogContext (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/@appium/base-driver/lib/express/middleware.js:86:7)
    at Layer.handle [as handle_request] (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:328:13)
    at /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:280:10)
    at logger (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/morgan/index.js:144:5)
    at Layer.handle [as handle_request] (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:328:13)
    at /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:280:10)
    at expressInit (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/middleware/init.js:40:5)
    at Layer.handle [as handle_request] (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:328:13)
    at /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:280:10)
    at query (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/middleware/query.js:45:5)
"use strict";
    at Layer.handle [as handle_request] (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:328:13)
 TypeError: this.unwrap(...).updateAsyncStorage is not a function
    at Object.updateAsyncContext (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/@appium/base-driver/node_modules/@appium/support/lib/logging.js:50:12)
    at handleLogContext (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/@appium/base-driver/lib/express/middleware.js:86:7)
    at Layer.handle [as handle_request] (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:328:13)
    at /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:280:10)
    at logger (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/morgan/index.js:144:5)
    at Layer.handle [as handle_request] (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:328:13)
    at /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:280:10)
    at expressInit (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/middleware/init.js:40:5)
    at Layer.handle [as handle_request] (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:328:13)
    at /Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:286:9
    at Function.process_params (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:346:12)
    at next (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:280:10)
    at query (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/middleware/query.js:45:5)
    at Layer.handle [as handle_request] (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/kazu/.nvm/versions/node/v16.15.1/lib/node_modules/appium/node_modules/express/lib/router/index.js:328:13)
[HTTP] <-- POST /session 500 24 ms - 3304
```

Logs with this PR:

```
[Appium] No plugins have been installed. Use the "appium plugin" command to install the one(s) you want to use.
[debug] [HTTP] Request idempotency key: 9e612882-1afd-45d8-9dc7-c41d0681fb5e
[HTTP] --> POST /session {"capabilities":{"alwaysMatch":{"platformName":"ios","appium:platformVersion":"17.2","appium:automationName":"xcuitest","browserName":"safari","appium:deviceName":"iPhone 15","pageLoadStrategy":"eager"},"firstMatch":[{}]}}
[debug] [AppiumDriver@f9cd] Calling AppiumDriver.createSession() with args: [null,null,{"alwaysMatch":{"platformName":"ios","appium:platformVersion":"17.2","appium:automationName":"xcuitest","browserName":"safari","appium:deviceName":"iPhone 15","pageLoadStrategy":"eager"},"firstMatch":[{}]}]
[debug] [AppiumDriver@f9cd] Event 'newSessionRequested' logged at 1719534706849 (17:31:46 GMT-0700 (Pacific Daylight Time))
...
```

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
