### PR TITLE
chore(appium): Bump the amount of max process listeners

### DIFF
--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -45,6 +45,14 @@ import {
 import net from 'node:net';
 
 const {resolveAppiumHome} = env;
+/*
+ * By default Node.js shows a warning
+ * if the actual amount of listeners exceeds the maximum amount,
+ * which equals to 10 by default. It is known that multiple drivers/plugins
+ * may assign custom listeners to the server process to handle, for example,
+ * the graceful shutdown scenario.
+ */
+const MAX_SERVER_PROCESS_LISTENERS = 100;
 
 /**
  *
@@ -433,6 +441,7 @@ async function main(args) {
     throw err;
   }
 
+  process.setMaxListeners(MAX_SERVER_PROCESS_LISTENERS);
   for (const signal of ['SIGINT', 'SIGTERM']) {
     process.once(signal, async function onSignal() {
       logger.info(`Received ${signal} - shutting down`);


### PR DESCRIPTION
```
(node:50562) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [process]. MaxListeners is 10. Use emitter.setMaxListeners() to increase limit
    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at _addListener (node:events:594:17)
    at process.addListener (node:events:612:10)
    at process.once (node:events:656:8)
    at Object.<anonymous> (/Users/elf/code/appium-windows-driver/lib/winappdriver.js:101:9)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1691:10)
    at Module.load (node:internal/modules/cjs/loader:1317:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1127:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
    at Module.require (node:internal/modules/cjs/loader:1339:12)
    at require (node:internal/modules/helpers:126:16)
    at Object.<anonymous> (/Users/elf/code/appium-windows-driver/lib/driver.js:4:1)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1691:10)
    at Module.load (node:internal/modules/cjs/loader:1317:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1127:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
    at Module.require (node:internal/modules/cjs/loader:1339:12)
    at require (node:internal/modules/helpers:126:16)
    at Object.<anonymous> (/Users/elf/code/appium-windows-driver/index.js:3:1)
    at Module._compile (node:internal/modules/cjs/loader:1546:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1691:10)
    at Module.load (node:internal/modules/cjs/loader:1317:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1127:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:217:24)
    at cjsLoader (node:internal/modules/esm/translators:329:5)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:260:7)
    at ModuleJob.run (node:internal/modules/esm/module_job:262:25)
    at onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:482:26)
    at DriverConfig.requireAsync (/opt/homebrew/lib/node_modules/appium/lib/extension/extension-config.js:600:24)
    at /opt/homebrew/lib/node_modules/appium/lib/extension/index.js:53:26
[Appium] Appium REST http interface listener started on http://0.0.0.0:4723
```