### PR TITLE
chore(base-driver): Optimize server close algorithm

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "sync-pkgs:license": "sync-monorepo-packages --force --no-package-json --packages=\"!packages/logger\" LICENSE",
     "test": "run-s test:quick",
     "test:ci": "run-s test:smoke test:unit test:types test:e2e",
-    "test:e2e": "lerna run --concurrency=2 test:e2e",
+    "test:e2e": "lerna run test:e2e",
     "test:quick": "run-s lint test:unit test:types",
     "test:slow": "run-s test:quick test:smoke test:e2e",
     "test:smoke": "smoker --all test:smoke",

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -54,7 +54,7 @@
     "postinstall": "node ./scripts/autoinstall-extensions.js",
     "publish:docs": "cross-env APPIUM_DOCS_PUBLISH=1 npm run build:docs",
     "test": "npm run test:unit",
-    "test:e2e": "mocha -p --timeout 1m --slow 30s \"./test/e2e/**/*.spec.js\"",
+    "test:e2e": "mocha --timeout 1m --slow 30s \"./test/e2e/**/*.spec.js\"",
     "test:smoke": "cross-env APPIUM_HOME=./local_appium_home node ./index.js driver install uiautomator2 && cross-env APPIUM_HOME=./local_appium_home node ./index.js driver list",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },

--- a/packages/base-driver/lib/express/server.js
+++ b/packages/base-driver/lib/express/server.js
@@ -214,7 +214,7 @@ function configureHttp({httpServer, reject, keepAliveTimeout}) {
           `Not all active connections have been closed within ` +
           `${timer.getDuration().asMilliSeconds.toFixed(0)}ms. Exiting anyway.`
         );
-        process.exit(0);
+        process.exit(process.exitCode ?? 0);
       }, SERVER_CLOSE_TIMEOUT_MS);
       httpServer.once('close', () => {
         log.info(

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "test": "npm run test:unit",
-    "test:e2e": "mocha -p --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
+    "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
     "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -36,7 +36,7 @@
   ],
   "scripts": {
     "test": "npm run test:unit",
-    "test:e2e": "mocha -p --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
+    "test:e2e": "mocha --timeout 20s --slow 10s \"./test/e2e/**/*.spec.js\"",
     "test:smoke": "node ./index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },


### PR DESCRIPTION
## Proposed changes

Judging by e2e tests a situation is possible where Appium server would freeze waiting until all sockets are closed. The current fix makes sure the process exits max 5 seconds later after the server is closed, thus closing all pending socket connections.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
