### PR TITLE
docs: update Appium 2 migration guide

### DIFF
--- a/packages/appium/docs/en/guides/migrating-1-to-2.md
+++ b/packages/appium/docs/en/guides/migrating-1-to-2.md
@@ -159,9 +159,9 @@ CHROMEDRIVER_VERSION=100 appium   # Appium 2
 ```
 * Some options can now be passed as [capabilities](https://appium.io/docs/en/latest/guides/caps/),
 for example:
-```bash
-appium --chromedriver-executable=/path/to/chromedriver # Appium 1
-appium:chromedriverExecutable = /path/to/chromedriver  # Appium 2
+```
+appium --chromedriver-executable=/path/to/chromedriver      # Appium 1
+{"appium:chromedriverExecutable": "/path/to/chromedriver"}  # Appium 2
 ```
 
 !!! info "Actions Needed"

--- a/packages/appium/docs/en/guides/migrating-1-to-2.md
+++ b/packages/appium/docs/en/guides/migrating-1-to-2.md
@@ -62,7 +62,7 @@ located at `$APPIUM_HOME/node_modules/appium-xcuitest-driver/node_modules/appium
 
 !!! info "Actions Needed"
 
-    If your code uses the paths to Appium driver files, update it to use the `APPIUM_HOME` environment
+    If your code uses paths to Appium driver files, update it to use the `APPIUM_HOME` environment
     variable
 
 ### Drivers Updated Separately
@@ -219,9 +219,9 @@ vendor prefix.
 
 The list of standard capabilities is described in the [WebDriver Protocol specification](https://www.w3.org/TR/webdriver/#capabilities),
 and includes a few commonly used capabilities like `browserName` and `platformName`. All other
-capabilities must now start with the vendor name and a colon (the vendor prefix), such as `appium:`.
-Since most of Appium's capabilities go beyond the standard W3C capabilities, all of them must
-include the `appium:` prefix (unless specified otherwise):
+capabilities must now start with the vendor name and a colon (the vendor prefix), for example,
+`moz:` or `goog:`. Since most of Appium's capabilities go beyond the standard W3C capabilities,
+all of them must include the `appium:` prefix (unless specified otherwise):
 
 ```
 deviceName        # Appium 1

--- a/packages/appium/docs/en/guides/migrating-1-to-2.md
+++ b/packages/appium/docs/en/guides/migrating-1-to-2.md
@@ -23,18 +23,6 @@ Appium 2 afterwards.
 
 ## Breaking Changes
 
-### Default Base Path Changed
-
-In Appium 1, the default Appium server URL was `http://localhost:4723/wd/hub`, where the `/wd/hub`
-part (the base path) was a legacy convention from Selenium 1. Appium 2 changes the default base
-path to `/`, therefore the default server URL is now `http://localhost:4723/`.
-
-!!! info "Actions Needed"
-
-    In your test scripts, change the base path of the target server URL from `/wd/hub` to `/`.
-    Alternatively, you can retain the Appium 1 base path by launching Appium with the
-    `--base-path=/wd/hub` [command-line argument](../cli/args.md).
-
 ### Drivers Installed Separately
 
 When installing Appium 1, all available drivers would be installed alongside the main Appium
@@ -77,53 +65,6 @@ located at `$APPIUM_HOME/node_modules/appium-xcuitest-driver/node_modules/appium
     If your code uses the paths to Appium driver files, update it to use the `APPIUM_HOME` environment
     variable
 
-### Driver-Specific CLI Options Changed
-
-With Appium 1, command-line options specific to particular drivers were all hosted on the main
-Appium server. So, for example, `--chromedriver-executable` was a CLI parameter you could use to
-set the Chromedriver location for the UiAutomator2 driver.
-
-In Appium 2, all driver-specific CLI options have been moved to the drivers themselves. However,
-depending on the driver, these options may now need to be passed in another way:
-
-* Some options can still be passed as different CLI flags, for example:
-```bash
-appium --webdriveragent-port=5000                 # Appium 1
-appium --driver-xcuitest-webdriveragent-port=5000 # Appium 2
-```
-* Some options can now be passed as environment variables, for example:
-```bash
-appium --chromedriver-version=100 # Appium 1
-CHROMEDRIVER_VERSION=100 appium   # Appium 2
-```
-* Some options can now be passed as [capabilities](https://appium.io/docs/en/latest/guides/caps/),
-for example:
-```bash
-appium --chromedriver-executable=/path/to/chromedriver # Appium 1
-appium:chromedriverExecutable = /path/to/chromedriver  # Appium 2
-```
-
-!!! info "Actions Needed"
-
-    If you are using driver-specific CLI options, refer to that driver's documentation for how to
-    apply them in Appium 2
-
-### Some Commands Moved to Drivers
-
-In Appium 1, commands that were specific to certain drivers were built into the main Appium server.
-Appium 2, in line with its modular approach, moves many such commands to the drivers themselves.
-For example, `pressKeyCode` was specific to the UiAutomator2 driver, and is now understood only by
-that driver.
-
-In practice, the only breaking change here is the error returned when invoking a command not
-implemented by the active driver. In Appium 1, this would return a `501 Not Yet Implemented` error,
-whereas Appium 2 now returns `404 Not Found`: if the active driver doesn't know about the command,
-the Appium server will not define the route corresponding to the command.
-
-!!! info "Actions Needed"
-
-    Ensure you have installed all the drivers you were using in Appium 1
-
 ### Drivers Updated Separately
 
 In Appium 1, in order to get updates to your drivers, you would simply wait for those updates to be
@@ -156,6 +97,101 @@ server package.
 !!! info "Actions Needed"
 
     Make sure to use the [Appium Extension CLI](../cli/extensions.md) to manage your drivers
+
+### Deprecated Packages No Longer Supported
+
+The Appium 1 ecosystem included several drivers, clients and other packages that had since been
+deprecated and replaced with newer packages. Appium 2 no longer includes support for these packages,
+and it is recommended to migrate to the following replacements:
+
+|Appium 1 Package|Replacement in Appium 2|
+|--|--|
+|iOS Driver|[XCUITest Driver](https://appium.github.io/appium-xcuitest-driver/latest/)|
+|UiAutomator Driver|[UiAutomator2](https://github.com/appium/appium-uiautomator2-driver/)|
+|`wd` Client|[WebdriverIO Client](https://webdriver.io/)|
+|Appium Desktop|[Appium Inspector](https://github.com/appium/appium-inspector)|
+
+!!! info "Actions Needed"
+
+    If you are using any of the aforementioned package(s), migrate to their recommended replacement(s)
+
+### Default Base Path Changed
+
+In Appium 1, the default Appium server URL was `http://localhost:4723/wd/hub`, where the `/wd/hub`
+part (the base path) was a legacy convention from Selenium 1. Appium 2 changes the default base
+path to `/`, therefore the default server URL is now `http://localhost:4723/`.
+
+!!! info "Actions Needed"
+
+    In your test scripts, change the base path of the target server URL from `/wd/hub` to `/`.
+    Alternatively, you can retain the Appium 1 base path by launching Appium with the
+    `--base-path=/wd/hub` [command-line argument](../cli/args.md).
+
+### Server Port 0 No Longer Supported
+
+In Appium 1, it was possible to specify `--port 0` during server startup, which had the effect of
+starting Appium on a random free port. Appium 2 no longer allows this, and requires port values to
+be `1` or higher. If you wish to start Appium on a random port, you must now take care of this on
+your own prior to launching the server.
+
+!!! info "Actions Needed"
+
+    If you are launching Appium with `--port 0`, change the port number value to `1` or higher
+
+### Driver-Specific CLI Options Changed
+
+With Appium 1, command-line options specific to particular drivers were all hosted on the main
+Appium server. So, for example, `--chromedriver-executable` was a CLI parameter you could use to
+set the Chromedriver location for the UiAutomator2 driver.
+
+In Appium 2, all driver-specific CLI options have been moved to the drivers themselves. However,
+depending on the driver, these options may now need to be passed in another way:
+
+* Some options can still be passed as different CLI flags, for example:
+```bash
+appium --webdriveragent-port=5000                 # Appium 1
+appium --driver-xcuitest-webdriveragent-port=5000 # Appium 2
+```
+* Some options can now be passed as environment variables, for example:
+```bash
+appium --chromedriver-version=100 # Appium 1
+CHROMEDRIVER_VERSION=100 appium   # Appium 2
+```
+* Some options can now be passed as [capabilities](https://appium.io/docs/en/latest/guides/caps/),
+for example:
+```bash
+appium --chromedriver-executable=/path/to/chromedriver # Appium 1
+appium:chromedriverExecutable = /path/to/chromedriver  # Appium 2
+```
+
+!!! info "Actions Needed"
+
+    If you are using driver-specific CLI options, refer to that driver's documentation for how to
+    apply them in Appium 2
+
+### Filepaths No Longer Supported for Some CLI Options
+
+In Appium 1, some server command-line options could be invoked by passing a filepath as their
+value, and Appium would then parse the contents of that file as the actual value for that option.
+There were four options that supported this:
+
+* `--nodeconfig`
+* `--default-capabilities`
+* `--allow-insecure`
+* `--deny-insecure`
+
+Appium 2 no longer attempts to parse the contents of filepaths passed to these options, and offers
+two ways to specify the value for these options:
+
+* As strings, directly on the command line
+    * `--nodeconfig` / `--default-capabilities`: JSON string
+    * `--allow-insecure` / `--deny-insecure`: comma-separated list
+* In the [Appium Configuration file](./config.md)
+
+!!! info "Actions Needed"
+
+    If you are using any of the aforementioned CLI options with a filepath value, update your code
+    to pass the file contents either directly or through the Appium config file
 
 ### Old Protocols Dropped
 
@@ -240,6 +276,22 @@ For more information on capabilities, have a look at the [Capabilities Guide](./
     Add the `appium:` prefix to all Appium-specific capabilities used in your tests, or wrap them
     inside an `appium:options` object
 
+### Some Commands Moved to Drivers
+
+In Appium 1, commands that were specific to certain drivers were built into the main Appium server.
+Appium 2, in line with its modular approach, moves many such commands to the drivers themselves.
+For example, `pressKeyCode` was specific to the UiAutomator2 driver, and is now understood only by
+that driver.
+
+In practice, the only breaking change here is the error returned when invoking a command not
+implemented by the active driver. In Appium 1, this would return a `501 Not Yet Implemented` error,
+whereas Appium 2 now returns `404 Not Found`: if the active driver doesn't know about the command,
+the Appium server will not define the route corresponding to the command.
+
+!!! info "Actions Needed"
+
+    Ensure you have installed all the drivers you were using in Appium 1
+
 ### Deprecated Commands Removed
 
 In addition to the driver-specific commands moved to the drivers themselves, some commands which
@@ -278,58 +330,6 @@ are no longer bundled with Appium 2:
     ```
     appium --use-plugins=images,execute-driver
     ```
-
-### Filepaths No Longer Supported for Some CLI Options
-
-In Appium 1, some server command-line options could be invoked by passing a filepath as their
-value, and Appium would then parse the contents of that file as the actual value for that option.
-There were four options that supported this:
-
-* `--nodeconfig`
-* `--default-capabilities`
-* `--allow-insecure`
-* `--deny-insecure`
-
-Appium 2 no longer attempts to parse the contents of filepaths passed to these options, and offers
-two ways to specify the value for these options:
-
-* As strings, directly on the command line
-    * `--nodeconfig` / `--default-capabilities`: JSON string
-    * `--allow-insecure` / `--deny-insecure`: comma-separated list
-* In the [Appium Configuration file](./config.md)
-
-!!! info "Actions Needed"
-
-    If you are using any of the aforementioned CLI options with a filepath value, update your code
-    to pass the file contents either directly or through the Appium config file
-
-### Deprecated Packages No Longer Supported
-
-The Appium 1 ecosystem included several drivers, clients and other packages that had since been
-deprecated and replaced with newer packages. Appium 2 no longer includes support for these packages,
-and it is recommended to migrate to the following replacements:
-
-|Appium 1 Package|Replacement in Appium 2|
-|--|--|
-|iOS Driver|[XCUITest Driver](https://appium.github.io/appium-xcuitest-driver/latest/)|
-|UiAutomator Driver|[UiAutomator2](https://github.com/appium/appium-uiautomator2-driver/)|
-|`wd` Client|[WebdriverIO Client](https://webdriver.io/)|
-|Appium Desktop|[Appium Inspector](https://github.com/appium/appium-inspector)|
-
-!!! info "Actions Needed"
-
-    If you are using any of the aforementioned package(s), migrate to their recommended replacement(s)
-
-### Server Port 0 No Longer Supported
-
-In Appium 1, it was possible to specify `--port 0` during server startup, which had the effect of
-starting Appium on a random free port. Appium 2 no longer allows this, and requires port values to
-be `1` or higher. If you wish to start Appium on a random port, you must now take care of this on
-your own prior to launching the server.
-
-!!! info "Actions Needed"
-
-    If you are launching Appium with `--port 0`, change the port number value to `1` or higher
 
 ### Internal Packages Renamed
 

--- a/packages/appium/docs/en/guides/migrating-1-to-2.md
+++ b/packages/appium/docs/en/guides/migrating-1-to-2.md
@@ -6,141 +6,133 @@ This document is a guide for those who are using Appium 1 and wish to migrate to
 contains a list of breaking changes and how to migrate your environments or test suites to ensure
 compatibility with Appium 2.
 
-!!! note
+Appium 2 is the biggest Appium release in over 5 years. It is _not_ focused on changing the
+automation behavior for any particular platform, but instead re-envisions Appium into an
+_ecosystem_ of automation tools:
 
-  Latest Appium drivers/plugins would have update since we created this documentation
-  because we keep developing the ecosystem.
-
-## Overview of Appium 2
-
-Appium 2 is the most major new release of Appium in over 5 years. The changes in Appium 2 are _not_
-primarily related to changes in automation behaviors for specific platforms. Instead, Appium 2
-reenvisions Appium as a _platform_ where "drivers" (code projects that introduce support for
-automation of a given platform) and "plugins" (code projects that allow for overriding, altering,
-extending, or adding behaviors to Appium) can be easily created and shared.
+* The core Appium module retains only platform-agnostic functionality
+* Functionality for automating specific platforms is moved to separate _driver_ modules
+* Functionality for altering/extending Appium is moved to separate _plugin_ modules
 
 At the same time, the Appium project is taking the opportunity to remove many old and deprecated
 bits of functionality.
 
-Together these do introduce a few breaking changes to how Appium is installed, how drivers and
-various features are managed, and protocol support. These are detailed below.
+Since Appium 2 is a major architectural change, ^^we do not recommend directly updating your
+Appium 1 installations to Appium 2^^. Instead, please uninstall Appium 1 first, and only install
+Appium 2 afterwards.
 
 ## Breaking Changes
 
-### :bangbang: Default server base path
+### Default Base Path Changed
 
-With Appium 1, the server would accept commands by default on `http://localhost:4723/wd/hub`. The
-`/wd/hub` base path was a legacy convention from the days of migrating from Selenium 1 to Selenium
-2, and is no longer relevant. As such the default base path for the server is now `/`. If you want
-to retain the old behaviour, you can set the base path via a command line argument as follows:
+In Appium 1, the default Appium server URL was `http://localhost:4723/wd/hub`, where the `/wd/hub`
+part (the base path) was a legacy convention from Selenium 1. Appium 2 changes the default base
+path to `/`, therefore the default server URL is now `http://localhost:4723/`.
 
-```
-appium --base-path=/wd/hub
-```
+!!! info "Actions Needed"
 
-You can also set server arguments as [Config file](./config.md) properties.
+    In your test scripts, change the base path of the target server URL from `/wd/hub` to `/`.
+    Alternatively, you can retain the Appium 1 base path by launching Appium with the
+    `--base-path=/wd/hub` [command-line argument](../cli/args.md).
 
-### :bangbang: Installing drivers during setup
+### Drivers Installed Separately
 
-When you installed Appium 1, all available drivers would be installed at the same time as the main
-Appium server. This is no longer the case. Simply installing Appium 2 (e.g., by `npm i -g appium`),
-will install the Appium server only, but no drivers. To install drivers, you must instead use the
-new [Appium extension CLI](../cli/extensions.md). For example, to install the latest versions of the
-XCUITest and UiAutomator2 drivers, after installing Appium you would run the following commands:
+When installing Appium 1, all available drivers would be installed alongside the main Appium
+server. In Appium 2, due to its modular structure, this is no longer the case - by default,
+installing it only installs the core Appium server, without any drivers.
 
-```bash
-appium driver install uiautomator2     # installs the latest driver version
-appium driver install xcuitest@4.12.2  # installs a specific driver version
-```
+When it comes to installing Appium 2 drivers, there are several approaches you can take:
 
-At this point, your drivers are installed and ready. There's a lot more you can do with the Appium 2
-command line, so be sure to check out [its documentation](../cli/index.md). If you're running in a CI
-environment or want to install Appium along with some drivers all in one step, you can do so using
-some special flags during install, for example:
-
+* Add the `--drivers` flag when installing Appium, for example:
 ```bash
 npm i -g appium --drivers=xcuitest,uiautomator2
 ```
+* Use the [Appium Extension CLI](../cli/extensions.md), for example:
+```bash
+appium driver install uiautomator2
+```
+* Use the [Appium Setup CLI command](../cli/setup.md), for example:
+```bash
+appium setup mobile
+```
 
-This will install Appium and the two drivers for you in one go. Please uninstall any existing Appium 1
-`npm` packages (with `npm uninstall -g appium`) if you get an installation or startup error.
+Check the [Managing Drivers and Plugins guide](./managing-exts.md) for more information.
 
-### :bangbang: Drivers installation path
+!!! info "Actions Needed"
 
-When you installed Appium 1, all available drivers would be installed at the same time as the main
-Appium server, at `/path/to/appium/node_modules`. For example, `appium-webdriveragent` was located
+    When installing Appium 2, use one of the above approaches for installing your desired drivers
+
+### Driver Installation Path Changed
+
+When installing Appium 1, all available drivers would be installed as dependencies of the main
+Appium server, in `/path/to/appium/node_modules`. For example, `appium-webdriveragent` was located
 at `/path/to/appium/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent`.
 
-Appium 2 installs such dependencies in the path defined by the `APPIUM_HOME` environment variable.
-The default path is `~/.appium`. So, `appium-webdriveragent` would now be located at
-`$APPIUM_HOME/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent`.
+In Appium 2, drivers (and plugins) are installed at the path defined by the `APPIUM_HOME`
+environment variable, whose default value is `~/.appium`. So, `appium-webdriveragent` would now be
+located at `$APPIUM_HOME/node_modules/appium-xcuitest-driver/node_modules/appium-webdriveragent`.
 
-### :bangbang: Chromedriver installation flags
+!!! info "Actions Needed"
 
-In Appium 1, it was possible to customize the way Chromedriver was installed (as part of the
-UiAutomator2 driver for example), using the following command line flags:
+    If your code uses the paths to Appium driver files, update it to use the `APPIUM_HOME` environment
+    variable
 
-* `--chromedriver-skip-install`
-* `--chromedriver-version`
-* `--chromedriver-cdnurl`
-
-Because Appium 2 now installs drivers for you, and because these flags were implemented as `npm`
-config flags, they will no longer work. Instead, use the following environment variables during
-driver installation:
-
-* `APPIUM_SKIP_CHROMEDRIVER_INSTALL`
-* `CHROMEDRIVER_VERSION`
-* `CHROMEDRIVER_CDNURL`
-
-For example:
-
-```bash
-APPIUM_SKIP_CHROMEDRIVER_INSTALL=1 appium driver install uiautomator2
-```
-
-### :bangbang: Driver-specific command line options
+### Driver-Specific CLI Options Changed
 
 With Appium 1, command-line options specific to particular drivers were all hosted on the main
-Appium server. So, for example, `--chromedriver-executable` was a CLI parameter you could use with
-Appium to set the location of a specific Chromedriver version for use with, say, the UiAutomator2 driver.
+Appium server. So, for example, `--chromedriver-executable` was a CLI parameter you could use to
+set the Chromedriver location for the UiAutomator2 driver.
 
-With Appium 2, all driver- and platform-specific CLI params have been moved to the drivers themselves.
-To access the corresponding functionality, you'll need to refer to the driver/plugin documentation.
-In some cases, the extension will continue to expose CLI parameters. For example, the XCUITest driver
-used to expose a parameter `--webdriveragent-port`. Now, to access this parameter, it should be
-prefixed with `driver-xcuitest`, to differentiate it from parameters other drivers might also expose.
-To use this parameter, you thus need to start Appium with something like:
+In Appium 2, all driver-specific CLI options have been moved to the drivers themselves. However,
+depending on the driver, these options may now need to be passed in another way:
 
+* Some options can still be passed as different CLI flags, for example:
 ```bash
-appium --driver-xcuitest-webdriveragent-port=5000
+appium --webdriveragent-port=5000                 # Appium 1
+appium --driver-xcuitest-webdriveragent-port=5000 # Appium 2
+```
+* Some options can now be passed as environment variables, for example:
+```bash
+appium --chromedriver-version=100 # Appium 1
+CHROMEDRIVER_VERSION=100 appium   # Appium 2
+```
+* Some options can now be passed as [capabilities](https://appium.io/docs/en/latest/guides/caps/),
+for example:
+```bash
+appium --chromedriver-executable=/path/to/chromedriver # Appium 1
+appium:chromedriverExecutable = /path/to/chromedriver  # Appium 2
 ```
 
-Some drivers have done away with CLI args entirely in favour of default capabilities. With the
-above-mentioned `--chromedriver-executable` parameter for example, you now need to take advantage
-of the `appium:chromedriverExecutable` capability supported by the UiAutomator2 driver. To set this
-capability from the command line, do the following:
+!!! info "Actions Needed"
 
-```bash
-appium --default-capabilities '{"appium:chromedriverExecutable": "/path/to/chromedriver"}'
-```
+    If you are using driver-specific CLI options, refer to that driver's documentation for how to
+    apply them in Appium 2
 
-### :bangbang: Driver-specific automation commands
+### Some Commands Moved to Drivers
 
-The definition of certain commands that pertain only to specific drivers has been moved to those
-drivers' implementations. For example, `pressKeyCode` is specific to the UiAutomator2 driver and is
-now understood only by that driver. In practice, the only breaking change here is the kind of error
-you would encounter if the appropriate driver is not installed. Previously, you would get a `501
-Not Yet Implemented` error if using a driver that didn't implement the command. Now, you will get
-a `404 Not Found` error because if a driver that doesn't know about the command is not active, the
-main Appium server will not define the route corresponding to the command.
+In Appium 1, commands that were specific to certain drivers were built into the main Appium server.
+Appium 2, in line with its modular approach, moves many such commands to the drivers themselves.
+For example, `pressKeyCode` was specific to the UiAutomator2 driver, and is now understood only by
+that driver.
 
-### :bangbang: Driver updates
+In practice, the only breaking change here is the error returned when invoking a command not
+implemented by the active driver. In Appium 1, this would return a `501 Not Yet Implemented` error,
+whereas Appium 2 now returns `404 Not Found`: if the active driver doesn't know about the command,
+the Appium server will not define the route corresponding to the command.
 
-In the past, to get updates to your iOS or Android drivers, you'd simply wait for those updates to
-be rolled into a new release of Appium, and then update your Appium version. With Appium 2, the
-Appium server and the Appium drivers are versioned and released separately. This means that drivers
-can be on their own release cadence, and you can get the latest driver version right away, rather
-than waiting for a new Appium server release. The way to check for driver updates is with the CLI:
+!!! info "Actions Needed"
+
+    Ensure you have installed all the drivers you were using in Appium 1
+
+### Drivers Updated Separately
+
+In Appium 1, in order to get updates to your drivers, you would simply wait for those updates to be
+rolled into a new release of Appium, and then update your Appium version. With Appium 2, since the
+server and drivers are separate packages, they can release new versions independently from each
+other - this means that you no longer need to wait for a new Appium server release, but can install
+the latest driver versions right away.
+
+Checking for driver updates is done by using the [Appium Extension CLI](../cli/extensions.md):
 
 ```bash
 appium driver list --updates
@@ -152,213 +144,235 @@ If any updates are available, you can then run the `update` command for any give
 appium driver update xcuitest
 ```
 
-(For a complete description of the update command, check out the
-[Extension CLI](../cli/extensions.md#update) documentation)
-
-To update the Appium server itself, you do the same thing as in the past: `npm install -g appium`.
-Now, installing new versions of the Appium server will leave your drivers intact, so the whole
-process will be much more quick.
-
-If you would like to update to a specific driver version, not the latest, please uninstall the driver
-and install the desired version using the `install` subcommand instead of `update`.
+Updating the Appium server itself is the same as before:
 
 ```bash
-appium driver uninstall xcuitest
-appium driver install xcuitest@4.11.1
+npm update -g appium
 ```
 
-### :bangbang: Protocol changes
+However, in Appium 2 this process is a lot quicker, since drivers are no longer bundled with the
+server package.
+
+!!! info "Actions Needed"
+
+    Make sure to use the [Appium Extension CLI](../cli/extensions.md) to manage your drivers
+
+### Old Protocols Dropped
 
 Appium's API is based on the [W3C WebDriver Protocol](https://www.w3.org/TR/webdriver/), and it has
-supported this protocol for years. Before the W3C WebDriver Protocol was designed as a web standard,
-several other protocols were used for both Selenium and Appium. These protocols were the "JSONWP"
-(JSON Wire Protocol) and "MJSONWP" (Mobile JSON Wire Protocol). The W3C Protocol differs from the
-(M)JSONWP protocols in a few small ways.
+supported this protocol for years. Before this protocol was designed as a web standard, the 
+[JSON Wire Protocol](https://www.selenium.dev/documentation/legacy/json_wire_protocol/) (JSONWP)
+and [Mobile JSON Wire Protocol](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md)
+(MJSONWP) were used instead.
 
-Up until Appium 2, Appium supported both protocols, so that older Selenium/Appium clients could
-still communicate with newer Appium servers. Appium 2 removes support for older protocols and is
-now only compatible with the W3C WebDriver Protocol.
+In Appium 1, all of these protocols were supported, so that older Selenium/Appium clients could
+still communicate with newer Appium servers. Appium 2 removes support for JSONWP/MJSONWP and is now
+only compatible with the W3C WebDriver Protocol.
 
-### :bangbang: Capabilities must use vendor prefix
+!!! info "Actions Needed"
 
-One significant difference between old and new protocols is in the format of capabilities.
-Previously called "desired capabilities", and now called simply "capabilities", there is now a
-requirement for a so-called "vendor prefix" on any non-standard capabilities. The list of standard
-capabilities is given in the [WebDriver Protocol spec](https://www.w3.org/TR/webdriver/#capabilities),
-and includes a few commonly used capabilities such as `browserName` and `platformName`.
+    Make sure you are using Selenium/Appium clients compatible with the W3C WebDriver Protocol
 
-These standard capabilities continue to be used as-is. All other capabilities must include a
-"vendor prefix" in their name. A vendor prefix is a string followed by a colon, such as `appium:`.
-Most of Appium's capabilities go beyond the standard W3C capabilities and must therefore include
-vendor prefixes (we recommend that you use `appium:` unless directed otherwise by documentation).
-For example:
+### Capabilities Require Vendor Prefix
 
-- `appium:app`
-- `appium:noReset`
-- `appium:deviceName`
+In Appium 1, in order to create a session, you had to specify certain desired capabilities, which
+would indicate session parameters, e.g. the driver you want to use. Appium 2 retains this behavior
+and continues to accept desired capabilities (now renamed simply to 'capabilities'), but as part of
+the W3C WebDriver Protocol specification, all non-standard capabilities are now required to use a
+vendor prefix. 
 
-This requirement may or may not be a breaking change for your test suites when targeting Appium 2.
-If you're using an updated Appium client (at least one maintained by the Appium team), the client
-will add the `appium:` prefix for you on all necessary capabilities automatically. New versions of
-[Appium Inspector](https://github.com/appium/appium-inspector) will also do this. Cloud-based Appium
-providers may also do this. So simply be aware that if you get any messages to the effect that your
-capabilities lack a vendor prefix, this is how you solve that problem.
+The list of standard capabilities is described in the [WebDriver Protocol specification](https://www.w3.org/TR/webdriver/#capabilities),
+and includes a few commonly used capabilities like `browserName` and `platformName`. All other
+capabilities must now start with the vendor name and a colon (the vendor prefix), such as `appium:`.
+Since most of Appium's capabilities go beyond the standard W3C capabilities, all of them must
+include the `appium:` prefix (unless specified otherwise):
 
-To make everyone's lives a bit easier, we've also introduced the option of grouping up all
-Appium-related capabilities into one object capability, `appium:options`. You can bundle together
-anything that you would normally put an `appium:` prefix on into this one capability. Here's an
-example (in raw JSON) of how you might start an iOS session on the Safari browser using `appium:options`:
-
-```json
-{
-  "platformName": "iOS",
-  "browserName": "Safari",
-  "appium:options": {
-    "platformVersion": "14.4",
-    "deviceName": "iPhone 11",
-    "automationName": "XCUITest"
-  }
-}
+```
+deviceName        # Appium 1
+appium:deviceName # Appium 2
 ```
 
-(Of course, each client will have a different way of creating structured capabilities like
-`appium:options` or other ones that you might have seen such as `goog:chromeOptions`).
+This requirement may or may not be a breaking change for your test suites. Up-to-date versions of
+official Appium clients and the Appium Inspector will automatically add the `appium:` prefix to all
+non-standard capabilities, and the same may apply to cloud-based Appium providers.
 
-!!! note
+Additionally, if you are starting a session with multiple Appium-specific capabilities (which will
+likely be the case), it may seem repetitive to add the `appium:` prefix to each individual
+capability. To avoid this, you can optionally group up all these capabilities under a single object
+capability, `appium:options`, for example:
+
+=== "Default Approach"
+
+    ```json
+    {
+      "platformName": "iOS",
+      "browserName": "Safari",
+      "appium:platformVersion": "14.4",
+      "appium:deviceName": "iPhone 11",
+      "appium:automationName": "XCUITest"
+    }
+    ```
+
+=== "With `appium:options`"
+
+    ```json
+    {
+      "platformName": "iOS",
+      "browserName": "Safari",
+      "appium:options": {
+        "platformVersion": "14.4",
+        "deviceName": "iPhone 11",
+        "automationName": "XCUITest"
+      }
+    }
+    ```
+
+!!! warning
 
     Capabilities included in the `appium:options` object will overwrite capabilities of the same
-    name that are used outside of this object. (The `appium:options` syntax support by cloud
-    providers may vary.)
+    name that are used outside of this object. Note that cloud provider support for the
+    `appium:options` syntax may vary.
 
 For more information on capabilities, have a look at the [Capabilities Guide](./caps.md).
 
-### :bangbang: Removed Commands
+!!! info "Actions Needed"
 
-In addition to commands which have been moved to driver implementations, commands which were a part
-of the old JSON Wire Protocol and not a part of the W3C Protocol are no longer available:
+    Add the `appium:` prefix to all Appium-specific capabilities used in your tests, or wrap them
+    inside an `appium:options` object
+
+### Deprecated Commands Removed
+
+In addition to the driver-specific commands moved to the drivers themselves, some commands which
+were a part of the old JSON Wire Protocol and not a part of the W3C Protocol have been removed:
 
 - TODO (these commands are being identified and removed and will be updated here when complete)
 
-If you use a modern Appium or Selenium client, you should no longer have access to these anyway,
-so any breaking changes should appear on the client side first and foremost.
+If your Appium/Selenium client is up to date, it will most likely have already removed support for
+these commands.
 
-### :bangbang: Image analysis features moved to plugin
+!!! info "Actions Needed"
 
-One of the design goals for Appium 2 is to migrate non-core features into special extensions called
-[plugins](../ecosystem/plugins.md). This allows people to opt into features which require extra time
-to download or extra system setup. The various image-related features of Appium (image comparison,
-finding elements by image, etc...) have been moved into an officially supported plugin called
-[images](https://github.com/appium/appium/tree/master/packages/images-plugin).
+    Check your Appium client documentation for the affected methods, and adjust your code to use
+    their replacements
 
-If you use these image-related methods, to continue accessing them you will need to do two things:
+### Advanced Features Moved to Plugins
 
-1. Install the plugin: `appium plugin install images`
-2. Ensure you start the Appium server with access to run the plugin by including it in the list of
-   plugins designated on the command line, e.g., `appium --use-plugins=images`
+One of the design goals for Appium 2 is to extract non-core features into special extensions called
+[plugins](../ecosystem/plugins.md). Two such features of Appium 1 have been moved to plugins, and
+are no longer bundled with Appium 2:
 
-Image-related commands will also be removed on the client side of things, which means you will need
-to follow the instructions on the plugin README for installing client-side plugins to access these features.
+|Feature|Plugin Name|
+|--|--|
+|Image-related features (comparison, search by image, etc...)|[`images`](https://github.com/appium/appium/tree/master/packages/images-plugin)|
+|The Execute Driver Script feature|[`execute-driver`](https://github.com/appium/appium/tree/master/packages/execute-driver-plugin)|
 
-### :bangbang: Execute Driver Script command moved to plugin
+!!! info "Actions Needed"
 
-If you use the advanced Execute Driver Script feature (which allows you to send in a WebdriverIO
-script to have it executed completely on the server instead of command-by-command from the client),
-this functionality has been moved to a plugin. Here's what to do to keep using it:
+    If you were using the image-related features and/or the execute driver script feature in Appium
+    1, first install their plugin(s):
+    ```
+    appium plugin install images 
+    appium plugin install execute-driver
+    ```
+    Afterwards, make sure to activate the plugin(s) upon launching the Appium server:
+    ```
+    appium --use-plugins=images,execute-driver
+    ```
 
-1. Install the plugin: `appium plugin install execute-driver`
-2. Ensure you start the Appium server with access to run the plugin by including it in the list of
-   plugins designated on the command line, e.g., `appium --use-plugins=execute-driver`
+### Filepaths No Longer Supported for Some CLI Options
 
-### :bangbang: External Files No Longer Supported for `--nodeconfig`, `--default-capabilities`, `--allow-insecure` and `--deny-insecure`
+In Appium 1, some server command-line options could be invoked by passing a filepath as their
+value, and Appium would then parse the contents of that file as the actual value for that option.
+There were four options that supported this:
 
-These options can be provided as strings on the command line (a JSON string for `--nodeconfig` and
-a comma-separated list of strings for `--allow-insecure` and `--deny-insecure`). Arguments provided
-on the command line will likely need to be quoted or escaped.
+* `--nodeconfig`
+* `--default-capabilities`
+* `--allow-insecure`
+* `--deny-insecure`
 
-The recommended method to provide these options is through a [configuration file](./config.md).
+Appium 2 no longer attempts to parse the contents of filepaths passed to these options, and offers
+two ways to specify the value for these options:
 
-In summary, if you are using a JSON Appium config file, you can simply cut-and-paste the contents
-of your "nodeconfig" JSON file into the value of the `server.nodeconfig` property. Any CSV-like
-files you had previously provided for `--allow-insecure` and `--deny-insecure` become the values
-of the `server.allow-insecure` and `server.deny-insecure` properties in the Appium config files
-(respectively); both are arrays of strings.
+* As strings, directly on the command line
+    * `--nodeconfig` / `--default-capabilities`: JSON string
+    * `--allow-insecure` / `--deny-insecure`: comma-separated list
+* In the [Appium Configuration file](./config.md)
 
-### :bangbang: Old drivers removed
+!!! info "Actions Needed"
 
-The old iOS and Android (UiAutomator 1) drivers and related tools (e.g., `authorize-ios`) have been
-removed. They haven't been relevant for many years anyway.
+    If you are using any of the aforementioned CLI options with a filepath value, update your code
+    to pass the file contents either directly or through the Appium config file
 
-### :bangbang: Server can no longer be started with `--port 0`
+### Deprecated Packages No Longer Supported
 
-In Appium 1, it was possible to specify `--port 0` during server startup. This had the effect of
-starting Appium on a random free port. In Appium 2, port values must be `1` or higher. The random
-port assignment was never an intentional feature of Appium 1, but a consequence of how Node's
-HTTP servers work and the fact that there was no port input validation in Appium 1. If you want
-to find a random free port to start Appium on, you must now take care of this on your own prior to
-starting Appium. Starting Appium on an explicit and known port is the correct practice moving
-forward.
+The Appium 1 ecosystem included several drivers, clients and other packages that had since been
+deprecated and replaced with newer packages. Appium 2 no longer includes support for these packages,
+and it is recommended to migrate to the following replacements:
 
-### :warning: Internal packages renamed
+|Appium 1 Package|Replacement in Appium 2|
+|--|--|
+|iOS Driver|[XCUITest Driver](https://appium.github.io/appium-xcuitest-driver/latest/)|
+|UiAutomator Driver|[UiAutomator2](https://github.com/appium/appium-uiautomator2-driver/)|
+|`wd` Client|[WebdriverIO Client](https://webdriver.io/)|
+|Appium Desktop|[Appium Inspector](https://github.com/appium/appium-inspector)|
 
-Some Appium-internal NPM packages have been renamed (for example, `appium-base-driver` is now
-`@appium/base-driver`). This is not a breaking change for Appium users, only for people who have
-built software that directly incorporates Appium's code.
+!!! info "Actions Needed"
 
-### :warning: `wd` JavaScript client library no longer supported
+    If you are using any of the aforementioned package(s), migrate to their recommended replacement(s)
 
-For many years, some of Appium's authors maintained the [WD](https://github.com/admc/wd) client
-library. This library has been deprecated and has not been updated for use with the W3C WebDriver
-protocol. As such, if you're using this library you'll need to move to a more modern one. We
-recommend [WebdriverIO](https://webdriver.io).
+### Server Port 0 No Longer Supported
 
-### :warning: Appium Desktop replaced with Appium Inspector
+In Appium 1, it was possible to specify `--port 0` during server startup, which had the effect of
+starting Appium on a random free port. Appium 2 no longer allows this, and requires port values to
+be `1` or higher. If you wish to start Appium on a random port, you must now take care of this on
+your own prior to launching the server.
 
-The inspector functionality of Appium Desktop has been moved to its own app:
-[Appium Inspector](https://github.com/appium/appium-inspector). It is fully compatible with
-standalone Appium 2 servers, but also works with later versions of Appium 1 servers. Appium Desktop
-itself has been deprecated and is not compatible with Appium 2.
+!!! info "Actions Needed"
 
-In addition to the app, Appium Inspector also has a browser version, accessible at
-[inspector.appiumpro.com](https://inspector.appiumpro.com). Note that in order to use the
-browser version with a local Appium server, you'll need to first start the server with the
-`--allow-cors` flag.
+    If you are launching Appium with `--port 0`, change the port number value to `1` or higher
+
+### Internal Packages Renamed
+
+In Appium 1, the internal dependency packages were each located in their own repository. Appium 2
+moves to a monorepo structure and therefore renames many of these packages, for example:
+
+```
+appium-base-driver  # Appium 1
+@appium/base-driver # Appium 2
+```
+
+!!! info "Actions Needed"
+
+    If you do not directly import Appium packages into your code - none! However, if you do, make
+    sure to update the names of your Appium package imports!
 
 ## Major New Features
 
-Apart from the breaking changes mentioned above, in this section is a list of some of the major new
-features you may wish to take advantage of with Appium 2.
+Apart from the breaking changes mentioned above, here are some of the major new features you may
+wish to take advantage of with Appium 2:
 
-### Plugins
+### Third-Party Drivers and Plugins
 
-#### :tada: Server Plugins
+You are no longer limited to official drivers or plugins, or ones that the Appium team even knows
+about! Developers can now create their own custom drivers or plugins, which can be installed via
+Appium's [Extension CLI](../cli/extensions.md) from `npm`, `git`, GitHub, or even the local
+filesystem. Interested in building a driver or plugin? Check out the
+[Building Drivers](../developing/build-drivers.md) and
+[Building Plugins](../developing/build-plugins.md) guides.
 
-Appium extension authors can now develop their own server plugins, which can intercept and modify
-any Appium command, or even adjust the way the underlying Appium HTTP server itself works. To learn
-more about plugins, read the new [Appium Introduction](../intro/index.md). Interested in building
-a plugin? Check out the [Building Plugins](../developing/build-plugins.md) guide.
+### Configuration Files
 
-### :tada: Install drivers and plugins from anywhere
-
-You're no longer limited to the drivers that come with Appium, or that the Appium team even knows
-about! Appium extension authors can now develop custom drivers, which can be downloaded or
-installed via Appium's [Extension CLI](../cli/extensions.md) from `npm`, `git`, GitHub, or even the
-local filesystem. Interested in building a driver? Check out the [Building
-Drivers](../developing/build-drivers.md) guide.
-
-### :tada: Configuration Files
-
-Appium now supports _configuration files_ in addition to command-line arguments. In a nutshell,
-nearly all arguments which Appium 1 required to be provided on the CLI are now able to be expressed
-via a configuration file. Configuration files may be in JSON, JS, or YAML format. See the
-[Config Guide](./config.md) for a full explanation.
+Appium now supports _configuration files_ in addition to command-line arguments. Nearly all options
+or flags that had to be specified on the CLI in Appium 1, can now also be provided in a
+configuration file. The file can be in JSON, JS, or YAML format. For more information, refer to
+the [Config File Guide](./config.md).
 
 ## Special Notes for Cloud Providers
 
-The rest of this document has applied to Appium generally, but some of the architectural changes in
-Appium 2 will constitute breaking changes for Appium-related service providers, whether a
-cloud-based Appium host or an internal service. At the end of the day, the maintainer of the Appium
-server is responsible for installing and making available the various Appium drivers and plugins
-that end users may wish to use.
+Most of this guide has applied to Appium end users or developers, but some of the architectural
+changes in Appium 2 will constitute breaking changes for different Appium service providers. At the
+end of the day, the maintainer of the Appium server is responsible for installing and exposing the
+various Appium drivers and plugins that end users may wish to use.
 
 We encourage cloud providers to thoroughly read and understand our [recommendation for cloud
 provider capabilities](./caps.md#special-notes-for-cloud-providers) in order to support user needs in

--- a/packages/appium/docs/en/guides/migrating-1-to-2.md
+++ b/packages/appium/docs/en/guides/migrating-1-to-2.md
@@ -39,7 +39,7 @@ npm i -g appium --drivers=xcuitest,uiautomator2
 ```bash
 appium driver install uiautomator2
 ```
-* Use the [Appium Setup CLI command](../cli/setup.md), for example:
+* Use the [Appium Setup CLI command](../cli/setup.md) (added in Appium `2.6`), for example:
 ```bash
 appium setup mobile
 ```
@@ -115,7 +115,7 @@ and it is recommended to migrate to the following replacements:
 
     If you are using any of the aforementioned package(s), migrate to their recommended replacement(s)
 
-### Default Base Path Changed
+### Default Server Base Path Changed
 
 In Appium 1, the default Appium server URL was `http://localhost:4723/wd/hub`, where the `/wd/hub`
 part (the base path) was a legacy convention from Selenium 1. Appium 2 changes the default base
@@ -276,37 +276,6 @@ For more information on capabilities, have a look at the [Capabilities Guide](./
     Add the `appium:` prefix to all Appium-specific capabilities used in your tests, or wrap them
     inside an `appium:options` object
 
-### Some Commands Moved to Drivers
-
-In Appium 1, commands that were specific to certain drivers were built into the main Appium server.
-Appium 2, in line with its modular approach, moves many such commands to the drivers themselves.
-For example, `pressKeyCode` was specific to the UiAutomator2 driver, and is now understood only by
-that driver.
-
-In practice, the only breaking change here is the error returned when invoking a command not
-implemented by the active driver. In Appium 1, this would return a `501 Not Yet Implemented` error,
-whereas Appium 2 now returns `404 Not Found`: if the active driver doesn't know about the command,
-the Appium server will not define the route corresponding to the command.
-
-!!! info "Actions Needed"
-
-    Ensure you have installed all the drivers you were using in Appium 1
-
-### Deprecated Commands Removed
-
-In addition to the driver-specific commands moved to the drivers themselves, some commands which
-were a part of the old JSON Wire Protocol and not a part of the W3C Protocol have been removed:
-
-- TODO (these commands are being identified and removed and will be updated here when complete)
-
-If your Appium/Selenium client is up to date, it will most likely have already removed support for
-these commands.
-
-!!! info "Actions Needed"
-
-    Check your Appium client documentation for the affected methods, and adjust your code to use
-    their replacements
-
 ### Advanced Features Moved to Plugins
 
 One of the design goals for Appium 2 is to extract non-core features into special extensions called
@@ -330,6 +299,27 @@ are no longer bundled with Appium 2:
     ```
     appium --use-plugins=images,execute-driver
     ```
+
+### Endpoint Changes
+
+A few server endpoints used in Appium 1 were accepting old or unused parameters. Appium 2 removes
+support for these parameters. The following is a list of these changed endpoints, along with the
+parameters they no longer accept, as well as the parameters they continue to accept in Appium 2.
+
+* `POST /session/:sessionId/appium/device/gsm_signal`
+    * :octicons-x-24: `signalStrengh`
+    * :octicons-check-24: `signalStrength`
+* `POST /session/:sessionId/appium/element/:elementId/value`
+    * :octicons-x-24: `value`
+    * :octicons-check-24: `text`
+* `POST /session/:sessionId/appium/element/:elementId/replace_value`
+    * :octicons-x-24: `value`
+    * :octicons-check-24: `text`
+
+!!! info "Actions Needed"
+
+    Check your Appium client documentation for the methods using these endpoints, and adjust your
+    code to only use the accepted parameters
 
 ### Internal Packages Renamed
 


### PR DESCRIPTION
This is a rewrite of the Appium 2 migration guide, to make it easier to read and understand the actions required for migration, adopting a similar style to the Appium 3 migration guide. Better late than never, I suppose.

* In the overview, add suggestion to first uninstall Appium 1 before upgrading
* Rewrite each section under breaking changes and add an 'Actions Needed' callout for clarity
* Reorder sections under breaking changes (installation -> server launch -> session creation -> usage)
* Add mention of `appium setup` in the driver installation section
* Merge sections for chromedriver installation flags and driver-specific command line options
* Merge sections for image and execute driver script features being moved to plugins
* Merge sections for old drivers removed, and dropped support for `wd` and Appium Desktop
* Remove sections for driver-specific automation commands and removed commands
  * I compared the `routes.js` files for `appium-base-driver` and `@appium/base-driver` upon Appium 2 release, and the only removed routes belonged to the `images` and `execute-driver` plugins. However, a few routes had their parameters changed, so I added a new section for that
* Under major new features, merge the plugins section into the install drivers and plugins from anywhere section