### PR TITLE
fix(basedriver,appium): when rewriting socket urls, use a working hostname

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -772,9 +772,15 @@ class AppiumDriver extends DriverCore {
       // internal bidi urls it might want to proxy to, cause we are going to overwrite that
       // information here!
       if (dCaps.webSocketUrl && driverInstance.doesSupportBidi) {
-        const {address, port, basePath} = this.args;
+        const {port, basePath} = this.args;
+        // this is set by protocol.js when the client makes the request, so that we respond with the same host they used
+        const address = this.hostLastUsedByClient ?? this.args.address ;
         const scheme = `ws${this.server.isSecure() ? 's' : ''}`;
         const bidiUrl = `${scheme}://${address}:${port}${basePath}${BIDI_BASE_PATH}/${innerSessionId}`;
+        this.log.info(
+          `Upstream driver responded with webSocketUrl ${dCaps.webSocketUrl}, will rewrite to ` +
+            `${bidiUrl} for response to client`
+        );
         // @ts-ignore webSocketUrl gets sent by the client as a boolean, but then it is supposed
         // to come back from the server as a string. TODO figure out how to express this in our
         // capability constraint system

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -105,6 +105,8 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
 
   doesSupportBidi: boolean;
 
+  hostLastUsedByClient?: string;
+
   constructor(opts: InitialOpts = <InitialOpts>{}, shouldValidateCaps = true) {
     this._log = logger.getLogger(helpers.generateDriverLogPrefix(this as Core<C>));
 

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -356,6 +356,12 @@ function buildHandler(app, method, path, spec, driver, isSessCmd) {
         currentProtocol = determineProtocol(
           makeArgs(req.params, jsonObj, spec.payloadParams || {})
         );
+
+        // when a client connects, register the hostname actually used by the client, since it
+        // could be a custom name or 127.0.0.1 or another IP. We need it so that when we rewrite
+        // URLs to send back to the client, we can use the hostname they sent in rather than the
+        // address used to start the server, which might be an uncontactable hostname like 0.0.0.0
+        driver.hostLastUsedByClient = req.hostname;
       }
 
       // ensure that the json payload conforms to the spec

--- a/packages/base-driver/test/e2e/basedriver/websockets.e2e.spec.js
+++ b/packages/base-driver/test/e2e/basedriver/websockets.e2e.spec.js
@@ -46,10 +46,9 @@ describe('Websockets (e2e)', function () {
       _.keys(await baseServer.getWebSocketHandlers()).length.should.eql(1);
       await new B((resolve, reject) => {
         const client = new WebSocket(`ws://${TEST_HOST}:${port}${endpoint}`);
-        client.once('connection', (ws, req) => {
+        client.once('upgrade', (res) => {
           try {
-            ws.should.not.be.empty;
-            req.connection.remoteAddress.should.not.be.empty;
+            res.statusCode.should.eql(101);
           } catch (e) {
             reject(e);
           }


### PR DESCRIPTION
I.e., the one that the client used rather than an internal one

Also, update the websocket test so that it works