### PR TITLE
ci: add workflow to validate PR title

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,14 @@
+name: Conventional Commits
+on:
+  pull_request:
+
+jobs:
+  conventional:
+    name: PR Title
+    runs-on: ubuntu-latest
+    steps:
+    - uses: beemojs/conventional-pr-action@v3
+      with:
+        config-preset: angular
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,6 +1,7 @@
 name: Conventional Commits
 on:
   pull_request:
+    types: [opened, edited, synchronize, reopened]
 
 jobs:
   conventional:


### PR DESCRIPTION
This PR adds a dedicated CI action to validate whether PR titles follow conventional commit guidelines. Several driver repos have had this action for years, so I'm not sure why the main monorepo did not.