### PR TITLE
docs(appium): add NovaWindows driver to Appium other drivers list

### DIFF
--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -44,6 +44,7 @@ These drivers are not maintained by the Appium team and can be used to target ad
 |[Tizen](https://github.com/Samsung/appium-tizen-driver)|`--source=npm appium-tizen-driver`|Android|Native|Community / Samsung|
 |[TizenTV](https://github.com/headspinio/appium-tizen-tv-driver)|`--source=npm appium-tizen-tv-driver`|Samsung TV|Web|HeadSpin|
 |[Youi](https://github.com/YOU-i-Labs/appium-youiengine-driver)|`--source=npm appium-youiengine-driver`|iOS, Android, macOS, Linux, tvOS|Native|Community / You.i|
+|[NovaWindows](https://github.com/AutomateThePlanet/appium-novawindows-driver)|`--source=npm appium-novawindows-driver`|Windows|Native|Community / Automate The Planet|
 
 !!! note
 

--- a/packages/appium/docs/zh/ecosystem/drivers.md
+++ b/packages/appium/docs/zh/ecosystem/drivers.md
@@ -43,6 +43,7 @@ appium driver install <驱动名称>
 |[Tizen](https://github.com/Samsung/appium-tizen-driver)|`--source=npm appium-tizen-driver`|Android|Native|Community / Samsung|
 |[TizenTV](https://github.com/headspinio/appium-tizen-tv-driver)|`--source=npm appium-tizen-tv-driver`|Samsung TV|Web|HeadSpin|
 |[Youi](https://github.com/YOU-i-Labs/appium-youiengine-driver)|`--source=npm appium-youiengine-driver`|iOS, Android, macOS, Linux, tvOS|Native|Community / You.i|
+|[NovaWindows](https://github.com/AutomateThePlanet/appium-novawindows-driver)|`--source=npm appium-novawindows-driver`|Windows|Native|Community / Automate The Planet|
 
 !!! 注意
 


### PR DESCRIPTION
## Proposed changes

Adding the [NovaWindows](https://github.com/AutomateThePlanet/appium-novawindows-driver) Appium driver to the list of other drivers in the Appium Docs. The driver is fully open-source and does not rely on WinAppDriver. It was presented at AppiumConf 2025 and has recently been published on npm for easier installation.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

n/a
