### PR TITLE
fix(appium): update CLI help messages

### DIFF
--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -108,7 +108,7 @@ function makeInstallArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type.toUpperCase()}NAME`],
+      [`${type}Name`],
       {
         type: 'str',
         help:
@@ -152,7 +152,7 @@ function makeUninstallArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type.toUpperCase()}NAME`],
+      [`${type}Name`],
       {
         type: 'str',
         help:
@@ -172,7 +172,7 @@ function makeDoctorArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type.toUpperCase()}NAME`],
+      [`${type}Name`],
       {
         type: 'str',
         help:
@@ -192,7 +192,7 @@ function makeUpdateArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type.toUpperCase()}NAME`],
+      [`${type}Name`],
       {
         type: 'str',
         help:
@@ -224,7 +224,7 @@ function makeRunArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type.toUpperCase()}NAME`],
+      [`${type}Name`],
       {
         type: 'str',
         help:

--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -82,7 +82,7 @@ function makeListArgs(type) {
         required: false,
         default: false,
         action: 'store_true',
-        help: 'Show information about newer versions',
+        help: `Show information about available ${type} updates`,
         dest: 'showUpdates',
       },
     ],
@@ -92,7 +92,7 @@ function makeListArgs(type) {
         required: false,
         default: false,
         action: 'store_true',
-        help: 'Show more information about each extension',
+        help: `Show more information about each ${type}`,
         dest: 'verbose',
       },
     ],
@@ -112,9 +112,8 @@ function makeInstallArgs(type) {
       {
         type: 'str',
         help:
-          `Name of the ${type} to install, for example: ` + type === DRIVER_TYPE
-            ? DRIVER_EXAMPLE
-            : PLUGIN_EXAMPLE,
+          `Name of the ${type} to install, for example: ` +
+          (type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE),
       },
     ],
     [
@@ -136,9 +135,8 @@ function makeInstallArgs(type) {
         default: null,
         type: 'str',
         help:
-          `If installing from Git or GitHub, the package name, as defined in the plugin's ` +
-          `package.json file in the "name" field, cannot be determined automatically, and ` +
-          `should be reported here, otherwise the install will probably fail.`,
+          `The Node.js package name of the ${type}. ` +
+          `Required if "source" is set to "git" or "github".`,
         dest: 'packageName',
       },
     ],
@@ -158,9 +156,8 @@ function makeUninstallArgs(type) {
       {
         type: 'str',
         help:
-          `Name of the ${type} to uninstall, for example: ` + type === DRIVER_TYPE
-            ? DRIVER_EXAMPLE
-            : PLUGIN_EXAMPLE,
+          `Name of the ${type} to uninstall, for example: ` +
+          (type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE),
       },
     ],
   ]);
@@ -179,9 +176,8 @@ function makeDoctorArgs(type) {
       {
         type: 'str',
         help:
-          `Name of the ${type} to run doctor checks for, for example: ` + type === DRIVER_TYPE
-            ? DRIVER_EXAMPLE
-            : PLUGIN_EXAMPLE,
+          `Name of the ${type} to run doctor checks for, for example: ` +
+          (type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE),
       },
     ],
   ]);
@@ -201,12 +197,9 @@ function makeUpdateArgs(type) {
         type: 'str',
         help:
           `Name of the ${type} to update, or the word "installed" to update all installed ` +
-            `${type}s. To see available updates, run "appium ${type} list --installed --updates". ` +
-            'For example: ' +
-            type ===
-          DRIVER_TYPE
-            ? DRIVER_EXAMPLE
-            : PLUGIN_EXAMPLE,
+          `${type}s. To see available updates, run "appium ${type} list --installed --updates". ` +
+          'For example: ' +
+          (type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE),
       },
     ],
     [
@@ -216,8 +209,7 @@ function makeUpdateArgs(type) {
         default: false,
         action: 'store_true',
         help:
-          `Include updates that might have a new major revision, and potentially include ` +
-          `breaking changes`,
+          'Include any available major revision updates, which may potentially have breaking changes',
       },
     ],
   ]);
@@ -236,9 +228,8 @@ function makeRunArgs(type) {
       {
         type: 'str',
         help:
-          `Name of the ${type} to run a script from, for example: ` + type === DRIVER_TYPE
-            ? DRIVER_EXAMPLE
-            : PLUGIN_EXAMPLE,
+          `Name of the ${type} to run a script from, for example: ` +
+          (type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE),
       },
     ],
     [
@@ -248,9 +239,8 @@ function makeRunArgs(type) {
         nargs: '?',
         type: 'str',
         help:
-          `Name of the script to run from the ${type}. The script name must be a key ` +
-          `inside the "appium.scripts" field inside the ${type}'s "package.json" file. ` +
-          `If not provided then all available script names are going to be listed.`,
+          `Name of the ${type} script to run. If not provided, return a list ` +
+          `of available scripts for this ${type}.`,
       },
     ],
   ]);

--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -108,7 +108,7 @@ function makeInstallArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type}Name`],
+      [type],
       {
         type: 'str',
         help:
@@ -152,7 +152,7 @@ function makeUninstallArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type}Name`],
+      [type],
       {
         type: 'str',
         help:
@@ -172,7 +172,7 @@ function makeDoctorArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type}Name`],
+      [type],
       {
         type: 'str',
         help:
@@ -192,7 +192,7 @@ function makeUpdateArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type}Name`],
+      [type],
       {
         type: 'str',
         help:
@@ -224,7 +224,7 @@ function makeRunArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [`${type}Name`],
+      [type],
       {
         type: 'str',
         help:

--- a/packages/appium/lib/cli/args.js
+++ b/packages/appium/lib/cli/args.js
@@ -12,7 +12,7 @@ import {
 import {INSTALL_TYPES} from '../extension/extension-config';
 import {toParserArgs} from '../schema/cli-args';
 const DRIVER_EXAMPLE = 'xcuitest';
-const PLUGIN_EXAMPLE = 'find_by_image';
+const PLUGIN_EXAMPLE = 'images';
 
 /**
  * This is necessary because we pass the array into `argparse`. `argparse` is bad and mutates things. We don't want that.
@@ -32,7 +32,7 @@ const globalExtensionArgs = new Map([
       required: false,
       default: false,
       action: 'store_true',
-      help: 'Use JSON for output format',
+      help: 'Return output in JSON format',
       dest: 'json',
     },
   ],
@@ -108,7 +108,7 @@ function makeInstallArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [type],
+      [`${type.toUpperCase()}NAME`],
       {
         type: 'str',
         help:
@@ -123,7 +123,7 @@ function makeInstallArgs(type) {
         default: null,
         choices: INSTALL_TYPES_ARRAY,
         help:
-          `Where to look for the ${type} if it is not one of Appium's verified ` +
+          `Where to look for the ${type} if it is not one of Appium's official ` +
           `${type}s. Possible values: ${INSTALL_TYPES_ARRAY.join(', ')}`,
         dest: 'installType',
       },
@@ -152,7 +152,7 @@ function makeUninstallArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [type],
+      [`${type.toUpperCase()}NAME`],
       {
         type: 'str',
         help:
@@ -172,7 +172,7 @@ function makeDoctorArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [type],
+      [`${type.toUpperCase()}NAME`],
       {
         type: 'str',
         help:
@@ -192,12 +192,12 @@ function makeUpdateArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [type],
+      [`${type.toUpperCase()}NAME`],
       {
         type: 'str',
         help:
-          `Name of the ${type} to update, or the word "installed" to update all installed ` +
-          `${type}s. To see available updates, run "appium ${type} list --installed --updates". ` +
+          `Name of the ${type} to update, or "installed" to update all installed ${type}s. ` +
+          `To see available ${type} updates, run "appium ${type} list --installed --updates". ` +
           'For example: ' +
           (type === DRIVER_TYPE ? DRIVER_EXAMPLE : PLUGIN_EXAMPLE),
       },
@@ -209,7 +209,7 @@ function makeUpdateArgs(type) {
         default: false,
         action: 'store_true',
         help:
-          'Include any available major revision updates, which may potentially have breaking changes',
+          'Include any available major revision updates, which may have breaking changes',
       },
     ],
   ]);
@@ -224,7 +224,7 @@ function makeRunArgs(type) {
   return new Map([
     ...globalExtensionArgs,
     [
-      [type],
+      [`${type.toUpperCase()}NAME`],
       {
         type: 'str',
         help:

--- a/packages/appium/lib/cli/parser.js
+++ b/packages/appium/lib/cli/parser.js
@@ -22,6 +22,7 @@ import {
   SUBCOMMAND_MOBILE,
   SUBCOMMAND_DESKTOP,
   SUBCOMMAND_BROWSER,
+  SUBCOMMAND_RESET,
   getPresetDrivers,
   determinePlatformName
 } from './setup-command';
@@ -86,9 +87,6 @@ class ArgParser {
 
     const subParsers = parser.add_subparsers({dest: 'subcommand'});
 
-    // add the 'setup' command
-    ArgParser._addSetupToParser(subParsers);
-
     // add the 'server' subcommand, and store the raw arguments on the parser
     // object as a way for other parts of the code to work with the arguments
     // conceptually rather than just through argparse
@@ -98,6 +96,9 @@ class ArgParser {
 
     // add the 'driver' and 'plugin' subcommands
     ArgParser._addExtensionCommandsToParser(subParsers);
+
+    // add the 'setup' command
+    ArgParser._addSetupToParser(subParsers);
 
     // backwards compatibility / drop-in wrapper
     /**
@@ -207,8 +208,8 @@ class ArgParser {
   static _addServerToParser(subParser) {
     const serverParser = subParser.add_parser('server', {
       add_help: true,
-      help: 'Run an Appium server',
-      description: 'Run an Appium server (the "server" subcommand is optional)',
+      help: 'Start an Appium server',
+      description: 'Start an Appium server (the "server" subcommand is optional)',
     });
 
     ArgParser._patchExit(serverParser);
@@ -301,11 +302,12 @@ class ArgParser {
   static _addSetupToParser(subParser) {
     const setupParser = subParser.add_parser('setup', {
       add_help: true,
-      help: 'Install a preset of multiple drivers and plugins',
+      help: 'Batch install or uninstall Appium drivers and plugins',
       description:
         `Install a preset of official drivers/plugins compatible with the current host platform ` +
-        `(${determinePlatformName()}). Existing drivers/plugins will remain. ` +
-        `The default preset is "mobile".`,
+        `(${determinePlatformName()}). Existing drivers/plugins will remain. The default preset ` +
+        `is "mobile". Providing the special "reset" subcommand will instead uninstall all ` +
+        `drivers and plugins, and remove their related manifest files.`,
     });
 
 
@@ -332,6 +334,10 @@ class ArgParser {
         help:
           `The preset for desktop applications ` +
           `(drivers: ${_.join(getPresetDrivers(SUBCOMMAND_DESKTOP), ',')}; plugins: ${DEFAULT_PLUGINS})`
+      },
+      {
+        command: SUBCOMMAND_RESET,
+        help: 'Remove all installed drivers and plugins'
       },
     ];
 

--- a/packages/appium/lib/cli/parser.js
+++ b/packages/appium/lib/cli/parser.js
@@ -18,6 +18,7 @@ import {finalizeSchema, getArgSpec, hasArgSpec} from '../schema';
 import {rootDir} from '../config';
 import {getExtensionArgs, getServerArgs} from './args';
 import {
+  DEFAULT_PLUGINS,
   SUBCOMMAND_MOBILE,
   SUBCOMMAND_DESKTOP,
   SUBCOMMAND_BROWSER,
@@ -53,7 +54,8 @@ class ArgParser {
     const parser = new ArgumentParser({
       add_help: true,
       description:
-        'A webdriver-compatible server that facilitates automation of web, mobile, and other types of apps across various platforms.',
+        'A webdriver-compatible server that facilitates automation of web, mobile, and other ' +
+        'types of apps across various platforms.',
       prog,
     });
 
@@ -259,14 +261,12 @@ class ArgParser {
         {
           command: EXT_SUBCOMMAND_UPDATE,
           args: extensionArgs[type].update,
-          help: `Update installed ${type}s to the latest version`,
+          help: `Update one or more installed ${type}s to the latest version`,
         },
         {
           command: EXT_SUBCOMMAND_RUN,
           args: extensionArgs[type].run,
-          help:
-            `Run a script (defined inside the ${type}'s package.json under the ` +
-            `“scripts” field inside the “appium” field) from an installed ${type}`,
+          help: `Run a script (if any defined) from the given ${type}`,
         },
         {
           command: EXT_SUBCOMMAND_DOCTOR,
@@ -299,9 +299,11 @@ class ArgParser {
   static _addSetupToParser(subParser) {
     const setupParser = subParser.add_parser('setup', {
       add_help: true,
-      help: `Select a preset of official drivers/plugins to install ` +
-        `compatible with '${determinePlatformName()}' host platform. ` +
-        `Existing drivers/plugins will remain. The default preset is 'mobile'.`,
+      help: 'Install a preset of official drivers and plugins (default: "mobile")',
+      description:
+        `Install a preset of official drivers/plugins compatible with the current host platform ` +
+        `(${determinePlatformName()}). Existing drivers/plugins will remain. ` +
+        `The default preset is "mobile".`,
     });
 
 
@@ -313,15 +315,21 @@ class ArgParser {
     const parserSpecs = [
       {
         command: SUBCOMMAND_MOBILE,
-        help: `The preset for mobile devices: ${_.join(getPresetDrivers(SUBCOMMAND_MOBILE), ',')}`
+        help:
+          `The preset for mobile devices ` +
+          `(drivers: ${_.join(getPresetDrivers(SUBCOMMAND_MOBILE), ',')}; plugins: ${DEFAULT_PLUGINS})`
       },
       {
         command: SUBCOMMAND_BROWSER,
-        help: `The preset for desktop browser drivers: ${_.join(getPresetDrivers(SUBCOMMAND_BROWSER), ',')}`
+        help:
+          `The preset for desktop browsers ` +
+          `(drivers: ${_.join(getPresetDrivers(SUBCOMMAND_BROWSER), ',')}; plugins: ${DEFAULT_PLUGINS})`
       },
       {
         command: SUBCOMMAND_DESKTOP,
-        help: `The preset for desktop application drivers: ${_.join(getPresetDrivers(SUBCOMMAND_DESKTOP), ',')}`
+        help:
+          `The preset for desktop applications ` +
+          `(drivers: ${_.join(getPresetDrivers(SUBCOMMAND_DESKTOP), ',')}; plugins: ${DEFAULT_PLUGINS})`
       },
     ];
 

--- a/packages/appium/lib/cli/parser.js
+++ b/packages/appium/lib/cli/parser.js
@@ -208,6 +208,7 @@ class ArgParser {
     const serverParser = subParser.add_parser('server', {
       add_help: true,
       help: 'Run an Appium server',
+      description: 'Run an Appium server (the "server" subcommand is optional)',
     });
 
     ArgParser._patchExit(serverParser);
@@ -229,7 +230,8 @@ class ArgParser {
     for (const type of /** @type {[DriverType, PluginType]} */ ([DRIVER_TYPE, PLUGIN_TYPE])) {
       const extParser = subParsers.add_parser(type, {
         add_help: true,
-        help: `Access the ${type} management CLI commands`,
+        help: `Manage Appium ${type}s`,
+        description: `Manage Appium ${type}s using various subcommands`,
       });
 
       ArgParser._patchExit(extParser);
@@ -266,12 +268,12 @@ class ArgParser {
         {
           command: EXT_SUBCOMMAND_RUN,
           args: extensionArgs[type].run,
-          help: `Run a script (if any defined) from the given ${type}`,
+          help: `Run a script (if available) from the given ${type}`,
         },
         {
           command: EXT_SUBCOMMAND_DOCTOR,
           args: extensionArgs[type].doctor,
-          help: `Run doctor checks (if any defined) for the given ${type}`,
+          help: `Run doctor checks (if available) for the given ${type}`,
         },
       ];
 
@@ -299,7 +301,7 @@ class ArgParser {
   static _addSetupToParser(subParser) {
     const setupParser = subParser.add_parser('setup', {
       add_help: true,
-      help: 'Install a preset of official drivers and plugins (default: "mobile")',
+      help: 'Install a preset of multiple drivers and plugins',
       description:
         `Install a preset of official drivers/plugins compatible with the current host platform ` +
         `(${determinePlatformName()}). Existing drivers/plugins will remain. ` +

--- a/packages/appium/test/unit/parser.spec.js
+++ b/packages/appium/test/unit/parser.spec.js
@@ -304,7 +304,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'install', 'foobar']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('install');
-        args.driver.should.eql('foobar');
+        args.driverName.should.eql('foobar');
         should.not.exist(args.installType);
         args.json.should.eql(false);
       });
@@ -330,7 +330,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'uninstall', 'foobar']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('uninstall');
-        args.driver.should.eql('foobar');
+        args.driverName.should.eql('foobar');
         args.json.should.eql(false);
       });
       it('should allow json format', function () {
@@ -346,7 +346,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'update', 'foobar']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('update');
-        args.driver.should.eql('foobar');
+        args.driverName.should.eql('foobar');
         args.json.should.eql(false);
       });
       it('should allow json format', function () {
@@ -362,7 +362,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'run', 'foo']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('run');
-        args.driver.should.eql('foo');
+        args.driverName.should.eql('foo');
         _.isNull(args.scriptName).should.be.true;
         args.json.should.eql(false);
       });
@@ -370,7 +370,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'run', 'foo', 'bar']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('run');
-        args.driver.should.eql('foo');
+        args.driverName.should.eql('foo');
         args.scriptName.should.eql('bar');
         args.json.should.eql(false);
       });
@@ -385,7 +385,7 @@ describe('parser', function () {
         const args = p.parseArgs([PLUGIN_TYPE, 'run', 'foo']);
         args.subcommand.should.eql(PLUGIN_TYPE);
         args.pluginCommand.should.eql('run');
-        args.plugin.should.eql('foo');
+        args.pluginName.should.eql('foo');
         _.isNull(args.scriptName).should.be.true;
         args.json.should.eql(false);
       });
@@ -393,7 +393,7 @@ describe('parser', function () {
         const args = p.parseArgs([PLUGIN_TYPE, 'run', 'foo', 'bar']);
         args.subcommand.should.eql(PLUGIN_TYPE);
         args.pluginCommand.should.eql('run');
-        args.plugin.should.eql('foo');
+        args.pluginName.should.eql('foo');
         args.scriptName.should.eql('bar');
         args.json.should.eql(false);
       });

--- a/packages/appium/test/unit/parser.spec.js
+++ b/packages/appium/test/unit/parser.spec.js
@@ -304,7 +304,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'install', 'foobar']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('install');
-        args.driverName.should.eql('foobar');
+        args.driver.should.eql('foobar');
         should.not.exist(args.installType);
         args.json.should.eql(false);
       });
@@ -330,7 +330,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'uninstall', 'foobar']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('uninstall');
-        args.driverName.should.eql('foobar');
+        args.driver.should.eql('foobar');
         args.json.should.eql(false);
       });
       it('should allow json format', function () {
@@ -346,7 +346,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'update', 'foobar']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('update');
-        args.driverName.should.eql('foobar');
+        args.driver.should.eql('foobar');
         args.json.should.eql(false);
       });
       it('should allow json format', function () {
@@ -362,7 +362,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'run', 'foo']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('run');
-        args.driverName.should.eql('foo');
+        args.driver.should.eql('foo');
         _.isNull(args.scriptName).should.be.true;
         args.json.should.eql(false);
       });
@@ -370,7 +370,7 @@ describe('parser', function () {
         const args = p.parseArgs([DRIVER_TYPE, 'run', 'foo', 'bar']);
         args.subcommand.should.eql(DRIVER_TYPE);
         args.driverCommand.should.eql('run');
-        args.driverName.should.eql('foo');
+        args.driver.should.eql('foo');
         args.scriptName.should.eql('bar');
         args.json.should.eql(false);
       });
@@ -385,7 +385,7 @@ describe('parser', function () {
         const args = p.parseArgs([PLUGIN_TYPE, 'run', 'foo']);
         args.subcommand.should.eql(PLUGIN_TYPE);
         args.pluginCommand.should.eql('run');
-        args.pluginName.should.eql('foo');
+        args.plugin.should.eql('foo');
         _.isNull(args.scriptName).should.be.true;
         args.json.should.eql(false);
       });
@@ -393,7 +393,7 @@ describe('parser', function () {
         const args = p.parseArgs([PLUGIN_TYPE, 'run', 'foo', 'bar']);
         args.subcommand.should.eql(PLUGIN_TYPE);
         args.pluginCommand.should.eql('run');
-        args.pluginName.should.eql('foo');
+        args.plugin.should.eql('foo');
         args.scriptName.should.eql('bar');
         args.json.should.eql(false);
       });


### PR DESCRIPTION
## Proposed changes

This PR updates the CLI help messages. Some of the information there was outdated, incorrect, or even missing. The behavior of the CLI commands themselves remains unchanged.

* Fix all instances of help text for the driver/plugin name parameter due to incorrect ternary statements
* ~~Rename the driver/plugin name parameter from `driver`/`plugin` to `driverName`/`pluginName`. This is to distinguish the parameter from the `driver`/`plugin` subcommand keyword~~
* Change the example plugin name from `find_by_image` to `images` (we do not have a plugin named `find_by_image`)
* Change the order of subcommands when running `appium -h` (`setup` is now last instead of first)
* Add the missing installed plugins for all `appium setup` presets
* Add the missing `reset` sub-subcommand for `appium setup`
* Add `description` fields to the top-level subcommands (`server`/`driver`/`plugin`/`setup`)
* Clarify most other help messages

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update (if none of the other choices apply)
