### PR TITLE
fix(base-driver): ignore 'value' for /value endpoint

### DIFF
--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import {DEFAULT_BASE_PATH} from '../constants';
 import {match} from 'path-to-regexp';
 import {LRUCache} from 'lru-cache';
+import { util } from '@appium/support';
 
 /** @type {LRUCache<string, string>} */
 const COMMAND_NAMES_CACHE = new LRUCache({
@@ -149,7 +150,15 @@ export const METHOD_MAP = /** @type {const} */ ({
     POST: {
       command: 'setValue',
       payloadParams: {
-        required: ['text'],
+        validate: (jsonObj) =>
+          !util.hasValue(jsonObj.text) &&
+          'we require "text" params',
+        optional: ['text'],
+        // override the default argument constructor because of the special
+        // logic here. Appium wants to accept only 'text' for w3c protocl,
+        // but clients might send 'text' and 'value' for backward compatibility reason.
+        // Then, Appium will pickup only 'text' in the server side.
+        makeArgs: (jsonObj) => [jsonObj.text],
       },
     },
   },

--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -156,8 +156,8 @@ export const METHOD_MAP = /** @type {const} */ ({
         optional: ['text'],
         // override the default argument constructor because of the special
         // logic here. Appium wants to accept only 'text' for w3c protocl,
-        // but clients might send 'text' and 'value' for backward compatibility reason.
-        // Then, Appium will pickup only 'text' in the server side.
+        // but clients might send 'text' and 'value' for backward compatibility.
+        // Then, Appium will accept only 'text'.
         makeArgs: (jsonObj) => [jsonObj.text],
       },
     },

--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -151,7 +151,7 @@ export const METHOD_MAP = /** @type {const} */ ({
       payloadParams: {
         validate: (jsonObj) =>
           _.isUndefined(jsonObj.text) &&
-          'we require "text" params',
+          '"text" parameter is required',
         optional: ['text'],
         // override the default argument constructor because of the special
         // logic here. Appium wants to accept only 'text' for w3c protocl,

--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -2,7 +2,6 @@ import _ from 'lodash';
 import {DEFAULT_BASE_PATH} from '../constants';
 import {match} from 'path-to-regexp';
 import {LRUCache} from 'lru-cache';
-import { util } from '@appium/support';
 
 /** @type {LRUCache<string, string>} */
 const COMMAND_NAMES_CACHE = new LRUCache({
@@ -151,7 +150,7 @@ export const METHOD_MAP = /** @type {const} */ ({
       command: 'setValue',
       payloadParams: {
         validate: (jsonObj) =>
-          !util.hasValue(jsonObj.text) &&
+          _.isUndefined(jsonObj.text) &&
           'we require "text" params',
         optional: ['text'],
         // override the default argument constructor because of the special


### PR DESCRIPTION
## Proposed changes

Noticed that the current appium3 repo rejected `/value` endpoint requests when the coming request has `value` and `text` as below for client side backward compatibility implementation reason.

```
Progress: |ERROR AppiumLibCoreTest::PathTest#test_type (111.70s)
Minitest::UnexpectedError:         Selenium::WebDriver::Error::InvalidArgumentError: Some of the provided parameters are not known
        Known required parameters are: ["text"]
        You have provided: ["value","text"]
            /Users/runner/hostedtoolcache/Ruby/3.2.8/arm64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.32.0/lib/selenium/webdriver/remote/response.rb:63:in `add_cause'
            /Users/runner/hostedtoolcache/Ruby/3.2.8/arm64/lib/ruby/gems/3.2.0/gems/selenium-webdriver-4.32.0/lib/selenium/webdriver/remote/response.rb:41:in `error'
```

https://github.com/appium/ruby_lib_core/actions/runs/14946904200/job/41991386002?pr=611

Let's add custom validation like current master does https://github.com/appium/appium/blob/master/packages/base-driver/lib/protocol/routes.js to pick up only `text` (ignore 'value' in appium3)

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
