### PR TITLE
feat(appium): implement GET /appium/sessions and deprecate GET /sessions

### DIFF
--- a/packages/appium/docs/en/cli/args.md
+++ b/packages/appium/docs/en/cli/args.md
@@ -23,14 +23,14 @@ below.
 |--|--|--|--|--|
 |`--address`|IP address to listen on|string|`0.0.0.0`|`-a`|
 |`--allow-cors`|Whether the Appium server should allow web browser connections from any host|boolean|`false`||
-|`--allow-insecure`|Set which insecure features are allowed to run in this server's sessions. Features are defined on a driver level; see documentation for more details. Note that features defined via `--deny-insecure` will be disabled, even if also listed here. If string, a path to a text file containing policy or a comma-delimited list.|array<string>|`[]`||
+|`--allow-insecure`|Set which [insecure features](../guides/security.md) are allowed to run in this server's sessions. Most features are defined on a driver level; see driver documentation for more details. Individual features can be overridden by `--deny-insecure`. Has no effect in combination with `--relaxed-security`.|array<string>|`[]`||
 |`--base-path`|Base path to use as the prefix for all webdriver routes running on the server|string|`""`|`-pa`|
 |`--callback-address`|Callback IP address (default: same as `--address`)|string||`-ca`|
 |`--callback-port`|Callback port (default: same as `--port`) (Value must be between `1` and `65535`)|integer|`4723`|`-cp`|
 |`--config`|Path to an [Appium configuration JSON file](../guides/config.md)|string|||
 |`--debug-log-spacing`|Add exaggerated spacing in logs to help with visual inspection|boolean|`false`||
 |`--default-capabilities`|Set the default desired capabilities, which will be set on each session unless overridden by received capabilities. If a string, a path to a JSON file containing the capabilities, or raw JSON.|object||`-dc`|
-|`--deny-insecure`|Set which insecure features are not allowed to run in this server's sessions. Features are defined on a driver level; see documentation for more details. Features listed here will not be enabled even if also listed in `--allow-insecure`, and even if `--relaxed-security` is enabled. If string, a path to a text file containing policy or a comma-delimited list.|array<string>|`[]`||
+|`--deny-insecure`|Set which [insecure features](../guides/security.md) are not allowed to run in this server's sessions. Most features are defined on a driver level; see driver documentation for more details. Since all insecure features are disabled by default, this argument has no effect without either `--allow-insecure` or `--relaxed-security`, and is applied after both.|array<string>|`[]`||
 |`--driver`|Driver-specific configuration. Keys should correspond to driver package names|object|||
 |`--drivers-import-chunk-size`|The maximum amount of drivers that could be imported in parallel on server startup|number|`3`||
 |`--keep-alive-timeout`|Number of seconds the Appium server should apply as both the keep-alive timeout and the connection timeout for all requests. Setting this to `0` disables the timeout.|integer|`600`|`-ka`|
@@ -48,7 +48,7 @@ below.
 |`--plugin`|Plugin-specific configuration. Keys should correspond to plugin package names|object|||
 |`--plugins-import-chunk-size`|The maximum amount of plugins that could be imported in parallel on server startup|number|`7`||
 |`--port`|Port to listen on (Value must be between `1` and `65535`)|integer|`4723`|`-p`|
-|`--relaxed-security`|Disable additional security checks, so it is possible to use some advanced features, provided by drivers supporting this option. Only enable it if all the clients are in the trusted network and it's not the case if a client could potentially break out of the session sandbox. Specific features can be overridden by using `--deny-insecure`|boolean|`false`||
+|`--relaxed-security`|Allow all [insecure features](../guides/security.md). Only use this if all clients are in a trusted network and could not potentially break out of the session sandbox. Specific features can be overridden by using `--deny-insecure`.|boolean|`false`||
 |`--session-override`|Enables session override (clobbering)|boolean|`false`||
 |`--ssl-cert-path`|Absolute path to the `.cert` file if TLS is used. Must be provided together with `--ssl-key-path`. See the [SSL/TLS/SPDY Support guide](../guides/tls.md) for details|string|||
 |`--ssl-key-path`|Absolute path to the `.key` file if TLS is used. Must be provided together with `--ssl-cert-path`. See the [SSL/TLS/SPDY Support guide](../guides/tls.md) for details|string|||

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -207,12 +207,7 @@ class AppiumDriver extends DriverCore {
    * @returns {Promise<import('@appium/types').TimestampedMultiSessionData[]>}
    */
   async getAppiumSessions () {
-    // We are using `isFeatureEnabled` instead of `assertFeatureEnabled`,
-    // otherwise users that don't want to expose their session list
-    // will get an error every time someone tries to request them
-    if (!this.isFeatureEnabled(SESSION_DISCOVERY_FEATURE)) {
-      return [];
-    }
+    this.assertFeatureEnabled(SESSION_DISCOVERY_FEATURE);
     return _.toPairs(this.sessions).map(([id, driver]) => ({
       id,
       created: driver.sessionCreationTimestampMs,

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -188,6 +188,11 @@ class AppiumDriver extends DriverCore {
     });
   }
 
+  /**
+   * Retrieve information about all active sessions
+   * @returns {Promise<import('@appium/types').MultiSessionData[]>}
+   * @deprecated Use {@linkcode getAppiumSessions} instead
+   */
   async getSessions() {
     return _.toPairs(this.sessions).map(([id, driver]) => ({
       id,
@@ -195,9 +200,16 @@ class AppiumDriver extends DriverCore {
     }));
   }
 
+  /**
+   * Retrieve information about all active sessions
+   * @returns {Promise<import('@appium/types').DatedMultiSessionData[]>}
+   */
   async getAppiumSessions () {
-    throw new errors.NotImplementedError('Not implemented yet. ' +
-      'Please check https://github.com/appium/appium/issues/20880 for more details.');
+    return _.toPairs(this.sessions).map(([id, driver]) => ({
+      id,
+      created: driver.sessionCreationTime,
+      capabilities: /** @type {import('@appium/types').DriverCaps<any>} */ (driver.caps),
+    }));
   }
 
   printNewSessionAnnouncement(driverName, driverVersion, driverBaseVersion) {

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -202,12 +202,12 @@ class AppiumDriver extends DriverCore {
 
   /**
    * Retrieve information about all active sessions
-   * @returns {Promise<import('@appium/types').DatedMultiSessionData[]>}
+   * @returns {Promise<import('@appium/types').TimestampedMultiSessionData[]>}
    */
   async getAppiumSessions () {
     return _.toPairs(this.sessions).map(([id, driver]) => ({
       id,
-      created: driver.sessionCreationTime,
+      created: driver.sessionCreationTimestampMs,
       capabilities: /** @type {import('@appium/types').DriverCaps<any>} */ (driver.caps),
     }));
   }

--- a/packages/appium/lib/constants.js
+++ b/packages/appium/lib/constants.js
@@ -115,3 +115,8 @@ export const BIDI_BASE_PATH = '/bidi';
  * a bidi socket
  */
 export const BIDI_EVENT_NAME = 'bidiEvent';
+
+/**
+ * The name of the insecure feature that allows retrieving the list of active server sessions
+ */
+export const SESSION_DISCOVERY_FEATURE = 'session_discovery';

--- a/packages/appium/lib/insecure-features.ts
+++ b/packages/appium/lib/insecure-features.ts
@@ -1,0 +1,132 @@
+import _ from 'lodash';
+import logger from './logger';
+
+import type {AppiumDriver} from './appium';
+import type {ExternalDriver} from '@appium/types';
+
+const ALL_DRIVERS_MATCH = '*';
+const FEATURE_NAME_SEPARATOR = ':';
+
+/**
+ * Configures insecure features according to the values in `args.relaxedSecurityEnabled`,
+ * `args.allowInsecure`, and `args.denyInsecure`, and informs the user about any
+ * globally-applied features.
+ * Uses `logger` instead of `this.log` to reduce user confusion.
+ */
+export function configureGlobalFeatures(this: AppiumDriver) {
+  if (this.args.relaxedSecurityEnabled) {
+    logger.info(
+      `Enabling relaxed security. All insecure features will be ` +
+        `enabled unless explicitly disabled by --deny-insecure`,
+    );
+    this.relaxedSecurityEnabled = true;
+  } else if (!_.isEmpty(this.args.allowInsecure)) {
+    this.allowInsecure = validateFeatures(this.args.allowInsecure);
+    const globalAllowedFeatures = filterInsecureFeatures(this.allowInsecure);
+    if (!_.isEmpty(globalAllowedFeatures)) {
+      logger.info('Explicitly enabling insecure features:');
+      globalAllowedFeatures.forEach((a) => logger.info(`    ${a}`));
+    }
+  }
+  if (_.isEmpty(this.args.denyInsecure)) {
+    return;
+  }
+  this.denyInsecure = validateFeatures(this.args.denyInsecure);
+  const globalDeniedFeatures = filterInsecureFeatures(this.denyInsecure);
+  if (_.isEmpty(globalDeniedFeatures)) {
+    return;
+  }
+  logger.info('Explicitly disabling insecure features:');
+  globalDeniedFeatures.forEach((a) => logger.info(`    ${a}`));
+}
+
+/**
+ * If anything in the umbrella driver's insecure feature configuration applies to this driver,
+ * assign it to the driver instance
+ *
+ * @param driver
+ * @param driverName
+ */
+export function configureDriverFeatures(
+  this: AppiumDriver,
+  driver: ExternalDriver,
+  driverName: string,
+) {
+  if (this.relaxedSecurityEnabled) {
+    this.log.info(
+      `Enabling relaxed security for this session as per the server configuration. ` +
+        `All insecure features will be enabled unless explicitly disabled by --deny-insecure`,
+    );
+    driver.relaxedSecurityEnabled = true;
+  }
+  const allowedDriverFeatures = filterInsecureFeatures(this.allowInsecure, driverName);
+  if (!_.isEmpty(allowedDriverFeatures)) {
+    this.log.info('Explicitly enabling insecure features for this session ' +
+      'as per the server configuration:',
+    );
+    allowedDriverFeatures.forEach((a) => this.log.info(`    ${a}`));
+    driver.allowInsecure = allowedDriverFeatures;
+  }
+  const deniedDriverFeatures = filterInsecureFeatures(this.denyInsecure, driverName);
+  if (_.isEmpty(deniedDriverFeatures)) {
+    return;
+  }
+  this.log.info('Explicitly disabling insecure features for this session ' +
+    'as per the server configuration:',
+  );
+  deniedDriverFeatures.forEach((a) => this.log.info(`    ${a}`));
+  driver.denyInsecure = deniedDriverFeatures;
+}
+
+/**
+ * Validates the list of allowed/denied server features
+ *
+ * @param features
+ */
+function validateFeatures(features: string[]): string[] {
+  const validator = (fullName: string) => {
+    const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+    // TODO: This is for the backward compatibility with Appium2
+    // TODO: In Appium3 the separator will be mandatory
+    if (separatorPos < 0) {
+      return `${ALL_DRIVERS_MATCH}${FEATURE_NAME_SEPARATOR}${fullName}`;
+    }
+
+    const [automationName, featureName] = [
+      fullName.substring(0, separatorPos),
+      fullName.substring(separatorPos + 1)
+    ];
+    if (!automationName || !featureName) {
+      throw new Error(
+        `The full feature name must include both the destination automation name or the ` +
+        `'${ALL_DRIVERS_MATCH}' wildcard to apply the feature to all installed drivers, and ` +
+        `the feature name split by a colon, got '${fullName}' instead`
+      );
+    }
+    return fullName;
+  };
+  return features.map(validator);
+}
+
+/**
+ * Filters the list of insecure features to only those that are
+ * applicable to the given driver name.
+ * Assumes that all feature names have already been validated
+ *
+ * @param features
+ * @param driverName
+ */
+function filterInsecureFeatures(
+  features: string[],
+  driverName: string = ALL_DRIVERS_MATCH
+): string[] {
+  const filterFn = (fullName: string) => {
+    const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+    if (separatorPos <= 0) {
+      return false;
+    }
+    const automationName = fullName.substring(0, separatorPos);
+    return [driverName, ALL_DRIVERS_MATCH].includes(automationName);
+  };
+  return features.filter(filterFn);
+}

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -376,7 +376,7 @@ async function main(args) {
   await logStartupInfo(parsedArgs);
 
   // handle the insecure feature configuration since some features may apply globally
-  appiumDriver.configureInsecureFeatures();
+  appiumDriver.configureGlobalFeatures();
 
   const appiumHomeSourceName = determineAppiumHomeSource(args?.appiumHome);
   logger.debug(`The ${appiumHomeSourceName}: ${appiumHome}`);

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -375,6 +375,9 @@ async function main(args) {
 
   await logStartupInfo(parsedArgs);
 
+  // handle the insecure feature configuration since some features may apply globally
+  appiumDriver.configureInsecureFeatures();
+
   const appiumHomeSourceName = determineAppiumHomeSource(args?.appiumHome);
   logger.debug(`The ${appiumHomeSourceName}: ${appiumHome}`);
 

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -17,8 +17,6 @@ const STANDARD_CAPS_LOWERCASE = new Set([...STANDARD_CAPS].map((cap) => cap.toLo
 export const V4_BROADCAST_IP = '0.0.0.0';
 export const V6_BROADCAST_IP = '::';
 export const npmPackage = fs.readPackageJsonFrom(__dirname);
-const ALL_DRIVERS_MATCH = '*';
-const FEATURE_NAME_SEPARATOR = ':';
 
 /**
  *
@@ -461,57 +459,6 @@ export function adler32(str, seed = null) {
  */
 export function isBroadcastIp(address) {
   return [V4_BROADCAST_IP, V6_BROADCAST_IP, `[${V6_BROADCAST_IP}]`].includes(address);
-}
-
-/**
- * Validates the list of allowed/denied server features
- *
- * @param {string[]} features
- * @returns {string[]}
- */
-export function validateFeatures(features) {
-  const validator = (/** @type {string} */ fullName) => {
-    const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
-    // TODO: This is for the backward compatibility with Appium2
-    // TODO: In Appium3 the separator will be mandatory
-    if (separatorPos < 0) {
-      return `${ALL_DRIVERS_MATCH}${FEATURE_NAME_SEPARATOR}${fullName}`;
-    }
-
-    const [automationName, featureName] = [
-      fullName.substring(0, separatorPos),
-      fullName.substring(separatorPos + 1)
-    ];
-    if (!automationName || !featureName) {
-      throw new Error(
-        `The full feature name must include both the destination automation name or the ` +
-        `'${ALL_DRIVERS_MATCH}' wildcard to apply the feature to all installed drivers, and ` +
-        `the feature name split by a colon, got '${fullName}' instead`
-      );
-    }
-    return fullName;
-  };
-  return features.map(validator);
-}
-
-/**
- * Filters the list of insecure features to only those that are
- * applicable to the given driver name.
- * Assumes that all feature names have already been validated
- *
- * @param {string[]} features
- * @returns {string[]}
- */
-export function filterInsecureFeatures(features, driverName = ALL_DRIVERS_MATCH) {
-  const filterFn = (/** @type {string} */ fullName) => {
-    const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
-    if (separatorPos <= 0) {
-      return false;
-    }
-    const automationName = fullName.substring(0, separatorPos);
-    return [driverName, ALL_DRIVERS_MATCH].includes(automationName);
-  };
-  return features.filter(filterFn);
 }
 
 /**

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -495,6 +495,22 @@ export function validateFeatures(features) {
 }
 
 /**
+ * Filters the list of allowed/denied features to only those that are applied server-wide
+ * Assumes that all feature names have already been validated
+ *
+ * @param {string[]} features
+ * @returns {string[]}
+ */
+export function filterGlobalFeatures(features) {
+  const validator = (/** @type {string} */ fullName) => {
+    const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+    const automationName = fullName.substring(0, separatorPos);
+    return automationName === ALL_DRIVERS_MATCH;
+  };
+  return features.filter(validator);
+}
+
+/**
  * @typedef {import('@appium/types').StringRecord} StringRecord
  * @typedef {import('@appium/types').BaseDriverCapConstraints} BaseDriverCapConstraints
  */

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -502,12 +502,15 @@ export function validateFeatures(features) {
  * @returns {string[]}
  */
 export function filterGlobalFeatures(features) {
-  const validator = (/** @type {string} */ fullName) => {
+  const filterFn = (/** @type {string} */ fullName) => {
     const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
+    if (separatorPos <= 0) {
+      return false;
+    }
     const automationName = fullName.substring(0, separatorPos);
     return automationName === ALL_DRIVERS_MATCH;
   };
-  return features.filter(validator);
+  return features.filter(filterFn);
 }
 
 /**

--- a/packages/appium/lib/utils.js
+++ b/packages/appium/lib/utils.js
@@ -495,20 +495,21 @@ export function validateFeatures(features) {
 }
 
 /**
- * Filters the list of allowed/denied features to only those that are applied server-wide
+ * Filters the list of insecure features to only those that are
+ * applicable to the given driver name.
  * Assumes that all feature names have already been validated
  *
  * @param {string[]} features
  * @returns {string[]}
  */
-export function filterGlobalFeatures(features) {
+export function filterInsecureFeatures(features, driverName = ALL_DRIVERS_MATCH) {
   const filterFn = (/** @type {string} */ fullName) => {
     const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
     if (separatorPos <= 0) {
       return false;
     }
     const automationName = fullName.substring(0, separatorPos);
-    return automationName === ALL_DRIVERS_MATCH;
+    return [driverName, ALL_DRIVERS_MATCH].includes(automationName);
   };
   return features.filter(filterFn);
 }

--- a/packages/appium/test/unit/appiumdriver.spec.js
+++ b/packages/appium/test/unit/appiumdriver.spec.js
@@ -172,7 +172,7 @@ describe('AppiumDriver', function () {
         appium.sessions['xyz-321-abc'] = fakeDrivers[1];
         appium.sessions['123-abc-xyz'] = fakeDrivers[2];
 
-        let sessions = await appium.getSessions();
+        let sessions = await appium.getAppiumSessions();
         sessions.should.have.length(3);
 
         mockFakeDriver
@@ -182,7 +182,7 @@ describe('AppiumDriver', function () {
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS)]);
         await appium.createSession(undefined, null, W3C_CAPS);
 
-        sessions = await appium.getSessions();
+        sessions = await appium.getAppiumSessions();
         sessions.should.have.length(1);
 
         for (let mfd of mockFakeDrivers) {
@@ -265,10 +265,10 @@ describe('AppiumDriver', function () {
       });
       it('should remove the session if it is found', async function () {
         let [sessionId] = (await appium.createSession(null, null, W3C_CAPS)).value;
-        let sessions = await appium.getSessions();
+        let sessions = await appium.getAppiumSessions();
         sessions.should.have.length(1);
         await appium.deleteSession(sessionId);
-        sessions = await appium.getSessions();
+        sessions = await appium.getAppiumSessions();
         sessions.should.have.length(0);
       });
       it("should call inner driver's deleteSession method", async function () {
@@ -281,7 +281,7 @@ describe('AppiumDriver', function () {
         await mockFakeDriver.object.deleteSession();
       });
     });
-    describe('getSessions', function () {
+    describe('getAppiumSessions', function () {
       let appium, mockFakeDriver;
       let sessions;
       before(function () {
@@ -294,7 +294,7 @@ describe('AppiumDriver', function () {
         mockFakeDriver.restore();
       });
       it('should return an empty array of sessions', async function () {
-        sessions = await appium.getSessions();
+        sessions = await appium.getAppiumSessions();
         sessions.should.be.an('array');
         sessions.should.be.empty;
       });
@@ -316,12 +316,14 @@ describe('AppiumDriver', function () {
           .returns(['fake-session-id-2', removeAppiumPrefixes(caps2.alwaysMatch)]);
         let [session2Id, session2Caps] = (await appium.createSession(null, null, caps2)).value;
 
-        sessions = await appium.getSessions();
+        sessions = await appium.getAppiumSessions();
         sessions.should.be.an('array');
         sessions.should.have.length(2);
         sessions[0].id.should.equal(session1Id);
+        sessions[0].should.have.property('created');
         removeAppiumPrefixes(caps1.alwaysMatch).should.eql(session1Caps);
         sessions[1].id.should.equal(session2Id);
+        sessions[1].should.have.property('created');
         removeAppiumPrefixes(caps2.alwaysMatch).should.eql(session2Caps);
       });
     });

--- a/packages/appium/test/unit/appiumdriver.spec.js
+++ b/packages/appium/test/unit/appiumdriver.spec.js
@@ -108,34 +108,36 @@ describe('AppiumDriver', function () {
       return [appium, mockFakeDriver];
     }
     describe('configureGlobalFeatures', function () {
+      /** @type {AppiumDriver} */
+      let appium;
+
       /**
        * @param {import('@appium/types').DriverOpts<import('../../lib/appium').AppiumDriverConstraints>} cliArgs
        */
-      function getDriver(cliArgs) {
-        const appium = new AppiumDriver(cliArgs);
+      function createDriver(cliArgs) {
+        appium = new AppiumDriver(cliArgs);
         appium.configureGlobalFeatures();
-        return appium;
       };
       it('should not allow insecure features by default', function () {
-        const appium = getDriver({});
+        createDriver({});
         appium.allowInsecure.should.be.empty;
         appium.denyInsecure.should.be.empty;
         appium.relaxedSecurityEnabled.should.be.false;
       });
       it('should allow insecure features', function () {
-        const appium = getDriver({allowInsecure: ['foo:bar']});
+        createDriver({allowInsecure: ['foo:bar']});
         appium.allowInsecure.should.eql(['foo:bar']);
       });
       it('should deny insecure features', function () {
-        const appium = getDriver({denyInsecure: ['foo:baz']});
+        createDriver({denyInsecure: ['foo:baz']});
         appium.denyInsecure.should.eql(['foo:baz']);
       });
       it('should allow relaxed security', function () {
-        const appium = getDriver({relaxedSecurityEnabled: true});
+        createDriver({relaxedSecurityEnabled: true});
         appium.relaxedSecurityEnabled.should.be.true;
       });
       it('should ignore allowed features in combination with relaxed security', function () {
-        const appium = getDriver({
+        createDriver({
           allowInsecure: ['foo:bar'],
           relaxedSecurityEnabled: true,
         });
@@ -329,7 +331,7 @@ describe('AppiumDriver', function () {
        * @param {import('@appium/types').DriverOpts<import('../../lib/appium').AppiumDriverConstraints>} appiumArgs
        * @returns {Promise<FakeDriver>}
        */
-      async function getDriverAndInstance(appiumArgs) {
+      async function getDriverInstance(appiumArgs) {
         appium = new AppiumDriver(appiumArgs);
         appium.configureGlobalFeatures();
         const fakeDriver = new FakeDriver();
@@ -359,17 +361,17 @@ describe('AppiumDriver', function () {
         await appium.deleteSession(SESSION_ID);
       });
       it(`should not apply any insecure features by default`, async function () {
-        fakeDriver = await getDriverAndInstance({});
+        fakeDriver = await getDriverInstance({});
         fakeDriver.allowInsecure.should.be.empty;
         fakeDriver.denyInsecure.should.be.empty;
         fakeDriver.relaxedSecurityEnabled.should.be.false;
       });
       it(`should apply relaxed security`, async function () {
-        fakeDriver = await getDriverAndInstance({relaxedSecurityEnabled: true});;
+        fakeDriver = await getDriverInstance({relaxedSecurityEnabled: true});;
         fakeDriver.relaxedSecurityEnabled.should.be.true;
       });
       it(`should apply global-scope insecure features`, async function () {
-        fakeDriver = await getDriverAndInstance({
+        fakeDriver = await getDriverInstance({
           allowInsecure: ['*:foo'],
           denyInsecure: ['*:bar'],
         });
@@ -377,7 +379,7 @@ describe('AppiumDriver', function () {
         fakeDriver.denyInsecure.should.eql(['*:bar']);
       });
       it(`should apply driver-scope insecure features only if the driver name matches`, async function () {
-        fakeDriver = await getDriverAndInstance({allowInsecure: ['fake:foo', 'real:bar']});
+        fakeDriver = await getDriverInstance({allowInsecure: ['fake:foo', 'real:bar']});
         fakeDriver.allowInsecure.should.eql(['fake:foo']);
       });
     });

--- a/packages/appium/test/unit/appiumdriver.spec.js
+++ b/packages/appium/test/unit/appiumdriver.spec.js
@@ -108,34 +108,37 @@ describe('AppiumDriver', function () {
       return [appium, mockFakeDriver];
     }
     describe('configureGlobalFeatures', function () {
-      it('should not allow insecure features by default', function () {
-        const appium = new AppiumDriver({});
+      /**
+       * @param {import('@appium/types').DriverOpts<import('../../lib/appium').AppiumDriverConstraints>} cliArgs
+       */
+      function getDriver(cliArgs) {
+        const appium = new AppiumDriver(cliArgs);
         appium.configureGlobalFeatures();
+        return appium;
+      };
+      it('should not allow insecure features by default', function () {
+        const appium = getDriver({});
         appium.allowInsecure.should.be.empty;
         appium.denyInsecure.should.be.empty;
         appium.relaxedSecurityEnabled.should.be.false;
       });
       it('should allow insecure features', function () {
-        const appium = new AppiumDriver({allowInsecure: ['foo:bar']});
-        appium.configureGlobalFeatures();
+        const appium = getDriver({allowInsecure: ['foo:bar']});
         appium.allowInsecure.should.eql(['foo:bar']);
       });
       it('should deny insecure features', function () {
-        const appium = new AppiumDriver({denyInsecure: ['foo:baz']});
-        appium.configureGlobalFeatures();
+        const appium = getDriver({denyInsecure: ['foo:baz']});
         appium.denyInsecure.should.eql(['foo:baz']);
       });
       it('should allow relaxed security', function () {
-        const appium = new AppiumDriver({relaxedSecurityEnabled: true});
-        appium.configureGlobalFeatures();
+        const appium = getDriver({relaxedSecurityEnabled: true});
         appium.relaxedSecurityEnabled.should.be.true;
       });
       it('should ignore allowed features in combination with relaxed security', function () {
-        const appium = new AppiumDriver({
+        const appium = getDriver({
           allowInsecure: ['foo:bar'],
           relaxedSecurityEnabled: true,
         });
-        appium.configureGlobalFeatures();
         appium.allowInsecure.should.be.empty;
         appium.relaxedSecurityEnabled.should.be.true;
       });

--- a/packages/appium/test/unit/appiumdriver.spec.js
+++ b/packages/appium/test/unit/appiumdriver.spec.js
@@ -107,27 +107,27 @@ describe('AppiumDriver', function () {
 
       return [appium, mockFakeDriver];
     }
-    describe('configureInsecureFeatures', function () {
+    describe('configureGlobalFeatures', function () {
       it('should not allow insecure features by default', function () {
         const appium = new AppiumDriver({});
-        appium.configureInsecureFeatures();
+        appium.configureGlobalFeatures();
         appium.allowInsecure.should.be.empty;
         appium.denyInsecure.should.be.empty;
         appium.relaxedSecurityEnabled.should.be.false;
       });
       it('should allow insecure features', function () {
         const appium = new AppiumDriver({allowInsecure: ['foo:bar']});
-        appium.configureInsecureFeatures();
+        appium.configureGlobalFeatures();
         appium.allowInsecure.should.eql(['foo:bar']);
       });
       it('should deny insecure features', function () {
         const appium = new AppiumDriver({denyInsecure: ['foo:baz']});
-        appium.configureInsecureFeatures();
+        appium.configureGlobalFeatures();
         appium.denyInsecure.should.eql(['foo:baz']);
       });
       it('should allow relaxed security', function () {
         const appium = new AppiumDriver({relaxedSecurityEnabled: true});
-        appium.configureInsecureFeatures();
+        appium.configureGlobalFeatures();
         appium.relaxedSecurityEnabled.should.be.true;
       });
       it('should ignore allowed features in combination with relaxed security', function () {
@@ -135,7 +135,7 @@ describe('AppiumDriver', function () {
           allowInsecure: ['foo:bar'],
           relaxedSecurityEnabled: true,
         });
-        appium.configureInsecureFeatures();
+        appium.configureGlobalFeatures();
         appium.allowInsecure.should.be.empty;
         appium.relaxedSecurityEnabled.should.be.true;
       });
@@ -192,7 +192,7 @@ describe('AppiumDriver', function () {
         mockFakeDriver.verify();
       });
       it('should kill all other sessions if sessionOverride is on', async function () {
-        appium.configureInsecureFeatures();
+        appium.configureGlobalFeatures();
         appium.args.sessionOverride = true;
 
         // mock three sessions that should be removed when the new one is created
@@ -300,7 +300,7 @@ describe('AppiumDriver', function () {
         mockFakeDriver.restore();
       });
       it('should remove the session if it is found', async function () {
-        appium.configureInsecureFeatures();
+        appium.configureGlobalFeatures();
         let [sessionId] = (await appium.createSession(null, null, W3C_CAPS)).value;
         let sessions = await appium.getAppiumSessions();
         sessions.should.have.length(1);
@@ -323,7 +323,7 @@ describe('AppiumDriver', function () {
       let sessions;
       before(function () {
         [appium, mockFakeDriver] = getDriverAndFakeDriver(SESSION_DISCOVERY_ENABLED);
-        appium.configureInsecureFeatures();
+        appium.configureGlobalFeatures();
       });
       afterEach(async function () {
         for (let session of sessions) {

--- a/packages/appium/test/unit/appiumdriver.spec.js
+++ b/packages/appium/test/unit/appiumdriver.spec.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import {PLUGIN_TYPE} from '../../lib/constants';
+import {PLUGIN_TYPE, SESSION_DISCOVERY_FEATURE} from '../../lib/constants';
 import B from 'bluebird';
 import {BaseDriver} from '@appium/base-driver';
 import {FakeDriver} from '@appium/fake-driver';
@@ -14,6 +14,7 @@ import {rewiremock, BASE_CAPS, W3C_CAPS, W3C_PREFIXED_CAPS} from '../helpers';
 import {BasePlugin} from '@appium/base-plugin';
 
 const SESSION_ID = '1';
+const SESSION_DISCOVERY_ENABLED = {allowInsecure: [`*:${SESSION_DISCOVERY_FEATURE}`]};
 
 describe('AppiumDriver', function () {
   /** @type {import('sinon').SinonSandbox} */
@@ -112,7 +113,7 @@ describe('AppiumDriver', function () {
       /** @type {sinon.SinonMock} */
       let mockFakeDriver;
       beforeEach(function () {
-        [appium, mockFakeDriver] = getDriverAndFakeDriver();
+        [appium, mockFakeDriver] = getDriverAndFakeDriver(SESSION_DISCOVERY_ENABLED);
       });
       afterEach(async function () {
         mockFakeDriver.restore();
@@ -172,9 +173,6 @@ describe('AppiumDriver', function () {
         appium.sessions['xyz-321-abc'] = fakeDrivers[1];
         appium.sessions['123-abc-xyz'] = fakeDrivers[2];
 
-        let sessions = await appium.getAppiumSessions();
-        sessions.should.have.length(3);
-
         mockFakeDriver
           .expects('createSession')
           .once()
@@ -182,7 +180,7 @@ describe('AppiumDriver', function () {
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS)]);
         await appium.createSession(undefined, null, W3C_CAPS);
 
-        sessions = await appium.getAppiumSessions();
+        const sessions = await appium.getAppiumSessions();
         sessions.should.have.length(1);
 
         for (let mfd of mockFakeDrivers) {
@@ -258,7 +256,7 @@ describe('AppiumDriver', function () {
       let appium;
       let mockFakeDriver;
       beforeEach(function () {
-        [appium, mockFakeDriver] = getDriverAndFakeDriver();
+        [appium, mockFakeDriver] = getDriverAndFakeDriver(SESSION_DISCOVERY_ENABLED);
       });
       afterEach(function () {
         mockFakeDriver.restore();
@@ -285,7 +283,7 @@ describe('AppiumDriver', function () {
       let appium, mockFakeDriver;
       let sessions;
       before(function () {
-        [appium, mockFakeDriver] = getDriverAndFakeDriver();
+        [appium, mockFakeDriver] = getDriverAndFakeDriver(SESSION_DISCOVERY_ENABLED);
       });
       afterEach(async function () {
         for (let session of sessions) {

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -316,7 +316,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
         `Potentially insecure feature '${name}' has not been ` +
           `enabled. If you want to enable this feature and accept ` +
           `the security ramifications, please do so by following ` +
-          `the documented instructions at http://appium.io/docs/en/2.0/guides/security/`,
+          `the documented instructions at http://appium.io/docs/en/latest/guides/security/`,
       );
     }
   }

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -41,6 +41,8 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
 
   sessionId: string | null;
 
+  sessionCreationTime: number;
+
   opts: DriverOpts<C>;
 
   initialOpts: InitialOpts;

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -41,7 +41,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
 
   sessionId: string | null;
 
-  sessionCreationTime: number;
+  sessionCreationTimestampMs: number;
 
   opts: DriverOpts<C>;
 

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -10,6 +10,7 @@ import {
   type DriverCaps,
   type DriverData,
   type MultiSessionData,
+  type DatedMultiSessionData,
   type ServerArgs,
   type StringRecord,
   type W3CDriverCaps,
@@ -302,6 +303,7 @@ export class BaseDriver<
     this.validateDesiredCaps(caps);
 
     this.sessionId = util.uuidV4();
+    this.sessionCreationTime = Date.now();
     this.caps = caps;
     // merge caps onto opts so we don't need to worry about what's where
     this.opts = {..._.cloneDeep(this.initialOpts), ...this.caps};
@@ -345,6 +347,11 @@ export class BaseDriver<
 
     return [this.sessionId, caps] as CreateResult;
   }
+
+  /**
+   * Returns the session id and capabilities for the session
+   * @deprecated Use {@linkcode getAppiumSessions} instead for getting the session data.
+   */
   async getSessions() {
     const ret: MultiSessionData<C>[] = [];
 
@@ -359,8 +366,25 @@ export class BaseDriver<
   }
 
   /**
+   * Returns the session id, creation time and capabilities for the session
+   */
+  async getAppiumSessions() {
+    const ret: DatedMultiSessionData<C>[] = [];
+
+    if (this.sessionId) {
+      ret.push({
+        id: this.sessionId,
+        created: this.sessionCreationTime,
+        capabilities: this.caps,
+      });
+    }
+
+    return ret;
+  }
+
+  /**
    * Returns capabilities for the session and event history (if applicable)
-   * @deprecated Use {@linkcode ISessionCommands.getAppiumSessionCapabilities} instead for getting the capabilities.
+   * @deprecated Use {@linkcode getAppiumSessionCapabilities} instead for getting the capabilities.
    * Use {@linkcode EventCommands.getLogEvents} instead to get the event history.
    */
   async getSession() {

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -10,7 +10,6 @@ import {
   type DriverCaps,
   type DriverData,
   type MultiSessionData,
-  type DatedMultiSessionData,
   type ServerArgs,
   type StringRecord,
   type W3CDriverCaps,
@@ -303,7 +302,7 @@ export class BaseDriver<
     this.validateDesiredCaps(caps);
 
     this.sessionId = util.uuidV4();
-    this.sessionCreationTime = Date.now();
+    this.sessionCreationTimestampMs = Date.now();
     this.caps = caps;
     // merge caps onto opts so we don't need to worry about what's where
     this.opts = {..._.cloneDeep(this.initialOpts), ...this.caps};
@@ -350,7 +349,7 @@ export class BaseDriver<
 
   /**
    * Returns the session id and capabilities for the session
-   * @deprecated Use {@linkcode getAppiumSessions} instead for getting the session data.
+   * @deprecated Use AppiumDriver.getAppiumSessions instead for getting the session data.
    */
   async getSessions() {
     const ret: MultiSessionData<C>[] = [];
@@ -358,23 +357,6 @@ export class BaseDriver<
     if (this.sessionId) {
       ret.push({
         id: this.sessionId,
-        capabilities: this.caps,
-      });
-    }
-
-    return ret;
-  }
-
-  /**
-   * Returns the session id, creation time and capabilities for the session
-   */
-  async getAppiumSessions() {
-    const ret: DatedMultiSessionData<C>[] = [];
-
-    if (this.sessionId) {
-      ret.push({
-        id: this.sessionId,
-        created: this.sessionCreationTime,
         capabilities: this.caps,
       });
     }

--- a/packages/base-driver/test/unit/basedriver/capability.spec.js
+++ b/packages/base-driver/test/unit/basedriver/capability.spec.js
@@ -159,7 +159,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities?.noReset?.should.eql(false);
+      sessionCaps.capabilities.noReset?.should.eql(false);
     });
 
     it('should allow a string "true"', async function () {
@@ -174,7 +174,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities?.noReset?.should.eql(true);
+      sessionCaps.capabilities.noReset?.should.eql(true);
     });
 
     it('should allow a string "true" in string capabilities', async function () {
@@ -188,7 +188,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.false;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities?.language?.should.eql('true');
+      sessionCaps.capabilities.language?.should.eql('true');
     });
   });
 
@@ -205,7 +205,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities?.newCommandTimeout?.should.eql(1);
+      sessionCaps.capabilities.newCommandTimeout?.should.eql(1);
     });
 
     it('should allow a string "1.1"', async function () {
@@ -220,7 +220,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities?.newCommandTimeout?.should.eql(1.1);
+      sessionCaps.capabilities.newCommandTimeout?.should.eql(1.1);
     });
 
     it('should allow a string "1" in string capabilities', async function () {
@@ -234,7 +234,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.false;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities?.language?.should.eql('1');
+      sessionCaps.capabilities.language?.should.eql('1');
     });
   });
 

--- a/packages/base-driver/test/unit/basedriver/capability.spec.js
+++ b/packages/base-driver/test/unit/basedriver/capability.spec.js
@@ -159,7 +159,8 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities.noReset?.should.eql(false);
+      // @ts-expect-error the 'noReset' property should exist
+      sessionCaps.capabilities.noReset.should.eql(false);
     });
 
     it('should allow a string "true"', async function () {
@@ -174,7 +175,8 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities.noReset?.should.eql(true);
+      // @ts-expect-error the 'noReset' property should exist
+      sessionCaps.capabilities.noReset.should.eql(true);
     });
 
     it('should allow a string "true" in string capabilities', async function () {
@@ -188,7 +190,8 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.false;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities.language?.should.eql('true');
+      // @ts-expect-error the 'language' property should exist
+      sessionCaps.capabilities.language.should.eql('true');
     });
   });
 
@@ -205,7 +208,8 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities.newCommandTimeout?.should.eql(1);
+      // @ts-expect-error the 'newCommandTimeout' property should exist
+      sessionCaps.capabilities.newCommandTimeout.should.eql(1);
     });
 
     it('should allow a string "1.1"', async function () {
@@ -220,7 +224,8 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities.newCommandTimeout?.should.eql(1.1);
+      // @ts-expect-error the 'newCommandTimeout' property should exist
+      sessionCaps.capabilities.newCommandTimeout.should.eql(1.1);
     });
 
     it('should allow a string "1" in string capabilities', async function () {
@@ -234,7 +239,8 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.false;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.capabilities.language?.should.eql('1');
+      // @ts-expect-error the 'language' property should exist
+      sessionCaps.capabilities.language.should.eql('1');
     });
   });
 

--- a/packages/base-driver/test/unit/basedriver/capability.spec.js
+++ b/packages/base-driver/test/unit/basedriver/capability.spec.js
@@ -158,7 +158,7 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.true;
 
-      let sessions = await d.getSessions();
+      let sessions = await d.getAppiumSessions();
       sessions[0].capabilities.noReset.should.eql(false);
     });
 
@@ -173,7 +173,7 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.true;
 
-      let sessions = await d.getSessions();
+      let sessions = await d.getAppiumSessions();
       sessions[0].capabilities.noReset.should.eql(true);
     });
 
@@ -187,7 +187,7 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.false;
 
-      let sessions = await d.getSessions();
+      let sessions = await d.getAppiumSessions();
       sessions[0].capabilities.language.should.eql('true');
     });
   });
@@ -204,7 +204,7 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.true;
 
-      let sessions = await d.getSessions();
+      let sessions = await d.getAppiumSessions();
       sessions[0].capabilities.newCommandTimeout.should.eql(1);
     });
 
@@ -219,7 +219,7 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.true;
 
-      let sessions = await d.getSessions();
+      let sessions = await d.getAppiumSessions();
       sessions[0].capabilities.newCommandTimeout.should.eql(1.1);
     });
 
@@ -233,7 +233,7 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.false;
 
-      let sessions = await d.getSessions();
+      let sessions = await d.getAppiumSessions();
       sessions[0].capabilities.language.should.eql('1');
     });
   });

--- a/packages/base-driver/test/unit/basedriver/capability.spec.js
+++ b/packages/base-driver/test/unit/basedriver/capability.spec.js
@@ -158,8 +158,8 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.true;
 
-      let sessions = await d.getAppiumSessions();
-      sessions[0].capabilities.noReset.should.eql(false);
+      let sessionCaps = await d.getAppiumSessionCapabilities();
+      sessionCaps.noReset.should.eql(false);
     });
 
     it('should allow a string "true"', async function () {
@@ -173,8 +173,8 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.true;
 
-      let sessions = await d.getAppiumSessions();
-      sessions[0].capabilities.noReset.should.eql(true);
+      let sessionCaps = await d.getAppiumSessionCapabilities();
+      sessionCaps.noReset.should.eql(true);
     });
 
     it('should allow a string "true" in string capabilities', async function () {
@@ -187,8 +187,8 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.false;
 
-      let sessions = await d.getAppiumSessions();
-      sessions[0].capabilities.language.should.eql('true');
+      let sessionCaps = await d.getAppiumSessionCapabilities();
+      sessionCaps.language.should.eql('true');
     });
   });
 
@@ -204,8 +204,8 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.true;
 
-      let sessions = await d.getAppiumSessions();
-      sessions[0].capabilities.newCommandTimeout.should.eql(1);
+      let sessionCaps = await d.getAppiumSessionCapabilities();
+      sessionCaps.newCommandTimeout.should.eql(1);
     });
 
     it('should allow a string "1.1"', async function () {
@@ -219,8 +219,8 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.true;
 
-      let sessions = await d.getAppiumSessions();
-      sessions[0].capabilities.newCommandTimeout.should.eql(1.1);
+      let sessionCaps = await d.getAppiumSessionCapabilities();
+      sessionCaps.newCommandTimeout.should.eql(1.1);
     });
 
     it('should allow a string "1" in string capabilities', async function () {
@@ -233,8 +233,8 @@ describe('Desired Capabilities', function () {
       });
       logWarnSpy.called.should.be.false;
 
-      let sessions = await d.getAppiumSessions();
-      sessions[0].capabilities.language.should.eql('1');
+      let sessionCaps = await d.getAppiumSessionCapabilities();
+      sessionCaps.language.should.eql('1');
     });
   });
 

--- a/packages/base-driver/test/unit/basedriver/capability.spec.js
+++ b/packages/base-driver/test/unit/basedriver/capability.spec.js
@@ -159,7 +159,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.noReset.should.eql(false);
+      sessionCaps.capabilities?.noReset?.should.eql(false);
     });
 
     it('should allow a string "true"', async function () {
@@ -174,7 +174,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.noReset.should.eql(true);
+      sessionCaps.capabilities?.noReset?.should.eql(true);
     });
 
     it('should allow a string "true" in string capabilities', async function () {
@@ -188,7 +188,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.false;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.language.should.eql('true');
+      sessionCaps.capabilities?.language?.should.eql('true');
     });
   });
 
@@ -205,7 +205,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.newCommandTimeout.should.eql(1);
+      sessionCaps.capabilities?.newCommandTimeout?.should.eql(1);
     });
 
     it('should allow a string "1.1"', async function () {
@@ -220,7 +220,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.true;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.newCommandTimeout.should.eql(1.1);
+      sessionCaps.capabilities?.newCommandTimeout?.should.eql(1.1);
     });
 
     it('should allow a string "1" in string capabilities', async function () {
@@ -234,7 +234,7 @@ describe('Desired Capabilities', function () {
       logWarnSpy.called.should.be.false;
 
       let sessionCaps = await d.getAppiumSessionCapabilities();
-      sessionCaps.language.should.eql('1');
+      sessionCaps.capabilities?.language?.should.eql('1');
     });
   });
 

--- a/packages/driver-test-support/lib/unit-suite.js
+++ b/packages/driver-test-support/lib/unit-suite.js
@@ -94,14 +94,14 @@ export function driverUnitTestSuite(
     });
 
     it('should return sessions if no session exists', async function () {
-      let sessions = await d.getSessions();
+      let sessions = await d.getAppiumSessions();
       sessions.length.should.equal(0);
     });
 
     it('should return sessions', async function () {
       const caps = _.cloneDeep(w3cCaps);
       await d.createSession(caps);
-      let sessions = await d.getSessions();
+      let sessions = await d.getAppiumSessions();
 
       sessions.length.should.equal(1);
       sessions[0].should.include({

--- a/packages/driver-test-support/lib/unit-suite.js
+++ b/packages/driver-test-support/lib/unit-suite.js
@@ -93,26 +93,6 @@ export function driverUnitTestSuite(
       caps.should.equal(await d.getSession());
     });
 
-    it('should return sessions if no session exists', async function () {
-      let sessions = await d.getAppiumSessions();
-      sessions.length.should.equal(0);
-    });
-
-    it('should return sessions', async function () {
-      const caps = _.cloneDeep(w3cCaps);
-      await d.createSession(caps);
-      let sessions = await d.getAppiumSessions();
-
-      sessions.length.should.equal(1);
-      sessions[0].should.include({
-        id: d.sessionId,
-      });
-      sessions[0].capabilities.should.include({
-        deviceName: 'Commodore 64',
-        platformName: 'Fake',
-      });
-    });
-
     it('should fulfill an unexpected driver quit promise', async function () {
       // make a command that will wait a bit so we can crash while it's running
       sandbox.stub(d, 'getStatus').callsFake(async () => {

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -183,13 +183,29 @@ export interface IExecuteCommands {
   ): Promise<TReturn>;
 }
 
+/**
+ * Data returned by {@linkcode ISessionHandler.getSessions}.
+ *
+ * @typeParam C - The driver's constraints
+ */
 export interface MultiSessionData<C extends Constraints = Constraints> {
   id: string;
   capabilities: DriverCaps<C>;
 }
 
 /**
- * Data returned by {@linkcode ISessionCommands.getSession}.
+ * Data returned by {@linkcode ISessionHandler.getAppiumSessions}.
+ *
+ * @typeParam C - The driver's constraints
+ */
+export interface DatedMultiSessionData<C extends Constraints = Constraints> {
+  id: string;
+  created: number;
+  capabilities: DriverCaps<C>;
+}
+
+/**
+ * Data returned by {@linkcode ISessionHandler.getSession}.
  *
  * @typeParam C - The driver's constraints
  * @typeParam T - Any extra data the driver stuffs in here
@@ -477,6 +493,13 @@ export interface ISessionHandler<
   getSessions(): Promise<MultiSessionData[]>;
 
   /**
+   * Get data for all sessions running on an Appium server
+   *
+   * @returns A list of session data objects
+   */
+  getAppiumSessions(): Promise<DatedMultiSessionData[]>;
+
+  /**
    * Get the data for the current session
    *
    * @returns A session data object
@@ -610,6 +633,7 @@ export interface DriverStatus {
 export interface Core<C extends Constraints, Settings extends StringRecord = StringRecord> {
   shouldValidateCaps: boolean;
   sessionId: string | null;
+  sessionCreationTime: number;
   opts: DriverOpts<C>;
   initialOpts: InitialOpts;
   protocol?: Protocol;

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -194,11 +194,11 @@ export interface MultiSessionData<C extends Constraints = Constraints> {
 }
 
 /**
- * Data returned by {@linkcode ISessionHandler.getAppiumSessions}.
+ * Data returned by `AppiumDriver.getAppiumSessions`
  *
  * @typeParam C - The driver's constraints
  */
-export interface DatedMultiSessionData<C extends Constraints = Constraints> {
+export interface TimestampedMultiSessionData<C extends Constraints = Constraints> {
   id: string;
   created: number;
   capabilities: DriverCaps<C>;
@@ -493,13 +493,6 @@ export interface ISessionHandler<
   getSessions(): Promise<MultiSessionData[]>;
 
   /**
-   * Get data for all sessions running on an Appium server
-   *
-   * @returns A list of session data objects
-   */
-  getAppiumSessions(): Promise<DatedMultiSessionData[]>;
-
-  /**
    * Get the data for the current session
    *
    * @returns A session data object
@@ -633,7 +626,7 @@ export interface DriverStatus {
 export interface Core<C extends Constraints, Settings extends StringRecord = StringRecord> {
   shouldValidateCaps: boolean;
   sessionId: string | null;
-  sessionCreationTime: number;
+  sessionCreationTimestampMs: number;
   opts: DriverOpts<C>;
   initialOpts: InitialOpts;
   protocol?: Protocol;

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -200,7 +200,7 @@ export interface MultiSessionData<C extends Constraints = Constraints> {
  */
 export interface TimestampedMultiSessionData<C extends Constraints = Constraints> {
   id: string;
-  created: number;
+  created: number; // Unix timestamp in milliseconds
   capabilities: DriverCaps<C>;
 }
 


### PR DESCRIPTION
## Proposed changes

This PR adds an implementation for the `GET /appium/sessions` endpoint, according to #20880.
The target branch is intentionally set to `master`, _not_ `appium3` - seeing as `GET /sessions` has already been removed in Appium 3, it is beneficial for Appium 2 users to already have access to its replacement endpoint, for ease of migration.

I confirmed that these changes work using the Inspector (which already has support for this endpoint). Still, it would also be beneficial to add new tests specifically for validating the new `created` field - any suggestions welcome.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
