### PR TITLE
feat(logger): Use LRUCache to manage log history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22150,11 +22150,20 @@
       "dependencies": {
         "console-control-strings": "1.1.0",
         "lodash": "4.17.21",
+        "lru-cache": "10.3.0",
         "set-blocking": "2.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=8"
+      }
+    },
+    "packages/logger/node_modules/lru-cache": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
+      "integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ==",
+      "engines": {
+        "node": "14 || >=16.14"
       }
     },
     "packages/opencv": {
@@ -23142,7 +23151,15 @@
       "requires": {
         "console-control-strings": "1.1.0",
         "lodash": "4.17.21",
+        "lru-cache": "10.3.0",
         "set-blocking": "2.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.3.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.3.0.tgz",
+          "integrity": "sha512-CQl19J/g+Hbjbv4Y3mFNNXFEL/5t/KCg8POCuUqd4rMKjGG+j1ybER83hxV58zL+dFI1PTkt3GNFSHRt+d8qEQ=="
+        }
       }
     },
     "@appium/opencv": {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "console-control-strings": "1.1.0",
     "lodash": "4.17.21",
+    "lru-cache": "10.3.0",
     "set-blocking": "2.0.0"
   },
   "license": "ISC",

--- a/packages/logger/test/unit/basic-specs.js
+++ b/packages/logger/test/unit/basic-specs.js
@@ -363,7 +363,24 @@ describe('basic', async function () {
       log.log('verbose', 'test', 'log 2');
       log.log('verbose', 'test', 'log 3');
       log.log('verbose', 'test', 'log 4');
-      log.record.length.should.equal(3);
+      log.record.map(({message}) => message).should.eql([
+        'log 2',
+        'log 3',
+        'log 4',
+      ]);
+      log.maxRecordSize = 2;
+      log.log('verbose', 'test', 'log 5');
+      log.record.map(({message}) => message).should.eql([
+        'log 4',
+        'log 5',
+      ]);
+      log.maxRecordSize = 3;
+      log.log('verbose', 'test', 'log 6');
+      log.record.map(({message}) => message).should.eql([
+        'log 4',
+        'log 5',
+        'log 6',
+      ]);
     });
   });
 


### PR DESCRIPTION
## Proposed changes

LRUCache manages circular buffer logic better than a custom logic on top of vanilla array

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
