### PR TITLE
feat(appium): add inspector in preset plugin

### DIFF
--- a/packages/appium/docs/en/commands/index.md
+++ b/packages/appium/docs/en/commands/index.md
@@ -23,3 +23,4 @@ The command listings can be found here:
 * [Relaxed Caps Plugin](./relaxed-caps-plugin.md)
 * [Storage Plugin](./storage-plugin.md)
 * [Universal XML Plugin](./universal-xml-plugin.md)
+* [Inspector](https://github.com/appium/appium-inspector/tree/main/plugins)

--- a/packages/appium/docs/en/commands/index.md
+++ b/packages/appium/docs/en/commands/index.md
@@ -20,7 +20,7 @@ The command listings can be found here:
 * [Base Driver](./base-driver.md)
 * [Execute Driver Plugin](./execute-driver-plugin.md)
 * [Images Plugin](./images-plugin.md)
+* [Inspector](https://github.com/appium/appium-inspector/tree/main/plugins)
 * [Relaxed Caps Plugin](./relaxed-caps-plugin.md)
 * [Storage Plugin](./storage-plugin.md)
 * [Universal XML Plugin](./universal-xml-plugin.md)
-* [Inspector](https://github.com/appium/appium-inspector/tree/main/plugins)

--- a/packages/appium/docs/en/ecosystem/plugins.md
+++ b/packages/appium/docs/en/ecosystem/plugins.md
@@ -27,7 +27,6 @@ These plugins are are currently maintained by the Appium team:
 |[Storage](https://github.com/appium/appium/tree/master/packages/storage-plugin)|`storage`|Server-side storage with client-side management|
 |[Universal XML](https://github.com/appium/appium/tree/master/packages/universal-xml-plugin)|`universal-xml`|Instead of the standard XML format for iOS and Android, use an XML definition that is the same across both platforms|
 
-
 ### Other Plugins
 
 These plugins are not maintained by the Appium team and can provide additional functionality:

--- a/packages/appium/docs/en/ecosystem/plugins.md
+++ b/packages/appium/docs/en/ecosystem/plugins.md
@@ -22,10 +22,10 @@ These plugins are are currently maintained by the Appium team:
 |---|---|---|
 |[Execute Driver](https://github.com/appium/appium/tree/master/packages/execute-driver-plugin)|`execute-driver`|Run entire batches of commands in a single call to the Appium server|
 |[Images](https://github.com/appium/appium/tree/master/packages/images-plugin)|`images`|Image matching and comparison features|
+|[Inspector](https://github.com/appium/appium-inspector/tree/main/plugins)|`inspector`|Integrate the [Appium Inspector](https://github.com/appium/appium-inspector) directly into your Appium server installation, providing a web-based interface for inspecting and interacting with your application under test.|
 |[Relaxed Caps](https://github.com/appium/appium/tree/master/packages/relaxed-caps-plugin)|`relaxed-caps`|Relax Appium's requirement for vendor prefixes on capabilities|
 |[Storage](https://github.com/appium/appium/tree/master/packages/storage-plugin)|`storage`|Server-side storage with client-side management|
 |[Universal XML](https://github.com/appium/appium/tree/master/packages/universal-xml-plugin)|`universal-xml`|Instead of the standard XML format for iOS and Android, use an XML definition that is the same across both platforms|
-|[Inspector](https://github.com/appium/appium-inspector/tree/main/plugins)|`inspector`|Integrate the [Appium Inspector](https://github.com/appium/appium-inspector) directly into your Appium server installation, providing a web-based interface for inspecting and interacting with your application under test.|
 
 
 ### Other Plugins

--- a/packages/appium/docs/en/ecosystem/plugins.md
+++ b/packages/appium/docs/en/ecosystem/plugins.md
@@ -25,6 +25,8 @@ These plugins are are currently maintained by the Appium team:
 |[Relaxed Caps](https://github.com/appium/appium/tree/master/packages/relaxed-caps-plugin)|`relaxed-caps`|Relax Appium's requirement for vendor prefixes on capabilities|
 |[Storage](https://github.com/appium/appium/tree/master/packages/storage-plugin)|`storage`|Server-side storage with client-side management|
 |[Universal XML](https://github.com/appium/appium/tree/master/packages/universal-xml-plugin)|`universal-xml`|Instead of the standard XML format for iOS and Android, use an XML definition that is the same across both platforms|
+|[Inspector](https://github.com/appium/appium-inspector/tree/main/plugins)|`inspector`|Integrate the [Appium Inspector](https://github.com/appium/appium-inspector) directly into your Appium server installation, providing a web-based interface for inspecting and interacting with your application under test.|
+
 
 ### Other Plugins
 

--- a/packages/appium/lib/constants.js
+++ b/packages/appium/lib/constants.js
@@ -32,12 +32,12 @@ export const USE_ALL_PLUGINS = 'all';
 // npm package. I.e., these are the officially recognized plugins.
 export const KNOWN_PLUGINS = Object.freeze(
   /** @type {const} */ ({
-    images: '@appium/images-plugin',
     'execute-driver': '@appium/execute-driver-plugin',
+    images: '@appium/images-plugin',
+    inspector: 'appium-inspector-plugin',
     'relaxed-caps': '@appium/relaxed-caps-plugin',
     storage: '@appium/storage-plugin',
     'universal-xml': '@appium/universal-xml-plugin',
-    inspector: 'appium-inspector-plugin',
   }),
 );
 

--- a/packages/appium/lib/constants.js
+++ b/packages/appium/lib/constants.js
@@ -37,6 +37,7 @@ export const KNOWN_PLUGINS = Object.freeze(
     'relaxed-caps': '@appium/relaxed-caps-plugin',
     storage: '@appium/storage-plugin',
     'universal-xml': '@appium/universal-xml-plugin',
+    inspector: 'appium-inspector-plugin',
   }),
 );
 


### PR DESCRIPTION
## Proposed changes

Closes https://github.com/appium/appium/issues/20834

In terms of marketing perspective, we'd like to put the inspector plugin in the preset group.


```
$ npx appium plugin list
✔ Listing available plugins
- images [not installed]
- execute-driver [not installed]
- relaxed-caps [not installed]
- storage [not installed]
- universal-xml [not installed]
- inspector [not installed]
```

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
