### PR TITLE
chore(docutils): set dependency diff to v8.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19595,7 +19595,7 @@
         "@appium/support": "^7.0.0",
         "chalk": "4.1.2",
         "consola": "3.4.2",
-        "diff": "8.0.02",
+        "diff": "8.0.2",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "pkg-dir": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21091,7 +21091,7 @@
         "@appium/support": "^7.0.0",
         "chalk": "4.1.2",
         "consola": "3.4.2",
-        "diff": "8.0.02",
+        "diff": "8.0.2",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "pkg-dir": "5.0.0",

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -51,7 +51,7 @@
     "@appium/support": "^7.0.0",
     "chalk": "4.1.2",
     "consola": "3.4.2",
-    "diff": "8.0.02",
+    "diff": "8.0.2",
     "lilconfig": "3.1.3",
     "lodash": "4.17.21",
     "pkg-dir": "5.0.0",


### PR DESCRIPTION
## Proposed changes

Fixes #21493 

Set the diff dependency to 8.0.2 to resolve an issue where yarn couldn't parse the patch version.

Installing Appium 3.0.0 with yarn should now work without any errors.
```
yarn add appium@3.0.0
```

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules