### PR TITLE
chore: adjust eslint-config-appium-ts related files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ to driver/client documentation
 * [base-plugin](packages/base-plugin/CHANGELOG.md)
 * [docutils](packages/docutils/CHANGELOG.md)
 * [driver-test-support](packages/driver-test-support/CHANGELOG.md)
-* [eslint-config-appium](packages/eslint-config-appium/CHANGELOG.md)
 * [eslint-config-appium-ts](packages/eslint-config-appium-ts/CHANGELOG.md)
 * [fake-driver](packages/fake-driver/CHANGELOG.md)
 * [fake-plugin](packages/fake-plugin/CHANGELOG.md)
@@ -40,5 +39,6 @@ to driver/client documentation
 ## Removed Modules
 The changelog links used for these modules lead to the last version of their changelog file.
 * [doctor](https://github.com/appium/appium/blob/8daf5e123ac14c8325acf504fb33eb28e1a3dd78/packages/doctor/CHANGELOG.md) ([removal PR](https://github.com/appium/appium/pull/20805))
+* [eslint-config-appium](https://github.com/appium/appium/blob/4b3a8c2197a587ec5a2606b662e4e7667a7852cb/packages/eslint-config-appium/CHANGELOG.md) ([removal PR](https://github.com/appium/appium/pull/20856))
 * [gulp-plugins](https://github.com/appium/appium/blob/0823f0b60e40395cd1dc3b72cfa3c0092bc81302/packages/gulp-plugins/CHANGELOG.md) ([removal PR](https://github.com/appium/appium/pull/17943))
 * [typedoc-plugin-appium](https://github.com/appium/appium/blob/d6204b6902074210943d7bbbf72d139b9b170a20/packages/typedoc-plugin-appium/CHANGELOG.md) ([removal PR](https://github.com/appium/appium/pull/19465))

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       ],
       "devDependencies": {
         "@colors/colors": "1.6.0",
-        "@eslint/eslintrc": "3.1.0",
         "@eslint/js": "9.10.0",
         "@tsconfig/node14": "14.1.2",
         "@types/chai": "5.0.1",
@@ -327,59 +326,6 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ajv": {
-      "version": "6.12.6",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "9.10.0",
@@ -18404,17 +18350,16 @@
         "npm": ">=8"
       },
       "peerDependencies": {
-        "@eslint/compat": "^1.2.4",
-        "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "^9.10.0",
-        "@typescript-eslint/eslint-plugin": "^8.18.2",
-        "@typescript-eslint/parser": "^8.18.2",
-        "eslint": "^9.17.0",
-        "eslint-config-prettier": "^9.1.0",
-        "eslint-import-resolver-typescript": "^3.7.0",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-mocha": "^10.1.0",
-        "eslint-plugin-promise": "^7.2.0"
+        "@eslint/compat": "^1.1.0",
+        "@eslint/js": "^9.0.0",
+        "@typescript-eslint/eslint-plugin": "^8.0.0",
+        "@typescript-eslint/parser": "^8.0.0",
+        "eslint": "^9.0.0",
+        "eslint-config-prettier": "^9.0.0",
+        "eslint-import-resolver-typescript": "^3.5.0",
+        "eslint-plugin-import": "^2.30.0",
+        "eslint-plugin-mocha": "^10.4.0",
+        "eslint-plugin-promise": "^7.0.0"
       }
     },
     "packages/execute-driver-plugin": {
@@ -20774,41 +20719,6 @@
       "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
       "requires": {
         "@types/json-schema": "^7.0.15"
-      }
-    },
-    "@eslint/eslintrc": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
-      "requires": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "globals": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-          "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1"
-        }
       }
     },
     "@eslint/js": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sync-pkgs:appium-readme": "sync-monorepo-packages --force --no-package-json --packages=packages/appium README.md",
     "sync-pkgs:common-fields:default": "sync-monorepo-packages --packages=\"!packages/logger\" --fields=author,license,bugs,homepage,engines",
     "sync-pkgs:common-fields:logger": "sync-monorepo-packages --packages=\"packages/logger\" --fields=author,bugs,homepage,engines",
-    "sync-pkgs:keywords": "sync-monorepo-packages --field=keywords --packages=\"packages/*\" --packages=\"!packages/eslint-config-appium\" --packages=\"!packages/types\" --packages=\"!packages/eslint-config-appium-ts\" ",
+    "sync-pkgs:keywords": "sync-monorepo-packages --field=keywords --packages=\"packages/*\" --packages=\"!packages/types\" --packages=\"!packages/eslint-config-appium-ts\" ",
     "sync-pkgs:license": "sync-monorepo-packages --force --no-package-json --packages=\"!packages/logger\" LICENSE",
     "test": "run-s test:quick",
     "test:ci": "run-s test:smoke test:unit test:types test:e2e",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
   },
   "devDependencies": {
     "@colors/colors": "1.6.0",
-    "@eslint/eslintrc": "3.1.0",
     "@eslint/js": "9.10.0",
     "@tsconfig/node14": "14.1.2",
     "@types/chai": "5.0.1",

--- a/packages/eslint-config-appium-ts/CHANGELOG.md
+++ b/packages/eslint-config-appium-ts/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 1.0.0 [Unreleased]
+
+### ⚠ BREAKING CHANGES
+
+* This module is now ESM-only
+* Only ESLint flat config format is supported
+* Bump minimum ESLint version to v9
+* Rule changes:
+  * `@typescript-eslint/no-var-requires`: 'error' ->'off'
+  * `import/no-unresolved` is no longer set to 'off' for `*.test-d.ts` files
+  * `no-redeclare`: 1 ->'off'
+* New rules for all files:
+  * `@typescript-eslint/no-empty-object-type`: 'off'
+  * `@typescript-eslint/no-require-imports`: 'off'
+  * `import/named`: 'warn'
+  * `no-dupe-class-members`: 'off'
+* New rules only for test files:
+  * `@typescript-eslint/no-unused-expressions`: 'off'
+  * `import/no-named-as-default-member`: 'off'
+  * `mocha/consistent-spacing-between-blocks`: 'off'
+  * `mocha/max-top-level-suites`: 'off'
+  * `mocha/no-exports`: 'off'
+  * `mocha/no-setup-in-describe`: 'off'
+  * `mocha/no-skipped-tests`: 'off'
+
+
+
 ## [0.3.3](https://github.com/appium/appium/compare/@appium/eslint-config-appium-ts@0.3.2...@appium/eslint-config-appium-ts@0.3.3) (2024-04-08)
 
 **Note:** Version bump only for package @appium/eslint-config-appium-ts

--- a/packages/eslint-config-appium-ts/CHANGELOG.md
+++ b/packages/eslint-config-appium-ts/CHANGELOG.md
@@ -11,9 +11,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * Only ESLint flat config format is supported
 * Bump minimum ESLint version to v9
 * Rule changes:
-  * `@typescript-eslint/no-var-requires`: 'error' ->'off'
+  * `@typescript-eslint/no-var-requires`: 'error' -> 'off'
   * `import/no-unresolved` is no longer set to 'off' for `*.test-d.ts` files
-  * `no-redeclare`: 1 ->'off'
+  * `no-redeclare`: 1 -> 'off'
 * New rules for all files:
   * `@typescript-eslint/no-empty-object-type`: 'off'
   * `@typescript-eslint/no-require-imports`: 'off'

--- a/packages/eslint-config-appium-ts/README.md
+++ b/packages/eslint-config-appium-ts/README.md
@@ -1,10 +1,9 @@
 # @appium/eslint-config-appium-ts
 
-> Provides a reusable [ESLint](http://eslint.org/) [shared configuration](http://eslint.org/docs/developer-guide/shareable-configs) for [Appium](https://github.com/appium/appium) and Appium-adjacent projects (for TypeScript)
+> Provides a reusable [ESLint](http://eslint.org/) [shared configuration](http://eslint.org/docs/developer-guide/shareable-configs) for [Appium](https://github.com/appium/appium) and Appium-adjacent projects.
 
-## Motivation
-
-**If your package has no TypeScript sources, you don't need this.**  However, if your package _does_ have TypeScript sources, you can't lint those files without this.
+[![NPM version](http://img.shields.io/npm/v/@appium/eslint-config-appium-ts.svg)](https://npmjs.org/package/@appium/eslint-config-appium-ts)
+[![Downloads](http://img.shields.io/npm/dm/@appium/eslint-config-appium-ts.svg)](https://npmjs.org/package/@appium/eslint-config-appium-ts)
 
 ## Usage
 
@@ -14,12 +13,15 @@ Install the package with **`npm` v8 or newer**:
 npm install @appium/eslint-config-appium-ts --save-dev
 ```
 
-And then, in your `.eslintrc` file, extend the configuration:
+And then, in your `eslint.config.mjs` file, extend the configuration:
 
-```json
-{
-  "extends": "@appium/eslint-config-appium-ts"
-}
+```js
+import appiumConfig from '@appium/eslint-config-appium-ts';
+
+export default [
+  ...appiumConfig,
+  // add any other config changes 
+];
 ```
 
 ## Peer Dependencies
@@ -31,7 +33,6 @@ This config requires the following packages be installed (as peer dependencies) 
 - [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import)
 - [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha)
 - [eslint-plugin-promise](https://www.npmjs.com/package/eslint-plugin-promise)
-- [@appium/eslint-config-appium](https://www.npmjs.com/package/@appium/eslint-config-appium)
 - [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
 - [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser)
 

--- a/packages/eslint-config-appium-ts/index.mjs
+++ b/packages/eslint-config-appium-ts/index.mjs
@@ -165,13 +165,13 @@ export default [
        */
       '@typescript-eslint/no-unused-vars': 'warn',
       /**
-       * Allow native `Promise`s. **This overrides `@appium/eslint-config-appium`.**
+       * Allow native `Promise`s.
        * @remarks Originally, this was so that we could use [bluebird](https://npm.im/bluebird)
        * everywhere, but this is not strictly necessary.
        */
       'promise/no-native': 'off',
       /**
-       * Allow `async` functions without `await`.  **This overrides `@appium/eslint-config-appium`.**
+       * Allow `async` functions without `await`.
        * @remarks Originally, this was to be more clear about the return value of a function, but with
        * the addition of types, this is no longer necessary. Further, both `return somePromise` and
        * `return await somePromise` have their own use-cases.

--- a/packages/eslint-config-appium-ts/index.mjs
+++ b/packages/eslint-config-appium-ts/index.mjs
@@ -51,77 +51,6 @@ export default [
     },
     rules: {
       ...tsPlugin.configs.recommended.rules,
-      'no-console': 2,
-      semi: [2, 'always'],
-      radix: [2, 'always'],
-      'dot-notation': 2,
-      eqeqeq: [2, 'smart'],
-      'comma-dangle': 0,
-      'no-empty': 0,
-      'object-shorthand': 2,
-      'arrow-parens': [1, 'always'],
-      'arrow-body-style': [1, 'as-needed'],
-      'import/export': 2,
-      'import/no-unresolved': 2,
-      'import/no-duplicates': 2,
-      'promise/no-return-wrap': 1,
-      'promise/param-names': 1,
-      'promise/catch-or-return': 1,
-      'promise/prefer-await-to-then': 1,
-      'promise/prefer-await-to-callbacks': 1,
-      'no-var': 2,
-      curly: [2, 'all'],
-
-      // enforce spacing
-      'arrow-spacing': 2,
-      'keyword-spacing': 2,
-      'comma-spacing': [
-        2,
-        {
-          before: false,
-          after: true,
-        },
-      ],
-      'array-bracket-spacing': 2,
-      'no-trailing-spaces': 2,
-      'no-whitespace-before-property': 2,
-      'space-in-parens': [2, 'never'],
-      'space-before-blocks': [2, 'always'],
-      'space-unary-ops': [
-        2,
-        {
-          words: true,
-          nonwords: false,
-        },
-      ],
-      'space-infix-ops': 2,
-      'key-spacing': [
-        2,
-        {
-          mode: 'strict',
-          beforeColon: false,
-          afterColon: true,
-        },
-      ],
-      'no-multi-spaces': 2,
-      quotes: [
-        2,
-        'single',
-        {
-          avoidEscape: true,
-          allowTemplateLiterals: true,
-        },
-      ],
-      'no-buffer-constructor': 1,
-      'require-atomic-updates': 0,
-      'no-prototype-builtins': 1,
-      'no-redeclare': 'off',
-      '@typescript-eslint/no-require-imports': 'off',
-      '@typescript-eslint/no-empty-object-type': 'off',
-      'no-dupe-class-members': 'off',
-      '@typescript-eslint/no-var-requires': 'off',
-      'import/named': 'warn',
-
       /**
        * This rule is configured to warn if a `@ts-ignore` or `@ts-expect-error` directive is used
        * without explanation.
@@ -145,6 +74,7 @@ export default [
        * an empty interface can be a type alias, e.g., `type Foo = Bar` where `Bar` is an interface.
        */
       '@typescript-eslint/no-empty-interface': 'off',
+      '@typescript-eslint/no-empty-object-type': 'off',
       /**
        * Explicit `any` types are allowed.
        * @remarks Eventually this should be a warning, and finally an error, as we fully type the codebases.
@@ -160,16 +90,81 @@ export default [
        * non-null assertion.
        */
       '@typescript-eslint/no-non-null-assertion': 'warn',
+      '@typescript-eslint/no-require-imports': 'off',
       /**
        * Sometimes we want unused variables to be present in base class method declarations.
        */
       '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-var-requires': 'off',
+
+      'import/export': 2,
+      'import/named': 'warn',
+      'import/no-duplicates': 2,
+      'import/no-unresolved': 2,
+
+      'promise/catch-or-return': 1,
       /**
        * Allow native `Promise`s.
        * @remarks Originally, this was so that we could use [bluebird](https://npm.im/bluebird)
        * everywhere, but this is not strictly necessary.
        */
       'promise/no-native': 'off',
+      'promise/no-return-wrap': 1,
+      'promise/prefer-await-to-callbacks': 1,
+      'promise/prefer-await-to-then': 1,
+      'promise/param-names': 1,
+
+      'array-bracket-spacing': 2,
+      'arrow-body-style': [1, 'as-needed'],
+      'arrow-parens': [1, 'always'],
+      'arrow-spacing': 2,
+      /**
+       * Disables the `brace-style` rule.
+       * @remarks Due to the way `prettier` sometimes formats extremely verbose types, sometimes it is necessary
+       * to indent in a way that is not allowed by the default `brace-style` rule.
+       */
+      'brace-style': 'off',
+      'comma-dangle': 0,
+      'comma-spacing': [
+        2,
+        {
+          before: false,
+          after: true,
+        },
+      ],
+      'curly': [2, 'all'],
+      'dot-notation': 2,
+      'eqeqeq': [2, 'smart'],
+      'key-spacing': [
+        2,
+        {
+          mode: 'strict',
+          beforeColon: false,
+          afterColon: true,
+        },
+      ],
+      'keyword-spacing': 2,
+      'no-buffer-constructor': 1,
+      'no-console': 2,
+      'no-dupe-class-members': 'off',
+      'no-empty': 0,
+      'no-multi-spaces': 2,
+      'no-prototype-builtins': 1,
+      'no-redeclare': 'off',
+      'no-trailing-spaces': 2,
+      'no-var': 2,
+      'no-whitespace-before-property': 2,
+      'object-shorthand': 2,
+      'quotes': [
+        2,
+        'single',
+        {
+          avoidEscape: true,
+          allowTemplateLiterals: true,
+        },
+      ],
+      'radix': [2, 'always'],
+      'require-atomic-updates': 0,
       /**
        * Allow `async` functions without `await`.
        * @remarks Originally, this was to be more clear about the return value of a function, but with
@@ -177,13 +172,17 @@ export default [
        * `return await somePromise` have their own use-cases.
        */
       'require-await': 'off',
-
-      /**
-       * Disables the `brace-style` rule.
-       * @remarks Due to the way `prettier` sometimes formats extremely verbose types, sometimes it is necessary
-       * to indent in a way that is not allowed by the default `brace-style` rule.
-       */
-      'brace-style': 'off',
+      'semi': [2, 'always'],
+      'space-before-blocks': [2, 'always'],
+      'space-in-parens': [2, 'never'],
+      'space-infix-ops': 2,
+      'space-unary-ops': [
+        2,
+        {
+          words: true,
+          nonwords: false,
+        },
+      ],
     }
   },
 
@@ -204,14 +203,14 @@ export default [
        * the non-null assertion was invalid, the assertion would fail.
        */
       '@typescript-eslint/no-non-null-assertion': 'off',
-      'mocha/no-exclusive-tests': 2,
-      'mocha/no-mocha-arrows': 2,
-      'mocha/max-top-level-suites': 'off',
-      'mocha/consistent-spacing-between-blocks': 'off',
       '@typescript-eslint/no-unused-expressions': 'off',
-      'mocha/no-setup-in-describe': 'off',
-      'mocha/no-exports': 'off',
       'import/no-named-as-default-member': 'off',
+      'mocha/consistent-spacing-between-blocks': 'off',
+      'mocha/max-top-level-suites': 'off',
+      'mocha/no-exclusive-tests': 2,
+      'mocha/no-exports': 'off',
+      'mocha/no-mocha-arrows': 2,
+      'mocha/no-setup-in-describe': 'off',
       'mocha/no-skipped-tests': 'off',
     },
   },
@@ -220,11 +219,11 @@ export default [
     name: 'Ignores',
     ignores: [
       ...(fs.existsSync(gitignorePath) ? includeIgnoreFile(gitignorePath).ignores : []),
-      '**/*-d.ts',
-      '**/build/**',
-      '**/*.min.js',
-      '**/coverage/**',
       '**/.*',
+      '**/*-d.ts',
+      '**/*.min.js',
+      '**/build/**',
+      '**/coverage/**',
     ],
   }
 

--- a/packages/eslint-config-appium-ts/package.json
+++ b/packages/eslint-config-appium-ts/package.json
@@ -29,17 +29,16 @@
     "test:smoke": "exit 0"
   },
   "peerDependencies": {
-    "@eslint/compat": "^1.2.4",
-    "@eslint/eslintrc": "^3.1.0",
-    "@eslint/js": "^9.10.0",
-    "@typescript-eslint/eslint-plugin": "^8.18.2",
-    "@typescript-eslint/parser": "^8.18.2",
-    "eslint": "^9.17.0",
-    "eslint-config-prettier": "^9.1.0",
-    "eslint-import-resolver-typescript": "^3.7.0",
-    "eslint-plugin-import": "^2.31.0",
-    "eslint-plugin-mocha": "^10.1.0",
-    "eslint-plugin-promise": "^7.2.0"
+    "@eslint/compat": "^1.1.0",
+    "@eslint/js": "^9.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
+    "eslint-config-prettier": "^9.0.0",
+    "eslint-import-resolver-typescript": "^3.5.0",
+    "eslint-plugin-import": "^2.30.0",
+    "eslint-plugin-mocha": "^10.4.0",
+    "eslint-plugin-promise": "^7.0.0"
   },
   "engines": {
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0",

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -48,7 +48,7 @@ Appium extension authors--or anyone else--may use this config as well.
 
 - Do not upgrade to major versions of packages which have become ESM-only.  Unfortunately this is an explicit deny-list.
 - Groups (groups updates into single PR):
-  - ESLint-related and [@appium/eslint-config-appium](https://github.com/appium/appium/tree/master/eslint-config-appium)
+  - ESLint-related and [@appium/eslint-config-appium-ts](https://github.com/appium/appium/tree/master/eslint-config-appium-ts)
   - [teen_process](https://github.com/appium/node-teen_process) and its DT types
   - Appium-scoped (`@appium`) packages. This applies to _other_ repos which depend on Appium, such as official drivers.
 

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -44,7 +44,7 @@
     },
     {
       "extends": ["packages:eslint"],
-      "matchPackageNames": ["@appium/eslint-config-appium**"],
+      "matchPackageNames": ["@appium/eslint-config-appium-ts"],
       "groupName": "ESLint-related packages",
       "groupSlug": "eslint"
     },
@@ -54,7 +54,7 @@
       "groupSlug": "teen_process"
     },
     {
-      "matchPackageNames": ["appium", "@appium/**", "!@appium/eslint-config-appium**"],
+      "matchPackageNames": ["appium", "@appium/**", "!@appium/eslint-config-appium-ts"],
       "groupName": "Appium-related packages",
       "groupSlug": "appium"
     }


### PR DESCRIPTION
Some adjustments as a follow-up to #20856.

* Group and sort all `eslint-config-appium-ts` rules alphabetically
* Loosen required peer dependencies for `eslint-config-appium-ts` (e.g. `eslint` `^9.17.0` -> `^9.0.0`)
* Update readme and changelog of `eslint-config-appium-ts`
* Remove unused package `@eslint/eslintrc`
* Remove unnecessary remaining mentions of `eslint-config-appium`