### PR TITLE
fix(appium): handle getAppiumSessions as non session id commands

### DIFF
--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -978,4 +978,4 @@ export function routeToCommandName(endpoint, method, basePath = DEFAULT_BASE_PAT
 }
 
 // driver commands that do not require a session to already exist
-export const NO_SESSION_ID_COMMANDS = ['createSession', 'getStatus', 'getSessions'];
+export const NO_SESSION_ID_COMMANDS = ['createSession', 'getStatus', 'getSessions', 'getAppiumSessions'];


### PR DESCRIPTION
## Proposed changes

Extract this change from https://github.com/appium/appium/pull/20979

I missed to put the `getAppiumSessions` for `NO_SESSION_ID_COMMANDS` const usage. Perhaps the code can be refactored later but for now, just a quick fix.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
