### PR TITLE
docs: add links to AppiumConf archives

### DIFF
--- a/packages/appium/docs/en/resources.md
+++ b/packages/appium/docs/en/resources.md
@@ -18,3 +18,11 @@ maintainers, Jonathan Lipps, with lots of useful guides
 - [Appium and Selenium Fundamentals](https://ui.headspin.io/university/learn/appium-selenium-fundamentals-2020) - a comprehensive video course on learning Python, Selenium, and Appium by Jonathan Lipps
 - [Mobile Test Automation with Appium](https://testautomationu.applitools.com/appium-java-tutorial/) - a video course by Moataz Nabil
 - [Advanced Appium](https://www.linkedin.com/learning/advanced-appium) - a video course by Jonathan Lipps
+
+## Conference Archives
+
+- [AppiumConf 2018](https://www.youtube.com/playlist?list=PLhr2WKNPXcZOmOf1k2aqkbMZwnZb2pSZL)
+- [AppiumConf 2019](https://www.youtube.com/playlist?list=PL9Z-JgiTsOYSfJh9YKI9Stj3FMwHERw6w)
+- [AppiumConf 2021](https://www.youtube.com/playlist?list=PL9Z-JgiTsOYRCcJhDfmKAah9XmAp2b903)
+- [AppiumConf 2024](https://www.youtube.com/playlist?list=PL9Z-JgiTsOYQaU5i5LJtAWlh5WVZPi3If)
+- [SeleniumConf & AppiumConf 2025](https://www.youtube.com/playlist?list=PLRdSclUtJDYV2R92TLbmwxws6clruuTjH)


### PR DESCRIPTION
This adds links to YouTube playlists with past AppiumConf talks to the Resources docs page.