### PR TITLE
fix: adjust parameter for W3C element send keys endpoint

### DIFF
--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -154,7 +154,7 @@ export const METHOD_MAP = /** @type {const} */ ({
     POST: {
       command: 'setValue',
       payloadParams: {
-        required: ['value'],
+        required: ['text'],
       },
     },
   },

--- a/packages/base-driver/test/unit/protocol/routes.spec.js
+++ b/packages/base-driver/test/unit/protocol/routes.spec.js
@@ -41,7 +41,7 @@ describe('Protocol', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('dadd642a');
+      hash.should.equal('61e4a9e2');
     });
   });
 


### PR DESCRIPTION
Noticed a small bug that snuck in during removal of deprecated routes - the parameter name for the [W3C Element Send Keys endpoint](https://www.w3.org/TR/webdriver1/#dfn-element-send-keys) (`POST /session/:sessionId/element/:elementId/value`) was only accepting `value`, but the spec actually expects `text`.