### PR TITLE
fix(appium): Add appium module symlink while installing extensions

### DIFF
--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -975,7 +975,7 @@ async function injectAppiumSymlink(dstFolder) {
   let appiumModuleRoot;
   try {
     appiumModuleRoot = getAppiumModuleRoot();
-    const symlinkPath = path.join(dstFolder, 'appium');
+    const symlinkPath = path.join(dstFolder, path.basename(appiumModuleRoot));
     if (await fs.exists(dstFolder) && !(await fs.exists(symlinkPath))) {
       await fs.symlink(appiumModuleRoot, symlinkPath, system.isWindows() ? 'junction' : 'dir');
     }

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -454,14 +454,9 @@ class ExtensionCliCommand {
         return {pkg, installPath};
       });
 
-      // If the extension is installed, we try to inject the appium module symlink into global node_modules
-      // as well as into the extension's node_modules folder.
-      for (const root of [
-        path.join(path.dirname(installPath), 'node_modules'),
-        path.join(installPath, 'node_modules'),
-      ]) {
-        await injectAppiumSymlink.bind(this)(root);
-      }
+      // After the extension is installed, we try to inject the appium module symlink
+      // into the extension's node_modules folder if it is not there yet.
+      await injectAppiumSymlink.bind(this)(path.join(installPath, 'node_modules'));
 
       return this.getInstallationReceipt({
         pkg,

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -972,15 +972,19 @@ class ExtensionCliCommand {
  * @returns {Promise<void>}
  */
 async function injectAppiumSymlink(dstFolder) {
+  let appiumModuleRoot;
   try {
-    const appiumModuleRoot = getAppiumModuleRoot();
+    appiumModuleRoot = getAppiumModuleRoot();
     const symlinkPath = path.join(dstFolder, 'appium');
     if (await fs.exists(dstFolder) && !(await fs.exists(symlinkPath))) {
       await fs.symlink(appiumModuleRoot, symlinkPath, system.isWindows() ? 'junction' : 'dir');
     }
   } catch (error) {
     // This error is not fatal, we may still doing just fine if the module being loaded is a CJS one
-    this.log.info(`Cannot create a symlink to the appium module in '${dstFolder}'. Original error: ${error.message}`);
+    this.log.info(
+      `Cannot create a symlink to the appium module '${appiumModuleRoot}' in '${dstFolder}'. ` +
+      `Original error: ${error.message}`
+    );
   }
 }
 


### PR DESCRIPTION
Related to https://github.com/appium/appium-xcuitest-driver/pull/2587#issuecomment-3009109934

We do the module load hack, but it only works for CJS modules. ESM ones ignore NODE_PATH, so the only viable solution there is to explicitly inject a symlink while installing extensions