### PR TITLE
chore(deps): remove @types/diff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@types/bluebird": "3.5.42",
         "@types/chai": "5.2.1",
         "@types/chai-as-promised": "8.0.2",
-        "@types/diff": "8.0.0",
         "@types/express": "5.0.1",
         "@types/jsftp": "2.1.5",
         "@types/json-schema": "7.0.15",
@@ -2847,17 +2846,6 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/diff": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-8.0.0.tgz",
-      "integrity": "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==",
-      "deprecated": "This is a stub types definition. diff provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "diff": "*"
-      }
     },
     "node_modules/@types/eslint": {
       "version": "7.29.0",
@@ -22453,15 +22441,6 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true
     },
-    "@types/diff": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-8.0.0.tgz",
-      "integrity": "sha512-o7jqJM04gfaYrdCecCVMbZhNdG6T1MHg/oQoRFdERLV+4d+V7FijhiEAbFu0Usww84Yijk9yH58U4Jk4HbtzZw==",
-      "dev": true,
-      "requires": {
-        "diff": "*"
-      }
-    },
     "@types/eslint": {
       "version": "7.29.0",
       "dev": true,
@@ -23364,7 +23343,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
-        "ajv": "^8.0.0"
+        "ajv": "8.17.1"
       }
     },
     "ansi-colors": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "@types/bluebird": "3.5.42",
     "@types/chai": "5.2.1",
     "@types/chai-as-promised": "8.0.2",
-    "@types/diff": "8.0.0",
     "@types/express": "5.0.1",
     "@types/jsftp": "2.1.5",
     "@types/json-schema": "7.0.15",


### PR DESCRIPTION
This removes the deprecated `@types/diff` package, since `diff` v8 already ships with types.