### PR TITLE
fix(appium): Do not update BiDi commands for drivers which don't support it

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -344,7 +344,9 @@ class AppiumDriver extends DriverCore {
 
       // We also want to assign any new Bidi Commands that the driver has specified, including all
       // the standard bidi commands
-      driverInstance.updateBidiCommands(InnerDriver.newBidiCommands ?? {});
+      if (_.isFunction(driverInstance.updateBidiCommands)) {
+        driverInstance.updateBidiCommands(InnerDriver.newBidiCommands ?? {});
+      }
 
       if (!_.isEmpty(this.args.denyInsecure)) {
         this.log.info('Explicitly preventing use of insecure features:');


### PR DESCRIPTION
Addresses https://github.com/appium/appium/issues/20878