### PR TITLE
fix(support): Print an empty string if no arguments are provided to a logging function

### DIFF
--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -245,9 +245,7 @@ export class Log extends EventEmitter implements Logger {
     if (stack) {
       messageArguments.unshift(`${stack}\n`);
     }
-    const formattedMessage: string = messageArguments.length
-      ? util.format(...messageArguments)
-      : '';
+    const formattedMessage = util.format(...messageArguments);
 
     const m: MessageObject = {
       id: this._id++,

--- a/packages/support/lib/logging.js
+++ b/packages/support/lib/logging.js
@@ -67,8 +67,12 @@ export function getLogger(prefix = null) {
   for (const level of LEVELS) {
     wrappedLogger[level] = /** @param {any[]} args */ function (...args) {
       const finalPrefix = getFinalPrefix(this.prefix, isDebugTimestampLoggingEnabled);
-      // @ts-ignore This is OK
-      logger[level](finalPrefix, ...args);
+      if (args.length) {
+        // @ts-ignore This is OK
+        logger[level](finalPrefix, ...args);
+      } else {
+        logger[level](finalPrefix, '');
+      }
     };
   }
   if (!usingGlobalLog) {


### PR DESCRIPTION
## Proposed changes

`log.debug()` currently prints `undefined`, but should print an empty string instead

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
