### PR TITLE
chore(base-driver): Tune the deprecation warning message

### DIFF
--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -299,9 +299,9 @@ function buildHandler(app, method, path, spec, driver, isSessCmd) {
       if (spec.deprecated && !deprecatedCommandsLogged.has(spec.command)) {
         deprecatedCommandsLogged.add(spec.command);
         getLogger(driver, req.params.sessionId).warn(
-          `Command '${spec.command}' has been deprecated and will be removed in a future ` +
-            `version of Appium or your driver/plugin. Please use a different method or contact the ` +
-            `driver/plugin author to add explicit support for the command before it is removed`
+          `The '${method} ${path}' API has been deprecated and will be removed in a future ` +
+            `version of Appium or your driver/plugin. Please use a different API or contact the ` +
+            `driver/plugin author to add an explicit support for it.`
         );
       }
 

--- a/packages/base-driver/lib/protocol/protocol.js
+++ b/packages/base-driver/lib/protocol/protocol.js
@@ -299,7 +299,7 @@ function buildHandler(app, method, path, spec, driver, isSessCmd) {
       if (spec.deprecated && !deprecatedCommandsLogged.has(spec.command)) {
         deprecatedCommandsLogged.add(spec.command);
         getLogger(driver, req.params.sessionId).warn(
-          `The '${method} ${path}' API has been deprecated and will be removed in a future ` +
+          `The ${method} ${path} endpoint has been deprecated and will be removed in a future ` +
             `version of Appium or your driver/plugin. Please use a different API or contact the ` +
             `driver/plugin author to add an explicit support for it.`
         );


### PR DESCRIPTION
Currently the message mentions the internal method name instead of mentioning the actual METHOD PATH combination. This leads to unnecessary confusion, because we actually deprecate APIs rather than method handlers. For example, let say we have the legacy GET /log/types API, which we'd like to replace with GET /se/log/types one. Currently we mention the name of the method, which is `getLogTypes` in the warning message even if this particular method must still remain, We only want to deprecate one of REST APIs referencing that method (since both the new and the old one rely on the same method)