### PR TITLE
docs(appium): refer to Python client repository instead

### DIFF
--- a/packages/appium/docs/en/quickstart/test-java.md
+++ b/packages/appium/docs/en/quickstart/test-java.md
@@ -17,7 +17,6 @@ you could simply use the [AppiumDriver](https://github.com/appium/java-client/bl
 or build your custom derivatives from it. Check the [Drivers Support](https://github.com/appium/java-client#drivers-support)
 article to learn more about the current driver class implementations.
 
-Follow the [Usage Examples](https://github.com/appium/java-client#usage-examples) article in order understand
-how to invoke Java client features from your test framework.
+Follow the [Usage Examples](https://github.com/appium/java-client#usage-examples) article in order understand to how to invoke Java client features from your test framework.
 
 Once you've managed to successfully run a test, you can read on for some [next steps](./next-steps.md) to explore.

--- a/packages/appium/docs/en/quickstart/test-py.md
+++ b/packages/appium/docs/en/quickstart/test-py.md
@@ -14,47 +14,9 @@ so installing the Appium Python Client includes the selenium binding.
 pip install Appium-Python-Client
 ```
 
-This example uses Python's built-in `unittest` module, though you can use any Python test framework you want.
-The Appium Python client adds the `appium:` vendor prefix automatically.
-You usually do not need to worry about the prefix.
+Then, simply you could use the client features by importing webdriver module as
+`from appium import webdriver` in your test code.
+Follow the [Usage](https://github.com/appium/python-client#usage) article in order to
+understand how to use the Python client features further.
 
-```python title="test.py"
---8<-- "./sample-code/quickstarts/py/test.py"
-```
-
-!!! note
-
-    It's not within the scope of this guide to give a complete run-down on the Python client
-    library or everything that's happening here, so we'll leave the code itself unexplained in detail for now.
-
-    - You may want to read up particularly on Appium [Capabilities](../guides/caps.md).
-    - [functional test code](https://github.com/appium/python-client/tree/master/test/functional) in Python Client GitHub repository should help to find more working example.
-    - [Documentation](https://appium.github.io/python-client-sphinx/) also helps to find methods
-    defined in the Appium Python Client.
-
-!!! note
-
-    The sample code is available from [GitHub Appium repository](https://github.com/appium/appium/tree/master/packages/appium/sample-code/quickstarts/py).
-
-
-Basically, this code is doing the following:
-
-1. Defining a set of "Capabilities" (parameters) to send to the Appium server so Appium knows what
-kind of thing you want to automate.
-1. Starting an Appium session on the built-in Android settings app.
-1. Finding the "Battery" list item and clicking it.
-1. Pausing for a moment purely for visual effect.
-1. Ending the Appium session.
-
-That's it! Let's give it a try. Before you run the test, make sure that you have an Appium server
-running in another terminal session, otherwise you'll get an error about not being able to connect
-to one. Then, you can execute the script:
-
-```bash
-python test.py
-```
-
-If all goes well, you'll see the Settings app open up and navigate to the "Battery" view before the
-app closes again.
-
-Congratulations, you've started your Appium journey! Read on for some [next steps](./next-steps.md) to explore.
+Once you've managed to successfully run a test, you can read on for some [next steps](./next-steps.md) to explore.


### PR DESCRIPTION
## Proposed changes

Current example in appium.io for python client is old. This PR just refers to the client readme instead to up-to-date the example. This will reduce https://github.com/appium/python-client/issues/1077 this kind of issue.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
