### PR TITLE
feat(tsconfig): update base to Node20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@colors/colors": "1.6.0",
         "@eslint/js": "9.33.0",
-        "@tsconfig/node14": "14.1.4",
+        "@tsconfig/node20": "20.1.6",
         "@types/archiver": "6.0.3",
         "@types/argparse": "2.0.17",
         "@types/async-lock": "1.4.2",
@@ -2790,15 +2790,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node14": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.4.tgz",
-      "integrity": "sha512-S5G+j19uQt/7wiXFqGapQ1cSYHlAoxYreObGkOmawAknegyUjx8EXngqy6vAitLHqCFu3rzluPlk77pWMD4n1Q==",
-      "license": "MIT"
-    },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node20": {
+      "version": "20.1.6",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
+      "integrity": "sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ==",
       "license": "MIT"
     },
     "node_modules/@tsd/typescript": {
@@ -20869,7 +20869,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tsconfig/node14": "14.1.4"
+        "@tsconfig/node20": "20.1.6"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -21884,7 +21884,7 @@
     "@appium/tsconfig": {
       "version": "file:packages/tsconfig",
       "requires": {
-        "@tsconfig/node14": "14.1.4"
+        "@tsconfig/node20": "20.1.6"
       }
     },
     "@appium/types": {
@@ -23545,14 +23545,14 @@
       "version": "1.0.11",
       "dev": true
     },
-    "@tsconfig/node14": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-14.1.4.tgz",
-      "integrity": "sha512-S5G+j19uQt/7wiXFqGapQ1cSYHlAoxYreObGkOmawAknegyUjx8EXngqy6vAitLHqCFu3rzluPlk77pWMD4n1Q=="
-    },
     "@tsconfig/node16": {
       "version": "1.0.3",
       "dev": true
+    },
+    "@tsconfig/node20": {
+      "version": "20.1.6",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.6.tgz",
+      "integrity": "sha512-sz+Hqx9zwZDpZIV871WSbUzSqNIsXzghZydypnfgzPKLltVJfkINfUeTct31n/tTSa9ZE1ZOfKdRre1uHHquYQ=="
     },
     "@tsd/typescript": {
       "version": "5.9.2",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "devDependencies": {
     "@colors/colors": "1.6.0",
     "@eslint/js": "9.33.0",
-    "@tsconfig/node14": "14.1.4",
+    "@tsconfig/node20": "20.1.6",
     "@types/argparse": "2.0.17",
     "@types/archiver": "6.0.3",
     "@types/async-lock": "1.4.2",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -32,7 +32,7 @@
     "npm": ">=10"
   },
   "dependencies": {
-    "@tsconfig/node14": "14.1.4"
+    "@tsconfig/node20": "20.1.6"
   },
   "scripts": {
     "test:smoke": "node tsconfig.json && node tsconfig.plugin.json"

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "ts-node": {
     "transpileOnly": true
   },
@@ -16,7 +16,6 @@
     "sourceMap": true,
     "removeComments": false,
     "strict": false,
-    "types": ["node"],
-    "lib": ["es2020", "ES2021.WeakRef"]
+    "types": ["node"]
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node20/tsconfig.json",
   "files": [],
   "ts-node": {
     "transpileOnly": true


### PR DESCRIPTION
Since Appium 3 now requires Node 20 as the minimum, it makes sense to also update the tsconfig package and enable the features supported by this environment.
I'm not super familiar with how tsconfig works, but I assume this would not be a breaking change.