### PR TITLE
chore(renovate): add @types/supports-color to blocklist

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -15,6 +15,7 @@
   "packageRules": [
     {
       "matchPackageNames": [
+        "@types/supports-color",
         "@types/wrap-ansi",
         "chalk",
         "conf",


### PR DESCRIPTION
Version 10 of `@types/supports-color` turns the package into a stub and instead suggests to use the types built into `supports-color`. However, since we are using an older version of `supports-color` that does not ship with types, we are still interested in keeping `@types/supports-color` on v9. This means we can add the package to Renovate's blocklist for now (which already includes `supports-color`).