### PR TITLE
feat(docutils): add MkDocs Material codeblock & text format features

### DIFF
--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -10,6 +10,8 @@ markdown_extensions:
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
@@ -63,6 +65,8 @@ theme:
       quote: octicons/quote-16
   features:
     - content.action.edit
+    - content.code.annotate
+    - content.code.copy
     - navigation.sections
     - navigation.tabs
     - navigation.top

--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -1,20 +1,20 @@
 markdown_extensions:
-  - meta
-  - attr_list
   - admonition
+  - attr_list
+  - footnotes
   - md_in_html
+  - meta
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
-  - pymdownx.details
   - pymdownx.tabbed:
       alternate_style: true
-  - pymdownx.emoji:
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      emoji_generator: !!python/name:material.extensions.emoji.to_svg
-  - footnotes
   - toc:
       permalink: true
 

--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -4,6 +4,8 @@ markdown_extensions:
   - footnotes
   - md_in_html
   - meta
+  - pymdownx.caret
+  - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
@@ -13,10 +15,13 @@ markdown_extensions:
       line_spans: __span
       pygments_lang_class: true
   - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
   - pymdownx.snippets
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.tilde
   - tables
   - toc:
       permalink: true

--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -68,6 +68,7 @@ theme:
     - content.action.edit
     - content.code.annotate
     - content.code.copy
+    - content.tabs.link
     - navigation.sections
     - navigation.tabs
     - navigation.top

--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -21,6 +21,8 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - pymdownx.tilde
   - tables
   - toc:

--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -17,6 +17,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.tabbed:
       alternate_style: true
+  - tables
   - toc:
       permalink: true
 


### PR DESCRIPTION
This PR enables several nice documentation features from Material for MkDocs:
- [Copy button in code blocks](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-copy-button)
- [Annotations in code blocks](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#code-annotations)
- [Linked content tabs](https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#linked-content-tabs)
- [Additional text formatting](https://squidfunk.github.io/mkdocs-material/reference/formatting/) (highlighted, deleted, replaced, underlined, strikethrough, subscript, superscript, keyboard keys, inline comments)
- [Task lists](https://squidfunk.github.io/mkdocs-material/reference/lists/#using-task-lists)

The `tables` extension was also explicitly enabled (it was already enabled by default, but [just to be sure](https://squidfunk.github.io/mkdocs-material/reference/data-tables/#configuration))