### PR TITLE
Revert "chore(deps): update dependency conventional-changelog-conventionalcommits to v8"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "asyncbox": "3.0.0",
         "chai": "5.1.1",
         "chai-as-promised": "8.0.0",
-        "conventional-changelog-conventionalcommits": "8.0.0",
+        "conventional-changelog-conventionalcommits": "7.0.2",
         "cpy-cli": "5.0.0",
         "eslint": "8.57.0",
         "eslint-config-prettier": "9.1.0",
@@ -5643,16 +5643,15 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=16"
       }
     },
     "node_modules/conventional-changelog-core": {
@@ -25138,9 +25137,9 @@
       }
     },
     "conventional-changelog-conventionalcommits": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
+      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "asyncbox": "3.0.0",
     "chai": "5.1.1",
     "chai-as-promised": "8.0.0",
-    "conventional-changelog-conventionalcommits": "8.0.0",
+    "conventional-changelog-conventionalcommits": "7.0.2",
     "cpy-cli": "5.0.0",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",


### PR DESCRIPTION
Reverts appium/appium#20085

Seems like Lerna does not yet support v8:
https://github.com/lerna/lerna/issues/4021
https://stackoverflow.com/questions/78672949/lerna-and-changelogpreset-for-conventional-commits-failing-to-load