### PR TITLE
fix(base-driver): Return an empty object if the corresponding API response is undefined

### DIFF
--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -493,8 +493,12 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
       `Executing bidi command '${bidiCmd}' with params ${logParams} by passing to driver ` +
         `method '${command}'`,
     );
-    const res = (await this[command](...args)) ?? null;
-    this.log.debug(`Responding to bidi command '${bidiCmd}' with ${JSON.stringify(res)}`);
-    return res;
+    const response = await this[command](...args);
+    const finalResponse = _.isUndefined(response) ? {} : response;
+    this.log.debug(
+      `Responding to bidi command '${bidiCmd}' with ` +
+      `${_.truncate(JSON.stringify(finalResponse), {length: MAX_LOG_BODY_LENGTH})}`
+    );
+    return finalResponse;
   }
 }


### PR DESCRIPTION
## Proposed changes

This is related to a java-client-related discussion where we figured out that chrome returns an empty object ({}) in response to various BiDi method like session.subscribe, whereas appium returns null, thus breaking the client logic.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
