### PR TITLE
feat(storage-plugin): Tune the files keeping behaviour

### DIFF
--- a/packages/storage-plugin/README.md
+++ b/packages/storage-plugin/README.md
@@ -33,14 +33,16 @@ By default, the plugin creates a new temporary folder where it manages uploaded 
 It is also possible to customize the repository root folder path by assigning a custom path to the
 `APPIUM_STORAGE_ROOT` environment variable upon server startup. The plugin automatically deletes the
 root folder recursively upon server process termination, unless the server is
-killed forcefully. If `APPIUM_STORAGE_ROOT` points to folder, which already exists,
-then only files managed by the plugin lifecycle are going to be deleted upon storage
-reset or upon server process termination.
+killed forcefully. If `APPIUM_STORAGE_ROOT` points to an existing folder,
+then all files there are going to be preserved by default unless a different behavior is
+requested by [APPIUM_STORAGE_KEEP_ALL](#appium_storage_keep_all) environment variable value.
 
 #### APPIUM_STORAGE_KEEP_ALL
 
 If this environment variable is set to `true`, `1` or `yes` then the plugin will always keep
-the previously uploaded storage files even after the server process is terminated.
+storage files after the server process is terminated. All other
+values of this variable enforce the plugin to always delete all files
+from the storage folder.
 
 After the plugin is activated you may use the following API endpoints at your Appium server.
 These APIs are not connected to sessions and might be invoked without creating a test session.

--- a/packages/storage-plugin/README.md
+++ b/packages/storage-plugin/README.md
@@ -106,7 +106,8 @@ If a folder with the same name already exists in the storage, an error will be t
 curl http://127.0.0.1:4723/storage/list
 ```
 
-Lists all files previously uploaded to the storage. Only completed file uploads are listed.
+Lists all files that are present in the storage folder.
+Incomplete uploads are excluded from this list.
 The result of calling this API is a list of items, where each item has the following properties:
 
 - `name` (string): The name of the file in the storage

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -166,7 +166,7 @@ function prepareWebSockets(httpServer: AppiumServer, itemOptions: ItemOptions): 
 
 const getStorageSingleton = _.memoize(async () => {
   let storageRoot: string;
-  let shouldPreserveRoot: boolean;
+  let shouldPreserveRoot = false;
   let shouldPreserveFiles = false;
   if (process.env.APPIUM_STORAGE_ROOT) {
     storageRoot = process.env.APPIUM_STORAGE_ROOT;
@@ -174,14 +174,18 @@ const getStorageSingleton = _.memoize(async () => {
     log.info(`Set '${storageRoot}' as the server storage root folder`);
   } else {
     storageRoot = await tempDir.openDir();
-    shouldPreserveRoot = false;
     log.info(`Created '${storageRoot}' as the temporary server storage root folder`);
   }
   if (process.env.APPIUM_STORAGE_KEEP_ALL) {
     shouldPreserveFiles = ['true', '1', 'yes'].includes(_.toLower(process.env.APPIUM_STORAGE_KEEP_ALL));
   }
   if (shouldPreserveFiles) {
-    log.info('All server storage items will be preserved unless deleted explicitly');
+    log.info(`All server storage items will be always preserved unless deleted explicitly`);
+  } else {
+    log.info(
+      `All server storage items will be cleaned up automatically from '${storageRoot}' after ` +
+      `Appium server termination`
+    );
   }
   SHARED_STORAGE = new Storage(
     storageRoot,

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -144,7 +144,6 @@ function prepareWebSockets(httpServer: AppiumServer, itemOptions: ItemOptions): 
       };
       log.debug(`Notifying about the successful addition of '${itemOptions.name}' to the server storage`);
       signaler.emit('status', successEvent);
-      streamServer.close();
       STORAGE_ADDITIONS_CACHE.delete(itemOptions.sha1);
     } catch (e) {
       log.debug(`Notifying about a failure while adding '${itemOptions.name}' to the server storage`);

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -34,7 +34,9 @@ export class StoragePlugin extends BasePlugin {
       } catch (e) {
         [status, body] = toW3cResponseError(e);
       }
-      log.debug(`Responding to ${methodName} with ${JSON.stringify(body.value)}`);
+      log.debug(
+        `Responding to ${methodName} with ${_.truncate(JSON.stringify(body.value), {length: 200})}`
+      );
       res.set('content-type', 'application/json; charset=utf-8');
       res.status(status).send(body);
     };

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -167,23 +167,26 @@ function prepareWebSockets(httpServer: AppiumServer, itemOptions: ItemOptions): 
 const getStorageSingleton = _.memoize(async () => {
   let storageRoot: string;
   let shouldPreserveRoot: boolean;
+  let shouldPreserveFiles = false;
   if (process.env.APPIUM_STORAGE_ROOT) {
     storageRoot = process.env.APPIUM_STORAGE_ROOT;
-    shouldPreserveRoot = await fs.exists(storageRoot);
+    shouldPreserveRoot = shouldPreserveFiles = await fs.exists(storageRoot);
     log.info(`Set '${storageRoot}' as the server storage root folder`);
   } else {
     storageRoot = await tempDir.openDir();
     shouldPreserveRoot = false;
     log.info(`Created '${storageRoot}' as the temporary server storage root folder`);
   }
-  const shouldKeep = ['true', '1', 'yes'].includes(_.toLower(process.env.APPIUM_STORAGE_KEEP_ALL));
-  if (shouldKeep) {
-    log.info('All server storage items will be preserved unless deleted explcitly');
+  if (process.env.APPIUM_STORAGE_KEEP_ALL) {
+    shouldPreserveFiles = ['true', '1', 'yes'].includes(_.toLower(process.env.APPIUM_STORAGE_KEEP_ALL));
+  }
+  if (shouldPreserveFiles) {
+    log.info('All server storage items will be preserved unless deleted explicitly');
   }
   SHARED_STORAGE = new Storage(
     storageRoot,
     shouldPreserveRoot,
-    shouldKeep,
+    shouldPreserveFiles,
     log,
   );
   await SHARED_STORAGE.reset();

--- a/packages/storage-plugin/test/unit/storage.spec.cjs
+++ b/packages/storage-plugin/test/unit/storage.spec.cjs
@@ -49,15 +49,31 @@ describe('storage', function () {
     (await storage.delete('foo')).should.be.false;
   });
 
-  it('should only reset known files', async function () {
+  it('should reset all files if shouldPreserveFiles is not requested', async function () {
     const name = 'foo.bar';
+    const tmpName = 'bar.baz.filepart';
     await fs.writeFile(path.join(storageRoot, name), Buffer.alloc(1));
+    await fs.writeFile(path.join(storageRoot, tmpName), Buffer.alloc(1));
     storage = new Storage(storageRoot, true, false, log);
     const files = await storage.list();
-    _.isEmpty(files).should.be.true;
-    (await storage.delete(name)).should.be.false;
+    files.length.should.eql(1);
     await storage.reset();
-    (await fs.exists(path.join(storageRoot, name))).should.be.true;
+    (await fs.exists(path.join(storageRoot, name))).should.be.false;
+    (await fs.exists(path.join(storageRoot, tmpName))).should.be.false;
+  });
+
+  it('should only reset parital files if shouldPreserveFiles requested', async function () {
+    const name = 'foo.bar';
+    const tmpName = 'bar.baz.filepart';
+    await fs.writeFile(path.join(storageRoot, name), Buffer.alloc(1));
+    await fs.writeFile(path.join(storageRoot, tmpName), Buffer.alloc(1));
+    storage = new Storage(storageRoot, true, true, log);
+    let files = await storage.list();
+    files.length.should.eql(1);
+    await storage.reset();
+    files = await storage.list();
+    files.length.should.eql(1);
+    (await fs.exists(path.join(storageRoot, tmpName))).should.be.false;
   });
 
   it('should perform basic operations', async function () {


### PR DESCRIPTION
## Proposed changes

We want to fallback to a safe behaviour, where the plugin does not delete storage files if these were already present in the root folder feeded to the plugin via an env variable. Also, we'd like to always list all folder files to make the plugin more flexible in case we'd like to always reuse the same folder after server restart.
