### PR TITLE
feat(base-driver): Allow to prefix feature names with automation names

### DIFF
--- a/packages/appium/docs/en/guides/security.md
+++ b/packages/appium/docs/en/guides/security.md
@@ -44,6 +44,14 @@ might use. Here is an incomplete list of examples from some of Appium's official
 |`record_audio`|Allow recording of host machine audio inputs|XCUITest|
 |`execute_driver_script`| Allows to send a request which has multiple Appium commands.|Execute Driver Plugin|
 
+## Driver-scope security
+
+Since Appium server version 2.12.3 there is a possibility to prefix each feature name with the corresponding automationName where it is going to be applied. For example, if you provide the following features to allow:
+`uiautomator2:adb_shell,xcuitest:get_server_logs,*:record_audio`, then the `adb_shell` would only be allowed
+for the UiAutomator2 driver, `get_server` - for the XCUITest driver and the `record_audio` one - for
+all installed drivers. Feature names provided without explicit automation name prefix are equivalent to
+these having the `*:` prefix. The same feature naming rule applies to the list of denied features.
+
 ## Examples
 
 To turn on the `get_server_logs` feature for my Appium server, I could start it like this:

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -22,6 +22,7 @@ import {
   isBroadcastIp,
   fetchInterfaces,
   V4_BROADCAST_IP,
+  validateFeatures,
 } from './utils';
 import {util, node, logger} from '@appium/support';
 import {getDefaultsForExtension} from './schema';
@@ -697,13 +698,13 @@ class AppiumDriver extends DriverCore {
       if (!_.isEmpty(this.args.denyInsecure)) {
         this.log.info('Explicitly preventing use of insecure features:');
         this.args.denyInsecure.map((a) => this.log.info(`    ${a}`));
-        driverInstance.denyInsecure = this.args.denyInsecure;
+        driverInstance.denyInsecure = validateFeatures(this.args.denyInsecure);
       }
 
       if (!_.isEmpty(this.args.allowInsecure)) {
         this.log.info('Explicitly enabling use of insecure features:');
         this.args.allowInsecure.map((a) => this.log.info(`    ${a}`));
-        driverInstance.allowInsecure = this.args.allowInsecure;
+        driverInstance.allowInsecure = validateFeatures(this.args.allowInsecure);
       }
 
       // Likewise, any driver-specific CLI args that were passed in should be assigned directly to

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -464,6 +464,7 @@ export function isBroadcastIp(address) {
 }
 
 /**
+ * Validates the list of allowed/denied server features
  *
  * @param {string[]} features
  * @returns {string[]}
@@ -483,8 +484,9 @@ export function validateFeatures(features) {
     ];
     if (!automationName || !featureName) {
       throw new Error(
-        `The full feature name must include both the driver name/wildcard and the feature ` +
-        `name split by a colon, got '${fullName}' instead`
+        `The full feature name must include both the destination automation name or the '*' wildcard ` +
+        `to apply the feature to all installed drivers, and the feature name split by a colon, ` +
+        `got '${fullName}' instead`
       );
     }
     return fullName;

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -484,9 +484,9 @@ export function validateFeatures(features) {
     ];
     if (!automationName || !featureName) {
       throw new Error(
-        `The full feature name must include both the destination automation name or the '*' wildcard ` +
-        `to apply the feature to all installed drivers, and the feature name split by a colon, ` +
-        `got '${fullName}' instead`
+        `The full feature name must include both the destination automation name or the ` +
+        `'${ALL_DRIVERS_MATCH}' wildcard to apply the feature to all installed drivers, and ` +
+        `the feature name split by a colon, got '${fullName}' instead`
       );
     }
     return fullName;

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -1,6 +1,11 @@
 import _ from 'lodash';
 import logger from './logger';
-import {processCapabilities, PROTOCOLS, STANDARD_CAPS, errors} from '@appium/base-driver';
+import {
+  processCapabilities,
+  PROTOCOLS,
+  STANDARD_CAPS,
+  errors,
+} from '@appium/base-driver';
 import {inspect as dump} from 'util';
 import {node, fs} from '@appium/support';
 import path from 'path';
@@ -12,7 +17,8 @@ const STANDARD_CAPS_LOWERCASE = new Set([...STANDARD_CAPS].map((cap) => cap.toLo
 export const V4_BROADCAST_IP = '0.0.0.0';
 export const V6_BROADCAST_IP = '::';
 export const npmPackage = fs.readPackageJsonFrom(__dirname);
-
+const ALL_DRIVERS_MATCH = '*';
+const FEATURE_NAME_SEPARATOR = ':';
 
 /**
  *
@@ -455,6 +461,35 @@ export function adler32(str, seed = null) {
  */
 export function isBroadcastIp(address) {
   return [V4_BROADCAST_IP, V6_BROADCAST_IP, `[${V6_BROADCAST_IP}]`].includes(address);
+}
+
+/**
+ *
+ * @param {string[]} features
+ * @returns {string[]}
+ */
+export function validateFeatures(features) {
+  const validator = (/** @type {string} */ fullName) => {
+    const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+    // TODO: This is for the backward compatibility with Appium2
+    // TODO: In Appium3 the separator will be mandatory
+    if (separatorPos < 0) {
+      return `${ALL_DRIVERS_MATCH}${FEATURE_NAME_SEPARATOR}${fullName}`;
+    }
+
+    const [automationName, featureName] = [
+      fullName.substring(0, separatorPos),
+      fullName.substring(separatorPos + 1)
+    ];
+    if (!automationName || !featureName) {
+      throw new Error(
+        `The full feature name must include both the driver name/wildcard and the feature ` +
+        `name split by a colon, got '${fullName}' instead`
+      );
+    }
+    return fullName;
+  };
+  return features.map(validator);
 }
 
 /**

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -312,7 +312,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
    * not
    *
    * @param name - name of feature/command
-   * @deprecated
+   * @deprecated Use {@link assertFeatureEnabled} instead
    */
   ensureFeatureEnabled(name: string) {
     this.assertFeatureEnabled(name);

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -272,7 +272,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
     const parseFullName = (fullName: string) => {
       const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
       if (separatorPos < 0) {
-        // This should not happen as we preprocess cotresponding server arguments before
+        // This should not happen as we preprocess corresponding server arguments in advance
         throw new Error(
           `The full feature name must include both the driver name/wildcard and the feature ` +
           `name split by a colon, got '${fullName}' instead`

--- a/packages/base-driver/lib/constants.ts
+++ b/packages/base-driver/lib/constants.ts
@@ -7,15 +7,13 @@ import {Protocol} from '@appium/types';
 // server feature. Example rule:
 // 	{"pattern": "(.{1,150}).*", "flags": "s", "replacer": "$1"}
 // ^ cuts all log records to maximum 150 chars
-const MAX_LOG_BODY_LENGTH = 1024;
-const MJSONWP_ELEMENT_KEY = 'ELEMENT';
-const W3C_ELEMENT_KEY = util.W3C_WEB_ELEMENT_IDENTIFIER;
-const PROTOCOLS = {
+export const MAX_LOG_BODY_LENGTH = 1024;
+export const MJSONWP_ELEMENT_KEY = 'ELEMENT';
+export const W3C_ELEMENT_KEY = util.W3C_WEB_ELEMENT_IDENTIFIER;
+export const PROTOCOLS = {
   W3C: 'W3C',
   MJSONWP: 'MJSONWP',
 } as const satisfies Record<Protocol, Protocol>;
 
 // Before Appium 2.0, this default value was '/wd/hub' by historical reasons.
-const DEFAULT_BASE_PATH = '';
-
-export {MAX_LOG_BODY_LENGTH, MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY, PROTOCOLS, DEFAULT_BASE_PATH};
+export const DEFAULT_BASE_PATH = '';

--- a/packages/driver-test-support/lib/unit-suite.js
+++ b/packages/driver-test-support/lib/unit-suite.js
@@ -580,24 +580,17 @@ export function driverUnitTestSuite(
       d = new DriverClass();
     });
 
-    it('should say a feature is enabled when it is explicitly allowed', function () {
-      d.allowInsecure = ['foo', 'bar'];
-      d.isFeatureEnabled('foo').should.be.true;
-      d.isFeatureEnabled('bar').should.be.true;
-      d.isFeatureEnabled('baz').should.be.false;
-    });
-
-    it('should say a feature is not enabled if it is not enabled', function () {
-      d.allowInsecure = [];
-      d.isFeatureEnabled('foo').should.be.false;
-    });
-
-    it('should prefer denyInsecure to allowInsecure', function () {
-      d.allowInsecure = ['foo', 'bar'];
-      d.denyInsecure = ['foo'];
-      d.isFeatureEnabled('foo').should.be.false;
-      d.isFeatureEnabled('bar').should.be.true;
-      d.isFeatureEnabled('baz').should.be.false;
+    it('should throw an error if feature name is invalid', function () {
+      for (const name of [
+        'foo',
+        ':foo',
+        '*:',
+      ]) {
+        (() => {
+          d.allowInsecure = [name];
+          d.isFeatureEnabled('foo');
+        }).should.throw();
+      }
     });
 
     it('should allow global setting for insecurity', function () {
@@ -609,7 +602,7 @@ export function driverUnitTestSuite(
 
     it('global setting should be overrideable', function () {
       d.relaxedSecurityEnabled = true;
-      d.denyInsecure = ['foo', 'bar'];
+      d.denyInsecure = ['*:foo', '*:bar'];
       d.isFeatureEnabled('foo').should.be.false;
       d.isFeatureEnabled('bar').should.be.false;
       d.isFeatureEnabled('baz').should.be.true;

--- a/packages/driver-test-support/lib/unit-suite.js
+++ b/packages/driver-test-support/lib/unit-suite.js
@@ -614,6 +614,31 @@ export function driverUnitTestSuite(
       d.isFeatureEnabled('bar').should.be.false;
       d.isFeatureEnabled('baz').should.be.true;
     });
+
+    it('should say a feature is enabled if it is for this driver', function () {
+      d.opts.automationName = 'bar';
+      d.allowInsecure = ['bar:foo'];
+      d.isFeatureEnabled('foo').should.be.true;
+    });
+
+    it('should say a feature is enabled if it is for all drivers', function () {
+      d.opts.automationName = 'bar';
+      d.allowInsecure = ['*:foo'];
+      d.isFeatureEnabled('foo').should.be.true;
+    });
+
+    it('should say a feature is not enabled if it is not for this driver', function () {
+      d.opts.automationName = 'bar';
+      d.allowInsecure = ['baz:foo'];
+      d.isFeatureEnabled('foo').should.be.false;
+    });
+
+    it('should say a feature is not enabled if it is enabled and then disabled', function () {
+      d.opts.automationName = 'bar';
+      d.allowInsecure = ['bar:foo'];
+      d.denyInsecure = ['*:foo'];
+      d.isFeatureEnabled('foo').should.be.false;
+    });
   });
 }
 

--- a/packages/driver-test-support/lib/unit-suite.js
+++ b/packages/driver-test-support/lib/unit-suite.js
@@ -581,16 +581,10 @@ export function driverUnitTestSuite(
     });
 
     it('should throw an error if feature name is invalid', function () {
-      for (const name of [
-        'foo',
-        ':foo',
-        '*:',
-      ]) {
-        (() => {
-          d.allowInsecure = [name];
-          d.isFeatureEnabled('foo');
-        }).should.throw();
-      }
+      d.allowInsecure = ['foo'];
+      (() => {
+        d.isFeatureEnabled('foo');
+      }).should.throw();
     });
 
     it('should allow global setting for insecurity', function () {


### PR DESCRIPTION
## Proposed changes

This is part of Appium 3 migration preparation. The PR fine-tunes insecure features logic by allowing prefixes in denied/allowed feature names. For example: 
Previously we would have to provide something like `foo,bar,baz` to the list of allow-insecure features in order to enable them. This applies to all installed drivers, which verify these feature names. This PR allows to provide the list of features looking like `xcuitest:foo,uiautomator2:bar,*:baz`, which would ONLY enable feature `foo` for the `xcuitest` driver, feature `bar` - for `uiautomator2` driver, and feature `baz` for all installed drivers. For now providing a feature name without a colon would be parsed as this name would have the `*:` prefix, thus maintaining the backward compatibility. In Appium3 we MIGHT remove this check, thus enforcing users to always provide the prefix explicitly.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
