### PR TITLE
chore(support): revert #20797 as a backward compatibility

### DIFF
--- a/packages/support/lib/npm.js
+++ b/packages/support/lib/npm.js
@@ -201,17 +201,7 @@ export class NPM {
    * @param {InstallPackageOpts} opts
    * @returns {Promise<NpmInstallReceipt>}
    */
-  async installPackage(cwd, installStr, {pkgName, pkgVer, installType} = {}) {
-    let _installStr = installStr;
-    // FIXME: Please remove this '!pkgName' case after bumping major version of this support package.
-    // This is a temporary workaround for backward compatibility related to https://github.com/appium/appium/pull/20788
-    if (!pkgName) {
-      // Old appium package passes an empty 'pkgName' as part of the option. Then,
-      // we could consider it is for old argument case.
-      pkgName = installStr;
-      _installStr = pkgVer ? `${pkgName}@${pkgVer}` : pkgName;
-    }
-
+  async installPackage(cwd, installStr, {pkgName, installType}) {
     /** @type {any} */
     let dummyPkgJson;
     const dummyPkgPath = path.join(cwd, 'package.json');
@@ -235,7 +225,7 @@ export class NPM {
     }
 
     const cmd = installType === 'local' ? 'link' : 'install';
-    const res = await this.exec(cmd, [...installOpts, _installStr], {
+    const res = await this.exec(cmd, [...installOpts, installStr], {
       cwd,
       json: true,
       lockFile: this._getInstallLockfilePath(cwd),
@@ -297,10 +287,8 @@ export const npm = new NPM();
 /**
  * Options for {@link NPM.installPackage}
  * @typedef InstallPackageOpts
- * @property {string} [pkgName] - the name of the package to install. Used by appium package 2.12.2 and newer versions.
+ * @property {string} pkgName - the name of the package to install
  * @property {import('type-fest').LiteralUnion<'local', string>} [installType] - whether to install from a local path or from npm
- * @property {string} [pkgVer] - The version of the package to install.
-*                                This is used for backward compatibility for this support package v5 with appium package 2.12.1 and lower versions.
  */
 
 /**


### PR DESCRIPTION
BREAKING CHANGE: revert #20797 whcih was used for a backward compatibility

## Proposed changes

Revert https://github.com/appium/appium/pull/20797 as a breaking change to bump the `@appium/support`'s major version to not bring it to past `appium` packages.

This is only for support.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
