### PR TITLE
feat(base-driver): Migrate errors to typescript

### DIFF
--- a/packages/appium/test/unit/utils.spec.js
+++ b/packages/appium/test/unit/utils.spec.js
@@ -76,7 +76,6 @@ describe('utils', function () {
       res.error.jsonwpCode.should.eql(61);
       res.error.error.should.eql('invalid argument');
       res.error.w3cStatus.should.eql(400);
-      _.isNull(res.error._stacktrace).should.be.true;
     });
     it('should reject if W3C caps are not passing constraints', function () {
       const err = parseCapsForInnerDriver(W3C_CAPS, {
@@ -96,7 +95,6 @@ describe('utils', function () {
       error.jsonwpCode.should.eql(61);
       error.error.should.eql('invalid argument');
       error.w3cStatus.should.eql(400);
-      _.isNull(error._stacktrace).should.be.true;
     });
     it('should add appium prefixes to W3C caps that are not standard in W3C', function () {
       parseCapsForInnerDriver({

--- a/packages/base-driver/lib/express/middleware.js
+++ b/packages/base-driver/lib/express/middleware.js
@@ -128,9 +128,7 @@ export function catchAllHandler(err, req, res, next) {
   }
 
   log.error(`Uncaught error: ${err.message}`);
-  const error = new errors.UnknownError(err);
-  error.stacktrace = err.stack;
-  const [status, body] = getResponseForW3CError(error);
+  const [status, body] = getResponseForW3CError(err);
   res.status(status).json(body);
 }
 

--- a/packages/base-driver/lib/protocol/errors.ts
+++ b/packages/base-driver/lib/protocol/errors.ts
@@ -399,13 +399,16 @@ export class InsecureCertificateError extends ProtocolError {
   static error() {
     return 'insecure certificate';
   }
+  static w3cStatus() {
+    return HTTPStatusCodes.BAD_REQUEST;
+  }
 
   constructor(message: string = '', cause?: Error) {
     super(
       message ||
         'Navigation caused the user agent to hit a certificate warning, which is usually the result of an expired or invalid TLS certificate',
-      ElementIsNotSelectableError.code(),
-      UnknownError.w3cStatus(),
+      UnknownError.code(),
+      InsecureCertificateError.w3cStatus(),
       InsecureCertificateError.error(),
       cause,
     );

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -7,6 +7,7 @@ import {
   getResponseForW3CError,
   errorFromMJSONWPStatusCode,
   errorFromW3CJsonCode,
+  BadParametersError,
 } from './errors';
 import {METHOD_MAP, NO_SESSION_ID_COMMANDS} from './routes';
 import B from 'bluebird';
@@ -134,7 +135,7 @@ export function checkParams(paramSets, jsonObj, protocol) {
     if (paramSets.validate) {
       let message = paramSets.validate(jsonObj, protocol);
       if (message) {
-        throw new errors.BadParametersError(message, jsonObj);
+        throw new errors.InvalidArgumentError(message);
       }
     }
   }
@@ -165,7 +166,7 @@ export function checkParams(paramSets, jsonObj, protocol) {
       return;
     }
   }
-  throw new errors.BadParametersError(paramSets, receivedParams);
+  throw new BadParametersError(paramSets, receivedParams);
 }
 
 /*


### PR DESCRIPTION
Breaking changes:
- Removed BadParametersError from errors as it is only used internally and changed its signature
- Made w3c and jsonwp properties of ProtocolError private
- Fixed UnknownError constructor signature to accept same parameters as other protocol errors