### PR TITLE
chore: remove leftover getSessions code & update docs

### DIFF
--- a/packages/appium/docs/en/commands/base-driver.md
+++ b/packages/appium/docs/en/commands/base-driver.md
@@ -337,9 +337,9 @@ Get the current page/app source as HTML/XML
 
 The UI hierarchy in a platform-appropriate format (e.g., HTML for a web page)
 
-### `getSessions`
+### `getAppiumSessions`
 
-`GET` **`/sessions`**
+`GET` **`/appium/sessions`**
 
 Get data for all sessions running on an Appium server
 
@@ -347,17 +347,27 @@ Get data for all sessions running on an Appium server
 
 #### Response
 
-A list of session data objects.
-Each session data object will be returned with `id` and the session's capabilities as `capabilities` keys like an example below:
+A list of session data objects, where each object contains 3 keys:
+
+* `id`: the session ID
+* `created`: the session creation time as a Unix timestamp in milliseconds
+* `capabilities`: the session capabilities
+
+Data is only returned if the `session_discovery` [insecure feature](../guides/security.md)
+is enabled on the server.
+
+#### Example
 
 ```json
 [
   {
     "id":"ba30c6da-c266-4734-8ddb-c16f5bb53e16",
+    "created": 1736092760555,
     "capabilities":{ "platformName":"ios","browserName":"safari","automationName":"xcuitest","platformVersion":"17.2","deviceName":"iPhone 15" }
   },
   {
     "id":"1441110c-1ece-4e45-abbf-ebf404f45f0a",
+    "created": 1736092760555,
     "capabilities":{ "platformName":"ios","browserName":"safari","automationName":"xcuitest","platformVersion":"17.0","deviceName":"iPhone 14" }
   },
   ...

--- a/packages/appium/docs/en/guides/security.md
+++ b/packages/appium/docs/en/guides/security.md
@@ -27,9 +27,20 @@ Appium when starting it from the command line:
 
 |<div style="width:10em">Parameter</div>|Description|
 |---------------------------------------|-----------|
-|`--relaxed-security`|Turns on _all_ insecure features (unless blocked by `--deny-insecure`; see below)|
-|`--allow-insecure`|Turns on _only_ specified features. Features can be provided as a comma-separated list of feature names, or in the [Appium Configuration file](./config.md). For example, `--allow-insecure=adb_shell` will cause _only_ the ADB shell execution feature to be enabled. Has no effect when used in combination with `--relaxed-security`.|
-|`--deny-insecure`|Explicitly turns _off_ specified features, overriding `--relaxed-security` and any features specified using `--allow-insecure`. Like `--allow-insecure`, features can be provided as a comma-separated list of feature names, or in the [Appium Configuration file](./config.md).|
+|`--relaxed-security`|Turns on _all_ insecure features, except those blocked by `--deny-insecure`|
+|`--allow-insecure`|Turns on _only_ specified features, except those blocked by `--deny-insecure`. Has no effect when used in combination with `--relaxed-security`|
+|`--deny-insecure`|Explicitly turns _off_ specified features, overriding `--relaxed-security` and `--allow-insecure`|
+
+All of the above arguments can also be specified in the [Appium Configuration file](./config.md).
+
+Features passed to `--allow-insecure`/`--deny-insecure` must be specified as a comma-separated list,
+and each feature in the list must additionally include a prefix, indicating the driver to which the
+feature should apply. The prefix can be either the driver's `automationName`, or the wildcard (`*`)
+symbol, if the feature should be applied to all drivers. The prefix and feature name are separated
+using the colon character (`:`).
+
+For example, `first:foo` refers to the `foo` feature for the `first` driver, whereas `*:bar` refers
+to the `bar` feature for all drivers.
 
 ## Insecure Features
 
@@ -44,7 +55,8 @@ might use. Here is an incomplete list of examples from some of Appium's official
 |`record_audio`|Allow recording of host machine audio inputs|XCUITest|
 |`execute_driver_script`| Allows to send a request which has multiple Appium commands.|Execute Driver Plugin|
 
-Some insecure features operate on the server level, and do not require a driver session:
+Some insecure features operate on the server level, and do not require a driver session. Enabling
+these features requires using the wildcard prefix:
 
 |<div style="width:12em">Feature Name</div>|Description|
 |------------|-----------|
@@ -52,46 +64,26 @@ Some insecure features operate on the server level, and do not require a driver 
 
 ## Examples
 
-To turn on the `get_server_logs` feature, the Appium server could be started like this:
+Turn on the `foo` feature only for the `first` driver:
 
 ```bash
-appium --allow-insecure=get_server_logs
+appium --allow-insecure=first:foo
 ```
 
-To turn on multiple features:
+Turn on the `foo` feature for all drivers:
 
 ```bash
-appium --allow-insecure=get_server_logs,record_audio
+appium --allow-insecure=*:foo
 ```
 
-To allow all features except one:
+Turn on the `foo` feature for all drivers _except_ `first`:
 
 ```bash
-appium --relaxed-security --deny-insecure=adb_shell
+appium --allow-insecure=*:foo --deny-insecure=first:foo
 ```
 
-## Driver-scope security
+Turn on all features _except_ `foo` for all drivers:
 
-Since Appium server version `2.13`, it is possible to apply features on a per-driver basis. This
-can be achieved by prefixing each feature name with the `automationName` of the driver for which
-the feature should be applied. To apply a feature for all drivers, or to apply a server-level
-feature, the wildcard (`*`) prefix should be used.
-
-For example, the server could be started as follows:
 ```bash
-appium --allow-insecure=uiautomator2:adb_shell,xcuitest:get_server_logs,*:record_audio
+appium --relaxed-security --deny-insecure=*:foo
 ```
-
-This would result in the following:
-
-* The `adb_shell` feature would be enabled only for the UiAutomator2 driver
-* The `get_server_logs` feature would be enabled only for the XCUITest driver
-* The `record_audio` feature would be enabled for all drivers
-
-Feature provided without an explicit prefix are equivalent to having the wildcard prefix.
-These prefix rules apply to both the `--allow-insecure` and `--deny-insecure` server arguments.
-
-!!! warning
-
-    Starting from Appium 3, the scope prefix is required, and features provided without a scope will
-    raise an error. Note that the behavior of the `--relaxed-security` flag remains unchanged.

--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -187,18 +187,6 @@ class AppiumDriver extends DriverCore {
   }
 
   /**
-   * Retrieve information about all active sessions
-   * @returns {Promise<import('@appium/types').MultiSessionData[]>}
-   * @deprecated Use {@linkcode getAppiumSessions} instead
-   */
-  async getSessions() {
-    return _.toPairs(this.sessions).map(([id, driver]) => ({
-      id,
-      capabilities: /** @type {import('@appium/types').DriverCaps<any>} */ (driver.caps),
-    }));
-  }
-
-  /**
    * Retrieve information about all active sessions.
    * Results are returned only if the `session_discovery` insecure feature is enabled.
    * @returns {Promise<import('@appium/types').TimestampedMultiSessionData[]>}

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -9,7 +9,6 @@ import {
   type Driver,
   type DriverCaps,
   type DriverData,
-  type MultiSessionData,
   type ServerArgs,
   type StringRecord,
   type W3CDriverCaps,
@@ -345,23 +344,6 @@ export class BaseDriver<
     this.log.info(`Session created with session id: ${this.sessionId}`);
 
     return [this.sessionId, caps] as CreateResult;
-  }
-
-  /**
-   * Returns the session id and capabilities for the session
-   * @deprecated Use AppiumDriver.getAppiumSessions instead for getting the session data.
-   */
-  async getSessions() {
-    const ret: MultiSessionData<C>[] = [];
-
-    if (this.sessionId) {
-      ret.push({
-        id: this.sessionId,
-        capabilities: this.caps,
-      });
-    }
-
-    return ret;
   }
 
   /**

--- a/packages/driver-test-support/lib/unit-suite.js
+++ b/packages/driver-test-support/lib/unit-suite.js
@@ -212,7 +212,7 @@ export function driverUnitTestSuite(
           await B.delay(waitMs);
           return Date.now();
         });
-        sandbox.stub(d, 'getSessions').callsFake(async () => {
+        sandbox.stub(d, 'deleteSession').callsFake(async () => {
           await B.delay(waitMs);
           throw new Error('multipass');
         });
@@ -241,7 +241,7 @@ export function driverUnitTestSuite(
         let cmds = [];
         for (let i = 0; i < numCmds; i++) {
           if (i === 5) {
-            cmds.push(d.executeCommand('getSessions'));
+            cmds.push(d.executeCommand('deleteSession'));
           } else {
             cmds.push(d.executeCommand('getStatus'));
           }

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -150,16 +150,6 @@ export interface IExecuteCommands {
 }
 
 /**
- * Data returned by {@linkcode ISessionHandler.getSessions}.
- *
- * @typeParam C - The driver's constraints
- */
-export interface MultiSessionData<C extends Constraints = Constraints> {
-  id: string;
-  capabilities: DriverCaps<C>;
-}
-
-/**
  * Data returned by `AppiumDriver.getAppiumSessions`
  *
  * @typeParam C - The driver's constraints
@@ -450,13 +440,6 @@ export interface ISessionHandler<
    * @param driverData - the driver data for other currently-running sessions
    */
   deleteSession(sessionId?: string, driverData?: DriverData[]): Promise<DeleteResult | void>;
-
-  /**
-   * Get data for all sessions running on an Appium server
-   *
-   * @returns A list of session data objects
-   */
-  getSessions(): Promise<MultiSessionData[]>;
 
   /**
    * Get the data for the current session


### PR DESCRIPTION
Follow-up to #21233, addressing some comments:
* Remove leftover `getSessions` code
* Update security docs to use feature prefixes everywhere