### PR TITLE
fix: use v3 syntax for winston

### DIFF
--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -59,19 +59,7 @@ export async function init(args) {
   const transports = await createTransports(args);
   const transportNames = new Set(transports.map((tr) => tr.constructor.name));
 
-    // interface LoggerOptions {
-    //   levels?: Config.AbstractConfigSetLevels;
-    //   silent?: boolean;
-    //   format?: logform.Format;
-    //   level?: string;
-    //   exitOnError?: Function | boolean;
-    //   defaultMeta?: any;
-    //   transports?: Transport[] | Transport;
-    //   handleExceptions?: boolean;
-    //   handleRejections?: boolean;
-    //   exceptionHandlers?: any;
-    //   rejectionHandlers?: any;
-    // }
+
   log = createLogger({
     transports,
     levels: LEVELS_MAP,
@@ -157,6 +145,11 @@ function createConsoleTransport(args, logLvl) {
     name: 'console',
     level: logLvl,
     stderrLevels: ['error'],
+    format: format.combine(
+      formatTimestamp(args),
+      isLogColorEnabled(args) ? colorizeFormat : stripColorFormat,
+      formatLog(args, true),
+    ),
   });
 }
 
@@ -173,6 +166,11 @@ function createFileTransport(args, logLvl) {
     filename: args.logFile,
     maxFiles: 1,
     level: logLvl,
+    format: format.combine(
+      stripColorFormat,
+      formatTimestamp(args),
+      formatLog(args, false),
+    ),
   });
 }
 
@@ -199,6 +197,10 @@ function createHttpTransport(args, logLvl) {
     port,
     path: '/',
     level: logLvl,
+    format: format.combine(
+      stripColorFormat,
+      formatLog(args, false),
+    ),
   });
 }
 

--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -133,7 +133,7 @@ const stripColorFormat = format(function stripColor(info) {
  * @returns {transports.ConsoleTransportInstance}
  */
 function createConsoleTransport(args, logLvl) {
-  /** @type {AppiumConsoleTRansportOptions} */
+  /** @type {AppiumConsoleTransportOptions} */
   const opt = {
     name: 'console',
     level: logLvl,
@@ -358,7 +358,7 @@ export default init;
 /**
  * @typedef {import('appium/types').ParsedArgs} ParsedArgs
  * @typedef {import('@appium/logger').MessageObject} MessageObject
- * @typedef {transports.ConsoleTransportOptions & {name: string}} AppiumConsoleTRansportOptions
+ * @typedef {transports.ConsoleTransportOptions & {name: string}} AppiumConsoleTransportOptions
  * @typedef {transports.FileTransportOptions & {name: string}} AppiumFileTransportOptions
  * @typedef {transports.HttpTransportOptions & {name: string}} AppiumHttpTransportOptions
  */

--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -58,8 +58,6 @@ export async function init(args) {
 
   const transports = await createTransports(args);
   const transportNames = new Set(transports.map((tr) => tr.constructor.name));
-
-
   log = createLogger({
     transports,
     levels: LEVELS_MAP,

--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -62,12 +62,7 @@ export async function init(args) {
     transports,
     levels: LEVELS_MAP,
     handleExceptions: true,
-    exitOnError: false,
-    format: format.combine(
-      formatTimestamp(args),
-      isLogColorEnabled(args) ? colorizeFormat : stripColorFormat,
-      formatLog(args, false),
-    ),
+    exitOnError: false
   });
 
   const reportedLoggerErrors = new Set();

--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -133,7 +133,9 @@ const stripColorFormat = format(function stripColor(info) {
  * @returns {transports.ConsoleTransportInstance}
  */
 function createConsoleTransport(args, logLvl) {
-  return new transports.Console({
+  /** @type {AppiumConsoleTRansportOptions} */
+  const opt = {
+    name: 'console',
     level: logLvl,
     stderrLevels: ['error'],
     format: format.combine(
@@ -141,7 +143,8 @@ function createConsoleTransport(args, logLvl) {
       isLogColorEnabled(args) ? colorizeFormat : stripColorFormat,
       formatLog(args, true),
     ),
-  });
+  };
+  return new transports.Console(opt);
 }
 
 /**
@@ -151,7 +154,9 @@ function createConsoleTransport(args, logLvl) {
  * @returns {transports.FileTransportInstance}
  */
 function createFileTransport(args, logLvl) {
-  return new transports.File({
+  /** @type {AppiumFileTransportOptions} */
+  const opt = {
+    name: 'file',
     filename: args.logFile,
     maxFiles: 1,
     level: logLvl,
@@ -160,7 +165,8 @@ function createFileTransport(args, logLvl) {
       formatTimestamp(args),
       formatLog(args, false),
     ),
-  });
+  };
+  return new transports.File(opt);
 }
 
 /**
@@ -179,7 +185,9 @@ function createHttpTransport(args, logLvl) {
     port = parseInt(hostAndPort[1], 10);
   }
 
-  return new transports.Http({
+  /** @type {AppiumHttpTransportOptions} */
+  const opt = {
+    name: 'http',
     host,
     port,
     path: '/',
@@ -188,7 +196,8 @@ function createHttpTransport(args, logLvl) {
       stripColorFormat,
       formatLog(args, false),
     ),
-  });
+  };
+  return new transports.Http(opt);
 }
 
 /**
@@ -349,4 +358,7 @@ export default init;
 /**
  * @typedef {import('appium/types').ParsedArgs} ParsedArgs
  * @typedef {import('@appium/logger').MessageObject} MessageObject
+ * @typedef {transports.ConsoleTransportOptions & {name: string}} AppiumConsoleTRansportOptions
+ * @typedef {transports.FileTransportOptions & {name: string}} AppiumFileTransportOptions
+ * @typedef {transports.HttpTransportOptions & {name: string}} AppiumHttpTransportOptions
  */

--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -134,8 +134,6 @@ const stripColorFormat = format(function stripColor(info) {
  */
 function createConsoleTransport(args, logLvl) {
   return new transports.Console({
-    // @ts-expect-error The 'name' property should exist
-    name: 'console',
     level: logLvl,
     stderrLevels: ['error'],
     format: format.combine(
@@ -154,8 +152,6 @@ function createConsoleTransport(args, logLvl) {
  */
 function createFileTransport(args, logLvl) {
   return new transports.File({
-    // @ts-expect-error The 'name' property should exist
-    name: 'file',
     filename: args.logFile,
     maxFiles: 1,
     level: logLvl,
@@ -184,8 +180,6 @@ function createHttpTransport(args, logLvl) {
   }
 
   return new transports.Http({
-    // @ts-expect-error The 'name' property should exist
-    name: 'http',
     host,
     port,
     path: '/',

--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -58,9 +58,30 @@ export async function init(args) {
 
   const transports = await createTransports(args);
   const transportNames = new Set(transports.map((tr) => tr.constructor.name));
+
+    // interface LoggerOptions {
+    //   levels?: Config.AbstractConfigSetLevels;
+    //   silent?: boolean;
+    //   format?: logform.Format;
+    //   level?: string;
+    //   exitOnError?: Function | boolean;
+    //   defaultMeta?: any;
+    //   transports?: Transport[] | Transport;
+    //   handleExceptions?: boolean;
+    //   handleRejections?: boolean;
+    //   exceptionHandlers?: any;
+    //   rejectionHandlers?: any;
+    // }
   log = createLogger({
     transports,
     levels: LEVELS_MAP,
+    handleExceptions: true,
+    exitOnError: false,
+    format: format.combine(
+      formatTimestamp(args),
+      isLogColorEnabled(args) ? colorizeFormat : stripColorFormat,
+      formatLog(args, false),
+    ),
   });
 
   const reportedLoggerErrors = new Set();
@@ -134,16 +155,8 @@ function createConsoleTransport(args, logLvl) {
   return new transports.Console({
     // @ts-expect-error The 'name' property should exist
     name: 'console',
-    handleExceptions: true,
-    exitOnError: false,
-    json: false,
     level: logLvl,
     stderrLevels: ['error'],
-    format: format.combine(
-      formatTimestamp(args),
-      isLogColorEnabled(args) ? colorizeFormat : stripColorFormat,
-      formatLog(args, true),
-    ),
   });
 }
 
@@ -159,15 +172,7 @@ function createFileTransport(args, logLvl) {
     name: 'file',
     filename: args.logFile,
     maxFiles: 1,
-    handleExceptions: true,
-    exitOnError: false,
-    json: false,
     level: logLvl,
-    format: format.combine(
-      stripColorFormat,
-      formatTimestamp(args),
-      formatLog(args, false),
-    ),
   });
 }
 
@@ -193,14 +198,7 @@ function createHttpTransport(args, logLvl) {
     host,
     port,
     path: '/',
-    handleExceptions: true,
-    exitOnError: false,
-    json: false,
     level: logLvl,
-    format: format.combine(
-      stripColorFormat,
-      formatLog(args, false),
-    ),
   });
 }
 


### PR DESCRIPTION
## Proposed changes

Noticed that current winston v3 used in appium3 has wrong parameters. Current syntax is v2 one.

https://github.com/winstonjs/winston/blob/master/UPGRADE-3.0.md#winstonlogger

https://github.com/appium/appium-xcuitest-driver/pull/2582

For example, `handleExceptions`, `format` and `exitOnError` are in the `createLogger` rather than individual configs.

```
interface LoggerOptions {
  levels?: Config.AbstractConfigSetLevels;
  silent?: boolean;
  format?: logform.Format;
  level?: string;
  exitOnError?: Function | boolean;
  defaultMeta?: any;
  transports?: Transport[] | Transport;
  handleExceptions?: boolean;
  handleRejections?: boolean;
  exceptionHandlers?: any;
  rejectionHandlers?: any;
}
```

Each `transports` has below params, so I moved same config for `exitOnError` and `handleExceptions` to the top, but others remain in each place.

```
  interface TransportStreamOptions {
    format?: logform.Format;
    level?: string;
    silent?: boolean;
    handleExceptions?: boolean;
    handleRejections?: boolean;

    log?(info: any, next: () => void): any;
    logv?(info: any, next: () => void): any;
    close?(): void;
  }
```

In v3, to use json format, we need to give `format.json()` explicitly, so this PR just remove the json's one. 

I have checked log behavior with various options. They look working.

- `npx appium`
- `npx appium --log inu.log --log-no-color --log-timestamp --log-level warn`
- `npx appium --log inu.log  --log-timestamp --log-format json`
- `npx appium --log inu.log --log-no-color --log-timestamp --log-format json`
- `npx appium --log inu.log --log-no-color --log-timestamp`
- `npx appium --log inu.log --log-no-color --log-timestamp --log-level warn --log-format json`

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
