### PR TITLE
docs: add minor Appium 3-related adjustments & fix MkDocs warnings

### DIFF
--- a/packages/appium/docs/en/commands/base-driver.md
+++ b/packages/appium/docs/en/commands/base-driver.md
@@ -233,28 +233,6 @@ A possibly empty list of elements inside the shadow root matching the selector
 
 ### `getLog`
 
-`POST` **`/session/:sessionId/log`**
-
-Get the log for a given log type.
-
-!!! warning "Deprecated"
-
-    Please use the `/session/:sessionId/se/log` endpoint instead
-
-<!-- comment source: method-signature -->
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `type` | `string` | Name/key of log type as defined in ILogCommands.supportedLogTypes. |
-
-#### Response
-
-`any`
-
-### `getLog`
-
 `POST` **`/session/:sessionId/se/log`**
 
 Get the log for a given log type.
@@ -290,22 +268,6 @@ Get a list of events that have occurred in the current session
 `EventHistory` \| `Record`<`string`, `number`\>
 
 The event history for the session
-
-### `getLogTypes`
-
-`GET` **`/session/:sessionId/log/types`**
-
-Get available log types as a list of strings
-
-!!! warning "Deprecated"
-
-    Please use the `/session/:sessionId/se/log/types` endpoint instead
-
-<!-- comment source: method-signature -->
-
-#### Response
-
-`string`[]
 
 ### `getLogTypes`
 
@@ -510,30 +472,6 @@ Set the various timeouts associated with a session
 
 ``null``
 
-### `implicitWait`
-
-`POST` **`/session/:sessionId/timeouts/implicit_wait`**
-
-Set the implicit wait timeout
-
-!!! warning "Deprecated"
-
-    Please use the `/session/:sessionId/timeouts` endpoint instead
-
-Use `timeouts` instead
-
-<!-- comment source: method-signature -->
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `ms` | `string` \| `number` | the timeout in ms |
-
-#### Response
-
-``null``
-
 ### `logCustomEvent`
 
 `POST` **`/session/:sessionId/appium/log_event`**
@@ -548,24 +486,6 @@ Add a custom-named event to the Appium event log
 | :------ | :------ | :------ |
 | `vendor` | `string` | the name of the vendor or tool the event belongs to, to namespace the event |
 | `event` | `string` | the name of the event itself |
-
-#### Response
-
-``null``
-
-### `reset`
-
-`POST` **`/session/:sessionId/appium/app/reset`**
-
-Reset the current session (run the delete session and create session subroutines)
-
-!!! warning "Deprecated"
-
-    Please use each driver's launch, activate, terminate or cleanup method.
-
-Use explicit session management commands instead
-
-<!-- comment source: method-signature -->
 
 #### Response
 

--- a/packages/appium/docs/en/developing/build-plugins.md
+++ b/packages/appium/docs/en/developing/build-plugins.md
@@ -170,7 +170,7 @@ This is the most normal behavior for Appium plugins -- to modify or replace the 
 more commands that would normally be handled by the active driver. To override the default command
 handling, you need to implement `async` methods in your class with the same name as the Appium
 commands to be handled (just exactly how [drivers themselves are
-implemented](./build-drivers.md#implement-webdriver-commands)). Curious what command names there
+implemented](./build-drivers.md#implement-webdriver-classic-commands)). Curious what command names there
 are? They are defined in the Appium base driver's
 [routes.js](https://github.com/appium/appium-base-driver/blob/master/lib/protocol/routes.js) file,
 and of course you can add more as defined in the next section.

--- a/packages/appium/docs/en/developing/config-system.md
+++ b/packages/appium/docs/en/developing/config-system.md
@@ -250,7 +250,7 @@ An `ArgSpec` object stores the following metadata:
 | `dest`          | Property name in parsed arguments object (as returned by `argparse`'s `parse_args()`) |
 | `defaultValue?` | Value of the `default` keyword in schema, if appropriate                              |
 
-When a schema is [finalized](#schema-finalization), the `Map` is populated with `ArgSpec` objects
+When a schema is [finalized](#schema-loading), the `Map` is populated with `ArgSpec` objects
 for all known arguments.
 
 So when the adapter is creating the pipeline of functions for the argument's `type`, it already has

--- a/packages/appium/docs/en/guides/event-timing.md
+++ b/packages/appium/docs/en/guides/event-timing.md
@@ -67,12 +67,7 @@ generate various kinds of reports from event timings output:
 
 ## Add a custom event
 
-!!! warning "TODO"
-
-    The links to the commands in the following paragraph do not yet work since these docs are under
-    construction.
-
 You can add custom events that will show up in the event timings data. You can send a custom event
-name to the Appium server using the [Log Event API](#TODO), and the server will store the
-timestamp. The [Get Events](#TODO) command can be used to retrieve named events' timestamps later
-on.
+name to the Appium server using the [Log Custom Event API](../commands/base-driver.md#logcustomevent),
+and the server will store the timestamp. The [Get Log Events](../commands/base-driver.md#getlogevents)
+command can be used to retrieve named events' timestamps later on.

--- a/packages/appium/docs/en/quickstart/requirements.md
+++ b/packages/appium/docs/en/quickstart/requirements.md
@@ -8,9 +8,9 @@ title: System Requirements
 The basic requirements for the Appium server are:
 
 * A macOS, Linux, or Windows operating system
-* [Node.js](https://nodejs.org) version in the [SemVer](https://semver.org) range `^14.17.0 || ^16.13.0 || >=18.0.0`
+* [Node.js](https://nodejs.org) version in the [SemVer](https://semver.org) range `^20.19.0 || ^22.12.0 || >=24.0.0`
     * LTS is recommended
-* [`npm`](https://npmjs.com) version `>=8` (`npm` is usually bundled with Node.js, but can be upgraded
+* [`npm`](https://npmjs.com) version `>=10` (`npm` is usually bundled with Node.js, but can be upgraded
 independently)
 
 By itself, Appium is relatively lightweight and doesn't have significant disk space or RAM


### PR DESCRIPTION
* Remove commands removed in Appium 3 from the base-driver commands reference page
* Fix the required Node/npm versions in quickstart
* Fix various MkDocs warnings about incorrect link anchors