### PR TITLE
docs: update various miscellaneous documents for Appium 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ most of which have their own changelogs. Links to these individual changelogs ar
 
 ## Main Appium Module
 
-* ### [Appium 2 Changelog](packages/appium/CHANGELOG.md)
+* ### [Appium Changelog](packages/appium/CHANGELOG.md)
 * [Appium 1.x Changelog](https://github.com/appium/appium/blob/1.x/CHANGELOG.md)
 
 ## Drivers / Clients
@@ -16,6 +16,7 @@ to driver/client documentation
 * [execute-driver-plugin](packages/execute-driver-plugin/CHANGELOG.md)
 * [images-plugin](packages/images-plugin/CHANGELOG.md)
 * [relaxed-caps-plugin](packages/relaxed-caps-plugin/CHANGELOG.md)
+* [storage-plugin](packages/storage-plugin/CHANGELOG.md)
 * [universal-xml-plugin](packages/universal-xml-plugin/CHANGELOG.md)
 
 ## Other Modules
@@ -30,7 +31,6 @@ to driver/client documentation
 * [opencv](packages/opencv/CHANGELOG.md)
 * [plugin-test-support](packages/plugin-test-support/CHANGELOG.md)
 * [schema](packages/schema/CHANGELOG.md)
-* [storage-plugin](packages/storage-plugin/CHANGELOG.md)
 * [strongbox](packages/strongbox/CHANGELOG.md)
 * [support](packages/support/CHANGELOG.md)
 * [test-support](packages/test-support/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -39,18 +39,13 @@ programming languages, which means there is an entire ecosystem of related softw
 * [__Clients__](#clients) allow writing Appium tests in your programming language of choice
 * [__Plugins__](#plugins) allow to further extend Appium functionality
 
-## Migrating From Appium 1 to Appium 2
+## Upgrading From Older Versions
 
-As of January 1st, 2022, the Appium team no longer maintains or supports Appium 1. All officially
-supported platform drivers are only compatible with Appium 2.
+The Appium team only provides support for the most recent version of Appium. If you wish to upgrade from
+an older major Appium version, please refer to the migration guides:
 
-__[Please read the Migration Guide](https://appium.io/docs/en/latest/guides/migrating-1-to-2/) if you
-are still using Appium 1.__
-
-> [!WARNING]
-> If you use Appium Desktop or Appium Server GUI, you will not be able to upgrade to Appium 2, as
-both of these tools have been deprecated. Please use [Appium Inspector](https://github.com/appium/appium-inspector)
-in combination with a standalone Appium 2 server.
+* [Appium v2 to v3](https://appium.io/docs/en/latest/guides/migrating-2-to-3/)
+* [Appium v1 to v2](https://appium.io/docs/en/latest/guides/migrating-1-to-2/)
 
 ## Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,4 +3,4 @@
 The old Appium 1.x docs used to be in this directory. Now, they are available only on the [1.x
 branch](https://github.com/appium/appium/tree/1.x/docs).
 
-Appium 2.x docs are located in [packages/appium/docs](../packages/appium/docs) in this repo.
+Current Appium docs are located in [packages/appium/docs](../packages/appium/docs) in this repo.

--- a/packages/appium/CHANGELOG.md
+++ b/packages/appium/CHANGELOG.md
@@ -5,7 +5,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [3.0.0](https://github.com/appium/appium/compare/appium@3.0.0-rc.2...appium@3.0.0) (2025-08-18)
 
-**Note:** Version bump only for package appium
+### Appium 3 Is Here! 🚀
+
+[See the blog post](https://appium.io/docs/en/latest/blog/2025/08/07/-appium-3/)
+and [the migration guide](https://appium.io/docs/en/latest/guides/migrating-2-to-3/) for more details.
 
 
 

--- a/packages/appium/docs/en/commands/base-driver.md
+++ b/packages/appium/docs/en/commands/base-driver.md
@@ -5,7 +5,7 @@
 `POST` **`/session`**
 
 Historically the first two arguments were reserved for JSONWP capabilities.
-Appium 2 has dropped the support of these, so now we only accept capability
+These are no longer supported since Appium 2, so now we only accept capability
 objects in W3C format and thus allow any of the three arguments to represent
 the latter.
 

--- a/packages/appium/docs/en/developing/config-system.md
+++ b/packages/appium/docs/en/developing/config-system.md
@@ -2,8 +2,8 @@
 title: Appium's Config System
 ---
 
-Appium 2 supports [configuration files](../guides/config.md). A configuration file is intended to
-have (nearly) 1:1 parity with command-line arguments. An end user can supply Appium 2 with
+Appium includes support for [configuration files](../guides/config.md). A configuration file is
+intended to have (nearly) 1:1 parity with command-line arguments. An end user can supply Appium with
 a configuration file, CLI args, or both (the args have precedence over the config file).
 
 This document will be a technical overview of how the configuration system works. It is intended
@@ -323,7 +323,7 @@ One of the design goals of this system is the following:
 _An extension should be able to register custom CLI arguments with the Appium, and a user should be
 able to use them like any other argument_.
 
-Previously, Appium 2 accepted arguments in this manner (via `--driverArgs`), but validation was
+Previously, Appium accepted arguments in this manner (via `--driverArgs`), but validation was
 hand-rolled and required extension implementors to use a custom API. It also required the user to
 awkwardly pass a JSON string as the configuration on the command-line. Further, no contextual help
 (via `--help`) existed for these arguments.

--- a/packages/appium/docs/en/developing/index.md
+++ b/packages/appium/docs/en/developing/index.md
@@ -5,7 +5,7 @@ hide:
 title: Intro to Development
 ---
 
-Appium 2 is built with a modular structure, which means that Appium extensions (drivers and plugins)
+Appium is built with a modular structure, which means that Appium extensions (drivers and plugins)
 are decoupled from the main Appium module, and you only need to install the extensions that you
 want to use. This modular structure also unlocks the ability to develop entirely new extensions!
 

--- a/packages/appium/docs/en/guides/caps.md
+++ b/packages/appium/docs/en/guides/caps.md
@@ -144,7 +144,7 @@ drivers and plugins. It is of course up to each service provider how they wish t
 discovery, installation, and availability of any official or third party drivers or plugins. But
 the Appium team does provide several suggestions, for consistency across the industry. _These are
 recommendations only,_ and not a standard, but adopting it will help users to navigate the increased
-complexity that working with Appium 2 in a cloud environment may bring.
+complexity that working with Appium in a cloud environment may bring.
 
 ### Suggested capabilities
 

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -32,7 +32,8 @@ ended before the release of Appium 2, which meant that even users on outdated No
 able to use it.
 
 Appium 3 drops support for outdated Node versions, and bumps the minimum required version to Node
-`20.19.0` (with the semver range `^20.19.0 || ^22.12.0 || >=24.0.0`), as well as the minimum `npm` version to `10`.
+`20.19.0` (with the semver range `^20.19.0 || ^22.12.0 || >=24.0.0`), as well as the minimum `npm`
+version to `10`.
 
 !!! info "Actions Needed"
 

--- a/packages/appium/docs/en/guides/migrating-2-to-3.md
+++ b/packages/appium/docs/en/guides/migrating-2-to-3.md
@@ -32,7 +32,7 @@ ended before the release of Appium 2, which meant that even users on outdated No
 able to use it.
 
 Appium 3 drops support for outdated Node versions, and bumps the minimum required version to Node
-`20.19.0`, as well as the minimum `npm` version to `10`.
+`20.19.0` (with the semver range `^20.19.0 || ^22.12.0 || >=24.0.0`), as well as the minimum `npm` version to `10`.
 
 !!! info "Actions Needed"
 

--- a/packages/appium/docs/en/intro/history.md
+++ b/packages/appium/docs/en/intro/history.md
@@ -177,7 +177,7 @@ and Appium became an Impact Project in the foundation.
 ## Appium 2.0
 
 Appium 2 was released in 2023 and introduced an entirely revamped architecture, shifting focus to Appium
-as an ecosystem rather than a singular project. This unlocked the ability for anyone to develop
+as an ecosystem rather than an all-in-one project. This unlocked the ability for anyone to develop
 and share their own Appium extensions (drivers and plugins), opening up a world of possibilities
 for automation-related development for platforms far beyond iOS and Android! As a result,
 many third-party extensions were created, such as new drivers for Flutter and Windows, plugins for
@@ -189,4 +189,8 @@ contributors for their voluntary work on the project.
 
 ## Appium 3.0
 
-2025 also saw the release of Appium 3.
+2025 saw the release of Appium 3. This update was a lot smaller than Appium 2 and included only a
+few behavioral changes, instead focusing on removing deprecated code and updating compatibility for
+more modern ecosystems. Still, this reduced scope was also to be expected: since Appium 2, the
+main feature development efforts had shifted to individual drivers and plugins, many of which had
+gone through multiple major updates during the Appium 2 era.

--- a/packages/appium/docs/en/intro/history.md
+++ b/packages/appium/docs/en/intro/history.md
@@ -157,8 +157,7 @@ it was easy for users or third-party developers to build their own Appium
 on the Appium codebase, and to see support for new platforms added to Appium by
 groups other than the core team. That vision has begun to be fulfilled, with
 groups like Microsoft and Youi.tv adding drivers to Appium for Windows desktop
-app automation and Youi.tv app automation, respectively. Who knows what
-platforms will be added next?
+app automation and Youi.tv app automation, respectively.
 
 ## Appium To The People
 
@@ -172,11 +171,22 @@ foundation, we hope that the door will open even more widely for new
 contributors, either as individuals or representing one of the many companies
 which now have an interest in seeing Appium move forward.
 
-Eventually, the JS Foundation merged into the [OpenJS Foundation](https://openjsf.org), and Appium
-is currently an Impact Project in the foundation.
+Eventually, the JS Foundation merged into the [OpenJS Foundation](https://openjsf.org),
+and Appium became an Impact Project in the foundation.
 
 ## Appium 2.0
 
-Appium 2 was released in 2023, with a new focus on Appium as an ecosystem rather than a singular
-project. Drivers and plugins can be developed and shared by anyone, opening up a world of
-possibilities for automation-related development for platforms far beyond iOS and Android.
+Appium 2 was released in 2023 and introduced an entirely revamped architecture, shifting focus to Appium
+as an ecosystem rather than a singular project. This unlocked the ability for anyone to develop
+and share their own Appium extensions (drivers and plugins), opening up a world of possibilities
+for automation-related development for platforms far beyond iOS and Android! As a result,
+many third-party extensions were created, such as new drivers for Flutter and Windows, plugins for
+mocking APIs and managing device farms, new Appium clients based on Rust and Swift, and much more.
+
+Around this time was also when we started a sponsorship program for Appium, which attracted various
+major and minor sponsors alike. This allowed us to give back to the Appium community, by compensating
+contributors for their voluntary work on the project.
+
+## Appium 3.0
+
+2025 also saw the release of Appium 3.

--- a/packages/base-plugin/package.json
+++ b/packages/base-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@appium/base-plugin",
   "version": "3.0.0",
-  "description": "The base plugin used to create Appium 2.0 plugins",
+  "description": "The base plugin used to create Appium plugins",
   "keywords": [
     "automation",
     "javascript",

--- a/packages/relaxed-caps-plugin/README.md
+++ b/packages/relaxed-caps-plugin/README.md
@@ -16,7 +16,7 @@ do not have a prefix.
 
 There are a lot of test scripts out there that don't conform to the W3C capability requirements,
 so this plugin is designed to make it easy to keep running these scripts even with the stricter
-capability requirements in Appium 2.
+capability requirements since Appium 2.
 
 ## Installation
 


### PR DESCRIPTION
This is a small update of various documents (main docs, READMEs, CHANGELOGs) to adjust them for the Appium 3 release:
* Adjust mentions of Appium 2 that imply it to be the latest version
* Update Appium 3.0.0 changelog with links to the blog and migration guide
* Update the Appium History document
* Add exact semver range to the Appium 3 migration guide (otherwise it's only listed in the system requirements document)