### PR TITLE
fix(types): Update the `setValue` method parameter type to reflect actual usage

### DIFF
--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -1095,10 +1095,10 @@ export interface ExternalDriver<
    * Send keystrokes to an element (or otherwise set its value)
    * @see {@link https://w3c.github.io/webdriver/#element-send-keys}
    *
-   * @param text - the text to send to the element
+   * @param text - the text (string) or value (string[]) to send to the element
    * @param elementId - the id of the element
    */
-  setValue?(text: string, elementId: string): Promise<void>;
+  setValue?(text: string | string[], elementId: string): Promise<void>;
 
   /**
    * Execute JavaScript (or some other kind of script) in the browser/app context


### PR DESCRIPTION
## Proposed changes

The Python Appium client sends both `text` and `value` arguments, where `text` is a string and `value` is an array of strings (keys to be pressed). Updated the parameter type for `text` in `setValue` from `string` to `string | string[]` to accommodate both use cases.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
