### PR TITLE
chore(base-driver): Mark geolocation-related methods as deprecated

### DIFF
--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -327,8 +327,15 @@ export const METHOD_MAP = /** @type {const} */ ({
     POST: {command: 'setRotation', payloadParams: {required: ['x', 'y', 'z']}},
   },
   '/session/:sessionId/location': {
-    GET: {command: 'getGeoLocation'},
-    POST: {command: 'setGeoLocation', payloadParams: {required: ['location']}},
+    GET: {
+      command: 'getGeoLocation',
+      deprecated: true,
+    },
+    POST: {
+      command: 'setGeoLocation',
+      payloadParams: {required: ['location']},
+      deprecated: true,
+    },
   },
   '/session/:sessionId/orientation': {
     GET: {command: 'getOrientation'},


### PR DESCRIPTION
These methods are part of the obsolete MJWP protocol