### PR TITLE
chore(schema,tsconfig,universal-xml-plugin): fix repository field in package.json

### DIFF
--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -19,7 +19,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/appium/appium.git",
-    "directory": "schema"
+    "directory": "packages/schema"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -21,6 +21,11 @@
   "bugs": {
     "url": "https://github.com/appium/appium/issues"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/tsconfig"
+  },
   "homepage": "https://appium.io",
   "engines": {
     "node": "^14.17.0 || ^16.13.0 || >=18.0.0",

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -18,7 +18,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/appium/appium-plugins.git"
+    "url": "https://github.com/appium/appium.git",
+    "directory": "packages/universal-xml-plugin"
   },
   "license": "Apache-2.0",
   "author": "https://github.com/appium",


### PR DESCRIPTION
I noticed that the links to PRs in the `universal-xml-plugin` changelog were leading to a non-existent page. This was due to a misconfiguration in the `repository` field in `package.json`, which is fixed in this PR.
I then checked this field for all other packages and found that `schema` and `tsconfig` were also not aligned, so those are also adjusted here.