### PR TITLE
docs: add storage-plugin documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ to driver/client documentation
 * [opencv](packages/opencv/CHANGELOG.md)
 * [plugin-test-support](packages/plugin-test-support/CHANGELOG.md)
 * [schema](packages/schema/CHANGELOG.md)
+* [storage-plugin](packages/storage-plugin/CHANGELOG.md)
 * [strongbox](packages/strongbox/CHANGELOG.md)
 * [support](packages/support/CHANGELOG.md)
 * [test-support](packages/test-support/CHANGELOG.md)

--- a/packages/appium/docs/en/commands/index.md
+++ b/packages/appium/docs/en/commands/index.md
@@ -21,4 +21,5 @@ The command listings can be found here:
 * [Execute Driver Plugin](./execute-driver-plugin.md)
 * [Images Plugin](./images-plugin.md)
 * [Relaxed Caps Plugin](./relaxed-caps-plugin.md)
+* [Storage Plugin](./storage-plugin.md)
 * [Universal XML Plugin](./universal-xml-plugin.md)

--- a/packages/appium/docs/en/commands/storage-plugin.md
+++ b/packages/appium/docs/en/commands/storage-plugin.md
@@ -1,0 +1,113 @@
+# Plugin: storage
+
+!!! tip
+
+    All of these commands can be invoked without creating a session, allowing you to
+    prepare your test environment in advance.
+
+### `addStorageItem`
+
+`POST` **`/storage/add`**
+
+Add a new file to the storage
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | the name used to save the file (must not include path separator characters) |
+| `sha1` | `string` | SHA1 hash of the file to be uploaded |
+
+#### Example
+
+```bash
+curl -X POST --header "Content-Type: application/json" --data '{"name":"app.ipa","sha1":"ccc963411b2621335657963322890305ebe96186"}' http://127.0.0.1:4723/storage/add
+```
+
+#### Response
+
+`AddRequestResult`
+
+A JSON object in the following format:
+```json
+{
+  "ws": {
+    "stream": "/storage/add/ccc963411b2621335657963322890305ebe96186/stream",
+    "events": "/storage/add/ccc963411b2621335657963322890305ebe96186/events"
+  },
+  "ttlMs": 300000
+}
+```
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `ws.stream` | `string` | the pathname of the streaming web socket used to upload the file content |
+| `ws.events` | `string` | the pathname of the events web socket used to notify about upload success or a failure |
+| `ttlMs` | `number` | the amount of milliseconds both web sockets will be kept active before they expire, or a file payload would be successfully uploaded |
+
+
+### `listStorageItems`
+
+`GET` **`/storage/list`**
+
+List all files present in the storage
+
+#### Example
+
+```bash
+curl http://127.0.0.1:4723/storage/list
+```
+
+#### Response
+
+`List<StorageItem>`
+
+A list of items, where each item has the following properties:
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | the name of the file in the storage |
+| `path` | `string` | full path to the file on the remote file system |
+| `size` | `number` | file size in bytes |
+
+### `deleteStorageItem`
+
+`POST` **`/storage/delete`**
+
+Deletes a file in the storage with the specified name
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | the name of the file to be deleted |
+
+#### Example
+
+```bash
+curl -X POST --header "Content-Type: application/json" --data '{"name":"app.ipa"}' http://127.0.0.1:4723/storage/delete
+```
+
+#### Response
+
+`boolean`
+
+`false` if the file does not exist in the storage, or `true` upon successful file deletion 
+
+### `resetStorage`
+
+`POST` **`/storage/reset`**
+
+Deletes all uploaded files and stops any incomplete uploads.
+If the `APPIUM_STORAGE_KEEP_ALL` flag is enabled, all uploaded files will be preserved,
+and only the incomplete uploads will be stopped.
+
+#### Example
+
+```bash
+curl -X POST http://127.0.0.1:4723/storage/reset
+```
+
+#### Response
+
+`undefined`

--- a/packages/appium/docs/en/commands/storage-plugin.md
+++ b/packages/appium/docs/en/commands/storage-plugin.md
@@ -2,7 +2,7 @@
 
 !!! tip
 
-    All of these commands can be invoked without creating a session, allowing you to
+    All these commands can be invoked without creating a session, allowing you to
     prepare your test environment in advance.
 
 ### `addStorageItem`

--- a/packages/appium/docs/en/ecosystem/plugins.md
+++ b/packages/appium/docs/en/ecosystem/plugins.md
@@ -23,6 +23,7 @@ These plugins are are currently maintained by the Appium team:
 |[Execute Driver](https://github.com/appium/appium/tree/master/packages/execute-driver-plugin)|`execute-driver`|Run entire batches of commands in a single call to the Appium server|
 |[Images](https://github.com/appium/appium/tree/master/packages/images-plugin)|`images`|Image matching and comparison features|
 |[Relaxed Caps](https://github.com/appium/appium/tree/master/packages/relaxed-caps-plugin)|`relaxed-caps`|Relax Appium's requirement for vendor prefixes on capabilities|
+|[Storage](https://github.com/appium/appium/tree/master/packages/storage-plugin)|`storage`|Server-side storage with client-side management|
 |[Universal XML](https://github.com/appium/appium/tree/master/packages/universal-xml-plugin)|`universal-xml`|Instead of the standard XML format for iOS and Android, use an XML definition that is the same across both platforms|
 
 ### Other Plugins

--- a/packages/appium/docs/mkdocs-en.yml
+++ b/packages/appium/docs/mkdocs-en.yml
@@ -46,6 +46,7 @@ nav:
       - commands/execute-driver-plugin.md
       - commands/images-plugin.md
       - commands/relaxed-caps-plugin.md
+      - commands/storage-plugin.md
       - commands/universal-xml-plugin.md
   - Guides:
       - Migration:

--- a/packages/appium/lib/constants.js
+++ b/packages/appium/lib/constants.js
@@ -35,6 +35,7 @@ export const KNOWN_PLUGINS = Object.freeze(
     images: '@appium/images-plugin',
     'execute-driver': '@appium/execute-driver-plugin',
     'relaxed-caps': '@appium/relaxed-caps-plugin',
+    'storage': '@appium/storage-plugin',
     'universal-xml': '@appium/universal-xml-plugin',
   }),
 );

--- a/packages/appium/lib/constants.js
+++ b/packages/appium/lib/constants.js
@@ -35,7 +35,7 @@ export const KNOWN_PLUGINS = Object.freeze(
     images: '@appium/images-plugin',
     'execute-driver': '@appium/execute-driver-plugin',
     'relaxed-caps': '@appium/relaxed-caps-plugin',
-    'storage': '@appium/storage-plugin',
+    storage: '@appium/storage-plugin',
     'universal-xml': '@appium/universal-xml-plugin',
   }),
 );

--- a/packages/storage-plugin/README.md
+++ b/packages/storage-plugin/README.md
@@ -1,9 +1,10 @@
-# Storage Plugin
+# @appium/storage-plugin
 
-The purpose of Storage plugin is to create server-side file storage.
-This allows to manage various files, like application packages,
-from the client side. Only one storage may exist per server process,
-shared by all testing sessions.
+> Appium plugin for server-side file storage
+
+This plugin adds the ability to create a dedicated storage space on the server side,
+which can be managed from the client side. This can be useful for files like application packages.
+Only one storage may exist per server process, shared by all testing sessions.
 
 > [!WARNING]
 > This plugin is designed to be used with servers deployed in private networks.
@@ -13,7 +14,7 @@ shared by all testing sessions.
 ## Installation
 
 ```bash
-appium plugin install --source=npm @appium/storage-plugin
+appium plugin install storage
 ```
 
 ## Usage
@@ -25,6 +26,34 @@ appium --use-plugins=storage
 ```
 
 By default, the plugin creates a new temporary folder where it manages uploaded files.
+
+[Refer to the Appium documentation for a list of commands supported by this plugin.](https://appium.io/docs/en/latest/commands/storage-plugin/)
+
+### Storing a File
+
+The procedure for storing a local file on the Appium server is as follows:
+
+- Calculate the [SHA1](https://en.wikipedia.org/wiki/SHA-1) hash of the source file
+- Decide the name of the destination file in the server storage (it can be the same as the original file name)
+- Send a `POST` request to the `/storage/add` endpoint, which will return the `events` and `stream` websocket paths
+- Connect to both web sockets
+- Start listening for messages on the `events` web socket. Each message there is a JSON object wrapped
+  to a string. The message must be either `{"value": {"success": true, "name":"app.ipa","sha1":"ccc963411b2621335657963322890305ebe96186"}}` to notify about a successful
+  file upload, or `{"value": {"error": "<error signature>", "message": "<error message>", "traceback": "<server traceback>"}}`
+  to notify about any exceptions during the upload process.
+- Start reading the source file into small chunks. The recommended size of a single chunk is 64 KB.
+- After each chunk is retrieved, pass it to the `stream` web socket.
+- After the last chunk upload is completed, either close the `stream` web
+  socket to explicitly notify the server about the upload completion, or
+  wait until the success event is delivered from the `events` web socket
+  as soon as file hashes successfully match.
+  The server must always deliver either a success or a failure
+  event via the `events` web socket as described above.
+
+It is also possible to upload multiple files in parallel (up to 20 jobs are supported).
+Only flat files hierarchies are supported in the storage, no subfolders are allowed.
+IF a file with the same name already exists in the storage, it will be overridden with the new one.
+If a folder with the same name already exists in the storage, an error will be thrown.
 
 ### Environment Variables
 
@@ -43,99 +72,6 @@ If this environment variable is set to `true`, `1` or `yes` then the plugin will
 storage files after the server process is terminated. All other
 values of this variable enforce the plugin to always delete all files
 from the storage folder.
-
-After the plugin is activated you may use the following API endpoints at your Appium server.
-These APIs are not connected to sessions and might be invoked without creating a test session.
-Such design allows to prepare the testing environment in the `before` hook prior to
-creating any driver instances.
-
-### POST /storage/add
-
-```bash
-curl -X POST --header "Content-Type: application/json" --data '{"name":"app.ipa","sha1":"ccc963411b2621335657963322890305ebe96186"}' http://127.0.0.1:4723/storage/add
-```
-
-The purpose of this command is to upload files to the remote storage partially
-to avoid excessive memory usage. In order to upload a file from a local file system
-to the Appium server's file system it is necessary to perform following steps:
-
-- Calculate [SHA1](https://en.wikipedia.org/wiki/SHA-1) hash of the source file
-- Decide the name of the destination file in the server storage. It might be the same as the original file name.
-- Perform a request to this endpoint to notify the server about the intention to add a new storage item where parameters are:
-  - `name` (required): The destination file name. It could be the same as the local one. Must not include any path separator characters.
-  - `sha1` (required): SHA1 hash of the destination file. Must be the same as the hash of the source file. Used to verify the uploaded file after all chunks are sent to the server.
-- The received response is a JSON that looks like
-
-  ```json
-  {
-    "ws": {
-      "stream": "/storage/add/ccc963411b2621335657963322890305ebe96186/stream",
-      "events": "/storage/add/ccc963411b2621335657963322890305ebe96186/events"
-    },
-    "ttlMs": 300000
-  }
-  ```
-
-  where:
-  - `ws.stream`: the pathname of the streaming web socket used to upload the file content
-  - `ws.events`: the pathname of the events web socket used to notify about upload success or a failure
-  - `ttlMs`: the amount of milliseconds both web sockets will be kept active before they expire, or a file
-  payload would be successfully uploaded
-- Connect to both web sockets.
-- Start listening for messages on the `events` web socket. Each message there is a JSON object wrapped
-  to a string. The message must be either `{"value": {"success": true, "name":"app.ipa","sha1":"ccc963411b2621335657963322890305ebe96186"}}` to notify about a successful
-  file upload, or `{"value": {"error": "<error signature>", "message": "<error message>", "traceback": "<server traceback>"}}`
-  to notify about any exceptions during the upload process.
-- Start reading the source file into small chunks. The recommended size of a single chunk is 64 KB.
-- After each chunk is retrieved pass it to the `stream` web socket.
-- After the last chunk upload is completed either close the `stream` web
-  socket to explicitly notify the server about the upload completion, or
-  wait until the success event is delivered from the `events` web socket
-  as soon as file hashes successfully match.
-  The server must always deliver either a success or a failure
-  event via the `events` web socket as described above.
-
-It is also possible to upload multiple files in parallel (up to 20 jobs are supported).
-Only flat files hierarchies are supported in the storage, no subfolders are allowed.
-IF a file with the same name already exists in the storage, it will be overridden with the new one.
-If a folder with the same name already exists in the storage, an error will be thrown.
-
-### GET /storage/list
-
-```bash
-curl http://127.0.0.1:4723/storage/list
-```
-
-Lists all files that are present in the storage folder.
-Incomplete uploads are excluded from this list.
-The result of calling this API is a list of items, where each item has the following properties:
-
-- `name` (string): The name of the file in the storage
-- `path` (string): Full path to the file on the remote file system
-- `size` (number): File size in bytes
-
-### POST /storage/delete
-
-```bash
-curl -X POST --header "Content-Type: application/json" --data '{"name":"app.ipa"}' http://127.0.0.1:4723/storage/delete
-```
-
-Deletes an existing storage file. If a file with the given name is not present in the storage
-then this API returns `false`, otherwise `true` upon successful file deletion.
-
-Accepted parameters:
-
-- `name` (required): The name of the file in the storage to be deleted
-
-### POST /storage/reset
-
-```bash
-curl -X POST http://127.0.0.1:4723/storage/reset
-```
-
-Resets the server storage by deleting all uploaded files as well as incomplete uploads.
-If [APPIUM_STORAGE_KEEP_ALL](#appium_storage_keep_all) flag is enabled then
-only the latter is going to be cleaned up.
 
 ## Examples
 

--- a/packages/storage-plugin/README.md
+++ b/packages/storage-plugin/README.md
@@ -52,7 +52,7 @@ The procedure for storing a local file on the Appium server is as follows:
 
 It is also possible to upload multiple files in parallel (up to 20 jobs are supported).
 Only flat files hierarchies are supported in the storage, no subfolders are allowed.
-IF a file with the same name already exists in the storage, it will be overridden with the new one.
+If a file with the same name already exists in the storage, it will be overridden with the new one.
 If a folder with the same name already exists in the storage, an error will be thrown.
 
 ### Environment Variables

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -65,24 +65,24 @@ STORAGE_HANDLERS.addStorageItem = async function addStorageItem(
 };
 
 STORAGE_HANDLERS.listStorageItems = async function listStorageItems(): Promise<StorageItem[]> {
-  return await excuteStorageMethod(
+  return await executeStorageMethod(
     async (storage: Storage) => await storage.list()
   );
 };
 
 STORAGE_HANDLERS.deleteStorageItem = async function deleteStorageItem(req: Request): Promise<boolean> {
-  return await excuteStorageMethod(
+  return await executeStorageMethod(
     async (storage: Storage) => await storage.delete(parseRequestArgs(req, ['name']).name)
   );
 };
 
 STORAGE_HANDLERS.resetStorage = async function resetStorage(): Promise<void> {
-  await excuteStorageMethod(
+  await executeStorageMethod(
     async (storage: Storage) => await storage.reset()
   );
 };
 
-async function excuteStorageMethod<T>(method: (storage: Storage) => Promise<T>): Promise<T> {
+async function executeStorageMethod<T>(method: (storage: Storage) => Promise<T>): Promise<T> {
   const storage = await getStorageSingleton();
   return await method(storage);
 }


### PR DESCRIPTION
## Proposed changes

This aligns the `storage-plugin` documentation format to match the one used by other plugins:
* Move the plugin API docs into a dedicated Appium docs page and reference it in the README
* Add links to the plugin in aggregate changelog and Ecosystem page
* Add the plugin to the list of known plugins (to allow for the `storage` installation key)
* Fix a typo

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)
