### PR TITLE
fix(base-driver): Drop unknown method arguments

### DIFF
--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -155,6 +155,13 @@ export function checkParams(
   // go through the required parameters and check against our arguments
   let matchedReqParamSet: string[] = [];
   for (const requiredParamsSet of requiredParams) {
+    if (!_.isArray(requiredParamsSet)) {
+      log.warn(
+        `The required parameter set item ${JSON.stringify(requiredParamsSet)} is not an array. ` +
+        `This is a bug in the method map definition.`
+      );
+      continue;
+    }
     if (_.isEmpty(_.difference(requiredParamsSet, actualParamNames))) {
       return pickKnownParams(
         args,

--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -149,7 +149,7 @@ export function checkParams(
 
   if (_.isEmpty(requiredParams)) {
     // if we don't have any required parameters, then just filter out unknown ones
-    return pickKnownParams(args, _.difference(actualParamNames, [], optionalParams));
+    return pickKnownParams(args, _.difference(actualParamNames, optionalParams));
   }
 
   // go through the required parameters and check against our arguments

--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -99,7 +99,7 @@ function pickKnownParams(args: Record<string, any>, unknownNames: string[]): Rec
   if (_.isEmpty(unknownNames)) {
     return args;
   }
-  log.info(`The following script arguments are not known and will be ignored: ${unknownNames}`);
+  log.info(`The following arguments are not known and will be ignored: ${unknownNames}`);
   return _.pickBy(args, (v, k) => !unknownNames.includes(k));
 }
 

--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -156,11 +156,11 @@ export function checkParams(
   let matchedReqParamSet: string[] = [];
   for (const requiredParamsSet of requiredParams) {
     if (!_.isArray(requiredParamsSet)) {
-      log.warn(
-        `The required parameter set item ${JSON.stringify(requiredParamsSet)} is not an array. ` +
+      throw new Error(
+        `The required parameter set item ${JSON.stringify(requiredParamsSet)} ` +
+        `in ${JSON.stringify(paramSpec)} is not an array. ` +
         `This is a bug in the method map definition.`
       );
-      continue;
     }
     if (_.isEmpty(_.difference(requiredParamsSet, actualParamNames))) {
       return pickKnownParams(

--- a/packages/base-driver/test/unit/protocol/protocol.spec.js
+++ b/packages/base-driver/test/unit/protocol/protocol.spec.js
@@ -1,0 +1,95 @@
+import { checkParams } from '../../../lib/protocol/protocol';
+
+describe('Protocol', function () {
+  let chai;
+  let should;
+
+  before(async function () {
+    chai = await import('chai');
+    const chaiAsPromised = await import('chai-as-promised');
+    chai.use(chaiAsPromised.default);
+    should = chai.should();
+  });
+
+  describe('checkParams', function () {
+    it('should pass if no params are needed, but some are given', function () {
+      const args = checkParams(
+        {},
+        {
+          foo: 'foo',
+          bar: 'bar',
+          baz: 'baz',
+        }
+      );
+      args.should.eql({});
+    });
+
+    it('should preserve session id', function () {
+      const args = checkParams(
+        {
+          optional: ['bar', 'baz'],
+        },
+        {
+          sessionId: 'sessionId',
+          id: 'id',
+          bar: 'bar',
+        }
+      );
+      args.should.eql({
+        sessionId: 'sessionId',
+        id: 'id',
+        bar: 'bar',
+      });
+    });
+
+    it('should pass if no required params are needed', function () {
+      const args = checkParams(
+        {
+          optional: ['bar', 'baz'],
+        },
+        {
+          foo: 'foo',
+          bar: 'bar',
+          baz: 'baz',
+        }
+      );
+      args.should.eql({
+        bar: 'bar',
+        baz: 'baz'
+      });
+    });
+
+    it('should drop unknown params', function () {
+      const args = checkParams(
+        {
+          required: ['foo'],
+          optional: ['bar'],
+        },
+        {
+          foo: 'foo',
+          bar: 'bar',
+          baz: 'baz',
+        }
+      );
+      args.should.eql({
+          foo: 'foo',
+          bar: 'bar'
+      });
+    });
+
+    it('should fail if required params are missing', function () {
+      should.throw(() => {
+        checkParams(
+          {
+            required: ['foo'],
+            optional: ['bar'],
+          },
+          {
+            bar: 'bar',
+            baz: 'baz',
+          }
+        );
+      });
+    });
+  });
+});

--- a/packages/base-driver/test/unit/protocol/protocol.spec.js
+++ b/packages/base-driver/test/unit/protocol/protocol.spec.js
@@ -91,5 +91,23 @@ describe('Protocol', function () {
         );
       });
     });
+
+    it('should pass if a set of required params is matched', function () {
+      const args = checkParams(
+        {
+          required: [['foo'], ['bar']],
+          optional: ['baz'],
+        },
+        {
+          foo: 'foo',
+          bar: 'bar',
+          baz: 'baz',
+        }
+      );
+      args.should.eql({
+        foo: 'foo',
+        baz: 'baz',
+      });
+    });
   });
 });

--- a/packages/base-driver/test/unit/protocol/routes.spec.js
+++ b/packages/base-driver/test/unit/protocol/routes.spec.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import {METHOD_MAP, routeToCommandName} from '../../../lib/protocol';
 import crypto from 'crypto';
 
-describe('Protocol', function () {
+describe('Routes', function () {
   // TODO test against an explicit protocol rather than a hash of a previous
   // protocol
   let chai;


### PR DESCRIPTION
Related to https://github.com/appium/ruby_lib_core/actions/runs/14946904200/job/41991386002?pr=611

The PR fixes the unexpected driver behavior where it was throwing an error for unknown method arguments instead of dropping them with a log message.