### PR TITLE
chore(deps): fix old ws import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18833,26 +18833,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "packages/appium/node_modules/ws": {
-      "version": "8.14.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "packages/appium/node_modules/yaml": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",


### PR DESCRIPTION
`package-lock.json` seems to include an older `ws` version, even though the `appium` package's `package.json` uses a newer one. This removes the entry and fixes the resulting vulnerability.