### PR TITLE
docs(appium): use event endpoint to get event timing

### DIFF
--- a/packages/appium/docs/en/guides/event-timing.md
+++ b/packages/appium/docs/en/guides/event-timing.md
@@ -46,7 +46,7 @@ exhaustive list to share here. It's best to actually get one of these responses
 from a real session to inspect the possible event types.)
 
 The `commands` property is an array of objects. Each object has the name of the
-Appium-internal command (for example, `click`), as well as the time the command
+Appium-internal command (for example `click`), as well as the time the command
 started processing and the time it finished processing.
 
 With this data, you can calculate the time between events, or a strict timeline

--- a/packages/appium/docs/en/guides/event-timing.md
+++ b/packages/appium/docs/en/guides/event-timing.md
@@ -10,9 +10,9 @@ information and command length. This is an advanced feature that is controlled
 by the use of the `appium:eventTimings` capability (set it to `true` to log event
 timings).
 
-With this capability turned on, the `GET /session/:id` response (i.e., the
-response to `driver.getSessionDetails()` or similar, depending on client) will
-be decorated with an `events` property. This is the structure of that `events`
+With this capability turned on, the `POST /session/:id/appium/events` response (i.e., 
+the response to `driver.logs.events` or similar, depending on client) will be 
+decorated with an `events` property. This is the structure of that `events`
 property:
 
 ```
@@ -46,7 +46,7 @@ exhaustive list to share here. It's best to actually get one of these responses
 from a real session to inspect the possible event types.)
 
 The `commands` property is an array of objects. Each object has the name of the
-Appium-internal command (for example `click`), as well as the time the command
+Appium-internal command (for example, `click`), as well as the time the command
 started processing and the time it finished processing.
 
 With this data, you can calculate the time between events, or a strict timeline
@@ -54,7 +54,7 @@ of events, or statistical information about average length of a certain type of
 command, and so on.
 
 You can only receive data about events that have happened when you make the
-call to `/session/:id`, so the best time to get data about an entire session is
+call to `/session/:id/appium/events`, so the best time to get data about an entire session is
 right before quitting it.
 
 The Appium team maintains an event timings parser tool that can be used to

--- a/packages/appium/docs/en/guides/event-timing.md
+++ b/packages/appium/docs/en/guides/event-timing.md
@@ -61,6 +61,10 @@ The Appium team maintains an event timings parser tool that can be used to
 generate various kinds of reports from event timings output:
 [appium/appium-event-parser](https://github.com/appium/appium-event-parser).
 
+!!! note
+
+    In the past, the events were available as a part of `GET /session/:id` response
+
 ## Add a custom event
 
 !!! warning "TODO"

--- a/packages/appium/docs/en/guides/event-timing.md
+++ b/packages/appium/docs/en/guides/event-timing.md
@@ -63,7 +63,7 @@ generate various kinds of reports from event timings output:
 
 !!! note
 
-    In the past, the events were available as a part of `GET /session/:id` response
+    In the past, events were available as a part of `GET /session/:id` response
 
 ## Add a custom event
 


### PR DESCRIPTION
## Proposed changes

In my search, python client added this endpoint call implementation in late 2019. So... we could use this `/session/:id/appium/events` as the primary endpoint today to get events since that exists so long.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
