### PR TITLE
fix(base-driver): calls startNewCommandTimeout before returning NotYetImplementedError

### DIFF
--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -98,6 +98,7 @@ export class BaseDriver<
 
     // If we don't have this command, it must not be implemented
     if (!this[cmd]) {
+      await this.startNewCommandTimeout();
       throw new errors.NotYetImplementedError();
     }
 


### PR DESCRIPTION
## Proposed changes

Noticed that if `throw new errors.NotYetImplementedError();` was called in a session, it never calls `await this.startNewCommandTimeout();`. So once the error is raised, current implementation will not behave newCommandTimeout behavior.

(This is not related to https://github.com/appium/appium/pull/20379 fix for an issue, btw)

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/appium/appium/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
