### PR TITLE
feat(base-driver): Drop the unzip logic from basedriver helpers

### DIFF
--- a/packages/base-driver/test/unit/basedriver/helpers.spec.js
+++ b/packages/base-driver/test/unit/basedriver/helpers.spec.js
@@ -1,11 +1,8 @@
-import {zip, fs, tempDir} from '@appium/support';
 import {
-  configureApp,
   isPackageOrBundle,
   duplicateKeys,
   parseCapsArray,
 } from '../../../lib/basedriver/helpers';
-import sinon from 'sinon';
 
 describe('helpers', function () {
   let should;
@@ -106,35 +103,6 @@ describe('helpers', function () {
         0,
       ];
       duplicateKeys(input, 'foo', 'FOO').should.deep.equal(expectedOutput);
-    });
-  });
-
-  describe('#configureApp', function () {
-    let sandbox;
-
-    beforeEach(function () {
-      sandbox = sinon.createSandbox();
-      sandbox.stub(zip, 'extractAllTo').resolves();
-      sandbox.stub(zip, 'assertValidZip').resolves();
-      sandbox.stub(fs, 'mv').resolves();
-      sandbox.stub(fs, 'stat').resolves({
-        isFile: () => true,
-        isDirectory: () => false,
-      });
-      sandbox.stub(fs, 'exists').resolves(true);
-      sandbox.stub(fs, 'hash').resolves('0xDEADBEEF');
-      sandbox.stub(fs, 'glob').resolves(['/path/to/an.apk']);
-      sandbox.stub(fs, 'rimraf').resolves();
-      sandbox.stub(tempDir, 'openDir').resolves('/some/dir');
-    });
-
-    afterEach(function () {
-      sandbox.restore();
-    });
-
-    it('should pass "useSystemUnzip" flag through to @appium/support', async function () {
-      await configureApp('/path/to/an.apk.zip', '.apk');
-      zip.extractAllTo.getCall(0).lastArg.useSystemUnzip.should.be.true;
     });
   });
 });


### PR DESCRIPTION
## Proposed changes

This is one of the breaking changes needed for the Appium 3 release.
It removes automatic heuristics related to files unarchiving from base driver helpers.
All related heuristics must be done by drivers themselves as they have more knowledge about particular package requirements.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
