### PR TITLE
docs: add Appium 3 migration guide

### DIFF
--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -90,137 +90,208 @@ projects may want to check [the Express 5 Migration Guide](https://expressjs.com
 ## Endpoint Changes
 ### Removed
 
-The following are all endpoints removed in Appium 3. Where applicable, a replacement endpoint is
-also listed, along with any extra information.
+The following are all endpoints removed in Appium 3. Where applicable, one or more suggested
+replacement endpoints are also listed, along with any extra information.
 
 * `GET /sessions`
-    * :octicons-arrow-right-24: `GET /appium/sessions`[^1]
+    * :octicons-arrow-right-24: `GET /appium/sessions`
 * `POST /session/:sessionId/accept_alert`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/accept`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: alert` [^xcui]
+        * `mobile: acceptAlert` [^uia2]
 * `GET /session/:sessionId/alert_text`
     * :octicons-arrow-right-24: `GET /session/:sessionId/alert/text`
 * `POST /session/:sessionId/alert_text`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/text`
 * `POST /session/:sessionId/appium/app/background`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: backgroundApp` [^esp] [^uia2] [^xcui]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: backgroundApp` [^xcui] [^uia2] [^espr]
 * `POST /session/:sessionId/appium/app/close`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: terminateApp` [^esp] [^uia2] [^xcui]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: terminateApp` [^xcui] [^uia2] [^espr]
+        * `macos: terminateApp` [^mac]
+        * `windows: closeApp` [^win]
 * `POST /session/:sessionId/appium/app/end_test_coverage`
     * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/appium/app/launch`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: launchApp` [^xcui]
-    * :octicons-info-24: Espresso and UiAutomator2 drivers also have `mobile: activateApp`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: launchApp` [^xcui]
+        * `mobile: activateApp` [^uia2] [^espr]
+        * `macos: launchApp` or `macos: activateApp` [^mac]
+        * `windows: launchApp` [^win]
 * `POST /session/:sessionId/appium/app/reset`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: clearApp` [^esp] [^uia2] [^xcui]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: clearApp` [^xcui] [^uia2] [^espr]
     * :octicons-info-24: XCUITest driver supports this only in simulators
 * `POST /session/:sessionId/appium/app/strings`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getAppStrings` [^esp] [^uia2] [^xcui]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: getAppStrings` [^xcui] [^uia2] [^espr]
 * `GET /session/:sessionId/appium/device/app_state`
     * :octicons-arrow-right-24: `POST /session/:sessionId/appium/device/app_state`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: queryAppState` [^xcui] [^uia2] [^espr]
+        * `macos: queryAppState` [^mac]
 * `GET /session/:sessionId/appium/device/current_activity`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getCurrentActivity` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: getCurrentActivity` [^uia2] [^espr]
 * `GET /session/:sessionId/appium/device/current_package`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getCurrentPackage` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: getCurrentPackage` [^uia2] [^espr]
 * `GET /session/:sessionId/appium/device/display_density`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getDisplayDensity` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: getDisplayDensity` [^uia2] [^espr]
 * `POST /session/:sessionId/appium/device/finger_print`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: fingerPrint` [^esp] [^uia2] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: fingerPrint` [^uia2] [^espr] [^sim]
 * `POST /session/:sessionId/appium/device/get_clipboard`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getClipboard` [^esp] [^uia2] [^xcui]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: getClipboard` [^xcui] [^uia2] [^espr]
+        * `mobile: getPasteboard` [^xcui] [^sim]
+        * `windows: getClipboard` [^win]
 * `POST /session/:sessionId/appium/device/gsm_call`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmCall` [^esp] [^uia2] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: gsmCall` [^uia2] [^espr] [^sim]
 * `POST /session/:sessionId/appium/device/gsm_signal`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmSignal` [^esp] [^uia2] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: gsmSignal` [^uia2] [^espr] [^sim]
 * `POST /session/:sessionId/appium/device/gsm_voice`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmVoice` [^esp] [^uia2] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: gsmVoice` [^uia2] [^espr] [^sim]
 * `POST /session/:sessionId/appium/device/is_locked`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: isLocked` [^esp] [^uia2] [^xcui]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: isLocked` [^xcui] [^uia2] [^espr]
 * `POST /session/:sessionId/appium/device/keyevent`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: pressKey` [^uia2] [^espr]
+        * `macos: keys` [^mac]
+        * `windows: keys` [^win]
+    * :octicons-info-24: XCUITest driver also supports `mobile: keys` on iPadOS
 * `POST /session/:sessionId/appium/device/lock`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: lock` [^esp] [^uia2] [^xcui]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: lock` [^xcui] [^uia2] [^espr]
 * `POST /session/:sessionId/appium/device/long_press_keycode`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey` [^esp] [^uia2]
-    * :octicons-info-24: Set the `isLongPress` value in the payload data
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: pressKey` [^uia2] [^espr]
 * `POST /session/:sessionId/appium/device/network_speed`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: networkSpeed` [^esp] [^uia2] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: networkSpeed` [^uia2] [^espr] [^sim]
 * `POST /session/:sessionId/appium/device/open_notifications`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: statusBar` [^esp] [^uia2]
-    * :octicons-info-24: Set the `command` value in the payload data to `expandNotifications`
-    * :octicons-info-24: UiAutomator2 driver also has `mobile: openNotifications`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: statusBar` [^uia2] [^espr]
+        * `mobile: openNotifications` [^uia2]
 * `POST /session/:sessionId/appium/device/power_ac`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: powerAC` [^esp] [^uia2] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: powerAC` [^uia2] [^espr] [^sim]
 * `POST /session/:sessionId/appium/device/power_capacity`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: powerCapacity` [^esp] [^uia2] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: powerCapacity` [^uia2] [^espr] [^sim]
 * `POST /session/:sessionId/appium/device/press_keycode`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey` [^esp] [^uia2]
-    * :octicons-info-24: XCUITest driver also has `mobile: pressButton`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: pressKey` [^uia2] [^espr]
+        * `macos: keys` [^mac]
+        * `windows: keys` [^win]
+    * :octicons-info-24: XCUITest driver also supports `mobile: keys` on iPadOS
 * `POST /session/:sessionId/appium/device/send_sms`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: sendSms` [^esp] [^uia2] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: sendSms` [^uia2] [^espr] [^sim]
 * `POST /session/:sessionId/appium/device/set_clipboard`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setClipboard` [^esp] [^uia2] [^xcui]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: setClipboard` [^xcui] [^uia2] [^espr]
+        * `mobile: setPasteboard` [^xcui] [^sim]
+        * `windows: setClipboard` [^win]
 * `POST /session/:sessionId/appium/device/shake`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: shake` [^xcui] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: shake` [^xcui] [^sim]
 * `POST /session/:sessionId/appium/device/start_activity`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: startActivity` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: startActivity` [^uia2] [^espr]
 * `GET /session/:sessionId/appium/device/system_bars`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getSystemBars` [^esp] [^uia2]
-    * :octicons-info-24: XCUITest driver also has `mobile: deviceScreenInfo`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: deviceScreenInfo` [^xcui]
+        * `mobile: getSystemBars` [^uia2] [^espr]
 * `POST /session/:sessionId/appium/device/toggle_airplane_mode`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity` [^esp] [^uia2]
-    * :octicons-info-24: Set the `airplaneMode` value in the payload data
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: setConnectivity` [^uia2] [^espr]
 * `POST /session/:sessionId/appium/device/toggle_data`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity` [^esp] [^uia2]
-    * :octicons-info-24: Set the `data` value in the payload data
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: setConnectivity` [^uia2] [^espr]
 * `POST /session/:sessionId/appium/device/toggle_location_services`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: toggleGps` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: toggleGps` [^uia2] [^espr]
 * `POST /session/:sessionId/appium/device/toggle_wifi`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity` [^esp] [^uia2]
-    * :octicons-info-24: Set the `wifi` value in the payload data
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: setConnectivity` [^uia2] [^espr]
 * `POST /session/:sessionId/appium/device/unlock`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: unlock` [^esp] [^uia2] [^xcui]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: unlock` [^xcui] [^uia2] [^espr]
 * `POST /session/:sessionId/appium/element/:elementId/value`
     * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
 * `POST /session/:sessionId/appium/element/:elementId/replace_value`
     * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
 * `POST /session/:sessionId/appium/getPerformanceData`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getPerformanceData` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: getPerformanceData` [^uia2] [^espr]
 * `POST /session/:sessionId/appium/performanceData/types`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getPerformanceDataTypes` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: getPerformanceDataTypes` [^uia2] [^espr]
 * `POST /session/:sessionId/appium/receive_async_response`
     * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/appium/simulator/toggle_touch_id_enrollment`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: enrollBiometric` [^xcui] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: enrollBiometric` [^xcui] [^sim]
 * `POST /session/:sessionId/appium/simulator/touch_id`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: sendBiometricMatch` [^xcui] [^sim]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
+    `mobile: sendBiometricMatch` [^xcui] [^sim]
 * `POST /session/:sessionId/appium/start_recording_screen`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: startMediaProjectionRecording` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: startXCTestScreenRecording` [^xcui]
+        * `mobile: startMediaProjectionRecording` [^uia2] [^espr]
+        * `macos: startRecordingScreen` or `macos: startNativeScreenRecording` [^mac]
+        * `windows: startRecordingScreen` [^win]
 * `POST /session/:sessionId/appium/stop_recording_screen`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: stopMediaProjectionRecording` [^esp] [^uia2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: stopXCTestScreenRecording` [^xcui]
+        * `mobile: stopMediaProjectionRecording` [^uia2] [^espr]
+        * `macos: stopRecordingScreen` or `macos: stopNativeScreenRecording` [^mac]
+        * `windows: stopRecordingScreen` [^win]
 * `GET /session/:sessionId/application_cache/status`
     * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/buttondown`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` action
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys` [^win]
 * `POST /session/:sessionId/buttonup`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerUp`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerUp` action
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys` [^win]
 * `POST /session/:sessionId/click`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerUp`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
+    `pointerUp` actions
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `macos: click` or `macos: rightClick` [^mac]
+        * `windows: click` [^win]
 * `POST /session/:sessionId/dismiss_alert`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/dismiss`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: alert` [^xcui]
+        * `mobile: dismissAlert` [^uia2]
 * `POST /session/:sessionId/doubleclick`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerUp`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
+    `pointerUp` actions
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `macos: doubleClick` [^mac]
+        * `windows: click` [^win]
 * `POST /session/:sessionId/element/active`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/active`
 * `GET /session/:sessionId/element/:elementId/equals/:otherId`
     * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/element/:elementId/location`
-    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect` [^1]
+    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
 * `GET /session/:sessionId/element/:elementId/location_in_view`
     * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/element/:elementId/pageIndex`
     * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/element/:elementId/size`
-    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect` [^1]
+    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
 * `POST /session/:sessionId/element/:elementId/submit`
     * :octicons-no-entry-fill-12: No replacement available - the form submission button needs
     to be clicked
@@ -230,7 +301,6 @@ also listed, along with any extra information.
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/async`
 * `POST /session/:sessionId/keys`
     * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
-    * :fontawesome-solid-triangle-exclamation: Now requires the element ID
 * `GET /session/:sessionId/local_storage`
     * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/local_storage`
@@ -248,7 +318,7 @@ also listed, along with any extra information.
 * `GET /session/:sessionId/log/types`
     * :octicons-arrow-right-24: `GET /session/:sessionId/se/log/types`
 * `POST /session/:sessionId/moveto`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerMove`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerMove` action
 * `GET /session/:sessionId/screenshot/:elementId`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/screenshot`
 * `GET /session/:sessionId/session_storage`
@@ -265,30 +335,33 @@ also listed, along with any extra information.
     * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/timeouts/async_script`
     * :octicons-arrow-right-24: `POST /session/:sessionId/timeouts`
-    * :octicons-info-24: Set the `script` value in the payload data
 * `POST /session/:sessionId/timeouts/implicit_wait`
     * :octicons-arrow-right-24: `POST /session/:sessionId/timeouts`
-    * :octicons-info-24: Set the `implicit` value in the payload data
 * `POST /session/:sessionId/touch/click`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerUp`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
+    `pointerUp` actions
 * `POST /session/:sessionId/touch/doubleclick`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerUp`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
+    `pointerUp` actions
 * `POST /session/:sessionId/touch/down`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` action
 * **`POST /session/:sessionId/touch/flick`**
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerMove` / `pointerUp`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown`,
+    `pointerMove` & `pointerUp` actions
 * **`POST /session/:sessionId/touch/longclick`**
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pause` / `pointerUp`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown`, `pause`
+    & `pointerUp` actions
 * `POST /session/:sessionId/touch/multi/perform`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
 * `POST /session/:sessionId/touch/move`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerMove`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerMove` action
 * `POST /session/:sessionId/touch/perform`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
 * `POST /session/:sessionId/touch/scroll`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerMove` / `pointerUp`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown`,
+    `pointerMove` & `pointerUp` actions
 * `POST /session/:sessionId/touch/up`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerUp`)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerUp` action
 * `GET /session/:sessionId/window_handle`
     * :octicons-arrow-right-24: `GET /session/:sessionId/window`
 * `GET /session/:sessionId/window/handle`
@@ -297,13 +370,13 @@ also listed, along with any extra information.
     * :octicons-arrow-right-24: `POST /session/:sessionId/window/maximize`
     * :fontawesome-solid-triangle-exclamation: Only supported for the current window
 * `GET /session/:sessionId/window/:windowhandle/position`
-    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect` [^1]
+    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect`
     * :fontawesome-solid-triangle-exclamation: Only supported for the current window
 * `POST /session/:sessionId/window/:windowhandle/position`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/window/rect` [^2]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/window/rect`
     * :fontawesome-solid-triangle-exclamation: Only supported for the current window
 * `GET /session/:sessionId/window/:windowhandle/size`
-    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect` [^1]
+    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect`
     * :fontawesome-solid-triangle-exclamation: Only supported for the current window
 
 ### Modified
@@ -331,9 +404,9 @@ still accepts in Appium 3.
     * :octicons-x-24: `name`
     * :octicons-check-24: `handle`
 
-[^1]: Response includes additional fields
-[^2]: Request allows additional fields
-[^esp]: Supported in Espresso driver
-[^uia2]: Supported in UiAutomator2 driver
-[^xcui]: Supported in XCUITest driver
+[^xcui]: Supported in [XCUITest driver](https://appium.github.io/appium-xcuitest-driver/latest/)
+[^uia2]: Supported in [UiAutomator2 driver](https://github.com/appium/appium-uiautomator2-driver/)
+[^espr]: Supported in [Espresso driver](https://github.com/appium/appium-espresso-driver)
+[^mac]: Supported in [Mac2 driver](https://github.com/appium/appium-mac2-driver)
+[^win]: Supported in [Windows driver](https://github.com/appium/appium-windows-driver)
 [^sim]: Supported in emulators/simulators only

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -35,9 +35,10 @@ close-to-direct replacements in either standard W3C endpoints, other Appium endp
 driver-specific extension commands. These endpoints, along with replacements (where applicable)
 are listed [in the **Removed Endpoints** section](#removed).
 
-Some standard W3C endpoints used in Appium 2 were also present in the old JSONWP specification, but
-required different parameters. Appium 3 changes these endpoints to only accept the W3C parameters.
-These endpoints are listed [in the **Modified Endpoints** section](#modified).
+Some W3C endpoints used in Appium 2 were also defined in old JSONWP specification, but required
+different parameters, and Appium 2 supported both parameter sets for the same endpoints. Appium 3
+changes these endpoints to only accept the W3C parameters. These endpoints are listed
+[in the **Modified Endpoints** section](#modified).
 
 !!! info "Actions Needed"
 

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -1,6 +1,11 @@
 ---
 title: Migrating to Appium 3
 ---
+<style>
+    .md-typeset .grid {
+        grid-template-columns: repeat(auto-fit,minmax(min(100%,11rem),1fr));
+    }
+</style>
 
 This document is a guide for those who are using Appium 2 and would like to upgrade to Appium 3.
 It contains a list of breaking changes, as well as suggestions for handling them.
@@ -12,9 +17,9 @@ upgrade with fewer breaking changes, which should result in a much simpler migra
 
 ### Node 20+ Required
 
-With Appium 2, the minimum required Node version was set to `14.17.0`. Support for Node 14 had
-already ended before the release of Appium 2, which meant that even users on outdated Node versions
-were able to use it.
+With Appium 2, the minimum required Node version was `14.17.0`. Support for Node 14 had already
+ended before the release of Appium 2, which meant that even users on outdated Node versions were
+able to use it.
 
 Appium 3 drops support for outdated Node versions, and bumps the minimum required version to Node
 `20.9.0`, as well as the minimum `npm` version to `10`.
@@ -91,209 +96,220 @@ projects may want to check [the Express 5 Migration Guide](https://expressjs.com
 ### Removed
 
 The following are all endpoints removed in Appium 3. Where applicable, one or more suggested
-replacement endpoints are also listed, along with any extra information.
+replacement endpoints are also listed, along with any extra information. Since many of the
+suggested options are specific to certain drivers, where applicable, icons are used to indicate
+the drivers which support that option:
+
+<div class="grid cards" markdown>
+
+-   :material-apple:{ .lg } - [XCUITest driver](https://appium.github.io/appium-xcuitest-driver/latest/)
+-   :material-android:{ .lg } - [UiAutomator2 driver](https://github.com/appium/appium-uiautomator2-driver/)
+-   :material-coffee:{ .lg } - [Espresso driver](https://github.com/appium/appium-espresso-driver)
+-   :material-apple-finder:{ .lg } - [Mac2 driver](https://github.com/appium/appium-mac2-driver)
+-   :material-microsoft-windows:{ .lg } - [Windows driver](https://github.com/appium/appium-windows-driver)
+
+</div>
 
 * `GET /sessions`
     * :octicons-arrow-right-24: `GET /appium/sessions`
 * `POST /session/:sessionId/accept_alert`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/accept`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: alert` [^xcui]
-        * `mobile: acceptAlert` [^uia2]
+        * `mobile: alert` :material-apple:
+        * `mobile: acceptAlert` :material-android:
 * `GET /session/:sessionId/alert_text`
     * :octicons-arrow-right-24: `GET /session/:sessionId/alert/text`
 * `POST /session/:sessionId/alert_text`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/text`
 * `POST /session/:sessionId/appium/app/background`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: backgroundApp` [^xcui] [^uia2] [^espr]
+    `mobile: backgroundApp` :material-apple: :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/app/close`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: terminateApp` [^xcui] [^uia2] [^espr]
-        * `macos: terminateApp` [^mac]
-        * `windows: closeApp` [^win]
+        * `mobile: terminateApp` :material-apple: :material-android: :material-coffee:
+        * `macos: terminateApp` :material-apple-finder:
+        * `windows: closeApp` :material-microsoft-windows:
 * `POST /session/:sessionId/appium/app/end_test_coverage`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/appium/app/launch`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: launchApp` [^xcui]
-        * `mobile: activateApp` [^uia2] [^espr]
-        * `macos: launchApp` or `macos: activateApp` [^mac]
-        * `windows: launchApp` [^win]
+        * `mobile: launchApp` :material-apple:
+        * `mobile: activateApp` :material-android: :material-coffee:
+        * `macos: launchApp` or `macos: activateApp` :material-apple-finder:
+        * `windows: launchApp` :material-microsoft-windows:
 * `POST /session/:sessionId/appium/app/reset`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: clearApp` [^xcui] [^uia2] [^espr]
-    * :octicons-info-24: XCUITest driver supports this only in simulators
+    `mobile: clearApp` :material-apple: [^sim] :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/app/strings`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: getAppStrings` [^xcui] [^uia2] [^espr]
+    `mobile: getAppStrings` :material-apple: :material-android: :material-coffee:
 * `GET /session/:sessionId/appium/device/app_state`
     * :octicons-arrow-right-24: `POST /session/:sessionId/appium/device/app_state`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: queryAppState` [^xcui] [^uia2] [^espr]
-        * `macos: queryAppState` [^mac]
+        * `mobile: queryAppState` :material-apple: :material-android: :material-coffee:
+        * `macos: queryAppState` :material-apple-finder:
 * `GET /session/:sessionId/appium/device/current_activity`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: getCurrentActivity` [^uia2] [^espr]
+    `mobile: getCurrentActivity` :material-android: :material-coffee:
 * `GET /session/:sessionId/appium/device/current_package`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: getCurrentPackage` [^uia2] [^espr]
+    `mobile: getCurrentPackage` :material-android: :material-coffee:
 * `GET /session/:sessionId/appium/device/display_density`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: getDisplayDensity` [^uia2] [^espr]
+    `mobile: getDisplayDensity` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/device/finger_print`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: fingerPrint` [^uia2] [^espr] [^sim]
+    `mobile: fingerPrint` :material-android: [^sim] :material-coffee: [^sim]
 * `POST /session/:sessionId/appium/device/get_clipboard`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: getClipboard` [^xcui] [^uia2] [^espr]
-        * `mobile: getPasteboard` [^xcui] [^sim]
-        * `windows: getClipboard` [^win]
+        * `mobile: getClipboard` :material-apple: :material-android: :material-coffee:
+        * `mobile: getPasteboard` :material-apple: [^sim]
+        * `windows: getClipboard` :material-microsoft-windows:
 * `POST /session/:sessionId/appium/device/gsm_call`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: gsmCall` [^uia2] [^espr] [^sim]
+    `mobile: gsmCall` :material-android: [^sim] :material-coffee: [^sim]
 * `POST /session/:sessionId/appium/device/gsm_signal`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: gsmSignal` [^uia2] [^espr] [^sim]
+    `mobile: gsmSignal` :material-android: [^sim] :material-coffee: [^sim]
 * `POST /session/:sessionId/appium/device/gsm_voice`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: gsmVoice` [^uia2] [^espr] [^sim]
+    `mobile: gsmVoice` :material-android: [^sim] :material-coffee: [^sim]
 * `POST /session/:sessionId/appium/device/is_locked`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: isLocked` [^xcui] [^uia2] [^espr]
+    `mobile: isLocked` :material-apple: :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/device/keyevent`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: pressKey` [^uia2] [^espr]
-        * `macos: keys` [^mac]
-        * `windows: keys` [^win]
-    * :octicons-info-24: XCUITest driver also supports `mobile: keys` on iPadOS
+        * `mobile: keys` :material-apple: (iPadOS only)
+        * `mobile: pressKey` :material-android: :material-coffee:
+        * `macos: keys` :material-apple-finder:
+        * `windows: keys` :material-microsoft-windows:
 * `POST /session/:sessionId/appium/device/lock`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: lock` [^xcui] [^uia2] [^espr]
+    `mobile: lock` :material-apple: :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/device/long_press_keycode`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: pressKey` [^uia2] [^espr]
+    `mobile: pressKey` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/device/network_speed`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: networkSpeed` [^uia2] [^espr] [^sim]
+    `mobile: networkSpeed` :material-android: [^sim] :material-coffee: [^sim]
 * `POST /session/:sessionId/appium/device/open_notifications`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: statusBar` [^uia2] [^espr]
-        * `mobile: openNotifications` [^uia2]
+        * `mobile: statusBar` :material-android: :material-coffee:
+        * `mobile: openNotifications` :material-android:
 * `POST /session/:sessionId/appium/device/power_ac`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: powerAC` [^uia2] [^espr] [^sim]
+    `mobile: powerAC` :material-android: [^sim] :material-coffee: [^sim]
 * `POST /session/:sessionId/appium/device/power_capacity`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: powerCapacity` [^uia2] [^espr] [^sim]
+    `mobile: powerCapacity` :material-android: [^sim] :material-coffee: [^sim]
 * `POST /session/:sessionId/appium/device/press_keycode`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: pressKey` [^uia2] [^espr]
-        * `macos: keys` [^mac]
-        * `windows: keys` [^win]
-    * :octicons-info-24: XCUITest driver also supports `mobile: keys` on iPadOS
+        * `mobile: keys` :material-apple: (iPadOS only)
+        * `mobile: pressKey` :material-android: :material-coffee:
+        * `macos: keys` :material-apple-finder:
+        * `windows: keys` :material-microsoft-windows:
 * `POST /session/:sessionId/appium/device/send_sms`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: sendSms` [^uia2] [^espr] [^sim]
+    `mobile: sendSms` :material-android: [^sim] :material-coffee: [^sim]
 * `POST /session/:sessionId/appium/device/set_clipboard`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: setClipboard` [^xcui] [^uia2] [^espr]
-        * `mobile: setPasteboard` [^xcui] [^sim]
-        * `windows: setClipboard` [^win]
+        * `mobile: setClipboard` :material-apple: :material-android: :material-coffee:
+        * `mobile: setPasteboard` :material-apple: [^sim]
+        * `windows: setClipboard` :material-microsoft-windows:
 * `POST /session/:sessionId/appium/device/shake`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: shake` [^xcui] [^sim]
+    `mobile: shake` :material-apple: [^sim]
 * `POST /session/:sessionId/appium/device/start_activity`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: startActivity` [^uia2] [^espr]
+    `mobile: startActivity` :material-android: :material-coffee:
 * `GET /session/:sessionId/appium/device/system_bars`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: deviceScreenInfo` [^xcui]
-        * `mobile: getSystemBars` [^uia2] [^espr]
+        * `mobile: deviceScreenInfo` :material-apple:
+        * `mobile: getSystemBars` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/device/toggle_airplane_mode`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: setConnectivity` [^uia2] [^espr]
+    `mobile: setConnectivity` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/device/toggle_data`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: setConnectivity` [^uia2] [^espr]
+    `mobile: setConnectivity` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/device/toggle_location_services`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: toggleGps` [^uia2] [^espr]
+    `mobile: toggleGps` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/device/toggle_wifi`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: setConnectivity` [^uia2] [^espr]
+    `mobile: setConnectivity` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/device/unlock`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: unlock` [^xcui] [^uia2] [^espr]
+    `mobile: unlock` :material-apple: :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/element/:elementId/value`
     * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
 * `POST /session/:sessionId/appium/element/:elementId/replace_value`
     * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
 * `POST /session/:sessionId/appium/getPerformanceData`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: getPerformanceData` [^uia2] [^espr]
+    `mobile: getPerformanceData` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/performanceData/types`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: getPerformanceDataTypes` [^uia2] [^espr]
+    `mobile: getPerformanceDataTypes` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/receive_async_response`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/appium/simulator/toggle_touch_id_enrollment`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: enrollBiometric` [^xcui] [^sim]
+    `mobile: enrollBiometric` :material-apple: [^sim]
 * `POST /session/:sessionId/appium/simulator/touch_id`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
-    `mobile: sendBiometricMatch` [^xcui] [^sim]
+    `mobile: sendBiometricMatch` :material-apple: [^sim]
 * `POST /session/:sessionId/appium/start_recording_screen`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: startXCTestScreenRecording` [^xcui]
-        * `mobile: startMediaProjectionRecording` [^uia2] [^espr]
-        * `macos: startRecordingScreen` or `macos: startNativeScreenRecording` [^mac]
-        * `windows: startRecordingScreen` [^win]
+        * `mobile: startXCTestScreenRecording` :material-apple:
+        * `mobile: startMediaProjectionRecording` :material-android: :material-coffee:
+        * `macos: startRecordingScreen` or `macos: startNativeScreenRecording` :material-apple-finder:
+        * `windows: startRecordingScreen` :material-microsoft-windows:
 * `POST /session/:sessionId/appium/stop_recording_screen`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: stopXCTestScreenRecording` [^xcui]
-        * `mobile: stopMediaProjectionRecording` [^uia2] [^espr]
-        * `macos: stopRecordingScreen` or `macos: stopNativeScreenRecording` [^mac]
-        * `windows: stopRecordingScreen` [^win]
+        * `mobile: stopXCTestScreenRecording` :material-apple:
+        * `mobile: stopMediaProjectionRecording` :material-android: :material-coffee:
+        * `macos: stopRecordingScreen` or `macos: stopNativeScreenRecording` :material-apple-finder:
+        * `windows: stopRecordingScreen` :material-microsoft-windows:
 * `GET /session/:sessionId/application_cache/status`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/buttondown`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` action
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys` [^win]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys` :material-microsoft-windows:
 * `POST /session/:sessionId/buttonup`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerUp` action
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys` [^win]
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys` :material-microsoft-windows:
 * `POST /session/:sessionId/click`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
     `pointerUp` actions
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `macos: click` or `macos: rightClick` [^mac]
-        * `windows: click` [^win]
+        * `macos: click` or `macos: rightClick` :material-apple-finder:
+        * `windows: click` :material-microsoft-windows:
 * `POST /session/:sessionId/dismiss_alert`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/dismiss`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `mobile: alert` [^xcui]
-        * `mobile: dismissAlert` [^uia2]
+        * `mobile: alert` :material-apple:
+        * `mobile: dismissAlert` :material-android:
 * `POST /session/:sessionId/doubleclick`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
     `pointerUp` actions
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `macos: doubleClick` [^mac]
-        * `windows: click` [^win]
+        * `macos: doubleClick` :material-apple-finder:
+        * `windows: click` :material-microsoft-windows:
 * `POST /session/:sessionId/element/active`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/active`
 * `GET /session/:sessionId/element/:elementId/equals/:otherId`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `GET /session/:sessionId/element/:elementId/location`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
 * `GET /session/:sessionId/element/:elementId/location_in_view`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `GET /session/:sessionId/element/:elementId/pageIndex`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `GET /session/:sessionId/element/:elementId/size`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
 * `POST /session/:sessionId/element/:elementId/submit`
-    * :octicons-no-entry-fill-12: No replacement available - the form submission button needs
+    * :octicons-no-entry-24: No replacement available - the form submission button needs
     to be clicked
 * `POST /session/:sessionId/execute`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync`
@@ -302,17 +318,17 @@ replacement endpoints are also listed, along with any extra information.
 * `POST /session/:sessionId/keys`
     * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
 * `GET /session/:sessionId/local_storage`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/local_storage`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `DELETE /session/:sessionId/local_storage`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `GET /session/:sessionId/local_storage/key/:key`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `DELETE /session/:sessionId/local_storage/key/:key`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `GET /session/:sessionId/local_storage/size`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/log`
     * :octicons-arrow-right-24: `POST /session/:sessionId/se/log`
 * `GET /session/:sessionId/log/types`
@@ -322,17 +338,17 @@ replacement endpoints are also listed, along with any extra information.
 * `GET /session/:sessionId/screenshot/:elementId`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/screenshot`
 * `GET /session/:sessionId/session_storage`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/session_storage`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `DELETE /session/:sessionId/session_storage`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `GET /session/:sessionId/session_storage/key/:key`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `DELETE /session/:sessionId/session_storage/key/:key`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `GET /session/:sessionId/session_storage/size`
-    * :octicons-no-entry-fill-12: No replacement available
+    * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/timeouts/async_script`
     * :octicons-arrow-right-24: `POST /session/:sessionId/timeouts`
 * `POST /session/:sessionId/timeouts/implicit_wait`
@@ -404,9 +420,4 @@ still accepts in Appium 3.
     * :octicons-x-24: `name`
     * :octicons-check-24: `handle`
 
-[^xcui]: Supported in [XCUITest driver](https://appium.github.io/appium-xcuitest-driver/latest/)
-[^uia2]: Supported in [UiAutomator2 driver](https://github.com/appium/appium-uiautomator2-driver/)
-[^espr]: Supported in [Espresso driver](https://github.com/appium/appium-espresso-driver)
-[^mac]: Supported in [Mac2 driver](https://github.com/appium/appium-mac2-driver)
-[^win]: Supported in [Windows driver](https://github.com/appium/appium-windows-driver)
 [^sim]: Supported in emulators/simulators only

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -94,9 +94,7 @@ The following are all endpoints removed in Appium 3. Where applicable, a replace
 also listed, along with any extra information.
 
 * `GET /sessions`
-    * :octicons-arrow-right-24: `GET /appium/sessions`
-    * :octicons-info-24: Each session object also includes the `created` field with
-    the session creation Unix timestamp
+    * :octicons-arrow-right-24: `GET /appium/sessions`[^1]
 * `POST /session/:sessionId/accept_alert`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/accept`
 * `GET /session/:sessionId/alert_text`
@@ -104,169 +102,125 @@ also listed, along with any extra information.
 * `POST /session/:sessionId/alert_text`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/text`
 * `POST /session/:sessionId/appium/app/background`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: backgroundApp`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: backgroundApp` [^esp] [^uia2] [^xcui]
 * `POST /session/:sessionId/appium/app/close`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: terminateApp`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: terminateApp` [^esp] [^uia2] [^xcui]
 * `POST /session/:sessionId/appium/app/end_test_coverage`
     * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/appium/app/launch`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: launchApp`
-    * :octicons-info-24: Supported in drivers: XCUITest
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: launchApp` [^xcui]
     * :octicons-info-24: Espresso and UiAutomator2 drivers also have `mobile: activateApp`
 * `POST /session/:sessionId/appium/app/reset`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: clearApp`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest (simulator only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: clearApp` [^esp] [^uia2] [^xcui]
+    * :octicons-info-24: XCUITest driver supports this only in simulators
 * `POST /session/:sessionId/appium/app/strings`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getAppStrings`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getAppStrings` [^esp] [^uia2] [^xcui]
 * `GET /session/:sessionId/appium/device/app_state`
     * :octicons-arrow-right-24: `POST /session/:sessionId/appium/device/app_state`
 * `GET /session/:sessionId/appium/device/current_activity`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getCurrentActivity`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getCurrentActivity` [^esp] [^uia2]
 * `GET /session/:sessionId/appium/device/current_package`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getCurrentPackage`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getCurrentPackage` [^esp] [^uia2]
 * `GET /session/:sessionId/appium/device/display_density`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getDisplayDensity`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getDisplayDensity` [^esp] [^uia2]
 * `POST /session/:sessionId/appium/device/finger_print`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: fingerPrint`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: fingerPrint` [^esp] [^uia2] [^sim]
 * `POST /session/:sessionId/appium/device/get_clipboard`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getClipboard`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getClipboard` [^esp] [^uia2] [^xcui]
 * `POST /session/:sessionId/appium/device/gsm_call`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmCall`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmCall` [^esp] [^uia2] [^sim]
 * `POST /session/:sessionId/appium/device/gsm_signal`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmSignal`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmSignal` [^esp] [^uia2] [^sim]
 * `POST /session/:sessionId/appium/device/gsm_voice`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmVoice`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmVoice` [^esp] [^uia2] [^sim]
 * `POST /session/:sessionId/appium/device/is_locked`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: isLocked`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: isLocked` [^esp] [^uia2] [^xcui]
 * `POST /session/:sessionId/appium/device/keyevent`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey` [^esp] [^uia2]
 * `POST /session/:sessionId/appium/device/lock`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: lock`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: lock` [^esp] [^uia2] [^xcui]
 * `POST /session/:sessionId/appium/device/long_press_keycode`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey` [^esp] [^uia2]
     * :octicons-info-24: Set the `isLongPress` value in the payload data
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
 * `POST /session/:sessionId/appium/device/network_speed`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: networkSpeed`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: networkSpeed` [^esp] [^uia2] [^sim]
 * `POST /session/:sessionId/appium/device/open_notifications`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: statusBar`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: statusBar` [^esp] [^uia2]
     * :octicons-info-24: Set the `command` value in the payload data to `expandNotifications`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (which also has `mobile: openNotifications`)
+    * :octicons-info-24: UiAutomator2 driver also has `mobile: openNotifications`
 * `POST /session/:sessionId/appium/device/power_ac`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: powerAC`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: powerAC` [^esp] [^uia2] [^sim]
 * `POST /session/:sessionId/appium/device/power_capacity`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: powerCapacity`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: powerCapacity` [^esp] [^uia2] [^sim]
 * `POST /session/:sessionId/appium/device/press_keycode`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey` [^esp] [^uia2]
     * :octicons-info-24: XCUITest driver also has `mobile: pressButton`
 * `POST /session/:sessionId/appium/device/send_sms`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: sendSms`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: sendSms` [^esp] [^uia2] [^sim]
 * `POST /session/:sessionId/appium/device/set_clipboard`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setClipboard`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setClipboard` [^esp] [^uia2] [^xcui]
 * `POST /session/:sessionId/appium/device/shake`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: shake`
-    * :octicons-info-24: Supported in drivers: XCUITest (simulator only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: shake` [^xcui] [^sim]
 * `POST /session/:sessionId/appium/device/start_activity`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: startActivity`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: startActivity` [^esp] [^uia2]
 * `GET /session/:sessionId/appium/device/system_bars`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getSystemBars`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getSystemBars` [^esp] [^uia2]
     * :octicons-info-24: XCUITest driver also has `mobile: deviceScreenInfo`
 * `POST /session/:sessionId/appium/device/toggle_airplane_mode`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity` [^esp] [^uia2]
     * :octicons-info-24: Set the `airplaneMode` value in the payload data
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
 * `POST /session/:sessionId/appium/device/toggle_data`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity` [^esp] [^uia2]
     * :octicons-info-24: Set the `data` value in the payload data
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
 * `POST /session/:sessionId/appium/device/toggle_location_services`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: toggleGps`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: toggleGps` [^esp] [^uia2]
 * `POST /session/:sessionId/appium/device/toggle_wifi`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity` [^esp] [^uia2]
     * :octicons-info-24: Set the `wifi` value in the payload data
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
 * `POST /session/:sessionId/appium/device/unlock`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: unlock`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: unlock` [^esp] [^uia2] [^xcui]
 * `POST /session/:sessionId/appium/element/:elementId/value`
     * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
 * `POST /session/:sessionId/appium/element/:elementId/replace_value`
     * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
 * `POST /session/:sessionId/appium/getPerformanceData`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getPerformanceData`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getPerformanceData` [^esp] [^uia2]
 * `POST /session/:sessionId/appium/performanceData/types`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getPerformanceDataTypes`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getPerformanceDataTypes` [^esp] [^uia2]
 * `POST /session/:sessionId/appium/receive_async_response`
     * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/appium/simulator/toggle_touch_id_enrollment`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: enrollBiometric`
-    * :octicons-info-24: Supported in drivers: XCUITest (simulator only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: enrollBiometric` [^xcui] [^sim]
 * `POST /session/:sessionId/appium/simulator/touch_id`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: sendBiometricMatch`
-    * :octicons-info-24: Supported in drivers: XCUITest (simulator only)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: sendBiometricMatch` [^xcui] [^sim]
 * `POST /session/:sessionId/appium/start_recording_screen`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: startMediaProjectionRecording`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: startMediaProjectionRecording` [^esp] [^uia2]
 * `POST /session/:sessionId/appium/stop_recording_screen`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: stopMediaProjectionRecording`
-    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: stopMediaProjectionRecording` [^esp] [^uia2]
 * `GET /session/:sessionId/application_cache/status`
     * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/buttondown`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerDown` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown`)
 * `POST /session/:sessionId/buttonup`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerUp` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerUp`)
 * `POST /session/:sessionId/click`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerDown` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerUp`)
 * `POST /session/:sessionId/dismiss_alert`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/dismiss`
 * `POST /session/:sessionId/doubleclick`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerDown` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerUp`)
 * `POST /session/:sessionId/element/active`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/active`
 * `GET /session/:sessionId/element/:elementId/equals/:otherId`
     * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/element/:elementId/location`
-    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
-    * :octicons-info-24: Response also includes the `width` and `height` fields with the element
-    size values
+    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect` [^1]
 * `GET /session/:sessionId/element/:elementId/location_in_view`
     * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/element/:elementId/pageIndex`
     * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/element/:elementId/size`
-    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
-    * :octicons-info-24: Response also includes the `x` and `y` fields with the element location
-    values
+    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect` [^1]
 * `POST /session/:sessionId/element/:elementId/submit`
     * :octicons-no-entry-fill-12: No replacement available - the form submission button needs
     to be clicked
@@ -294,8 +248,7 @@ also listed, along with any extra information.
 * `GET /session/:sessionId/log/types`
     * :octicons-arrow-right-24: `GET /session/:sessionId/se/log/types`
 * `POST /session/:sessionId/moveto`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerMove` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerMove`)
 * `GET /session/:sessionId/screenshot/:elementId`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/screenshot`
 * `GET /session/:sessionId/session_storage`
@@ -317,33 +270,25 @@ also listed, along with any extra information.
     * :octicons-arrow-right-24: `POST /session/:sessionId/timeouts`
     * :octicons-info-24: Set the `implicit` value in the payload data
 * `POST /session/:sessionId/touch/click`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerDown` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerUp`)
 * `POST /session/:sessionId/touch/doubleclick`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerDown` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerUp`)
 * `POST /session/:sessionId/touch/down`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerDown` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown`)
 * **`POST /session/:sessionId/touch/flick`**
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerDown`, `pointerMove` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerMove` / `pointerUp`)
 * **`POST /session/:sessionId/touch/longclick`**
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerDown`, `pause` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pause` / `pointerUp`)
 * `POST /session/:sessionId/touch/multi/perform`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
 * `POST /session/:sessionId/touch/move`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerMove` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerMove`)
 * `POST /session/:sessionId/touch/perform`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
 * `POST /session/:sessionId/touch/scroll`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerDown`, `pointerMove` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerDown` / `pointerMove` / `pointerUp`)
 * `POST /session/:sessionId/touch/up`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
-    * :octicons-info-24: Use the `pointerUp` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` (`pointerUp`)
 * `GET /session/:sessionId/window_handle`
     * :octicons-arrow-right-24: `GET /session/:sessionId/window`
 * `GET /session/:sessionId/window/handle`
@@ -352,20 +297,14 @@ also listed, along with any extra information.
     * :octicons-arrow-right-24: `POST /session/:sessionId/window/maximize`
     * :fontawesome-solid-triangle-exclamation: Only supported for the current window
 * `GET /session/:sessionId/window/:windowhandle/position`
-    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect` [^1]
     * :fontawesome-solid-triangle-exclamation: Only supported for the current window
-    * :octicons-info-24: Response also includes the `width` and `height` fields with
-    the window size values
 * `POST /session/:sessionId/window/:windowhandle/position`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/window/rect`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/window/rect` [^2]
     * :fontawesome-solid-triangle-exclamation: Only supported for the current window
-    * :octicons-info-24: Also supports the `width` and `height` fields for setting the
-    window size
 * `GET /session/:sessionId/window/:windowhandle/size`
-    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect` [^1]
     * :fontawesome-solid-triangle-exclamation: Only supported for the current window
-    * :octicons-info-24: Response also includes the `x` and `y` fields with the window
-    position values
 
 ### Modified
 
@@ -391,3 +330,10 @@ still accepts in Appium 3.
 * `POST /session/:sessionId/window`
     * :octicons-x-24: `name`
     * :octicons-check-24: `handle`
+
+[^1]: Response includes additional fields
+[^2]: Request allows additional fields
+[^esp]: Supported in Espresso driver
+[^uia2]: Supported in UiAutomator2 driver
+[^xcui]: Supported in XCUITest driver
+[^sim]: Supported in emulators/simulators only

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -8,7 +8,9 @@ It contains a list of breaking changes, as well as suggestions for handling them
 While Appium 2 was a major overhaul of the entire Appium architecture, Appium 3 is a smaller
 upgrade with fewer breaking changes, which should result in a much simpler migration process.
 
-## Node 20+ Required
+## Breaking Changes
+
+### Node 20+ Required
 
 With Appium 2, the minimum required Node version was set to `14.17.0`. Support for Node 14 had
 already ended before the release of Appium 2, which meant that even users on outdated Node versions
@@ -21,22 +23,23 @@ Appium 3 drops support for outdated Node versions, and bumps the minimum require
 
     Upgrade Node.js to `v20.9.0` or newer, and `npm` to `v10` or newer
 
-## Old Endpoints Removed
+### Deprecated Endpoints Removed
 
-Appium 3 removes many server endpoints that do not conform to the endpoint template defined in the
-[W3C WebDriver specification](https://w3c.github.io/webdriver/#extensions-0). Nearly all of these
-have direct or close-to-direct replacements in either standard W3C endpoints, other Appium
-endpoints, or driver-specific extension commands.
+Appium 3 removes many previously deprecated server endpoints. Nearly all of these have direct or
+close-to-direct replacements in either standard W3C endpoints, other Appium endpoints, or
+driver-specific extension commands. These endpoints, along with replacements (where applicable)
+are listed [in the **Removed Endpoints** section](#removed).
 
-A full list of these endpoints, along with replacements (where applicable) is available
-[at the bottom of this page](#removed-endpoints).
+Some standard W3C endpoints used in Appium 2 were also present in the old JSONWP specification, but
+required different parameters. Appium 3 changes these endpoints to only accept the W3C parameters.
+These endpoints are listed [in the **Modified Endpoints** section](#modified).
 
 !!! info "Actions Needed"
 
     Check your Appium client documentation for the affected methods, and adjust your code to use
     their replacements
 
-## Feature Flag Prefix Required
+### Feature Flag Prefix Required
 
 With Appium 2, it was possible to opt into certain [insecure features](http://appium.io/docs/en/latest/guides/security/)
 on server startup, which could be enabled using the `--allow-insecure` or `--relaxed-security`
@@ -64,7 +67,7 @@ without a scope. Note that the behavior of the `--relaxed-security` flag remains
     appium --allow-insecure=*:adb_shell
     ```
 
-## Unzip Logic Removed
+### Unzip Logic Removed
 
 Appium 3 removes the custom unzip logic used when working with files such as application packages.
 Such files are often only relevant to particular platforms, therefore the functionality for
@@ -74,7 +77,7 @@ handling such operations has been moved to relevant drivers.
 
     Ensure you are using the most recent versions of your drivers
 
-## Express 5
+### Express 5
 
 Appium 3 upgrades the internally-used `express` dependency from `v4` to `v5`. This should not
 affect users who use Appium directly, but developers integrating parts of Appium into their own
@@ -84,4 +87,177 @@ projects may want to check [the Express 5 Migration Guide](https://expressjs.com
 
     None! (hopefully)
 
-## Removed Endpoints
+## Endpoint Changes
+### Removed
+
+The following are all endpoints removed in Appium 3. Where applicable, a replacement endpoint is
+also listed, along with any extra information.
+
+* `GET /sessions`
+    * :octicons-arrow-right-24: `GET /appium/sessions`
+    * :octicons-info-24: Each session object also includes the `created` field with
+    the session creation Unix timestamp
+* `POST /session/:sessionId/accept_alert`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/alert/accept`
+* `GET /session/:sessionId/alert_text`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/alert/text`
+* `POST /session/:sessionId/alert_text`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/alert/text`
+* `GET /session/:sessionId/appium/device/app_state`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/appium/device/app_state`
+* `GET /session/:sessionId/application_cache/status`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `POST /session/:sessionId/buttondown`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerDown` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `POST /session/:sessionId/buttonup`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerUp` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `POST /session/:sessionId/click`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerDown` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `POST /session/:sessionId/dismiss_alert`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/alert/dismiss`
+* `POST /session/:sessionId/doubleclick`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerDown` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `POST /session/:sessionId/element/active`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/element/active`
+* `GET /session/:sessionId/element/:elementId/equals/:otherId`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `GET /session/:sessionId/element/:elementId/location`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
+    * :octicons-info-24: Response also includes the `width` and `height` fields with the element
+    size values
+* `GET /session/:sessionId/element/:elementId/location_in_view`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `GET /session/:sessionId/element/:elementId/pageIndex`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `GET /session/:sessionId/element/:elementId/size`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
+    * :octicons-info-24: Response also includes the `x` and `y` fields with the element location
+    values
+* `POST /session/:sessionId/element/:elementId/submit`
+    * :octicons-no-entry-fill-12: No W3C replacement available - the form submission button needs
+    to be clicked
+* `POST /session/:sessionId/execute`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync`
+* `POST /session/:sessionId/execute_async`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/async`
+* `POST /session/:sessionId/keys`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
+    * :fontawesome-solid-triangle-exclamation: Now requires the element ID
+* `GET /session/:sessionId/local_storage`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `POST /session/:sessionId/local_storage`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `DELETE /session/:sessionId/local_storage`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `GET /session/:sessionId/local_storage/key/:key`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `DELETE /session/:sessionId/local_storage/key/:key`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `GET /session/:sessionId/local_storage/size`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `POST /session/:sessionId/log`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/se/log`
+* `POST /session/:sessionId/log/types`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/se/log/types`
+* `POST /session/:sessionId/moveto`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerMove` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `GET /session/:sessionId/screenshot/:elementId`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/screenshot`
+* `GET /session/:sessionId/session_storage`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `POST /session/:sessionId/session_storage`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `DELETE /session/:sessionId/session_storage`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `GET /session/:sessionId/session_storage/key/:key`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `DELETE /session/:sessionId/session_storage/key/:key`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `GET /session/:sessionId/session_storage/size`
+    * :octicons-no-entry-fill-12: No W3C replacement available
+* `POST /session/:sessionId/timeouts/async_script`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/timeouts`
+    * :octicons-info-24: Set the `script` value in the payload data
+* `POST /session/:sessionId/timeouts/implicit_wait`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/timeouts`
+    * :octicons-info-24: Set the `implicit` value in the payload data
+* `POST /session/:sessionId/touch/click`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerDown` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `POST /session/:sessionId/touch/doubleclick`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerDown` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `POST /session/:sessionId/touch/down`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerDown` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* **`POST /session/:sessionId/touch/flick`**
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerDown`, `pointerMove` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* **`POST /session/:sessionId/touch/longclick`**
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerDown`, `pause` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `POST /session/:sessionId/touch/multi/perform`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+* `POST /session/:sessionId/touch/move`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerMove` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `POST /session/:sessionId/touch/perform`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+* `POST /session/:sessionId/touch/scroll`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerDown`, `pointerMove` and `pointerUp` actions in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `POST /session/:sessionId/touch/up`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
+    * :octicons-info-24: Use the `pointerUp` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
+* `GET /session/:sessionId/window_handle`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/window`
+* `GET /session/:sessionId/window/handle`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/window`
+* `POST /session/:sessionId/window/:windowhandle/maximize`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/window/maximize`
+    * :fontawesome-solid-triangle-exclamation: Only supported for the current window
+* `GET /session/:sessionId/window/:windowhandle/position`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect`
+    * :fontawesome-solid-triangle-exclamation: Only supported for the current window
+    * :octicons-info-24: Response also includes the `width` and `height` fields with
+    the window size values
+* `POST /session/:sessionId/window/:windowhandle/position`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/window/rect`
+    * :fontawesome-solid-triangle-exclamation: Only supported for the current window
+    * :octicons-info-24: Also supports the `width` and `height` fields for setting the
+    window size
+* `GET /session/:sessionId/window/:windowhandle/size`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/window/rect`
+    * :fontawesome-solid-triangle-exclamation: Only supported for the current window
+    * :octicons-info-24: Response also includes the `x` and `y` fields with the window
+    position values
+
+### Modified
+
+The following are all endpoints modified in Appium 3, by removing handling for old or unused
+parameters. Each endpoint lists the parameters it no longer accepts, as well as the parameters it
+still accepts in Appium 3.
+
+* `POST /session`
+    * :octicons-x-24: `desiredCapabilities`, `requiredCapabilities`
+    * :octicons-check-24: `capabilities`
+* `POST /session/:sessionId/alert/text`
+    * :octicons-x-24: `value`
+    * :octicons-check-24: `text`
+* `GET /session/:sessionId/appium/device/system_time`
+    * :octicons-x-24: `format`
+    * :octicons-check-24: None
+* `POST /session/:sessionId/element/:elementId/value`
+    * :octicons-x-24: `value`
+    * :octicons-check-24: `text`
+* `POST /session/:sessionId/timeouts`
+    * :octicons-x-24: `type`, `ms`
+    * :octicons-check-24: `script`, `pageLoad`, `implicit`
+* `POST /session/:sessionId/window`
+    * :octicons-x-24: `name`
+    * :octicons-check-24: `handle`

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -275,16 +275,15 @@ the drivers which support that option:
     * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/buttondown`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` action
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys` :material-microsoft-windows:
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys`
+    :material-microsoft-windows:
 * `POST /session/:sessionId/buttonup`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerUp` action
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys` :material-microsoft-windows:
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys`
+    :material-microsoft-windows:
 * `POST /session/:sessionId/click`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
     `pointerUp` actions
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `macos: click` or `macos: rightClick` :material-apple-finder:
-        * `windows: click` :material-microsoft-windows:
 * `POST /session/:sessionId/dismiss_alert`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/dismiss`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
@@ -293,9 +292,6 @@ the drivers which support that option:
 * `POST /session/:sessionId/doubleclick`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
     `pointerUp` actions
-    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
-        * `macos: doubleClick` :material-apple-finder:
-        * `windows: click` :material-microsoft-windows:
 * `POST /session/:sessionId/element/active`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/active`
 * `GET /session/:sessionId/element/:elementId/equals/:otherId`
@@ -309,14 +305,13 @@ the drivers which support that option:
 * `GET /session/:sessionId/element/:elementId/size`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
 * `POST /session/:sessionId/element/:elementId/submit`
-    * :octicons-no-entry-24: No replacement available - the form submission button needs
-    to be clicked
+    * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/execute`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync`
 * `POST /session/:sessionId/execute_async`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/async`
 * `POST /session/:sessionId/keys`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
+    * :octicons-no-entry-24: No replacement available
 * `GET /session/:sessionId/local_storage`
     * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/local_storage`
@@ -356,17 +351,39 @@ the drivers which support that option:
 * `POST /session/:sessionId/touch/click`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
     `pointerUp` actions
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: tap` or `mobile: tapWithNumberOfTaps` :material-apple:
+        * `mobile: clickGesture` :material-android:
+        * `mobile: clickAction` :material-coffee:
+        * `macos: click`, `macos: rightClick`, `macos: press` or `macos: tap` :material-apple-finder:
+        * `windows: click` :material-microsoft-windows:
 * `POST /session/:sessionId/touch/doubleclick`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
     `pointerUp` actions
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: doubleTap` or `mobile: tapWithNumberOfTaps` :material-apple:
+        * `mobile: doubleClickGesture` :material-android:
+        * `mobile: clickAction` :material-coffee:
+        * `macos: doubleClick` or `macos: doubleTap` :material-apple-finder:
+        * `windows: click` :material-microsoft-windows:
 * `POST /session/:sessionId/touch/down`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` action
-* **`POST /session/:sessionId/touch/flick`**
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys`
+    :material-microsoft-windows:
+* `POST /session/:sessionId/touch/flick`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown`,
     `pointerMove` & `pointerUp` actions
-* **`POST /session/:sessionId/touch/longclick`**
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: flingGesture`
+    :material-android:
+* `POST /session/:sessionId/touch/longclick`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown`, `pause`
     & `pointerUp` actions
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: touchAndHold` :material-apple:
+        * `mobile: longClickGesture` :material-android:
+        * `mobile: clickAction` :material-coffee:
+        * `macos: press` :material-apple-finder:
+        * `windows: click` :material-microsoft-windows:
 * `POST /session/:sessionId/touch/multi/perform`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
 * `POST /session/:sessionId/touch/move`
@@ -376,8 +393,16 @@ the drivers which support that option:
 * `POST /session/:sessionId/touch/scroll`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown`,
     `pointerMove` & `pointerUp` actions
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
+        * `mobile: scroll` or `mobile: swipe` :material-apple:
+        * `mobile: scrollGesture` or `mobile: swipeGesture` :material-android:
+        * `mobile: swipe` :material-coffee:
+        * `macos: scroll` or `macos: swipe` :material-apple-finder:
+        * `windows: scroll` :material-microsoft-windows:
 * `POST /session/:sessionId/touch/up`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerUp` action
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys`
+    :material-microsoft-windows:
 * `GET /session/:sessionId/window_handle`
     * :octicons-arrow-right-24: `GET /session/:sessionId/window`
 * `GET /session/:sessionId/window/handle`

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -1,0 +1,87 @@
+---
+title: Migrating to Appium 3
+---
+
+This document is a guide for those who are using Appium 2 and would like to upgrade to Appium 3.
+It contains a list of breaking changes, as well as suggestions for handling them.
+
+While Appium 2 was a major overhaul of the entire Appium architecture, Appium 3 is a smaller
+upgrade with fewer breaking changes, which should result in a much simpler migration process.
+
+## Node 20+ Required
+
+With Appium 2, the minimum required Node version was set to `14.17.0`. Support for Node 14 had
+already ended before the release of Appium 2, which meant that even users on outdated Node versions
+were able to use it.
+
+Appium 3 drops support for outdated Node versions, and bumps the minimum required version to Node
+`20.9.0`, as well as the minimum `npm` version to `10`.
+
+!!! info "Actions Needed"
+
+    Upgrade Node.js to `v20.9.0` or newer, and `npm` to `v10` or newer
+
+## Old Endpoints Removed
+
+Appium 3 removes many server endpoints that do not conform to the endpoint template defined in the
+[W3C WebDriver specification](https://w3c.github.io/webdriver/#extensions-0). Nearly all of these
+have direct or close-to-direct replacements in either standard W3C endpoints, other Appium
+endpoints, or driver-specific extension commands.
+
+A full list of these endpoints, along with replacements (where applicable) is available
+[at the bottom of this page](#removed-endpoints).
+
+!!! info "Actions Needed"
+
+    Check your Appium client documentation for the affected methods, and adjust your code to use
+    their replacements
+
+## Feature Flag Prefix Required
+
+With Appium 2, it was possible to opt into certain [insecure features](http://appium.io/docs/en/latest/guides/security/)
+on server startup, which could be enabled using the `--allow-insecure` or `--relaxed-security`
+flags. Appium `2.13` added the ability to optionally provide a scope prefix to specific features,
+ensuring that they would only be enabled for the specified driver (or all of them).
+
+Appium 3 makes the scope prefix mandatory, and will throw an error if features are specified
+without a scope. Note that the behavior of the `--relaxed-security` flag remains unchanged.
+
+!!! info "Actions Needed"
+
+    If you use the `--allow-insecure` server flag, add a scope prefix before each feature name.
+    For example, if you use the UiAutomator2 `adb_shell` feature, on Appium 2 you would enable it
+    like this:
+    ```
+    appium --allow-insecure=adb_shell
+    ```
+    On Appium 3, to ensure this feature is only activated for UiAutomator2, you can run it like so:
+    ```
+    appium --allow-insecure=uiautomator2:adb_shell
+    ```
+    Alternatively, if you wish to keep the Appium 2 behavior and enable the feature for _all_
+    drivers that support it, you can run it like so:
+    ```
+    appium --allow-insecure=*:adb_shell
+    ```
+
+## Unzip Logic Removed
+
+Appium 3 removes the custom unzip logic used when working with files such as application packages.
+Such files are often only relevant to particular platforms, therefore the functionality for
+handling such operations has been moved to relevant drivers.
+
+!!! info "Actions Needed"
+
+    Ensure you are using the most recent versions of your drivers
+
+## Express 5
+
+Appium 3 upgrades the internally-used `express` dependency from `v4` to `v5`. This should not
+affect users who use Appium directly, but developers integrating parts of Appium into their own
+projects may want to check [the Express 5 Migration Guide](https://expressjs.com/en/guide/migrating-5.html).
+
+!!! info "Actions Needed"
+
+    None! (hopefully)
+
+## Removed Endpoints

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -135,7 +135,7 @@ the drivers which support that option:
 * `POST /session/:sessionId/appium/app/launch`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
         * `mobile: launchApp` :material-apple:
-        * `mobile: activateApp` :material-android: :material-coffee:
+        * `mobile: activateApp` or `mobile: startActivity` :material-android: :material-coffee:
         * `macos: launchApp` or `macos: activateApp` :material-apple-finder:
         * `windows: launchApp` :material-microsoft-windows:
 * `POST /session/:sessionId/appium/app/reset`
@@ -253,7 +253,7 @@ the drivers which support that option:
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
     `mobile: getPerformanceDataTypes` :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/receive_async_response`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/async`
 * `POST /session/:sessionId/appium/simulator/toggle_touch_id_enrollment`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with
     `mobile: enrollBiometric` :material-apple: [^sim]

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -314,6 +314,7 @@ the drivers which support that option:
 * `POST /session/:sessionId/keys`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `keyDown` & `keyUp`
     actions
+        * Selenium-based clients can also use [Send Keys](https://www.selenium.dev/documentation/webdriver/actions_api/keyboard/#send-keys)
 * `GET /session/:sessionId/local_storage`
     * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/local_storage`
@@ -332,6 +333,7 @@ the drivers which support that option:
     * :octicons-arrow-right-24: `GET /session/:sessionId/se/log/types`
 * `POST /session/:sessionId/moveto`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerMove` action
+        * Selenium-based clients can also use [Move by Offset](https://www.selenium.dev/documentation/webdriver/actions_api/mouse/#move-by-offset)
 * `GET /session/:sessionId/screenshot/:elementId`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/screenshot`
 * `GET /session/:sessionId/session_storage`
@@ -353,6 +355,7 @@ the drivers which support that option:
 * `POST /session/:sessionId/touch/click`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
     `pointerUp` actions
+        * Selenium-based clients can also use [Click and Release](https://www.selenium.dev/documentation/webdriver/actions_api/mouse/#click-and-release)
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
         * `mobile: tap` or `mobile: tapWithNumberOfTaps` :material-apple:
         * `mobile: clickGesture` :material-android:
@@ -362,6 +365,7 @@ the drivers which support that option:
 * `POST /session/:sessionId/touch/doubleclick`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` &
     `pointerUp` actions
+        * Selenium-based clients can also use [Double Click](https://www.selenium.dev/documentation/webdriver/actions_api/mouse/#double-click)
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
         * `mobile: doubleTap` or `mobile: tapWithNumberOfTaps` :material-apple:
         * `mobile: doubleClickGesture` :material-android:
@@ -390,6 +394,7 @@ the drivers which support that option:
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
 * `POST /session/:sessionId/touch/move`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerMove` action
+        * Selenium-based clients can also use [Move by Offset](https://www.selenium.dev/documentation/webdriver/actions_api/mouse/#move-by-offset)
 * `POST /session/:sessionId/touch/perform`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
 * `POST /session/:sessionId/touch/scroll`

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -131,7 +131,8 @@ the drivers which support that option:
         * `macos: terminateApp` :material-apple-finder:
         * `windows: closeApp` :material-microsoft-windows:
 * `POST /session/:sessionId/appium/app/end_test_coverage`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: shell`
+    :material-android: :material-coffee:
 * `POST /session/:sessionId/appium/app/launch`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with one of:
         * `mobile: launchApp` :material-apple:
@@ -273,7 +274,7 @@ the drivers which support that option:
         * `macos: stopRecordingScreen` or `macos: stopNativeScreenRecording` :material-apple-finder:
         * `windows: stopRecordingScreen` :material-microsoft-windows:
 * `GET /session/:sessionId/application_cache/status`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `POST /session/:sessionId/buttondown`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `pointerDown` action
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `windows: keys`
@@ -296,17 +297,17 @@ the drivers which support that option:
 * `POST /session/:sessionId/element/active`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/active`
 * `GET /session/:sessionId/element/:elementId/equals/:otherId`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `GET /session/:sessionId/element/:elementId/location`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
 * `GET /session/:sessionId/element/:elementId/location_in_view`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `GET /session/:sessionId/element/:elementId/pageIndex`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: MJSONWP protocol command with no direct replacement
 * `GET /session/:sessionId/element/:elementId/size`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
 * `POST /session/:sessionId/element/:elementId/submit`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `POST /session/:sessionId/execute`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync`
 * `POST /session/:sessionId/execute_async`
@@ -316,17 +317,17 @@ the drivers which support that option:
     actions
         * Selenium-based clients can also use [Send Keys](https://www.selenium.dev/documentation/webdriver/actions_api/keyboard/#send-keys)
 * `GET /session/:sessionId/local_storage`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `POST /session/:sessionId/local_storage`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `DELETE /session/:sessionId/local_storage`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `GET /session/:sessionId/local_storage/key/:key`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `DELETE /session/:sessionId/local_storage/key/:key`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `GET /session/:sessionId/local_storage/size`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `POST /session/:sessionId/log`
     * :octicons-arrow-right-24: `POST /session/:sessionId/se/log`
 * `GET /session/:sessionId/log/types`
@@ -337,17 +338,17 @@ the drivers which support that option:
 * `GET /session/:sessionId/screenshot/:elementId`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/screenshot`
 * `GET /session/:sessionId/session_storage`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `POST /session/:sessionId/session_storage`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `DELETE /session/:sessionId/session_storage`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `GET /session/:sessionId/session_storage/key/:key`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `DELETE /session/:sessionId/session_storage/key/:key`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `GET /session/:sessionId/session_storage/size`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-no-entry-24: JSONWP protocol command with no direct replacement
 * `POST /session/:sessionId/timeouts/async_script`
     * :octicons-arrow-right-24: `POST /session/:sessionId/timeouts`
 * `POST /session/:sessionId/timeouts/implicit_wait`

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -35,10 +35,10 @@ close-to-direct replacements in either standard W3C endpoints, other Appium endp
 driver-specific extension commands. These endpoints, along with replacements (where applicable)
 are listed [in the **Removed Endpoints** section](#removed).
 
-Some W3C endpoints used in Appium 2 were also defined in old JSONWP specification, but required
-different parameters, and Appium 2 supported both parameter sets for the same endpoints. Appium 3
-changes these endpoints to only accept the W3C parameters. These endpoints are listed
-[in the **Modified Endpoints** section](#modified).
+Some W3C endpoints used in Appium also existed in the old JSONWP standard, but required other
+parameters. With Appium 2, both standards for these endpoints were supported. Appium 3 changes
+these endpoints by removing support for the JSONWP parameters, and only accepting the W3C
+parameters. These endpoints are listed [in the **Modified Endpoints** section](#modified).
 
 !!! info "Actions Needed"
 
@@ -75,9 +75,9 @@ without a scope. Note that the behavior of the `--relaxed-security` flag remains
 
 ### Unzip Logic Removed
 
-Appium 3 removes the custom unzip logic used when working with files such as application packages.
+Appium 3 removes the custom unzip logic used when working with files like application packages.
 Such files are often only relevant to particular platforms, therefore the functionality for
-handling such operations has been moved to relevant drivers.
+handling these operations has been moved to relevant drivers.
 
 !!! info "Actions Needed"
 
@@ -430,8 +430,8 @@ the drivers which support that option:
 ### Modified
 
 The following are all endpoints modified in Appium 3, by removing handling for old or unused
-parameters. Each endpoint lists the parameters it no longer accepts, as well as the parameters it
-still accepts in Appium 3.
+parameters (note that no new parameters have been added). Each endpoint lists the parameters it no
+longer accepts, as well as the parameters it continues to accept in Appium 3.
 
 * `POST /session`
     * :octicons-x-24: `desiredCapabilities`, `requiredCapabilities`

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -103,10 +103,140 @@ also listed, along with any extra information.
     * :octicons-arrow-right-24: `GET /session/:sessionId/alert/text`
 * `POST /session/:sessionId/alert_text`
     * :octicons-arrow-right-24: `POST /session/:sessionId/alert/text`
+* `POST /session/:sessionId/appium/app/background`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: backgroundApp`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+* `POST /session/:sessionId/appium/app/close`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: terminateApp`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+* `POST /session/:sessionId/appium/app/end_test_coverage`
+    * :octicons-no-entry-fill-12: No replacement available
+* `POST /session/:sessionId/appium/app/launch`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: launchApp`
+    * :octicons-info-24: Supported in drivers: XCUITest
+    * :octicons-info-24: Espresso and UiAutomator2 drivers also have `mobile: activateApp`
+* `POST /session/:sessionId/appium/app/reset`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: clearApp`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest (simulator only)
+* `POST /session/:sessionId/appium/app/strings`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getAppStrings`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
 * `GET /session/:sessionId/appium/device/app_state`
     * :octicons-arrow-right-24: `POST /session/:sessionId/appium/device/app_state`
+* `GET /session/:sessionId/appium/device/current_activity`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getCurrentActivity`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `GET /session/:sessionId/appium/device/current_package`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getCurrentPackage`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `GET /session/:sessionId/appium/device/display_density`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getDisplayDensity`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/device/finger_print`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: fingerPrint`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+* `POST /session/:sessionId/appium/device/get_clipboard`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getClipboard`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+* `POST /session/:sessionId/appium/device/gsm_call`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmCall`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+* `POST /session/:sessionId/appium/device/gsm_signal`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmSignal`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+* `POST /session/:sessionId/appium/device/gsm_voice`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: gsmVoice`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+* `POST /session/:sessionId/appium/device/is_locked`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: isLocked`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+* `POST /session/:sessionId/appium/device/keyevent`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/device/lock`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: lock`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+* `POST /session/:sessionId/appium/device/long_press_keycode`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey`
+    * :octicons-info-24: Set the `isLongPress` value in the payload data
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/device/network_speed`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: networkSpeed`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+* `POST /session/:sessionId/appium/device/open_notifications`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: statusBar`
+    * :octicons-info-24: Set the `command` value in the payload data to `expandNotifications`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (which also has `mobile: openNotifications`)
+* `POST /session/:sessionId/appium/device/power_ac`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: powerAC`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+* `POST /session/:sessionId/appium/device/power_capacity`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: powerCapacity`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+* `POST /session/:sessionId/appium/device/press_keycode`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: pressKey`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-info-24: XCUITest driver also has `mobile: pressButton`
+* `POST /session/:sessionId/appium/device/send_sms`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: sendSms`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2 (emulators only)
+* `POST /session/:sessionId/appium/device/set_clipboard`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setClipboard`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+* `POST /session/:sessionId/appium/device/shake`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: shake`
+    * :octicons-info-24: Supported in drivers: XCUITest (simulator only)
+* `POST /session/:sessionId/appium/device/start_activity`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: startActivity`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `GET /session/:sessionId/appium/device/system_bars`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getSystemBars`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+    * :octicons-info-24: XCUITest driver also has `mobile: deviceScreenInfo`
+* `POST /session/:sessionId/appium/device/toggle_airplane_mode`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity`
+    * :octicons-info-24: Set the `airplaneMode` value in the payload data
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/device/toggle_data`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity`
+    * :octicons-info-24: Set the `data` value in the payload data
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/device/toggle_location_services`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: toggleGps`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/device/toggle_wifi`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: setConnectivity`
+    * :octicons-info-24: Set the `wifi` value in the payload data
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/device/unlock`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: unlock`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2, XCUITest
+* `POST /session/:sessionId/appium/element/:elementId/value`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
+* `POST /session/:sessionId/appium/element/:elementId/replace_value`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
+* `POST /session/:sessionId/appium/getPerformanceData`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getPerformanceData`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/performanceData/types`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: getPerformanceDataTypes`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/receive_async_response`
+    * :octicons-no-entry-fill-12: No replacement available
+* `POST /session/:sessionId/appium/simulator/toggle_touch_id_enrollment`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: enrollBiometric`
+    * :octicons-info-24: Supported in drivers: XCUITest (simulator only)
+* `POST /session/:sessionId/appium/simulator/touch_id`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: sendBiometricMatch`
+    * :octicons-info-24: Supported in drivers: XCUITest (simulator only)
+* `POST /session/:sessionId/appium/start_recording_screen`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: startMediaProjectionRecording`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
+* `POST /session/:sessionId/appium/stop_recording_screen`
+    * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync` with `mobile: stopMediaProjectionRecording`
+    * :octicons-info-24: Supported in drivers: Espresso, UiAutomator2
 * `GET /session/:sessionId/application_cache/status`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/buttondown`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
     * :octicons-info-24: Use the `pointerDown` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
@@ -124,21 +254,21 @@ also listed, along with any extra information.
 * `POST /session/:sessionId/element/active`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/active`
 * `GET /session/:sessionId/element/:elementId/equals/:otherId`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/element/:elementId/location`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
     * :octicons-info-24: Response also includes the `width` and `height` fields with the element
     size values
 * `GET /session/:sessionId/element/:elementId/location_in_view`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/element/:elementId/pageIndex`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/element/:elementId/size`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/rect`
     * :octicons-info-24: Response also includes the `x` and `y` fields with the element location
     values
 * `POST /session/:sessionId/element/:elementId/submit`
-    * :octicons-no-entry-fill-12: No W3C replacement available - the form submission button needs
+    * :octicons-no-entry-fill-12: No replacement available - the form submission button needs
     to be clicked
 * `POST /session/:sessionId/execute`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/sync`
@@ -148,38 +278,38 @@ also listed, along with any extra information.
     * :octicons-arrow-right-24: `POST /session/:sessionId/element/:elementId/value`
     * :fontawesome-solid-triangle-exclamation: Now requires the element ID
 * `GET /session/:sessionId/local_storage`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/local_storage`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `DELETE /session/:sessionId/local_storage`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/local_storage/key/:key`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `DELETE /session/:sessionId/local_storage/key/:key`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/local_storage/size`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/log`
     * :octicons-arrow-right-24: `POST /session/:sessionId/se/log`
-* `POST /session/:sessionId/log/types`
-    * :octicons-arrow-right-24: `POST /session/:sessionId/se/log/types`
+* `GET /session/:sessionId/log/types`
+    * :octicons-arrow-right-24: `GET /session/:sessionId/se/log/types`
 * `POST /session/:sessionId/moveto`
     * :octicons-arrow-right-24: `POST /session/:sessionId/actions`
     * :octicons-info-24: Use the `pointerMove` action in the [W3C Actions API](https://www.w3.org/TR/webdriver2/#actions)
 * `GET /session/:sessionId/screenshot/:elementId`
     * :octicons-arrow-right-24: `GET /session/:sessionId/element/:elementId/screenshot`
 * `GET /session/:sessionId/session_storage`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/session_storage`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `DELETE /session/:sessionId/session_storage`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/session_storage/key/:key`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `DELETE /session/:sessionId/session_storage/key/:key`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `GET /session/:sessionId/session_storage/size`
-    * :octicons-no-entry-fill-12: No W3C replacement available
+    * :octicons-no-entry-fill-12: No replacement available
 * `POST /session/:sessionId/timeouts/async_script`
     * :octicons-arrow-right-24: `POST /session/:sessionId/timeouts`
     * :octicons-info-24: Set the `script` value in the payload data

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -312,7 +312,8 @@ the drivers which support that option:
 * `POST /session/:sessionId/execute_async`
     * :octicons-arrow-right-24: `POST /session/:sessionId/execute/async`
 * `POST /session/:sessionId/keys`
-    * :octicons-no-entry-24: No replacement available
+    * :octicons-arrow-right-24: `POST /session/:sessionId/actions` with the `keyDown` & `keyUp`
+    actions
 * `GET /session/:sessionId/local_storage`
     * :octicons-no-entry-24: No replacement available
 * `POST /session/:sessionId/local_storage`

--- a/packages/appium/docs/mkdocs-en.yml
+++ b/packages/appium/docs/mkdocs-en.yml
@@ -50,6 +50,7 @@ nav:
       - commands/universal-xml-plugin.md
   - Guides:
       - Migration:
+          - guides/migrating-2-to-3.md
           - guides/migrating-1-to-2.md
       - Server/Driver Configuration:
           - guides/managing-exts.md


### PR DESCRIPTION
This PR adds a migration guide from Appium 2 to Appium 3.

The guide covers all the items listed in #20792 (except the Inspector integration, as that is covered under removed endpoints) and provides required actions for each item. Most notably, it also includes a full list of removed endpoints, and one or more suggested replacements (all the ones I could find).

There are still 18 endpoints for which I could not find replacements, but perhaps there is a different related endpoint for each of them?

* `POST /session/:sessionId/appium/app/end_test_coverage`
* `GET /session/:sessionId/application_cache/status`
* `GET /session/:sessionId/element/:elementId/equals/:otherId`
* `GET /session/:sessionId/element/:elementId/location_in_view`
* `GET /session/:sessionId/element/:elementId/pageIndex`
* `POST /session/:sessionId/element/:elementId/submit` - the Selenium docs simply list that the replacement is calling the click action on the form submission button
* `GET/POST/DELETE/ /session/:sessionId/local_storage/*` (6 endpoints)
* `GET/POST/DELETE/ /session/:sessionId/session_storage/*` (6 endpoints)