### PR TITLE
chore(base-driver): Mark /session/:sessionId/network_connection deprecated

### DIFF
--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -349,6 +349,7 @@ export const METHOD_MAP = /** @type {const} */ ({
     POST: {
       command: 'setNetworkConnection',
       payloadParams: {unwrap: 'parameters', required: ['type']},
+      deprecated: true,
     },
   },
   '/session/:sessionId/receive_async_response': {

--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -345,7 +345,7 @@ export const METHOD_MAP = /** @type {const} */ ({
     GET: {command: 'getContexts'},
   },
   '/session/:sessionId/network_connection': {
-    GET: {command: 'getNetworkConnection'},
+    GET: {command: 'getNetworkConnection', deprecated: true},
     POST: {
       command: 'setNetworkConnection',
       payloadParams: {unwrap: 'parameters', required: ['type']},


### PR DESCRIPTION
Related to https://github.com/appium/appium-android-driver/pull/994