### PR TITLE
fix(eslint-config-appium-ts): adjust dependency configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -334,7 +334,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.4.tgz",
       "integrity": "sha512-S8ZdQj/N69YAtuqFt7653jwcvuUj131+6qGLUyDqfDg1OIoBQ66OCuXC473YQfO2AaxITTutiRQiDwoo7ZLYyg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -12841,7 +12840,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mjpeg-consumer": {
@@ -20022,20 +20021,22 @@
       "name": "@appium/eslint-config-appium-ts",
       "version": "1.0.4",
       "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
-        "npm": ">=10"
-      },
-      "peerDependencies": {
+      "dependencies": {
         "@eslint/compat": "^1.1.0",
         "@eslint/js": "^9.0.0",
-        "eslint": "^9.0.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-import-resolver-typescript": "^4.0.0",
         "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-mocha": "^10.4.0",
         "eslint-plugin-promise": "^7.0.0",
         "typescript-eslint": "^8.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "npm": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0"
       }
     },
     "packages/execute-driver-plugin": {
@@ -21419,7 +21420,16 @@
     },
     "@appium/eslint-config-appium-ts": {
       "version": "file:packages/eslint-config-appium-ts",
-      "requires": {}
+      "requires": {
+        "@eslint/compat": "^1.1.0",
+        "@eslint/js": "^9.0.0",
+        "eslint-config-prettier": "^10.0.0",
+        "eslint-import-resolver-typescript": "^4.0.0",
+        "eslint-plugin-import": "^2.30.0",
+        "eslint-plugin-mocha": "^10.4.0",
+        "eslint-plugin-promise": "^7.0.0",
+        "typescript-eslint": "^8.0.0"
+      }
     },
     "@appium/execute-driver-plugin": {
       "version": "file:packages/execute-driver-plugin",
@@ -22167,7 +22177,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.4.tgz",
       "integrity": "sha512-S8ZdQj/N69YAtuqFt7653jwcvuUj131+6qGLUyDqfDg1OIoBQ66OCuXC473YQfO2AaxITTutiRQiDwoo7ZLYyg==",
-      "peer": true,
       "requires": {}
     },
     "@eslint/config-array": {
@@ -24764,7 +24773,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
-        "ajv": "^8.0.0"
+        "ajv": "8.17.1"
       }
     },
     "ansi-colors": {
@@ -30474,7 +30483,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
-      "devOptional": true
+      "dev": true
     },
     "mjpeg-consumer": {
       "version": "2.0.0",

--- a/packages/eslint-config-appium-ts/README.md
+++ b/packages/eslint-config-appium-ts/README.md
@@ -7,7 +7,7 @@
 
 ## Usage
 
-Install the package with **`npm` v8 or newer**:
+Install the package:
 
 ```bash
 npm install @appium/eslint-config-appium-ts --save-dev
@@ -23,18 +23,6 @@ export default [
   // add any other config changes 
 ];
 ```
-
-## Peer Dependencies
-
-This config requires the following packages be installed (as peer dependencies) in your project.  See the `package.json` for the required versions.
-
-- [eslint](https://www.npmjs.com/package/eslint)
-- [eslint-config-prettier](https://www.npmjs.com/package/eslint-config-prettier)
-- [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import)
-- [eslint-plugin-mocha](https://www.npmjs.com/package/eslint-plugin-mocha)
-- [eslint-plugin-promise](https://www.npmjs.com/package/eslint-plugin-promise)
-- [@typescript-eslint/eslint-plugin](https://www.npmjs.com/package/@typescript-eslint/eslint-plugin)
-- [@typescript-eslint/parser](https://www.npmjs.com/package/@typescript-eslint/parser)
 
 ## Notes
 

--- a/packages/eslint-config-appium-ts/package.json
+++ b/packages/eslint-config-appium-ts/package.json
@@ -28,16 +28,18 @@
   "scripts": {
     "test:smoke": "exit 0"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@eslint/compat": "^1.1.0",
     "@eslint/js": "^9.0.0",
-    "eslint": "^9.0.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-import-resolver-typescript": "^4.0.0",
     "eslint-plugin-import": "^2.30.0",
     "eslint-plugin-mocha": "^10.4.0",
     "eslint-plugin-promise": "^7.0.0",
     "typescript-eslint": "^8.0.0"
+  },
+  "peerDependencies": {
+    "eslint": "^9.0.0"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",


### PR DESCRIPTION
This adjusts the `eslint-config-appium-ts` package to import all of its dependent packages and configs (except `eslint` itself) as `dependencies` instead of `peerDependencies`.

Why?
1) This approach is listed in [the ESLint documentation](https://eslint.org/docs/latest/extend/shareable-configs#publishing-a-shareable-config)
2) Other popular configs follow a similar approach and only put `eslint` in their `peerDependencies` ([some](https://github.com/prettier/eslint-config-prettier/blob/main/package.json) [examples](https://github.com/Shopify/web-configs/blob/main/packages/eslint-plugin/package.json) [here](https://github.com/gajus/eslint-config-canonical/blob/main/package.json))
3) The current dependency configuration may be the reason why Renovate PRs on the Appium Inspector repo have begun to fail, since Renovate appears to now be removing dependencies with `peer: true` and `optional: true`. This change should fix that issue as well.