### PR TITLE
fix(execute-driver-plugin): replace vm2 with Node's built-in vm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3978,6 +3978,7 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -17948,21 +17949,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/vm2": {
-      "version": "3.9.19",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
-      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
-      "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      },
-      "bin": {
-        "vm2": "bin/vm2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
     "node_modules/wait-port": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.0.4.tgz",
@@ -19895,7 +19881,6 @@
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
         "source-map-support": "0.5.21",
-        "vm2": "3.9.19",
         "webdriverio": "8.40.5"
       },
       "engines": {
@@ -20936,7 +20921,6 @@
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
         "source-map-support": "0.5.21",
-        "vm2": "3.9.19",
         "webdriverio": "8.40.5"
       }
     },
@@ -23944,7 +23928,8 @@
       "requires": {}
     },
     "acorn-walk": {
-      "version": "8.2.0"
+      "version": "8.2.0",
+      "dev": true
     },
     "add-stream": {
       "version": "1.0.0",
@@ -33480,15 +33465,6 @@
     "vm-browserify": {
       "version": "1.1.2",
       "dev": true
-    },
-    "vm2": {
-      "version": "3.9.19",
-      "resolved": "https://registry.npmjs.org/vm2/-/vm2-3.9.19.tgz",
-      "integrity": "sha512-J637XF0DHDMV57R6JyVsTak7nIL8gy5KH4r1HiwWLf/4GBbb5MKL5y7LpmF4A8E2nR6XmzpmMFQ7V7ppPTmUQg==",
-      "requires": {
-        "acorn": "^8.7.0",
-        "acorn-walk": "^8.2.0"
-      }
     },
     "wait-port": {
       "version": "1.0.4",

--- a/packages/execute-driver-plugin/lib/execute-child.js
+++ b/packages/execute-driver-plugin/lib/execute-child.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import B from 'bluebird';
-import vm from 'vm';
+import vm from 'node:vm';
 import {logger, util} from 'appium/support';
 
 const log = logger.getLogger('ExecuteDriver Child');

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -42,7 +42,6 @@
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
     "source-map-support": "0.5.21",
-    "vm2": "3.9.19",
     "webdriverio": "8.40.5"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR drops the unsafe `vm2` module and replaces it with Node's built-in `vm` module. The change only affects `execute-driver-plugin`.
Since the affected code is responsible for executing arbitrary JS, I don't think it's possible to validate with 100% certainty that the new `vm` behavior exactly matches the previously configured `vm2` behavior, but they are identical as far as the tests go, at least.
Still, I did check `vm2`'s documentation. `NodeVM` (what was used until now) allowed to use Node built-ins, but none of them were actually enabled in the plugin code, so moving to `vm` does not reduce any functionality here.