### PR TITLE
docs: update aggregate changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,36 +1,44 @@
 # Aggregate Changelog
 
-Appium contains many different modules and supports a variety of drivers, plugins and clients, most of which have their own changelogs. Links to these individual changelogs are aggregated here.
+The Appium monorepo contains many different modules and supports a variety of drivers, plugins and clients,
+most of which have their own changelogs. Links to these individual changelogs are aggregated here.
 
 ## Main Appium Module
 
 * ### [Appium 2 Changelog](packages/appium/CHANGELOG.md)
 * [Appium 1.x Changelog](https://github.com/appium/appium/blob/1.x/CHANGELOG.md)
 
-## Appium Drivers / Clients / Plugins
-* Refer to the [Appium Ecosystem](https://appium.io/docs/en/latest/ecosystem/) page for links to specific driver/client/plugin documentation
-* Changelogs for plugins maintained by Appium Team are also linked in the Other Modules section below
+## Drivers / Clients
+Refer to the [Appium Ecosystem](https://appium.io/docs/en/latest/ecosystem/) page for links
+to driver/client documentation
 
-## Other Appium Modules
+## Plugins
+* [execute-driver-plugin](packages/execute-driver-plugin/CHANGELOG.md)
+* [images-plugin](packages/images-plugin/CHANGELOG.md)
+* [relaxed-caps-plugin](packages/relaxed-caps-plugin/CHANGELOG.md)
+* [universal-xml-plugin](packages/universal-xml-plugin/CHANGELOG.md)
+
+## Other Modules
 * [base-driver](packages/base-driver/CHANGELOG.md)
 * [base-plugin](packages/base-plugin/CHANGELOG.md)
-* [doctor](packages/doctor/CHANGELOG.md)
 * [docutils](packages/docutils/CHANGELOG.md)
 * [driver-test-support](packages/driver-test-support/CHANGELOG.md)
 * [eslint-config-appium](packages/eslint-config-appium/CHANGELOG.md)
 * [eslint-config-appium-ts](packages/eslint-config-appium-ts/CHANGELOG.md)
-* [execute-driver-plugin](packages/execute-driver-plugin/CHANGELOG.md)
 * [fake-driver](packages/fake-driver/CHANGELOG.md)
 * [fake-plugin](packages/fake-plugin/CHANGELOG.md)
-* [images-plugin](packages/images-plugin/CHANGELOG.md)
 * [logger](packages/logger/CHANGELOG.md)
 * [opencv](packages/opencv/CHANGELOG.md)
 * [plugin-test-support](packages/plugin-test-support/CHANGELOG.md)
-* [relaxed-caps-plugin](packages/relaxed-caps-plugin/CHANGELOG.md)
 * [schema](packages/schema/CHANGELOG.md)
 * [strongbox](packages/strongbox/CHANGELOG.md)
 * [support](packages/support/CHANGELOG.md)
 * [test-support](packages/test-support/CHANGELOG.md)
 * [tsconfig](packages/tsconfig/CHANGELOG.md)
 * [types](packages/types/CHANGELOG.md)
-* [universal-xml-plugin](packages/universal-xml-plugin/CHANGELOG.md)
+
+## Removed Modules
+The changelog links used for these modules lead to the last version of their changelog file.
+* [doctor](https://github.com/appium/appium/blob/8daf5e123ac14c8325acf504fb33eb28e1a3dd78/packages/doctor/CHANGELOG.md) ([removal PR](https://github.com/appium/appium/pull/20805))
+* [gulp-plugins](https://github.com/appium/appium/blob/0823f0b60e40395cd1dc3b72cfa3c0092bc81302/packages/gulp-plugins/CHANGELOG.md) ([removal PR](https://github.com/appium/appium/pull/17943))
+* [typedoc-plugin-appium](https://github.com/appium/appium/blob/d6204b6902074210943d7bbbf72d139b9b170a20/packages/typedoc-plugin-appium/CHANGELOG.md) ([removal PR](https://github.com/appium/appium/pull/19465))


### PR DESCRIPTION
## Proposed changes

This is a small refresh of the monorepo-level aggregate changelog:
* Move plugins to their own category (users are likely to find them more relevant than e.g. `driver-test-support`)
* Add category for removed modules (currently only `doctor`, `gulp-plugins` and `typedoc-plugin-appium`)
  * Include a link to the PR where the respective module was removed

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update (if none of the other choices apply)