### PR TITLE
chore(base-driver): Mark IME commands and receive_async_response as deprecated

### DIFF
--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -304,16 +304,16 @@ export const METHOD_MAP = /** @type {const} */ ({
   // Appium specific
   //
   '/session/:sessionId/ime/available_engines': {
-    GET: {command: 'availableIMEEngines'},
+    GET: {command: 'availableIMEEngines', deprecated: true},
   },
   '/session/:sessionId/ime/active_engine': {
-    GET: {command: 'getActiveIMEEngine'},
+    GET: {command: 'getActiveIMEEngine', deprecated: true},
   },
   '/session/:sessionId/ime/activated': {
-    GET: {command: 'isIMEActivated'},
+    GET: {command: 'isIMEActivated', deprecated: true},
   },
   '/session/:sessionId/ime/deactivate': {
-    POST: {command: 'deactivateIMEEngine'},
+    POST: {command: 'deactivateIMEEngine', deprecated: true},
   },
   '/session/:sessionId/ime/activate': {
     POST: {command: 'activateIMEEngine', payloadParams: {required: ['engine']}},
@@ -351,6 +351,7 @@ export const METHOD_MAP = /** @type {const} */ ({
     POST: {
       command: 'receiveAsyncResponse',
       payloadParams: {required: ['status', 'value']},
+      deprecated: true,
     },
   },
   '/appium/sessions': {

--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -316,7 +316,11 @@ export const METHOD_MAP = /** @type {const} */ ({
     POST: {command: 'deactivateIMEEngine', deprecated: true},
   },
   '/session/:sessionId/ime/activate': {
-    POST: {command: 'activateIMEEngine', payloadParams: {required: ['engine']}},
+    POST: {
+      command: 'activateIMEEngine',
+      payloadParams: {required: ['engine']},
+      deprecated: true,
+    },
   },
   '/session/:sessionId/rotation': {
     GET: {command: 'getRotation'},

--- a/packages/base-driver/lib/protocol/validators.js
+++ b/packages/base-driver/lib/protocol/validators.js
@@ -10,6 +10,9 @@ function msValidator(ms) {
   }
 }
 
+/**
+ * @deprecated
+ */
 const validators = {
   setUrl: (url) => {
     // either an `xyz://`, `about:`, or `data:` scheme is allowed


### PR DESCRIPTION
https://github.com/appium/appium/pull/21198#discussion_r2041140683