### PR TITLE
fix(docutils): support Python 3.12+

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
           useRollingCache: true
           install-command: npm ci
       - name: Install dependencies (Python)
-        run: pip install -r packages/docutils/requirements.txt
+        run: pip install -r packages/docutils/requirements.txt --break-system-packages
       - name: Configure Git User
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -31,7 +31,7 @@ jobs:
         useRollingCache: true
         install-command: npm ci
     - name: Install dependencies (Python)
-      run: pip install -r packages/docutils/requirements.txt
+      run: pip install -r packages/docutils/requirements.txt --break-system-packages
     - name: Publish docs
       run: |
         cd packages/appium

--- a/packages/appium/docs/zh/contributing/develop.md
+++ b/packages/appium/docs/zh/contributing/develop.md
@@ -76,7 +76,7 @@ Our documentation system uses [MKDocs](https://www.mkdocs.org/) and therefore re
 
 ```sh
 # installing needed Python dependencies
-pip install -r packages/docutils/requirements.txt
+pip install -r packages/docutils/requirements.txt --break-system-packages
 # build the project
 npm run build
 # run dev server

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -141,7 +141,7 @@ export async function initPython({
 }: InitPythonOptions = {}): Promise<void> {
   pythonPath = pythonPath ?? (await findPython()) ?? NAME_PYTHON;
 
-  const args = ['-m', 'pip', 'install', '-r', REQUIREMENTS_TXT_PATH];
+  const args = ['-m', 'pip', 'install', '-r', REQUIREMENTS_TXT_PATH, '--break-system-packages'];
   if (upgrade) {
     args.push('--upgrade');
   }


### PR DESCRIPTION
I noticed that CI was failing on the Build Docs step, due to some errors with `pip`. This is because GitHub updated their Linux image from Ubuntu 22.04 to 24.04, thereby updating Python to 3.12, which breaks the behavior of installing packages globally with `pip`.
In order to preserve the old behavior, the `--break-system-packages` flag is now required. This PR adds this flag in all relevant locations.
An alternative solution is to create a virtual environment first, but I do not see much benefit to it for our use cases.
See https://github.com/actions/runner-images/issues/8615 for more information.