### PR TITLE
fix(appium): Wait for upstream web socket to open before sending data to it

### DIFF
--- a/packages/appium/lib/bidi-commands.ts
+++ b/packages/appium/lib/bidi-commands.ts
@@ -509,10 +509,10 @@ async function assertUpstreamState(
   ws: WebSocket,
   timeoutMs: number = 5000,
 ): Promise<WebSocket> {
-  if (ws.OPEN) {
+  if (ws.readyState === ws.OPEN) {
     return ws;
   }
-  if (ws.CLOSED || ws.CLOSING) {
+  if (ws.readyState > ws.OPEN) {
     throw new Error(
       `The upstream BiDi web socket at ${ws.url} is not open, ` +
       `so we cannot proxy connections to it`


### PR DESCRIPTION
## Proposed changes

Related to https://appium.slack.com/archives/C041RMLANUR/p1738448830072459

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
