### PR TITLE
feat: Add a possibility to mask sensitive log values depending on request headers

### DIFF
--- a/packages/base-driver/lib/express/middleware.js
+++ b/packages/base-driver/lib/express/middleware.js
@@ -82,8 +82,15 @@ export function handleLogContext(req, res, next) {
 
   const sessionId = SESSION_ID_PATTERN.exec(req.url)?.[1];
   const sessionInfo = sessionId ? {sessionId, sessionSignature: calcSignature(sessionId)} : {};
+  const doesContainSensitiveData = ['true', '1', 'yes'].includes(
+    _.toLower(_.first(req.headers['x-appium-is-sensitive']))
+  );
 
-  log.updateAsyncContext({requestId, ...sessionInfo}, true);
+  log.updateAsyncContext({
+    requestId,
+    ...sessionInfo,
+    isSensitive: doesContainSensitiveData,
+  }, true);
 
   return next();
 }

--- a/packages/base-driver/lib/express/middleware.js
+++ b/packages/base-driver/lib/express/middleware.js
@@ -82,14 +82,14 @@ export function handleLogContext(req, res, next) {
 
   const sessionId = SESSION_ID_PATTERN.exec(req.url)?.[1];
   const sessionInfo = sessionId ? {sessionId, sessionSignature: calcSignature(sessionId)} : {};
-  const doesContainSensitiveData = ['true', '1', 'yes'].includes(
-    _.toLower(_.first(req.headers['x-appium-is-sensitive']))
-  );
+  const isSensitiveHeaderValue = _.isArray(req.headers['x-appium-is-sensitive'])
+    ? _.first(req.headers['x-appium-is-sensitive'])
+    : req.headers['x-appium-is-sensitive'];
 
   log.updateAsyncContext({
     requestId,
     ...sessionInfo,
-    isSensitive: doesContainSensitiveData,
+    isSensitive: ['true', '1', 'yes'].includes(_.toLower(isSensitiveHeaderValue)),
   }, true);
 
   return next();

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -1,5 +1,6 @@
-import log from './lib/log';
+export { markSensitive } from './lib/log';
 export type * from './lib/types';
 
+import log from './lib/log';
 export {log};
 export default log;

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -389,7 +389,7 @@ export class Log extends EventEmitter implements Logger {
     // mask sensitive data
     if (_.has(result.arg, SENSITIVE_MESSAGE_KEY)) {
       const { isSensitive } = this._asyncStorage.getStore() ?? {};
-      result.arg = isSensitive ? DEFAULT_SECURE_REPLACER : arg[SENSITIVE_MESSAGE_KEY];
+      result.arg = isSensitive ? DEFAULT_SECURE_REPLACER : result.arg[SENSITIVE_MESSAGE_KEY];
     }
 
     // resolve stack traces to a plain string

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -386,12 +386,13 @@ export class Log extends EventEmitter implements Logger {
       stack: undefined,
     };
 
+    // mask sensitive data
     if (_.has(arg, SENSITIVE_MESSAGE_KEY)) {
       const { isSensitive } = this._asyncStorage.getStore() ?? {};
       result.arg = isSensitive ? DEFAULT_SECURE_REPLACER : arg[SENSITIVE_MESSAGE_KEY];
     }
 
-    // resolve stack traces to a plain string.
+    // resolve stack traces to a plain string
     if (_.isError(result.arg) && result.arg.stack) {
       result.stack = result.arg.stack + '';
       Object.defineProperty(result.arg, 'stack', {

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -392,9 +392,9 @@ export class Log extends EventEmitter implements Logger {
     }
 
     // resolve stack traces to a plain string.
-    if (_.isError(arg) && arg.stack) {
-      result.stack = arg.stack + '';
-      Object.defineProperty(arg, 'stack', {
+    if (_.isError(result.arg) && result.arg.stack) {
+      result.stack = result.arg.stack + '';
+      Object.defineProperty(result.arg, 'stack', {
         value: result.stack,
         enumerable: true,
         writable: true,

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -387,7 +387,7 @@ export class Log extends EventEmitter implements Logger {
     };
 
     // mask sensitive data
-    if (_.has(arg, SENSITIVE_MESSAGE_KEY)) {
+    if (_.has(result.arg, SENSITIVE_MESSAGE_KEY)) {
       const { isSensitive } = this._asyncStorage.getStore() ?? {};
       result.arg = isSensitive ? DEFAULT_SECURE_REPLACER : arg[SENSITIVE_MESSAGE_KEY];
     }

--- a/packages/logger/lib/secure-values-preprocessor.ts
+++ b/packages/logger/lib/secure-values-preprocessor.ts
@@ -6,7 +6,7 @@ import type {
   LogFilter,
 } from './types';
 
-const DEFAULT_REPLACER = '**SECURE**';
+export const DEFAULT_SECURE_REPLACER = '**SECURE**';
 
 /**
  * Type guard for log filter type
@@ -42,7 +42,7 @@ export class SecureValuesPreprocessor {
    */
   parseRule(rule: string | LogFilter): SecureValuePreprocessingRule {
     let pattern: string | undefined;
-    let replacer = DEFAULT_REPLACER;
+    let replacer = DEFAULT_SECURE_REPLACER;
     let flags = ['g'];
     if (_.isString(rule)) {
       if (rule.length === 0) {
@@ -142,7 +142,7 @@ export class SecureValuesPreprocessor {
 
     let result = str;
     for (const rule of this._rules) {
-      result = result.replace(rule.pattern, rule.replacer ?? DEFAULT_REPLACER);
+      result = result.replace(rule.pattern, rule.replacer ?? DEFAULT_SECURE_REPLACER);
     }
     return result;
   }

--- a/packages/logger/test/unit/basic-specs.js
+++ b/packages/logger/test/unit/basic-specs.js
@@ -1,10 +1,12 @@
 /* eslint-disable no-console */
-import { Log } from '../../lib/log';
+import { Log, markSensitive} from '../../lib/log';
 import { unleakString } from '../../lib/utils';
 import {Stream} from 'node:stream';
+import _ from 'lodash';
 
 describe('basic', function () {
   let chai;
+  /** @type {Log} */
   let log;
 
   before(async function () {
@@ -358,6 +360,15 @@ describe('basic', function () {
         log.log('verbose', 'oops', err);
         setTimeout(reject, 1000);
       });
+    });
+
+    it('replaces senstive messages', async function() {
+      log.updateAsyncStorage({isSensitive: true}, true);
+      log.log('verbose', 'test', markSensitive('log 1'));
+      _.last(log.record).message.should.eql('**SECURE**');
+      log.updateAsyncStorage({isSensitive: false}, true);
+      log.log('verbose', 'test', markSensitive('log 1'));
+      _.last(log.record).message.should.eql('log 1');
     });
 
     it('max record size', function() {

--- a/packages/support/lib/logging.js
+++ b/packages/support/lib/logging.js
@@ -1,4 +1,4 @@
-import globalLog from '@appium/logger';
+import globalLog, { markSensitive as _markSensitive } from '@appium/logger';
 import _ from 'lodash';
 import moment from 'moment';
 
@@ -82,6 +82,23 @@ export function getLogger(prefix = null) {
     wrappedLogger.level = 'verbose';
   }
   return /** @type {AppiumLogger} */ (wrappedLogger);
+}
+
+/**
+ * Marks arbitrary log message as sensitive.
+ * This message will then be replaced with the default replacer
+ * while being logged by any `info`, `debug`, etc. methods if the
+ * asyncStorage has `isSensitive` flag enabled in its async context.
+ * The latter is enabled by the corresponding HTTP middleware
+ * in response to the `X-Appium-Is-Sensitive` request header
+ * being set to 'true'.
+ *
+ * @template {any} T
+ * @param {T} logMessage
+ * @returns {{[k: string]: T}}
+ */
+export function markSensitive(logMessage) {
+  return _markSensitive(logMessage);
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

Related to the conversation initiated by @dprevost-LMI in https://github.com/appium/appium/pull/21118.

The idea is that if the server gets the request header `X-Appium-Is-Sensitive` set to `true` then the logger automatically replaces all values being marked as sensitive (via `support.logging.markSensitive` API) with the default mask text. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
