### PR TITLE
fix(base-driver): add * always for non-separator for backward compatibility

### DIFF
--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -272,9 +272,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
     const parseFullName = (fullName: string) => {
       let separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
       if (separatorPos < 0) {
-        // Workaround for lower appium packages
-        fullName = `${ALL_DRIVERS_MATCH}${FEATURE_NAME_SEPARATOR}${fullName}`;
-        separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+        return [ALL_DRIVERS_MATCH, fullName];
       }
       return [
         _.toLower(fullName.substring(0, separatorPos)),

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -270,7 +270,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
     const currentAutomationName = _.toLower(this.opts.automationName);
 
     const parseFullName = (fullName: string) => {
-      let separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+      const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
       if (separatorPos < 0) {
         return [ALL_DRIVERS_MATCH, fullName];
       }

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -270,8 +270,14 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
     const currentAutomationName = _.toLower(this.opts.automationName);
 
     const parseFullName = (fullName: string) => {
-      const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+      let separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
       if (separatorPos < 0) {
+        // TODO: This is for the backward compatibility with Appium 2.
+        // TODO: We should bring back to raise an Error below for Appium 3.
+        // throw new Error(
+        //   `The full feature name must include both the driver name/wildcard and the feature ` +
+        //   `name split by a colon, got '${fullName}' instead`
+        // );
         return [ALL_DRIVERS_MATCH, fullName];
       }
       return [

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -270,13 +270,11 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
     const currentAutomationName = _.toLower(this.opts.automationName);
 
     const parseFullName = (fullName: string) => {
-      const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+      let separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
       if (separatorPos < 0) {
-        // This should not happen as we preprocess corresponding server arguments in advance
-        throw new Error(
-          `The full feature name must include both the driver name/wildcard and the feature ` +
-          `name split by a colon, got '${fullName}' instead`
-        );
+        // Workaround for lower appium packages
+        fullName = `${ALL_DRIVERS_MATCH}${FEATURE_NAME_SEPARATOR}${fullName}`;
+        separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
       }
       return [
         _.toLower(fullName.substring(0, separatorPos)),

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -270,7 +270,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
     const currentAutomationName = _.toLower(this.opts.automationName);
 
     const parseFullName = (fullName: string) => {
-      let separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+      const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
       if (separatorPos < 0) {
         // TODO: This is for the backward compatibility with Appium 2.
         // TODO: We should bring back to raise an Error below for Appium 3.

--- a/packages/driver-test-support/lib/unit-suite.js
+++ b/packages/driver-test-support/lib/unit-suite.js
@@ -580,11 +580,9 @@ export function driverUnitTestSuite(
       d = new DriverClass();
     });
 
-    it('should throw an error if feature name is invalid', function () {
+    it('should handled with wild card if feature name is invalid', function () {
       d.allowInsecure = ['foo'];
-      (() => {
-        d.isFeatureEnabled('foo');
-      }).should.throw();
+      d.isFeatureEnabled('foo').should.be.true;
     });
 
     it('should allow global setting for insecurity', function () {


### PR DESCRIPTION
## Proposed changes


Base-driver change in https://github.com/appium/appium/pull/20793/files#diff-f1838792b23d8d547095fc6ce7e449672c87a7688d1372ee172ebcea14cf7d38R274-R280  affected old appium packages such as `appium@2.11.x` etc since that was minor version update.
It means they are currently required to add `*` etc to make the insecure work.

e.g.
```
appium --allow-insecure chromedriver_autodownload
```

So, The original PR works only with latest appium package, `2.13.0`.

It would be nice to bump the base-driver's major version update to avoid possible unexpected base-driver deps update in such lower environment as us.

note: this breaking change handling can be later like only in `appium3` branch for example.

So, let's add the workaround in the base-driver as a fix right now, and let me create a followup PR for the base driver with this change's revert with breaking change message to bump the base-driver's major version update to apply the change only for newer appium packages.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
