### PR TITLE
chore: remove sauce labs as project sponsor

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,6 @@ contribution of project development and leadership!
   </a>
 </p>
 
-<p align="center">
-  <a href="https://saucelabs.com/resources/blog/appium-strategic-partner"><img src="packages/appium/docs/overrides/assets/images/sponsor-logo-sauce.png"
-width="300" alt="Sauce Labs" /></a>
-</p>
-
 ### Other Sponsors
 
 A full list of sponsors is available at our [Sponsors page](https://appium.io/docs/en/latest/sponsors/).

--- a/packages/appium/README.md
+++ b/packages/appium/README.md
@@ -204,11 +204,6 @@ contribution of project development and leadership!
   </a>
 </p>
 
-<p align="center">
-  <a href="https://saucelabs.com/resources/blog/appium-strategic-partner"><img src="packages/appium/docs/overrides/assets/images/sponsor-logo-sauce.png"
-width="300" alt="Sauce Labs" /></a>
-</p>
-
 ### Other Sponsors
 
 A full list of sponsors is available at our [Sponsors page](https://appium.io/docs/en/latest/sponsors/).

--- a/packages/appium/docs/en/index.md
+++ b/packages/appium/docs/en/index.md
@@ -40,11 +40,6 @@ Android TV, Samsung), and more!
         <img src="assets/images/sponsor-logo-browserstack-light.png#only-light" style="width: 220px;" />
       </a>
     </div>
-    <div class="homepageSponsor">
-      <a href="https://saucelabs.com/resources/blog/appium-strategic-partner">
-        <img src="assets/images/sponsor-logo-sauce.png" style="width: 200px;" />
-      </a>
-    </div>
   </div>
 </div>
 

--- a/packages/appium/docs/en/sponsors.md
+++ b/packages/appium/docs/en/sponsors.md
@@ -35,7 +35,6 @@ contributors!
     <img src="../assets/images/sponsor-logo-browserstack-dark.png" width="250" alt="Browserstack"/>
   </picture>
 </a>
-<a style="padding-left: 1em" href="https://saucelabs.com/resources/blog/appium-strategic-partner" target="_blank"><img src="../assets/images/sponsor-logo-sauce.png" width="250"/></a>
 
 ## Gold Sponsors
 


### PR DESCRIPTION
Effective Feb 1 2025, Sauce Labs is no longer a project sponsor.