### PR TITLE
chore(appium): do not send message for the close in BiDi

### DIFF
--- a/packages/appium/lib/bidi-commands.ts
+++ b/packages/appium/lib/bidi-commands.ts
@@ -189,7 +189,7 @@ export function cleanupBidiSockets(this: AppiumDriver, sessionId: string): void 
     this.log.debug(`Closing bidi socket(s) associated with session ${sessionId}`);
     for (const ws of this.bidiSockets[sessionId]) {
       // 1001 means server is going away
-      ws.close(1001, 'Appium session is closing');
+      ws.close(1001);
     }
   } catch {}
   delete this.bidiSockets[sessionId];


### PR DESCRIPTION
## Proposed changes

When I tested this bidi with Ruby client, noticed that websocket connection end sent `Appium session is closing` plain text (not JSON), so it caused json parse error in  https://github.com/SeleniumHQ/selenium/blob/trunk/rb/lib/selenium/webdriver/common/websocket_connection.rb#L125

I couldn't find proper documentation about this message format in session close specific in https://w3c.github.io/webdriver-bidi/, but probably it might be JSON or just no message like `proxyClient.close(1000);` case...?


## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
