### PR TITLE
fix(docutils): add & adjust various log messages

### DIFF
--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -16,10 +16,9 @@ import {
   NAME_BIN,
   NAME_MIKE,
   NAME_MKDOCS_YML,
-  NAME_PYTHON,
 } from '../constants';
 import {DocutilsError} from '../error';
-import {findMike, findMkDocsYml, findPython, readPackageJson} from '../fs';
+import {findMike, findMkDocsYml, isMkDocsInstalled, readPackageJson, requirePython} from '../fs';
 import {getLogger} from '../logger';
 import {argify, spawnBackgroundProcess, SpawnBackgroundProcessOpts, stopwatch} from '../util';
 
@@ -37,6 +36,7 @@ async function doServe(
   opts: SpawnBackgroundProcessOpts = {},
 ) {
   const finalArgs = ['serve', ...args];
+  log.debug('Executing %s via: %s %O', NAME_MIKE, mikePath, finalArgs);
   return spawnBackgroundProcess(mikePath, finalArgs, opts);
 }
 
@@ -99,18 +99,17 @@ export async function deploy({
 }: DeployOpts = {}) {
   const stop = stopwatch('deploy');
 
-  const pythonPath = await findPython();
+  await requirePython();
 
-  if (!pythonPath) {
-    throw new DocutilsError(
-      `Could not find ${NAME_PYTHON}3/${NAME_PYTHON} executable in PATH; please install Python v3`,
-    );
+  const mkdocsInstalled = await isMkDocsInstalled();
+  if (!mkdocsInstalled) {
+    throw new DocutilsError(`Could not find MkDocs executable; please run "${NAME_BIN} init"`);
   }
 
   mkDocsYmlPath = mkDocsYmlPath ?? (await findMkDocsYml(cwd));
   if (!mkDocsYmlPath) {
     throw new DocutilsError(
-      `Could not find ${NAME_MKDOCS_YML} from ${cwd}; run "${NAME_BIN} init" to create it`,
+      `Could not find ${NAME_MKDOCS_YML} from ${cwd}; please run "${NAME_BIN} init"`,
     );
   }
   version = version ?? (await findDeployVersion(packageJsonPath, cwd));

--- a/packages/docutils/lib/builder/site.ts
+++ b/packages/docutils/lib/builder/site.ts
@@ -7,9 +7,9 @@
 
 import path from 'node:path';
 import {exec, TeenProcessExecOptions} from 'teen_process';
-import {DEFAULT_SITE_DIR, NAME_BIN, NAME_MKDOCS, NAME_MKDOCS_YML, NAME_PYTHON} from '../constants';
+import {DEFAULT_SITE_DIR, NAME_BIN, NAME_MKDOCS, NAME_MKDOCS_YML} from '../constants';
 import {DocutilsError} from '../error';
-import {findMkDocsYml, findPython, readMkDocsYml} from '../fs';
+import {findMkDocsYml, isMkDocsInstalled, readMkDocsYml, requirePython} from '../fs';
 import {getLogger} from '../logger';
 import {relative, spawnBackgroundProcess, SpawnBackgroundProcessOpts, stopwatch} from '../util';
 
@@ -58,11 +58,11 @@ export async function buildSite({
 }: BuildMkDocsOpts = {}) {
   const stop = stopwatch('build-mkdocs');
 
-  const pythonPath = await findPython();
-  if (!pythonPath) {
-    throw new DocutilsError(
-      `Could not find ${NAME_PYTHON}3/${NAME_PYTHON} executable in PATH; please install Python v3`,
-    );
+  const pythonPath = await requirePython();
+
+  const mkdocsInstalled = await isMkDocsInstalled();
+  if (!mkdocsInstalled) {
+    throw new DocutilsError(`Could not find MkDocs executable; please run "${NAME_BIN} init"`);
   }
 
   mkDocsYmlPath = mkDocsYmlPath
@@ -70,7 +70,7 @@ export async function buildSite({
     : await findMkDocsYml(cwd);
   if (!mkDocsYmlPath) {
     throw new DocutilsError(
-      `Could not find ${NAME_MKDOCS_YML} from ${cwd}; run "${NAME_BIN} init" to create it`,
+      `Could not find ${NAME_MKDOCS_YML} from ${cwd}; please run "${NAME_BIN} init"`,
     );
   }
   const mkdocsArgs = ['-f', mkDocsYmlPath];

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -74,11 +74,6 @@ export const NAME_TYPESCRIPT = 'typescript';
 export const NAME_ERR_ENOENT = 'ENOENT';
 
 /**
- * Code for a "file already exists" error
- */
-export const NAME_ERR_EEXIST = 'EEXIST';
-
-/**
  * Name of the default theme
  */
 export const NAME_THEME = 'material';
@@ -153,3 +148,8 @@ export const DEFAULT_SITE_DIR = 'site';
  * To ensure backwards compatibility, its environment variable version is used
  */
 export const PIP_ENV_VARS = {PIP_BREAK_SYSTEM_PACKAGES: '1'};
+
+/**
+ * Error message emitted when the path to Python was not found
+ */
+export const MESSAGE_PYTHON_MISSING = 'Could not find Python in PATH. Is it installed?';

--- a/packages/docutils/lib/scaffold.ts
+++ b/packages/docutils/lib/scaffold.ts
@@ -12,8 +12,8 @@ import {JsonValue, JsonObject} from 'type-fest';
 import {DocutilsError} from './error';
 import {relative} from './util';
 import _ from 'lodash';
-import {stringifyJson, readPackageJson, safeWriteFile} from './fs';
-import {NAME_ERR_ENOENT, NAME_ERR_EEXIST} from './constants';
+import {stringifyJson, readPackageJson, writeFileString} from './fs';
+import {NAME_ERR_ENOENT} from './constants';
 
 const log = getLogger('init');
 const dryRunLog = getLogger('dry-run', log);
@@ -91,7 +91,7 @@ export function createScaffoldTask<Opts extends ScaffoldTaskOptions, T extends J
     dest = dest ?? path.join(pkgDir, defaultFilename);
     const relativeDest = relativePath(dest);
     log.debug('Initializing %s', relativeDest);
-    let shouldWriteDest = false;
+    let destChangesNeeded = false;
     let isNew = false;
     let destContent: T;
     let result: ScaffoldTaskResult<T>;
@@ -103,7 +103,7 @@ export function createScaffoldTask<Opts extends ScaffoldTaskOptions, T extends J
       if (err.code !== NAME_ERR_ENOENT) {
         throw err;
       }
-      shouldWriteDest = true;
+      destChangesNeeded = true;
       log.debug('Creating new file %s', relativeDest);
       destContent = {} as T;
       isNew = true;
@@ -112,9 +112,9 @@ export function createScaffoldTask<Opts extends ScaffoldTaskOptions, T extends J
     const defaults: T = transform(defaultContent, opts, pkg);
     const finalDestContent: T = _.defaultsDeep({}, destContent, defaults);
 
-    shouldWriteDest = shouldWriteDest || !_.isEqual(destContent, finalDestContent);
+    destChangesNeeded = destChangesNeeded || !_.isEqual(destContent, finalDestContent);
 
-    if (shouldWriteDest) {
+    if (destChangesNeeded) {
       log.info('Changes needed in %s', relativeDest);
       log.debug('Original %s: %O', relativeDest, destContent);
       log.debug('Final %s: %O', relativeDest, finalDestContent);
@@ -126,20 +126,19 @@ export function createScaffoldTask<Opts extends ScaffoldTaskOptions, T extends J
         return result;
       }
 
-      try {
-        await safeWriteFile(dest, finalDestContent, overwrite);
-        if (isNew) {
-          log.success('Initialized %s', description);
-        } else {
-          log.success('Updated %s', description);
-        }
-      } catch (e) {
-        const err = e as NodeJS.ErrnoException;
-        // this should only be thrown if `force` is false
-        if (err.code === NAME_ERR_EEXIST) {
-          log.info(`${relativeDest} already exists; continuing...`);
-          log.debug(`Tried to apply patch:\n\n${patch}`);
-        } else {
+      if (!isNew && !overwrite) {
+        log.info('File %s already exists, continuing (enable overwrite with "--force")', relativeDest);
+        log.debug('Tried to apply patch:\n\n%s', patch);
+      } else {
+        try {
+          await writeFileString(dest, finalDestContent);
+          if (isNew) {
+            log.success('Initialized %s', description);
+          } else {
+            log.success('Updated %s', description);
+          }
+        } catch (e) {
+          const err = e as NodeJS.ErrnoException;
           throw new DocutilsError(`Could not write to ${relativeDest}. Reason: ${err.message}`, {
             cause: err,
           });

--- a/packages/docutils/lib/validate.ts
+++ b/packages/docutils/lib/validate.ts
@@ -13,6 +13,7 @@ import {satisfies} from 'semver';
 import {exec} from 'teen_process';
 import {
   DOCUTILS_PKG,
+  MESSAGE_PYTHON_MISSING,
   NAME_BIN,
   NAME_ERR_ENOENT,
   NAME_MKDOCS,
@@ -27,7 +28,15 @@ import {
   REQUIREMENTS_TXT_PATH,
 } from './constants';
 import {DocutilsError} from './error';
-import {findMkDocsYml, findPkgDir, readJson5, readMkDocsYml, whichNpm, findPython} from './fs';
+import {
+  findMkDocsYml,
+  findPkgDir,
+  isMkDocsInstalled,
+  readJson5,
+  readMkDocsYml,
+  whichNpm,
+  findPython,
+} from './fs';
 import {getLogger} from './logger';
 import {MkDocsYml, PipPackage} from './model';
 import {relative} from './util';
@@ -281,12 +290,16 @@ export class DocutilsValidator extends EventEmitter {
    * Validates that the correct version of `mkdocs` is installed
    */
   protected async validateMkDocs() {
-    const pythonPath = this.pythonPath ?? (await findPython());
+    log.debug(`Validating MkDocs version`);
 
+    const pythonPath = this.pythonPath ?? (await findPython());
     if (!pythonPath) {
-      return this.fail(
-        `Could not find ${NAME_PYTHON} executable in PATH. If it is installed, check your PATH environment variable.`,
-      );
+      return this.fail(MESSAGE_PYTHON_MISSING);
+    }
+
+    const mkdocsInstalled = await isMkDocsInstalled();
+    if (!mkdocsInstalled) {
+      return this.fail(`Could not find MkDocs executable; please run "${NAME_BIN} init"`);
     }
 
     let rawMkDocsVersion: string | undefined;
@@ -296,25 +309,20 @@ export class DocutilsValidator extends EventEmitter {
       return this.fail(`Failed to get MkDocs version: ${err}`);
     }
     const match = rawMkDocsVersion.match(MKDOCS_VERSION_REGEX);
-    if (match) {
-      const version = match[1];
-      const reqs = await this.parseRequirementsTxt();
-      const mkDocsPipPkg = _.find(reqs, {name: NAME_MKDOCS});
-      if (!mkDocsPipPkg) {
-        throw new DocutilsError(
-          `No ${NAME_MKDOCS} package in ${REQUIREMENTS_TXT_PATH}. This is a bug.`,
-        );
-      }
-      const {version: mkDocsReqdVersion} = mkDocsPipPkg;
-      if (version !== mkDocsReqdVersion) {
-        return this.fail(
-          `${NAME_MKDOCS} is v${version}, but ${REQUIREMENTS_TXT_PATH} requires v${mkDocsReqdVersion}`,
-        );
-      }
-    } else {
+    if (!match) {
+      return this.fail(`Could not parse MkDocs version. Output was ${rawMkDocsVersion}`);
+    }
+    const version = match[1];
+    const reqs = await this.parseRequirementsTxt();
+    const mkDocsPipPkg = _.find(reqs, {name: NAME_MKDOCS});
+    if (!mkDocsPipPkg) {
       throw new DocutilsError(
-        `Could not parse version from MkDocs. This is a bug. Output was ${rawMkDocsVersion}`,
+        `No ${NAME_MKDOCS} package in ${REQUIREMENTS_TXT_PATH}. This is a bug`,
       );
+    }
+    const {version: mkDocsReqdVersion} = mkDocsPipPkg;
+    if (version !== mkDocsReqdVersion) {
+      return this.fail(`MkDocs v${version} is installed, but v${mkDocsReqdVersion} is required`);
     }
 
     this.ok('MkDocs install OK');
@@ -325,13 +333,16 @@ export class DocutilsValidator extends EventEmitter {
    *
    * It checks if the file exists, if it can be parsed as YAML, and if it has a `site_name` property.
    */
-  protected async validateMkDocsConfig(mkDocsYmlPath?: string) {
-    mkDocsYmlPath = mkDocsYmlPath ?? this.mkDocsYmlPath ?? (await findMkDocsYml(this.cwd));
+  protected async validateMkDocsConfig() {
+    log.debug(`Validating ${NAME_MKDOCS_YML}`);
+
+    const mkDocsYmlPath = this.mkDocsYmlPath ?? (await findMkDocsYml(this.cwd));
     if (!mkDocsYmlPath) {
       return this.fail(
-        `Could not find ${NAME_MKDOCS_YML} from ${this.cwd}. Run "${NAME_BIN} init" to create it`,
+        `Could not find ${NAME_MKDOCS_YML} from ${this.cwd}; please run "${NAME_BIN} init"`,
       );
     }
+
     let mkDocsYml: MkDocsYml;
     try {
       mkDocsYml = await readMkDocsYml(mkDocsYmlPath);
@@ -358,24 +369,24 @@ export class DocutilsValidator extends EventEmitter {
    * This is required because other validators need `npm exec` to work, which is only available in npm 7+.
    */
   protected async validateNpmVersion() {
+    log.debug(`Validating ${NAME_NPM} version`);
+
     const npmEngineRange = DOCUTILS_PKG.engines?.npm;
     if (!npmEngineRange) {
-      throw new DocutilsError('Could not find property engines.npm in package.json. This is a bug');
+      throw new DocutilsError(`Could not find property 'engines.npm' in ${NAME_PACKAGE_JSON}. This is a bug`);
+    }
+
+    const npmPath = this.npmPath ?? (await whichNpm());
+    if (!npmPath) {
+      throw new DocutilsError(`Could not find ${NAME_NPM} in PATH. That seems weird, doesn't it?`);
     }
     try {
-      const npmPath = this.npmPath ?? (await whichNpm());
-      if (!npmPath) {
-        throw new DocutilsError(
-          `Could not find ${NAME_NPM} in PATH. That seems weird, doesn't it?`,
-        );
-      }
       const {stdout: npmVersion} = await exec(npmPath, ['-v']);
       if (!satisfies(npmVersion.trim(), npmEngineRange)) {
-        this.fail(`${NAME_NPM} is version ${npmVersion}, but ${npmEngineRange} is required`);
-        return;
+        return this.fail(`${NAME_NPM} v${npmVersion} is installed, but ${npmEngineRange} is required`);
       }
     } catch {
-      return this.fail(`Could not find ${this.npmPath} in PATH. Is it installed?`);
+      return this.fail(`Could not retrieve ${NAME_NPM} version`);
     }
     this.ok(`${NAME_NPM} version OK`);
   }
@@ -387,11 +398,14 @@ export class DocutilsValidator extends EventEmitter {
    * contents of our `requirements.txt`. Versions _must_ match exactly.
    */
   protected async validatePythonDeps() {
-    let pipListOutput: string;
+    log.debug(`Validating required ${NAME_PYTHON} package versions`);
+
     const pythonPath = this.pythonPath ?? (await findPython());
     if (!pythonPath) {
-      return this.fail(`Could not find ${NAME_PYTHON} in PATH. Is it installed?`);
+      return this.fail(MESSAGE_PYTHON_MISSING);
     }
+
+    let pipListOutput: string;
     try {
       ({stdout: pipListOutput} = await exec(pythonPath, [
         '-m',
@@ -401,16 +415,16 @@ export class DocutilsValidator extends EventEmitter {
         'json',
       ]));
     } catch {
-      return this.fail(`Could not find ${NAME_PIP} in PATH. Is it installed?`);
+      return this.fail(
+        `Could not find ${NAME_PIP} installation for Python at ${pythonPath}. Is it installed?`
+      );
     }
 
     let installedPkgs: PipPackage[];
     try {
       installedPkgs = JSON.parse(pipListOutput) as PipPackage[];
     } catch {
-      throw new DocutilsError(
-        `Could not parse output of "${NAME_PIP} list" as JSON: ${pipListOutput}`,
-      );
+      return this.fail(`Could not parse output of "${NAME_PIP} list" as JSON: ${pipListOutput}`);
     }
 
     const pkgsByName = _.mapValues(_.keyBy(installedPkgs, 'name'), 'version');
@@ -423,8 +437,7 @@ export class DocutilsValidator extends EventEmitter {
       const version = pkgsByName[reqdPkg.name];
       if (!version) {
         missingPackages.push(reqdPkg);
-      }
-      if (version !== reqdPkg.version) {
+      } else if (version !== reqdPkg.version) {
         invalidVersionPackages.push([reqdPkg, {name: reqdPkg.name, version}]);
       }
     }
@@ -464,32 +477,35 @@ export class DocutilsValidator extends EventEmitter {
    * Asserts that the Python version is 3.x
    */
   protected async validatePythonVersion() {
+    log.debug(`Validating ${NAME_PYTHON} version`);
+
     const pythonPath = this.pythonPath ?? (await findPython());
     if (!pythonPath) {
-      return this.fail(`Could not find ${NAME_PYTHON} in PATH. Is it installed?`);
+      return this.fail(MESSAGE_PYTHON_MISSING);
     }
 
     try {
       const {stdout} = await exec(pythonPath, ['--version']);
       if (!stdout.includes(PYTHON_VER_STR)) {
-        return this.fail(
-          `Could not find Python 3.x in PATH; found ${stdout}.  Please use --python-path`,
-        );
+        return this.fail(`Could not find Python 3.x in PATH; found ${stdout}`);
       }
     } catch {
-      return this.fail(`Could not find Python 3.x in PATH.`);
+      return this.fail(`Could not retrieve Python version`);
     }
     this.ok('Python version OK');
   }
 
   /**
-   * Asserts that TypeScript is installed, runnable, the correct version, and a parseable `tsconfig.json` exists.
+   * Asserts that TypeScript is installed, runnable, and the correct version.
    */
   protected async validateTypeScript() {
+    log.debug(`Validating ${NAME_TYPESCRIPT} version`);
+
     const pkgDir = await this.findPkgDir();
     if (!pkgDir) {
-      return this.fail(`Could not find package.json in ${this.cwd}`);
+      return this.fail(`Could not find ${NAME_PACKAGE_JSON} in ${this.cwd}`);
     }
+
     let typeScriptVersion: string;
     let rawTypeScriptVersion: string;
     try {
@@ -510,16 +526,15 @@ export class DocutilsValidator extends EventEmitter {
     }
 
     const reqdTypeScriptVersion = DOCUTILS_PKG.dependencies?.typescript;
-
     if (!reqdTypeScriptVersion) {
       throw new DocutilsError(
-        `Could not find a dep for ${NAME_TYPESCRIPT} in ${NAME_PACKAGE_JSON}. This is a bug.`,
+        `Could not find ${NAME_TYPESCRIPT} dependency in ${NAME_PACKAGE_JSON}. This is a bug`,
       );
     }
 
     if (!satisfies(typeScriptVersion, reqdTypeScriptVersion)) {
       return this.fail(
-        `Found TypeScript version ${typeScriptVersion}, but ${reqdTypeScriptVersion} is required`,
+        `TypeScript v${typeScriptVersion} is installed, but v${reqdTypeScriptVersion} is required`,
       );
     }
     this.ok('TypeScript install OK');
@@ -529,25 +544,23 @@ export class DocutilsValidator extends EventEmitter {
    * Validates a `tsconfig.json` file
    */
   protected async validateTypeScriptConfig() {
+    log.debug(`Validating ${NAME_TSCONFIG_JSON}`);
+
     const pkgDir = await this.findPkgDir();
     if (!pkgDir) {
-      return this.fail(new DocutilsError(`Could not find package.json in ${this.cwd}`));
+      return this.fail(`Could not find ${NAME_PACKAGE_JSON} in ${this.cwd}`);
     }
-    const tsconfigJsonPath = (this.tsconfigJsonPath =
-      this.tsconfigJsonPath ?? path.join(pkgDir, NAME_TSCONFIG_JSON));
+
+    const tsconfigJsonPath = this.tsconfigJsonPath ?? path.join(pkgDir, NAME_TSCONFIG_JSON);
     const relTsconfigJsonPath = relative(this.cwd, tsconfigJsonPath);
     try {
       await readJson5(tsconfigJsonPath);
     } catch (e) {
       if (e instanceof SyntaxError) {
-        return this.fail(
-          new DocutilsError(`Unparseable ${NAME_TSCONFIG_JSON} at ${relTsconfigJsonPath}: ${e}`),
-        );
+        return this.fail(`Could not parse ${NAME_TSCONFIG_JSON} at ${relTsconfigJsonPath}: ${e}`);
       }
       return this.fail(
-        new DocutilsError(
-          `Missing ${NAME_TSCONFIG_JSON} at ${relTsconfigJsonPath}; "${NAME_BIN} init" can help`,
-        ),
+        `Could not find ${NAME_TSCONFIG_JSON} at ${relTsconfigJsonPath}; please run "${NAME_BIN} init"`,
       );
     }
 

--- a/packages/docutils/lib/validate.ts
+++ b/packages/docutils/lib/validate.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import {fs, util} from '@appium/support';
+import {fs, npm, util} from '@appium/support';
 import chalk from 'chalk';
 import _ from 'lodash';
 import {EventEmitter} from 'node:events';
@@ -380,8 +380,9 @@ export class DocutilsValidator extends EventEmitter {
     if (!npmPath) {
       throw new DocutilsError(`Could not find ${NAME_NPM} in PATH. That seems weird, doesn't it?`);
     }
+
     try {
-      const {stdout: npmVersion} = await exec(npmPath, ['-v']);
+      const {stdout: npmVersion} = await npm.exec('-v', [], {cwd: this.cwd});
       if (!satisfies(npmVersion.trim(), npmEngineRange)) {
         return this.fail(`${NAME_NPM} v${npmVersion} is installed, but ${npmEngineRange} is required`);
       }
@@ -506,10 +507,15 @@ export class DocutilsValidator extends EventEmitter {
       return this.fail(`Could not find ${NAME_PACKAGE_JSON} in ${this.cwd}`);
     }
 
+    const npmPath = this.npmPath ?? (await whichNpm());
+    if (!npmPath) {
+      throw new DocutilsError(`Could not find ${NAME_NPM} in PATH. That seems weird, doesn't it?`);
+    }
+
     let typeScriptVersion: string;
     let rawTypeScriptVersion: string;
     try {
-      ({stdout: rawTypeScriptVersion} = await exec(NAME_NPM, ['exec', 'tsc', '--', '--version'], {
+      ({stdout: rawTypeScriptVersion} = await npm.exec('exec', ['tsc', '--', '--version'], {
         cwd: pkgDir,
       }));
     } catch {


### PR DESCRIPTION
This PR adjusts validation for the `docutils` executable:
* Add missing error messages:
  * if `appium-docs init` is called without Python being installed
  * if `appium-docs build` is called without `mkdocs` being installed
* Add missing debug messages:
  * when calling `appium-docs validate`
  * when calling `appium-docs build --deploy --serve`
* Adjust info message when calling `appium-docs init` with an existing `tsconfig.json` file 
* Adjust debug messages when calling `appium-docs validate`

