### PR TITLE
fix(renovate): adjust config for Renovate v38

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>appium/appium//renovate/default"],
-  "schedule": ["after 10pm and before 5:00am"],
+  "schedule": [
+    "after 10pm",
+    "before 5:00am"
+  ],
   "timezone": "America/Vancouver"
 }

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -57,7 +57,6 @@ Appium extension authors--or anyone else--may use this config as well.
 ### Additional Config
 
 - Uses the parent directory for the commit scope if applicable; otherwise uses `deps`. The parent directory is _typically_ only applicable in monorepos.
-- Attempts transititive remediation of vulns
 
 ## License
 

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -45,7 +45,7 @@
     },
     {
       "extends": ["packages:eslint"],
-      "matchPackagePrefixes": ["@appium/eslint-config-appium"],
+      "matchPackageNames": ["@appium/eslint-config-appium**"],
       "groupName": "ESLint-related packages",
       "groupSlug": "eslint"
     },
@@ -55,13 +55,10 @@
       "groupSlug": "teen_process"
     },
     {
-      "matchPackagePrefixes": ["@appium/"],
-      "excludePackageNames": ["@appium/eslint-config-appium", "@appium/eslint-config-appium-ts"],
-      "matchPackageNames": "appium",
+      "matchPackageNames": ["appium", "@appium/**", "!@appium/eslint-config-appium**"],
       "groupName": "Appium-related packages",
       "groupSlug": "appium"
     }
   ],
-  "semanticCommitScope": "{{#if parentDir}}{{parentDir}}{{else}}deps{{/if}}",
-  "transitiveRemediation": true
+  "semanticCommitScope": "{{#if parentDir}}{{parentDir}}{{else}}deps{{/if}}"
 }


### PR DESCRIPTION
I observed that Renovate has not been making any dependency PRs for over a week, while it continues to work fine on the Inspector repo. As it turns out, on August 6th, the Renovate instance used by this repo updated to v38, and since then, it has been throwing errors due to an invalid config. [Version 38 did have some breaking changes](https://docs.renovatebot.com/release-notes-for-major-versions/#version-38), and this PR adjusts the config accordingly:

* Change all `matchPackage*` options to `matchPackageNames` which now supports regex and glob
* Remove `transitiveRemediation` option since it has been removed (apparently it did not work for npm >= 7 anyway)
* Split the `schedule` option into individual time points
  * Not related to Renovate v38; I just saw in the logs that Renovate auto-adjusted the config to this format