### PR TITLE
chore(docutils): remove tsconfig-related code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2673,53 +2673,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@sliphua/lilconfig-ts-loader": {
-      "version": "3.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.get": "^4",
-        "make-error": "^1",
-        "ts-node": "^9",
-        "tslib": "^2"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "lilconfig": ">=2"
-      }
-    },
-    "node_modules/@sliphua/lilconfig-ts-loader/node_modules/diff": {
-      "version": "4.0.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@sliphua/lilconfig-ts-loader/node_modules/ts-node": {
-      "version": "9.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
-      }
-    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -4507,6 +4460,7 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -6367,6 +6321,7 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-env": {
@@ -10630,6 +10585,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -11277,6 +11233,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
       "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -11563,6 +11520,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
@@ -18409,6 +18367,7 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18614,7 +18573,7 @@
     },
     "packages/base-driver": {
       "name": "@appium/base-driver",
-      "version": "10.0.0-beta.0",
+      "version": "10.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/support": "^6.1.0",
@@ -19043,7 +19002,7 @@
     },
     "packages/base-plugin": {
       "name": "@appium/base-plugin",
-      "version": "3.0.0-beta.0",
+      "version": "3.0.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/base-driver": "^10.0.0-beta.0",
@@ -19060,21 +19019,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/support": "^6.1.0",
-        "@appium/tsconfig": "^0.3.5",
-        "@sliphua/lilconfig-ts-loader": "3.2.2",
         "chalk": "4.1.2",
         "consola": "3.4.2",
         "diff": "7.0.0",
-        "json5": "2.2.3",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "pkg-dir": "5.0.0",
         "read-pkg": "5.2.0",
-        "semver": "7.7.1",
         "source-map-support": "0.5.21",
         "teen_process": "2.3.1",
         "type-fest": "4.40.0",
-        "typescript": "5.8.3",
         "yaml": "2.7.1",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
@@ -19177,18 +19131,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/docutils/node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "packages/docutils/node_modules/yaml": {
@@ -20863,21 +20805,16 @@
       "version": "file:packages/docutils",
       "requires": {
         "@appium/support": "^6.1.0",
-        "@appium/tsconfig": "^0.3.5",
-        "@sliphua/lilconfig-ts-loader": "3.2.2",
         "chalk": "4.1.2",
         "consola": "3.4.2",
         "diff": "7.0.0",
-        "json5": "2.2.3",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "pkg-dir": "5.0.0",
         "read-pkg": "5.2.0",
-        "semver": "7.7.1",
         "source-map-support": "0.5.21",
         "teen_process": "2.3.1",
         "type-fest": "4.40.0",
-        "typescript": "5.8.3",
         "yaml": "2.7.1",
         "yargs": "17.7.2",
         "yargs-parser": "21.1.1"
@@ -20929,10 +20866,6 @@
           "version": "4.40.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
           "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw=="
-        },
-        "typescript": {
-          "version": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
         },
         "yaml": {
           "version": "2.7.1",
@@ -23333,31 +23266,6 @@
         }
       }
     },
-    "@sliphua/lilconfig-ts-loader": {
-      "version": "3.2.2",
-      "requires": {
-        "lodash.get": "^4",
-        "make-error": "^1",
-        "ts-node": "^9",
-        "tslib": "^2"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "4.0.2"
-        },
-        "ts-node": {
-          "version": "9.1.1",
-          "requires": {
-            "arg": "^4.1.0",
-            "create-require": "^1.1.0",
-            "diff": "^4.0.1",
-            "make-error": "^1.1.1",
-            "source-map-support": "^0.5.17",
-            "yn": "3.1.1"
-          }
-        }
-      }
-    },
     "@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -24657,7 +24565,8 @@
       }
     },
     "arg": {
-      "version": "4.1.3"
+      "version": "4.1.3",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1"
@@ -25933,7 +25842,8 @@
       }
     },
     "create-require": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "cross-env": {
       "version": "7.0.3",
@@ -28704,7 +28614,8 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.3"
+      "version": "2.2.3",
+      "dev": true
     },
     "jsonc-parser": {
       "version": "3.2.0",
@@ -29181,7 +29092,8 @@
     "lilconfig": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.0.0.tgz",
-      "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g=="
+      "integrity": "sha512-K2U4W2Ff5ibV7j7ydLr+zLAkIg5JJ4lPn1Ltsdt+Tz/IjQ8buJ55pZAxoP34lqIiwtF9iAvtLv3JGv7CAyAg+g==",
+      "dev": true
     },
     "lines-and-columns": {
       "version": "1.2.4"
@@ -29369,7 +29281,8 @@
       }
     },
     "make-error": {
-      "version": "1.3.6"
+      "version": "1.3.6",
+      "dev": true
     },
     "make-fetch-happen": {
       "version": "13.0.1",
@@ -33966,7 +33879,8 @@
       }
     },
     "yn": {
-      "version": "3.1.1"
+      "version": "3.1.1",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0"

--- a/packages/docutils/lib/cli/command/init.ts
+++ b/packages/docutils/lib/cli/command/init.ts
@@ -3,7 +3,6 @@
  * @module
  */
 
-import _ from 'lodash';
 import type {CommandModule, InferredOptionTypes, Options} from 'yargs';
 import {init} from '../../init';
 import {getLogger} from '../../logger';
@@ -50,17 +49,6 @@ const opts = {
     describe: 'Overwrite existing configurations',
     group: InitCommandGroup.Behavior,
     type: 'boolean',
-  },
-  include: {
-    alias: 'i',
-    array: true,
-    coerce: (value: string | string[]) => _.castArray(value),
-    description: 'Files to include in compilation (globs OK)',
-    nargs: 1,
-    group: InitCommandGroup.MkDocs,
-    requiresArg: true,
-    type: 'string',
-    implies: 'mkdocs',
   },
   mkdocs: {
     default: true,
@@ -138,22 +126,6 @@ const opts = {
     requiresArg: true,
     type: 'string',
     implies: 'mkdocs',
-  },
-  'tsconfig-json': {
-    defaultDescription: './tsconfig.json',
-    describe: 'Path to new or existing tsconfig.json',
-    group: InitCommandGroup.Behavior,
-    nargs: 1,
-    normalize: true,
-    requiresArg: true,
-    type: 'string',
-    implies: 'typescript',
-  },
-  typescript: {
-    default: true,
-    description: 'Create tsconfig.json if needed',
-    group: InitCommandGroup.Behavior,
-    type: 'boolean',
   },
   upgrade: {
     alias: 'up',

--- a/packages/docutils/lib/cli/command/validate.ts
+++ b/packages/docutils/lib/cli/command/validate.ts
@@ -33,15 +33,6 @@ const opts = {
     requiresArg: true,
     type: 'string',
   },
-  'npm-path': {
-    defaultDescription: '(derived from shell)',
-    description: 'Path to npm executable',
-    group: ValidateCommandGroup.Paths,
-    nargs: 1,
-    normalize: true,
-    requiresArg: true,
-    type: 'string',
-  },
   python: {
     default: true,
     description: 'Validate Python 3 environment',
@@ -57,21 +48,6 @@ const opts = {
     requiresArg: true,
     type: 'string',
   },
-  'tsconfig-json': {
-    defaultDescription: './tsconfig.json',
-    describe: 'Path to tsconfig.json',
-    group: ValidateCommandGroup.Paths,
-    nargs: 1,
-    normalize: true,
-    requiresArg: true,
-    type: 'string',
-  },
-  typescript: {
-    default: true,
-    description: 'Validate TypeScript environment',
-    group: ValidateCommandGroup.Behavior,
-    type: 'boolean',
-  },
 } as const satisfies Record<string, Options>;
 
 type ValidateOptions = InferredOptionTypes<typeof opts>;
@@ -81,8 +57,8 @@ export default {
   describe: 'Validate Environment',
   builder(yargs) {
     return yargs.options(opts).check(async (argv) => {
-      if (!argv.python && !argv.typescript && !argv.mkdocs) {
-        return 'No validation targets specified; one or more of --python, --typescript or --mkdocs must be provided';
+      if (!argv.python && !argv.mkdocs) {
+        return 'No validation targets specified; one or more of --python or --mkdocs must be provided';
       }
       return checkMissingPaths(opts, ValidateCommandGroup.Paths, argv);
     });

--- a/packages/docutils/lib/cli/config.ts
+++ b/packages/docutils/lib/cli/config.ts
@@ -3,7 +3,6 @@
  * @module
  */
 
-import loadTs from '@sliphua/lilconfig-ts-loader';
 import {lilconfig, Loader} from 'lilconfig';
 import _ from 'lodash';
 import path from 'node:path';
@@ -20,10 +19,6 @@ const log = getLogger('config');
  * `lilconfig` loader for YAML
  */
 const loadYaml: Loader = _.rearg(YAML.parse, [2, 0, 1]);
-/**
- * `lilconfig` loader for ESM/CJS
- */
-const loadEsm: Loader = (filepath: string) => import(filepath);
 
 /**
  * Controls how we load/find a config file.
@@ -75,10 +70,6 @@ export async function loadConfig(filepath?: string, cwd = process.cwd()): Promis
     loaders: {
       '.yaml': loadYaml,
       '.yml': loadYaml,
-      '.ts': loadTs,
-      '.js': loadEsm,
-      '.cjs': loadEsm,
-      '.mjs': loadEsm,
     },
   });
 

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -64,11 +64,6 @@ export const NAME_PIP = 'pip';
 export const NAME_NPM = 'npm';
 
 /**
- * The name of the `typescript` package (not the `tsc` executable)
- */
-export const NAME_TYPESCRIPT = 'typescript';
-
-/**
  * Code for a "file not found" error
  */
 export const NAME_ERR_ENOENT = 'ENOENT';

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -18,10 +18,6 @@ export const NAME_BIN = 'appium-docs';
 export const NAME_MKDOCS_YML = 'mkdocs.yml';
 
 /**
- * Default name of the `tsconfig.json` config file
- */
-export const NAME_TSCONFIG_JSON = 'tsconfig.json';
-/**
  * `python` executable
  */
 export const NAME_PYTHON = 'python';

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -4,10 +4,8 @@
  */
 
 const {LogLevels} = require('consola');
-import {readFileSync} from 'node:fs';
 import {fs} from '@appium/support';
 import path from 'node:path';
-import {PackageJson} from 'type-fest';
 
 /**
  * CLI executable name
@@ -59,11 +57,6 @@ export const NAME_MIKE = 'mike';
 export const NAME_PIP = 'pip';
 
 /**
- * Name of the `npm` executable, which we use to check for
- */
-export const NAME_NPM = 'npm';
-
-/**
  * Code for a "file not found" error
  */
 export const NAME_ERR_ENOENT = 'ENOENT';
@@ -81,13 +74,6 @@ export const DEFAULT_LOG_LEVEL = 'info';
  * Blocking I/O
  */
 export const PKG_ROOT_DIR = fs.findRoot(__dirname);
-/**
- * Blocking I/O
- */
-
-export const DOCUTILS_PKG: PackageJson = JSON.parse(
-  readFileSync(path.join(PKG_ROOT_DIR, NAME_PACKAGE_JSON), 'utf8'),
-);
 
 /**
  * Path to the `requirements.txt` file (in this package)

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -4,7 +4,6 @@
  */
 
 import {fs} from '@appium/support';
-import * as JSON5 from 'json5';
 import _ from 'lodash';
 import path from 'node:path';
 import _pkgDir from 'pkg-dir';
@@ -43,16 +42,6 @@ export const stringifyYaml: (value: JsonValue) => string = _.partialRight(
   {indent: 2},
   undefined,
 );
-
-/**
- * Stringifies something into JSON5.  I think the only difference between this and `JSON.stringify`
- * is that if an object has a `toJSON5()` method, it will be used.
- * @param value Something to stringify
- * @returns JSON5 string
- */
-export const stringifyJson5: (value: JsonValue) => string = _.partialRight(JSON5.stringify, {
-  indent: 2,
-});
 
 /**
  * Pretty-stringifies a JSON value

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -16,7 +16,6 @@ import {
   NAME_MIKE,
   NAME_MKDOCS,
   NAME_MKDOCS_YML,
-  NAME_NPM,
   NAME_PACKAGE_JSON,
   NAME_PYTHON,
 } from './constants';
@@ -169,11 +168,6 @@ type WhichFunction = (cmd: string, opts?: {nothrow: boolean}) => Promise<string|
  * `which` with memoization
  */
 const cachedWhich = _.memoize(fs.which as WhichFunction);
-
-/**
- * Finds `npm` executable
- */
-export const whichNpm = _.partial(cachedWhich, NAME_NPM, {nothrow: true});
 
 /**
  * Finds `python` executable

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -32,7 +32,7 @@ const log = getLogger('fs');
  *
  * Caches result
  */
-export const findPkgDir = _.memoize(_pkgDir);
+const findPkgDir = _.memoize(_pkgDir);
 
 /**
  * Stringifies a thing into a YAML

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -144,14 +144,6 @@ async function _readPkgJson(
 export const readPackageJson = _.memoize(_readPkgJson);
 
 /**
- * Reads a JSON5 file and parses it
- */
-export const readJson5 = _.memoize(
-  async <T extends JsonValue>(filepath: string): Promise<T> =>
-    JSON5.parse(await fs.readFile(filepath, 'utf8')),
-);
-
-/**
  * Reads a JSON file and parses it
  */
 export const readJson = _.memoize(

--- a/packages/docutils/lib/model.ts
+++ b/packages/docutils/lib/model.ts
@@ -4,14 +4,7 @@
  * @module
  */
 
-import type {Jsonify, JsonValue, TsConfigJson as TsConfigJsonBase} from 'type-fest';
-
-/**
- * A `tsconfig.json` file w/ `$schema` prop
- */
-export type TsConfigJson = TsConfigJsonBase & {
-  $schema?: string;
-};
+import type {Jsonify, JsonValue} from 'type-fest';
 
 /**
  * The `nav` prop of an `mkdocs.yml` file

--- a/packages/docutils/lib/validate.ts
+++ b/packages/docutils/lib/validate.ts
@@ -89,11 +89,6 @@ export class DocutilsValidator extends EventEmitter {
   protected mkDocsYmlPath?: string;
 
   /**
-   * Path to the package directory.  If not provided, will be lazily resolved.
-   */
-  protected pkgDir?: string;
-
-  /**
    * Emitted when validation begins with a list of validation kinds to be performed
    * @event
    */

--- a/packages/docutils/lib/validate.ts
+++ b/packages/docutils/lib/validate.ts
@@ -89,11 +89,6 @@ export class DocutilsValidator extends EventEmitter {
   protected mkDocsYmlPath?: string;
 
   /**
-   * Path to `package.json`.  If not provided, will be lazily resolved.
-   */
-  protected packageJsonPath?: string;
-
-  /**
    * Path to the package directory.  If not provided, will be lazily resolved.
    */
   protected pkgDir?: string;
@@ -130,7 +125,6 @@ export class DocutilsValidator extends EventEmitter {
   constructor(opts: DocutilsValidatorOpts = {}) {
     super();
 
-    this.packageJsonPath = opts.packageJson;
     this.pythonPath = opts.pythonPath;
     this.cwd = opts.cwd ?? process.cwd();
     this.mkDocsYmlPath = opts.mkdocsYml;
@@ -423,10 +417,6 @@ export interface DocutilsValidatorOpts {
    * Path to `mkdocs.yml`
    */
   mkdocsYml?: string;
-  /**
-   * Path to `package.json`
-   */
-  packageJson?: string;
   /**
    * If `true`, run Python validation
    */

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -59,7 +59,6 @@
     "lodash": "4.17.21",
     "pkg-dir": "5.0.0",
     "read-pkg": "5.2.0",
-    "semver": "7.7.1",
     "source-map-support": "0.5.21",
     "teen_process": "2.3.1",
     "type-fest": "4.40.0",

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -49,12 +49,9 @@
   },
   "dependencies": {
     "@appium/support": "^6.1.0",
-    "@appium/tsconfig": "^0.3.5",
-    "@sliphua/lilconfig-ts-loader": "3.2.2",
     "chalk": "4.1.2",
     "consola": "3.4.2",
     "diff": "7.0.0",
-    "json5": "2.2.3",
     "lilconfig": "3.1.3",
     "lodash": "4.17.21",
     "pkg-dir": "5.0.0",
@@ -62,7 +59,6 @@
     "source-map-support": "0.5.21",
     "teen_process": "2.3.1",
     "type-fest": "4.40.0",
-    "typescript": "5.8.3",
     "yaml": "2.7.1",
     "yargs": "17.7.2",
     "yargs-parser": "21.1.1"


### PR DESCRIPTION
This PR removes all `tsconfig`-related code in `docutils`, since the code was only relevant when `typedoc` was used, which is no longer the case.