### PR TITLE
fix(docutils): restore support for Python <3.12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   docs:
     name: Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # TODO: change this to latest after adding handling for PEP 668
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies (Node.js)
@@ -44,7 +44,7 @@ jobs:
           useRollingCache: true
           install-command: npm ci
       - name: Install dependencies (Python)
-        run: pip install -r packages/docutils/requirements.txt --break-system-packages
+        run: pip install -r packages/docutils/requirements.txt
       - name: Configure Git User
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   docs:
     name: Docs
-    runs-on: ubuntu-22.04 # TODO: change this to latest after adding handling for PEP 668
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies (Node.js)
@@ -44,7 +44,7 @@ jobs:
           useRollingCache: true
           install-command: npm ci
       - name: Install dependencies (Python)
-        run: pip install -r packages/docutils/requirements.txt
+        run: PIP_BREAK_SYSTEM_PACKAGES=1 pip install -r packages/docutils/requirements.txt
       - name: Configure Git User
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-22.04 # TODO: change this to latest after adding handling for PEP 668
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -31,7 +31,7 @@ jobs:
         useRollingCache: true
         install-command: npm ci
     - name: Install dependencies (Python)
-      run: pip install -r packages/docutils/requirements.txt
+      run: PIP_BREAK_SYSTEM_PACKAGES=1 pip install -r packages/docutils/requirements.txt
     - name: Publish docs
       run: |
         cd packages/appium

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # TODO: change this to latest after adding handling for PEP 668
 
     strategy:
       matrix:
@@ -31,7 +31,7 @@ jobs:
         useRollingCache: true
         install-command: npm ci
     - name: Install dependencies (Python)
-      run: pip install -r packages/docutils/requirements.txt --break-system-packages
+      run: pip install -r packages/docutils/requirements.txt
     - name: Publish docs
       run: |
         cd packages/appium

--- a/packages/appium/docs/zh/contributing/develop.md
+++ b/packages/appium/docs/zh/contributing/develop.md
@@ -76,7 +76,7 @@ Our documentation system uses [MKDocs](https://www.mkdocs.org/) and therefore re
 
 ```sh
 # installing needed Python dependencies
-pip install -r packages/docutils/requirements.txt --break-system-packages
+pip install -r packages/docutils/requirements.txt
 # build the project
 npm run build
 # run dev server

--- a/packages/appium/docs/zh/contributing/develop.md
+++ b/packages/appium/docs/zh/contributing/develop.md
@@ -76,7 +76,7 @@ Our documentation system uses [MKDocs](https://www.mkdocs.org/) and therefore re
 
 ```sh
 # installing needed Python dependencies
-pip install -r packages/docutils/requirements.txt
+PIP_BREAK_SYSTEM_PACKAGES=1 pip install -r packages/docutils/requirements.txt
 # build the project
 npm run build
 # run dev server

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -151,4 +151,9 @@ export const DEFAULT_SITE_DIR = 'site';
  * pip 23.0 implements PEP 668, which may prevent overriding Python system packages
  * unless the --break-system-packages flag is passed
  */
-export const PIP_MIN_VERSION_NUMBER_FOR_FLAG = 23;
+export const PIP_MIN_VERSION_FOR_FLAG = '23.0';
+
+/**
+ * Extracts only the version number from the output of `pip --version`
+ */
+export const PIP_VERSION_REGEXP = /^pip (\d+(\d+|[.])*)/;

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -146,3 +146,9 @@ export const LogLevelMap = {
  * If the user does not specify a site directory _and_ the `mkdocs.yml` doesn't either, use this dir.
  */
 export const DEFAULT_SITE_DIR = 'site';
+
+/**
+ * pip 23.0 implements PEP 668, which may prevent overriding Python system packages
+ * unless the --break-system-packages flag is passed
+ */ 
+export const PIP_MIN_VERSION_NUMBER_FOR_FLAG = 23;

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -150,5 +150,5 @@ export const DEFAULT_SITE_DIR = 'site';
 /**
  * pip 23.0 implements PEP 668, which may prevent overriding Python system packages
  * unless the --break-system-packages flag is passed
- */ 
+ */
 export const PIP_MIN_VERSION_NUMBER_FOR_FLAG = 23;

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -152,4 +152,4 @@ export const DEFAULT_SITE_DIR = 'site';
  * unless the --break-system-packages flag is passed.
  * To ensure backwards compatibility, its environment variable version is used
  */
-export const PIP_BREAK_SYSTEM_PACKAGES_FLAG = 'PIP_BREAK_SYSTEM_PACKAGES=1';
+export const PIP_ENV_VARS = {PIP_BREAK_SYSTEM_PACKAGES: '1'};

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -149,11 +149,7 @@ export const DEFAULT_SITE_DIR = 'site';
 
 /**
  * pip 23.0 implements PEP 668, which may prevent overriding Python system packages
- * unless the --break-system-packages flag is passed
+ * unless the --break-system-packages flag is passed.
+ * To ensure backwards compatibility, its environment variable version is used
  */
-export const PIP_MIN_VERSION_FOR_FLAG = '23.0';
-
-/**
- * Extracts only the version number from the output of `pip --version`
- */
-export const PIP_VERSION_REGEXP = /^pip (\d+(\d+|[.])*)/;
+export const PIP_BREAK_SYSTEM_PACKAGES_FLAG = 'PIP_BREAK_SYSTEM_PACKAGES=1';

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -141,7 +141,7 @@ export async function initPython({
 }: InitPythonOptions = {}): Promise<void> {
   pythonPath = pythonPath ?? (await findPython()) ?? NAME_PYTHON;
 
-  const args = ['-m', 'pip', 'install', '-r', REQUIREMENTS_TXT_PATH, '--break-system-packages'];
+  const args = ['-m', 'pip', 'install', '-r', REQUIREMENTS_TXT_PATH];
   if (upgrade) {
     args.push('--upgrade');
   }

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -12,7 +12,6 @@ import {
   PIP_BREAK_SYSTEM_PACKAGES_FLAG,
   REQUIREMENTS_TXT_PATH,
 } from './constants';
-import {util} from '@appium/support';
 import YAML from 'yaml';
 import {exec} from 'teen_process';
 import {Simplify} from 'type-fest';

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -186,8 +186,8 @@ async function getPipMajorVersion(pythonPath: string): Promise<number> {
     if (code !== 0) {
       throw new DocutilsError(`Could not retrieve pip version. Reason: ${stdout}`);
     }
-    const pipVersionString = stdout.split(" ")[1];
-    const pipMajorVersionInt = parseInt(pipVersionString);
+    const pipVersionString = stdout.split(' ')[1];
+    const pipMajorVersionInt = parseInt(pipVersionString, 10);
     if (Number.isNaN(pipMajorVersionInt)) {
       throw new DocutilsError(`Could not retrieve pip version. Reason: ${stdout}`);
     }

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -188,8 +188,8 @@ async function getPipMajorVersion(pythonPath: string): Promise<number> {
     }
     const pipVersionString = stdout.split(' ')[1];
     const pipMajorVersionInt = parseInt(pipVersionString, 10);
-    if (Number.isNaN(pipMajorVersionInt)) {
-      throw new DocutilsError(`Could not retrieve pip version. Reason: ${stdout}`);
+    if (_.isNaN(pipMajorVersionInt)) {
+      throw new DocutilsError(`Could not parse the pip version from result: ${stdout}`);
     }
     return pipMajorVersionInt;
   } catch (err) {

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -5,13 +5,7 @@
  */
 
 import * as JSON5 from 'json5';
-import {
-  NAME_MKDOCS_YML,
-  NAME_TSCONFIG_JSON,
-  NAME_PYTHON,
-  PIP_BREAK_SYSTEM_PACKAGES_FLAG,
-  REQUIREMENTS_TXT_PATH,
-} from './constants';
+import {NAME_MKDOCS_YML, NAME_TSCONFIG_JSON, NAME_PYTHON, PIP_ENV_VARS, REQUIREMENTS_TXT_PATH} from './constants';
 import YAML from 'yaml';
 import {exec} from 'teen_process';
 import {Simplify} from 'type-fest';
@@ -146,19 +140,18 @@ export async function initPython({
   upgrade = false,
 }: InitPythonOptions = {}): Promise<void> {
   pythonPath = pythonPath ?? (await findPython()) ?? NAME_PYTHON;
-  const pythonPathWithFlag = [PIP_BREAK_SYSTEM_PACKAGES_FLAG, pythonPath].join(' ');
 
   const args = ['-m', 'pip', 'install', '-r', REQUIREMENTS_TXT_PATH];
   if (upgrade) {
     args.push('--upgrade');
   }
   if (dryRun) {
-    dryRunLog.info('Would execute command: %s %s', pythonPathWithFlag, args.join(' '));
+    dryRunLog.info('Would execute command: %s %s (environment variables: %s)', pythonPath, args.join(' '), PIP_ENV_VARS);
   } else {
-    log.debug('Executing command: %s %s', pythonPathWithFlag, args.join(' '));
+    log.debug('Executing command: %s %s (environment variables: %s)', pythonPath, args.join(' '), PIP_ENV_VARS);
     log.info('Installing Python dependencies...');
     try {
-      const result = await exec(pythonPathWithFlag, args, {shell: true});
+      const result = await exec(pythonPath, args, {env: PIP_ENV_VARS, shell: true});
       const {code, stdout} = result;
       if (code !== 0) {
         throw new DocutilsError(`Could not install Python dependencies. Reason: ${stdout}`);

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -146,9 +146,18 @@ export async function initPython({
     args.push('--upgrade');
   }
   if (dryRun) {
-    dryRunLog.info('Would execute command: %s %s (environment variables: %s)', pythonPath, args.join(' '), PIP_ENV_VARS);
+    dryRunLog.info(
+      'Would execute command: %s %s (environment variables: %s)',
+      pythonPath,
+      args.join(' '),
+      PIP_ENV_VARS,
+    );
   } else {
-    log.debug('Executing command: %s %s (environment variables: %s)', pythonPath, args.join(' '), PIP_ENV_VARS);
+    log.debug('Executing command: %s %s (environment variables: %s)',
+      pythonPath,
+      args.join(' '),
+      PIP_ENV_VARS,
+    );
     log.info('Installing Python dependencies...');
     try {
       const result = await exec(pythonPath, args, {env: PIP_ENV_VARS, shell: true});


### PR DESCRIPTION
This PR adds back `docutils` support for `pip` `< 23.0`, which was unintentionally broken with #20666. Compatibility with `pip` `>= 23.0` is still preserved.

Original PR description as follows:

This PR reverts #20666, as it broke the installation of `docutils` prerequisites when using `pip < 23.0`.
At the same time, this PR also removes the support for `pip >= 23.0` on distributions that prevent modifying system packages (which was also added in #20666). It will be reintroduced in the future.

The original change was prompted by GitHub upgrading their CI Linux runners to Ubuntu 24.04, but the rollout has now been halted due to this and other breaking changes. To prevent similar issues in the future on the Appium side, the CI Linux runners for affected jobs are temporarily explicitly set to Ubuntu 22.04.

