### PR TITLE
feat(base-driver): Print the closest match if the given script did not match

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7975,6 +7975,15 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "license": "ISC",
@@ -18137,6 +18146,7 @@
         "bluebird": "3.7.2",
         "body-parser": "1.20.3",
         "express": "4.21.2",
+        "fastest-levenshtein": "1.0.16",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
         "lru-cache": "10.4.3",
@@ -19649,6 +19659,7 @@
         "bluebird": "3.7.2",
         "body-parser": "1.20.3",
         "express": "4.21.2",
+        "fastest-levenshtein": "1.0.16",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
         "lru-cache": "10.4.3",
@@ -25843,6 +25854,11 @@
       "requires": {
         "strnum": "^1.0.5"
       }
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="
     },
     "fastq": {
       "version": "1.13.0",

--- a/packages/base-driver/lib/basedriver/commands/execute.ts
+++ b/packages/base-driver/lib/basedriver/commands/execute.ts
@@ -30,7 +30,7 @@ const ExecuteCommands: IExecuteCommands = {
       const closestMatch = closest(script, availableScripts);
       throw new errors.UnsupportedOperationError(
         `Unsupported execute method '${script}', did you mean '${closestMatch}'? ` +
-        `Make sure you have the most recent driver updates. ` +
+        `Make sure you have the installed ${Driver.name} is up-to-date. ` +
         `Execute methods available in the current driver version are: ` +
         availableScripts.join(', ')
       );

--- a/packages/base-driver/lib/basedriver/commands/execute.ts
+++ b/packages/base-driver/lib/basedriver/commands/execute.ts
@@ -10,6 +10,7 @@ import {
 } from '@appium/types';
 import {mixin} from './mixin';
 import {BaseDriver} from '../driver';
+import {closest} from 'fastest-levenshtein';
 
 declare module '../driver' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -26,9 +27,11 @@ const ExecuteCommands: IExecuteCommands = {
     const commandMetadata = {...Driver.executeMethodMap?.[script]};
     if (!commandMetadata.command) {
       const availableScripts = _.keys(Driver.executeMethodMap);
+      const closestMatch = closest(script, availableScripts);
       throw new errors.UnsupportedOperationError(
-        `Unsupported execute method '${script}'. Available methods ` +
-          `are: ${availableScripts.join(', ')}`
+        `Unsupported execute method '${script}', did you mean '${closestMatch}'? ` +
+        `Make sure you have the most recent driver updates. ` +
+        `Available methods are: ${availableScripts.join(', ')}`
       );
     }
     const args = validateExecuteMethodParams(protoArgs, commandMetadata.params);

--- a/packages/base-driver/lib/basedriver/commands/execute.ts
+++ b/packages/base-driver/lib/basedriver/commands/execute.ts
@@ -44,7 +44,7 @@ const ExecuteCommands: IExecuteCommands = {
           }
           return acc;
         }, {});
-      const sortedMatches = _.flatMap(
+      const sortedMatches = _.flatten(
         _.keys(matchesMap)
           .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
           .map((x) => matchesMap[x])

--- a/packages/base-driver/lib/basedriver/commands/execute.ts
+++ b/packages/base-driver/lib/basedriver/commands/execute.ts
@@ -34,12 +34,21 @@ const ExecuteCommands: IExecuteCommands = {
           `The current driver version does not define any execute methods.`
         );
       }
-      const matchesMap = _.fromPairs(
-        availableScripts.map((name) => [distance(script, name), name])
+      const matchesMap: StringRecord<string[]> = availableScripts
+        .map((name) => [distance(script, name), name])
+        .reduce((acc, [key, value]) => {
+          if (key in acc) {
+            acc[key].push(value);
+          } else {
+            acc[key] = [value];
+          }
+          return acc;
+        }, {});
+      const sortedMatches = _.flatMap(
+        _.keys(matchesMap)
+          .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
+          .map((x) => matchesMap[x])
       );
-      const sortedMatches = _.keys(matchesMap)
-        .sort((a, b) => parseInt(a, 10) - parseInt(b, 10))
-        .map((x) => matchesMap[x]);
       throw new errors.UnsupportedOperationError(
         `Unsupported execute method '${script}', did you mean '${sortedMatches[0]}'? ` +
         `Make sure the installed ${Driver.name} is up-to-date. ` +

--- a/packages/base-driver/lib/basedriver/commands/execute.ts
+++ b/packages/base-driver/lib/basedriver/commands/execute.ts
@@ -31,7 +31,8 @@ const ExecuteCommands: IExecuteCommands = {
       throw new errors.UnsupportedOperationError(
         `Unsupported execute method '${script}', did you mean '${closestMatch}'? ` +
         `Make sure you have the most recent driver updates. ` +
-        `Available methods are: ${availableScripts.join(', ')}`
+        `Execute methods available in the current driver version are: ` +
+        availableScripts.join(', ')
       );
     }
     const args = validateExecuteMethodParams(protoArgs, commandMetadata.params);

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -53,6 +53,7 @@
     "bluebird": "3.7.2",
     "body-parser": "1.20.3",
     "express": "4.21.2",
+    "fastest-levenshtein": "1.0.16",
     "http-status-codes": "2.3.0",
     "lodash": "4.17.21",
     "lru-cache": "10.4.3",


### PR DESCRIPTION
## Proposed changes

Just for the sake of better error messages. The newly included module ([fastest-levenshtein](https://www.npmjs.com/package/fastest-levenshtein)) is self-sufficient, and does not bring any additional transitive dependencies

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
