### PR TITLE
chore(base-driver): Print a log message if a command gets added into non-empty async lock waiting queue

### DIFF
--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -144,8 +144,19 @@ export class BaseDriver<
       }
     };
 
+    const synchronizationKey = BaseDriver.name;
+    // eslint-disable-next-line dot-notation
+    const commandsQueueLen: number = this.commandsQueueGuard['queues']?.[synchronizationKey]?.length ?? 0;
+    if (this.isCommandsQueueEnabled && commandsQueueLen > 0) {
+      this.log.debug(
+        `Scheduling the '${cmd}' command to the ${this.constructor.name} commands queue. ` +
+        `${util.pluralize('queue item', commandsQueueLen, true)} ${commandsQueueLen === 1 ? 'is' : 'are'} ` +
+        `already waiting for execution.`
+      );
+    }
+
     const res = this.isCommandsQueueEnabled
-      ? await this.commandsQueueGuard.acquire(BaseDriver.name, runCommandPromise)
+      ? await this.commandsQueueGuard.acquire(synchronizationKey, runCommandPromise)
       : await runCommandPromise();
 
     // log timing information about this command


### PR DESCRIPTION
Sometimes poorly written client scripts try to send multiple commands asynchronously while most of drivers only supports synchronous commands execution. This log message helps to catch such cases and make the size of the waiting queue visible to users.