### PR TITLE
fix(renovate): use chore prefix for all PRs

### DIFF
--- a/renovate/README.md
+++ b/renovate/README.md
@@ -42,7 +42,7 @@ Appium extension authors--or anyone else--may use this config as well.
 - `:enableVulnerabilityAlerts` - For "security" purposes
 - `:rebaseStalePrs` - Renovate will automatically rebase its PRs
 - `:semanticCommits` - Renovate will use semantic commit messages
-- `:semanticPrefixChore` - Renovate's PRs have the `chore` prefix in its semantic commit message
+- `:semanticCommitTypeAll(chore)` - Renovate's PRs have the `chore` prefix in its semantic commit message
 
 ### Custom Rules
 

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -10,7 +10,7 @@
     ":enableVulnerabilityAlerts",
     ":rebaseStalePrs",
     ":semanticCommits",
-    ":semanticPrefixChore"
+    ":semanticCommitTypeAll(chore)"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Currently Renovate PRs seems to sometimes have the `chore` prefix, and sometimes `fix`, which is inconsistent and adds unnecessary commits to the package changelogs. The `fix` prefix is applied due to `:semanticPrefixFixDepsChoreOthers`, which is included in `config:js-app` (see https://github.com/renovatebot/config-help/issues/712).
This PR ensures that Renovate PRs all have the `chore` prefix, as was originally intended according to the README.