### PR TITLE
feat(appium): Make server graceful shutdown timeout configurable via command line args

### DIFF
--- a/packages/appium/test/fixtures/default-args.js
+++ b/packages/appium/test/fixtures/default-args.js
@@ -19,6 +19,7 @@ export default {
   port: 4723,
   relaxedSecurityEnabled: false,
   sessionOverride: false,
+  shutdownTimeout: 5000,
   strictCaps: false,
   useDrivers: [],
   usePlugins: []

--- a/packages/base-driver/lib/express/server.js
+++ b/packages/base-driver/lib/express/server.js
@@ -211,13 +211,14 @@ function configureHttp({httpServer, reject, keepAliveTimeout, gracefulShutdownTi
   const originalClose = appiumServer.close.bind(appiumServer);
   appiumServer.close = async () =>
     await new B((_resolve, _reject) => {
+      log.info('Closing Appium HTTP server');
       const timer = new timing.Timer().start();
       const onTimeout = setTimeout(() => {
         if (gracefulShutdownTimeout > 0) {
           log.info(
             `Not all active connections have been closed within ${gracefulShutdownTimeout}ms. ` +
             `This timeout might be customized by the --shutdown-timeout command line ` +
-            `argument.`
+            `argument. Closing the server anyway.`
           );
         }
         process.exit(process.exitCode ?? 0);

--- a/packages/schema/lib/appium-config-schema.js
+++ b/packages/schema/lib/appium-config-schema.js
@@ -249,11 +249,33 @@ export const AppiumConfigJsonSchema = /** @type {const} */ ({
           type: 'boolean',
           appiumCliDest: 'relaxedSecurityEnabled',
         },
+        'shutdown-timeout': {
+          default: 5000,
+          description: 'For how long the server should delay its shutdown before force-closing all open connections to it. ' +
+            'Setting its value to zero should close the server without waiting for active connections.',
+          title: 'Graceful server shutdown timeout in milliseconds',
+          type: 'integer',
+          minimum: 0,
+        },
         'session-override': {
           default: false,
           description: 'Enables session override (clobbering)',
           title: 'session-override config',
           type: 'boolean',
+        },
+        'ssl-cert-path': {
+          description:
+            'Full path to the .cert file if TLS is used. Must be provided together with "ssl-key-path"',
+          title: '.cert file path',
+          appiumCliDest: 'sslCertificatePath',
+          type: 'string',
+        },
+        'ssl-key-path': {
+          description:
+            'Full path to the .key file if TLS is used. Must be provided together with "ssl-cert-path"',
+          title: '.key file path',
+          appiumCliDest: 'sslKeyPath',
+          type: 'string',
         },
         'strict-caps': {
           default: false,
@@ -308,20 +330,6 @@ export const AppiumConfigJsonSchema = /** @type {const} */ ({
           description: 'Also send log output to this http listener',
           format: 'uri',
           title: 'webhook config',
-          type: 'string',
-        },
-        'ssl-cert-path': {
-          description:
-            'Full path to the .cert file if TLS is used. Must be provided together with "ssl-key-path"',
-          title: '.cert file path',
-          appiumCliDest: 'sslCertificatePath',
-          type: 'string',
-        },
-        'ssl-key-path': {
-          description:
-            'Full path to the .key file if TLS is used. Must be provided together with "ssl-cert-path"',
-          title: '.key file path',
-          appiumCliDest: 'sslKeyPath',
           type: 'string',
         },
       },

--- a/packages/schema/lib/appium-config.schema.json
+++ b/packages/schema/lib/appium-config.schema.json
@@ -251,11 +251,30 @@
           "type": "boolean",
           "appiumCliDest": "relaxedSecurityEnabled"
         },
+        "shutdown-timeout": {
+          "default": 5000,
+          "description": "For how long the server should delay its shutdown before force-closing all open connections to it. Setting its value to zero should close the server without waiting for active connections.",
+          "title": "Graceful server shutdown timeout in milliseconds",
+          "type": "integer",
+          "minimum": 0
+        },
         "session-override": {
           "default": false,
           "description": "Enables session override (clobbering)",
           "title": "session-override config",
           "type": "boolean"
+        },
+        "ssl-cert-path": {
+          "description": "Full path to the .cert file if TLS is used. Must be provided together with \"ssl-key-path\"",
+          "title": ".cert file path",
+          "appiumCliDest": "sslCertificatePath",
+          "type": "string"
+        },
+        "ssl-key-path": {
+          "description": "Full path to the .key file if TLS is used. Must be provided together with \"ssl-cert-path\"",
+          "title": ".key file path",
+          "appiumCliDest": "sslKeyPath",
+          "type": "string"
         },
         "strict-caps": {
           "default": false,
@@ -304,18 +323,6 @@
           "description": "Also send log output to this http listener",
           "format": "uri",
           "title": "webhook config",
-          "type": "string"
-        },
-        "ssl-cert-path": {
-          "description": "Full path to the .cert file if TLS is used. Must be provided together with \"ssl-key-path\"",
-          "title": ".cert file path",
-          "appiumCliDest": "sslCertificatePath",
-          "type": "string"
-        },
-        "ssl-key-path": {
-          "description": "Full path to the .key file if TLS is used. Must be provided together with \"ssl-cert-path\"",
-          "title": ".key file path",
-          "appiumCliDest": "sslKeyPath",
           "type": "string"
         }
       },

--- a/packages/types/lib/appium-config.ts
+++ b/packages/types/lib/appium-config.ts
@@ -128,9 +128,21 @@ export type PortConfig = number;
  */
 export type RelaxedSecurityConfig = boolean;
 /**
+ * For how long the server should delay its shutdown before force-closing all open connections to it. Setting its value to zero should close the server without waiting for active connections.
+ */
+export type GracefulServerShutdownTimeoutInMilliseconds = number;
+/**
  * Enables session override (clobbering)
  */
 export type SessionOverrideConfig = boolean;
+/**
+ * Full path to the .cert file if TLS is used. Must be provided together with "ssl-key-path"
+ */
+export type CertFilePath = string;
+/**
+ * Full path to the .key file if TLS is used. Must be provided together with "ssl-cert-path"
+ */
+export type KeyFilePath = string;
 /**
  * Cause sessions to fail if desired caps are sent in that Appium does not recognize as valid for the selected device
  */
@@ -155,14 +167,6 @@ export type UsePluginsConfig = string[];
  * Also send log output to this http listener
  */
 export type WebhookConfig = string;
-/**
- * Full path to the .cert file if TLS is used. Must be provided together with "ssl-key-path"
- */
-export type CertFilePath = string;
-/**
- * Full path to the .key file if TLS is used. Must be provided together with "ssl-cert-path"
- */
-export type KeyFilePath = string;
 
 /**
  * A schema for Appium configuration files
@@ -204,15 +208,16 @@ export interface ServerConfig {
   plugin?: PluginConfig;
   port?: PortConfig;
   "relaxed-security"?: RelaxedSecurityConfig;
+  "shutdown-timeout"?: GracefulServerShutdownTimeoutInMilliseconds;
   "session-override"?: SessionOverrideConfig;
+  "ssl-cert-path"?: CertFilePath;
+  "ssl-key-path"?: KeyFilePath;
   "strict-caps"?: StrictCapsConfig;
   tmp?: TmpConfig;
   "trace-dir"?: TraceDirConfig;
   "use-drivers"?: UseDriversConfig;
   "use-plugins"?: UsePluginsConfig;
   webhook?: WebhookConfig;
-  "ssl-cert-path"?: CertFilePath;
-  "ssl-key-path"?: KeyFilePath;
 }
 /**
  * Set the default desired capabilities, which will be set on each session unless overridden by received capabilities. If a string, a path to a JSON file containing the capabilities, or raw JSON.


### PR DESCRIPTION
## Proposed changes

Currently this timeout is hardcoded to 5000ms. It makes sense to make it configurable instead

