### PR TITLE
docs: enhance ecosystem pages

### DIFF
--- a/packages/appium/docs/en/ecosystem/clients.md
+++ b/packages/appium/docs/en/ecosystem/clients.md
@@ -1,7 +1,4 @@
 ---
-hide:
-  - toc
-
 title: Appium Clients
 ---
 
@@ -9,35 +6,127 @@ You need a client to write and run Appium scripts. You'll want to become very
 familiar with your client documentation (as well as the documentation of any Selenium client that
 the Appium client depends on) since that will be your primary interface to Appium.
 
-To learn more about clients, read our [Client Intro](../intro/clients.md).
+To learn more about clients, check out the [Client Intro](../intro/clients.md).
 
-### Official Clients
+!!! note
+
+    If you maintain an Appium client that you would like to be listed here, feel free to create a PR!
+
+## Official Clients
 
 These clients are currently maintained by the Appium team:
 
-|Client|Language|
-|-|-|
-|[Appium Java client](https://github.com/appium/java-client)|Java|
-|[Appium Python client](https://github.com/appium/python-client)|Python|
-|[Appium Ruby Core client](https://github.com/appium/ruby_lib_core) (Recommended)<br>[Appium Ruby client](https://github.com/appium/ruby_lib)|Ruby|
-|[Appium .NET client](https://github.com/appium/dotnet-client)|C#|
+### [Java Client](https://github.com/appium/java-client)
 
-### Other Clients
+Language: :fontawesome-brands-java: Java
 
-These clients are not maintained by the Appium team and can be used with other languages:
+=== "Setup With Maven"
 
-|Client|Language|
-|-|-|
-|[WebdriverIO](https://webdriver.io/docs/appium)|Node.js|
-|[Nightwatch.js](https://nightwatchjs.org/guide/mobile-app-testing/introduction.html)|Node.js|
-|[RobotFramework](https://github.com/serhatbolsu/robotframework-appiumlibrary)|DSL|
-|[multicatch's appium-client](https://github.com/multicatch/appium-client)|Rust|
-|[SwiftAppium](https://github.com/milcgroup/swiftappium)|Swift|
+    ```xml
+    <dependency>
+      <groupId>io.appium</groupId>
+      <artifactId>java-client</artifactId>
+      <version>${version.you.require}</version>
+      <scope>test</scope>
+    </dependency>
+    ```
+=== "Setup With Gradle"
+
+    ```groovy
+    dependencies {
+      testImplementation 'io.appium:java-client:${version.you.require}'
+    }
+    ```
+
+### [Python Client](https://github.com/appium/python-client)
+
+Language: :fontawesome-brands-python: Python
+
+```sh title="Install From PyPi"
+pip install Appium-Python-Client
+```
+
+### [Ruby Core Client](https://github.com/appium/ruby_lib_core)
+
+Language: :material-language-ruby: Ruby
+
+```sh title="Install From RubyGems"
+gem install appium_lib_core
+```
+
+### [Ruby Client](https://github.com/appium/ruby_lib)
+
+Language: :material-language-ruby: Ruby
+
+This client is a wrapper for the Ruby Core Client with additional helper methods, though they may
+also result in additional complexity. For this reason, the Ruby Core Client is recommended instead.
+
+```sh title="Install From RubyGems"
+gem install appium_lib
+```
+
+### [.NET Client](https://github.com/appium/dotnet-client)
+
+Language: :simple-dotnet: C#
+
+```sh title="Install Using .NET CLI"
+dotnet add package Appium.WebDriver
+```
+
+## Other Clients
+
+These clients are not maintained by the Appium team and can be used with other languages.
 
 In general, any W3C WebDriver spec-compatible client will also integrate well with Appium, though
 some Appium-specific commands may not be implemented in other clients.
 
-!!! note
+### [WebdriverIO](https://webdriver.io/docs/appium)
 
-    If you maintain an Appium client that you would like to be listed in the Appium docs, feel free
-    to make a PR to add it to this section with a link to the documentation for the client.
+Language: :material-language-javascript: :material-language-typescript: JavaScript/TypeScript
+
+```sh title="Install Using npm"
+npm install @wdio/appium-service
+```
+
+### [Nightwatch.js](https://nightwatchjs.org/guide/mobile-app-testing/introduction.html)
+
+Language: :material-language-javascript: :material-language-typescript: JavaScript/TypeScript
+
+=== "Setup For Android"
+
+    ```sh
+    npx @nightwatch/mobile-helper android --appium
+    ```
+
+=== "Setup For iOS"
+
+    ```sh
+    npx @nightwatch/mobile-helper ios --appium
+    ```
+
+### [RobotFramework AppiumLibrary](https://github.com/serhatbolsu/robotframework-appiumlibrary)
+
+Language: :simple-robotframework: Robot Framework
+
+```sh title="Install From PyPi"
+pip install robotframework-appiumlibrary
+```
+
+### [multicatch's appium-client](https://github.com/multicatch/appium-client)
+
+Language: :simple-rust: Rust
+
+```sh title="Install Using Cargo"
+cargo add appium-client
+```
+
+### [SwiftAppium](https://github.com/milcgroup/swiftappium)
+
+Language: :material-language-swift: Swift
+
+```sh title="Install and Setup"
+git clone https://github.com/milcgroup/SwiftAppium.git
+cd SwiftAppium
+swift build
+swift run swiftappium
+```

--- a/packages/appium/docs/en/ecosystem/clients.md
+++ b/packages/appium/docs/en/ecosystem/clients.md
@@ -58,8 +58,8 @@ gem install appium_lib_core
 
 Language: :material-language-ruby: Ruby
 
-This client is a wrapper for the Ruby Core Client with additional helper methods, though they may
-also result in additional complexity. For this reason, the Ruby Core Client is recommended instead.
+This client is a wrapper for the Ruby Core Client with several helper methods, though this may
+add additional complexity, therefore the Ruby Core Client is recommended instead.
 
 ```sh title="Install From RubyGems"
 gem install appium_lib
@@ -84,8 +84,8 @@ some Appium-specific commands may not be implemented in other clients.
 
 Language: :material-language-javascript: :material-language-typescript: JavaScript/TypeScript
 
-```sh title="Install Using npm"
-npm install @wdio/appium-service
+```sh title="Setup Using npm"
+npm init wdio@latest .
 ```
 
 ### [Nightwatch.js](https://nightwatchjs.org/guide/mobile-app-testing/introduction.html)

--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -17,57 +17,57 @@ These drivers are currently maintained by the Appium team:
 
 ### [Chromium](https://github.com/appium/appium-chromium-driver)
 
-```sh
+* Target: Desktop and mobile Chromium browsers (Chrome, Microsoft Edge, etc.)
+* Mode: Web
+
+```sh title="Install This Driver"
 appium driver install chromium
 ```
 
-* Target platforms: Desktop and mobile Chromium browsers (Chrome, Microsoft Edge, etc.)
-* Mode: Web
-
 ### [Espresso](https://github.com/appium/appium-espresso-driver)
 
-```sh
+* Target: Android applications
+* Mode: Native
+
+```sh title="Install This Driver"
 appium driver install espresso
 ```
 
-* Target platform: Android
-* Mode: Native
+### [Gecko](https://github.com/appium/appium-geckodriver)
 
-### [Gecko](https://github.com/appium/appium-gecko-driver)
+* Target: Desktop and mobile Gecko browsers (Firefox)
+* Mode: Web
 
-```sh
+```sh title="Install This Driver"
 appium driver install gecko
 ```
 
-* Target platforms: Desktop and mobile Gecko browsers (Firefox)
-* Mode: Web
-
 ### [Mac2](https://github.com/appium/appium-mac2-driver)
 
-```sh
+* Target: macOS applications
+* Mode: Native
+
+```sh title="Install This Driver"
 appium driver install mac2
 ```
 
-* Target platform: macOS
-* Mode: Native
-
 ### [Safari](https://github.com/appium/appium-safari-driver)
 
-```sh
+* Target: Desktop and mobile Safari browsers
+* Mode: Web
+
+```sh title="Install This Driver"
 appium driver install safari
 ```
 
-* Target platforms: Desktop and mobile Safari browser
-* Mode: Web
-
 ### [UiAutomator2](https://github.com/appium/appium-uiautomator2-driver)
 
-```sh
+* Target: Android, Android TV, Android Wear applications
+* Modes: Native, Hybrid, Web
+
+```sh title="Install This Driver"
 appium driver install uiautomator2
 ```
-
-* Target platforms: Android, Android TV, Android Wear
-* Modes: Native, Hybrid, Web
 
 ### [Windows](https://github.com/appium/appium-windows-driver)
 
@@ -76,21 +76,21 @@ appium driver install uiautomator2
     Only the Node.js-based driver part is maintained by the Appium team. The server part
     (WinAppDriver executable) is provided by Microsoft, but has not been maintained since 2022.
 
-```sh
+* Target: Windows applications
+* Mode: Native
+
+```sh title="Install This Driver"
 appium driver install windows
 ```
 
-* Target platform: Windows 10 or later
-* Mode: Native
-
 ### [XCUITest](https://appium.github.io/appium-xcuitest-driver/)
 
-```sh
+* Target: iOS, iPadOS, tvOS applications
+* Modes: Native, Hybrid, Web
+
+```sh title="Install This Driver"
 appium driver install xcuitest
 ```
-
-* Target platforms: iOS, iPadOS, tvOS
-* Modes: Native, Hybrid, Web
 
 ## Other Drivers
 
@@ -98,33 +98,33 @@ These drivers are not maintained by the Appium team and can be used to target ot
 
 ### [Flutter](https://github.com/appium/appium-flutter-driver)
 
-```sh
-appium driver install --source=npm appium-flutter-driver
-```
-
-* Target platforms: iOS, Android
+* Target: iOS and Android applications built with Flutter
 * Mode: Native
 * Supported by: Appium Team / Community
 
-### [Flutter Integration](https://github.com/AppiumTestDistribution/appium-flutter-integration-driver)
-
-```sh
-appium driver install --source=npm appium-flutter-integration-driver
+```sh title="Install This Driver"
+appium driver install --source=npm appium-flutter-driver
 ```
 
-* Target platforms: iOS, Android
+### [Flutter Integration](https://github.com/AppiumTestDistribution/appium-flutter-integration-driver)
+
+* Target: iOS and Android applications built with Flutter
 * Mode: Native
 * Supported by: Community / `@AppiumTestDistribution`
 
-### [LG WebOS](https://github.com/headspinio/appium-lg-webos-driver)
-
-```sh
-appium driver install --source=npm appium-lg-webos-driver
+```sh title="Install This Driver"
+appium driver install --source=npm appium-flutter-integration-driver
 ```
 
-* Target platform: LG TV
+### [LG WebOS](https://github.com/headspinio/appium-lg-webos-driver)
+
+* Target: LG TV web applications
 * Mode: Web
 * Supported by: HeadSpin
+
+```sh title="Install This Driver"
+appium driver install --source=npm appium-lg-webos-driver
+```
 
 ### [Linux](https://github.com/fantonglang/appium-linux-driver)
 
@@ -132,36 +132,36 @@ appium driver install --source=npm appium-lg-webos-driver
 
     This driver has not been maintained since 2022 and requires a custom Appium installation
 
-```sh
+* Target: Linux applications
+* Mode: Native
+* Supported by: `@fantonglang`
+
+```sh title="Install This Driver"
 git clone https://github.com/fantonglang/appium
 cd appium
 yarn install
 node ./
 ```
 
-* Target platform: Linux
-* Mode: Native
-* Supported by: `@fantonglang`
-
 ### [NovaWindows](https://github.com/AutomateThePlanet/appium-novawindows-driver)
 
-```sh
-appium driver install --source=npm appium-novawindows-driver
-```
-
-* Target platform: Windows 10 or later
+* Target: Windows applications
 * Mode: Native
 * Supported by: Community / Automate The Planet
 
-### [Roku](https://github.com/headspinio/appium-roku-driver)
-
-```sh
-appium driver install --source=npm @headspinio/appium-roku-driver
+```sh title="Install This Driver"
+appium driver install --source=npm appium-novawindows-driver
 ```
 
-* Target platform: Roku
+### [Roku](https://github.com/headspinio/appium-roku-driver)
+
+* Target: Roku channels (applications)
 * Mode: Native
 * Supported by: HeadSpin
+
+```sh title="Install This Driver"
+appium driver install --source=npm @headspinio/appium-roku-driver
+```
 
 ### [Tizen](https://github.com/Samsung/appium-tizen-driver)
 
@@ -169,23 +169,23 @@ appium driver install --source=npm @headspinio/appium-roku-driver
 
     This driver has not been maintained since 2020 and is only compatible with Appium 1
 
-```sh
-npm install appium-tizen-driver
-```
-
-* Target platform: Tizen
+* Target: Tizen applications
 * Mode: Native
 * Supported by: Community / Samsung
 
-### [TizenTV](https://github.com/headspinio/appium-tizen-tv-driver)
-
-```sh
-appium driver install --source=npm appium-tizen-tv-driver
+```sh title="Install This Driver"
+npm install appium-tizen-driver
 ```
 
-* Target platform: Tizen TV
+### [TizenTV](https://github.com/headspinio/appium-tizen-tv-driver)
+
+* Target: Tizen TV web applications
 * Mode: Web
 * Supported by: HeadSpin
+
+```sh title="Install This Driver"
+appium driver install --source=npm appium-tizen-tv-driver
+```
 
 ### [You.i Engine](https://github.com/YOU-i-Labs/appium-youiengine-driver)
 
@@ -193,10 +193,10 @@ appium driver install --source=npm appium-tizen-tv-driver
 
     This driver has not been maintained since 2022 and is only compatible with Appium 1
 
-```sh
-npm install appium-youiengine-driver
-```
-
-* Target platforms: iOS, Android, macOS, Linux, tvOS
+* Target: iOS, Android, macOS, Linux, tvOS applications built with You.i Engine
 * Mode: Native
 * Supported by: Community / You.i
+
+```sh title="Install This Driver"
+npm install appium-youiengine-driver
+```

--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -71,7 +71,7 @@ appium driver install uiautomator2
 
 ### [Windows](https://github.com/appium/appium-windows-driver)
 
-!!! note
+!!! warning
 
     Only the Node.js-based driver part is maintained by the Appium team. The server part
     (WinAppDriver executable) is provided by Microsoft, but has not been maintained since 2022.
@@ -128,7 +128,7 @@ appium driver install --source=npm appium-lg-webos-driver
 
 ### [Linux](https://github.com/fantonglang/appium-linux-driver)
 
-!!! note
+!!! warning
 
     This driver has not been maintained since 2022 and requires a custom Appium installation
 
@@ -144,6 +144,11 @@ node ./
 ```
 
 ### [NovaWindows](https://github.com/AutomateThePlanet/appium-novawindows-driver)
+
+!!! info
+
+    This driver is recommended as a drop-in replacement for the partially unmaintained
+    [Windows driver](#windows)
 
 * Target: Windows applications
 * Mode: Native
@@ -165,7 +170,7 @@ appium driver install --source=npm @headspinio/appium-roku-driver
 
 ### [Tizen](https://github.com/Samsung/appium-tizen-driver)
 
-!!! note
+!!! warning
 
     This driver has not been maintained since 2020 and is only compatible with Appium 1
 
@@ -189,7 +194,7 @@ appium driver install --source=npm appium-tizen-tv-driver
 
 ### [You.i Engine](https://github.com/YOU-i-Labs/appium-youiengine-driver)
 
-!!! note
+!!! warning
 
     This driver has not been maintained since 2022 and is only compatible with Appium 1
 

--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -1,52 +1,202 @@
 ---
-hide:
-  - toc
-
 title: Appium Drivers
 ---
 
-You can't use Appium without at least one driver! Click on the link for each driver to see the
-specific installation instructions and documentation for that driver.
-
-Generally, drivers can be installed using their listed installation key, with the following command:
-```
-appium driver install <installation key>
-```
+You can't use Appium without a driver! Here you can find a list of all known Appium drivers,
+along with their installation commands and links to their documentation.
 
 To learn more about drivers, check out the [Driver Intro](../intro/drivers.md).
 
-### Official Drivers
+!!! note
+
+    If you maintain an Appium driver that you would like to be listed here, feel free to create a PR!
+
+## Official Drivers
 
 These drivers are currently maintained by the Appium team:
 
-|Driver|Installation Key|Platform(s)|Mode(s)|Important Notes|
-|--|--|--|--|--|
-|[Chromium](https://github.com/appium/appium-chromium-driver)|`chromium`|macOS, Windows, Linux|Web||
-|[Espresso](https://github.com/appium/appium-espresso-driver)|`espresso`|Android|Native||
-|[Gecko](https://github.com/appium/appium-geckodriver)|`gecko`|macOS, Windows, Linux, Android|Web||
-|[Mac2](https://github.com/appium/appium-mac2-driver)|`mac2`|macOS|Native||
-|[Safari](https://github.com/appium/appium-safari-driver)|`safari`|macOS, iOS|Web||
-|[UiAutomator2](https://github.com/appium/appium-uiautomator2-driver)|`uiautomator2`|Android|Native, Hybrid, Web||
-|[XCUITest](https://github.com/appium/appium-xcuitest-driver)|`xcuitest`|iOS|Native, Hybrid, Web||
-|[Windows](https://github.com/appium/appium-windows-driver)|`windows`|Windows|Native|Only the Node.js-based driver part is maintained by the Appium team. The server part (WinAppDriver executable) has not been maintained by Microsoft since 2022|
+### [Chromium](https://github.com/appium/appium-chromium-driver)
 
-### Other Drivers
+```sh
+appium driver install chromium
+```
 
-These drivers are not maintained by the Appium team and can be used to target additional platforms:
+* Target platforms: Desktop and mobile Chromium browsers (Chrome, Microsoft Edge, etc.)
+* Mode: Web
 
-|Driver|Installation Key|Platform(s)|Mode(s)|Supported By|Important Notes|
-|--|--|--|--|--|--|
-|[Flutter](https://github.com/appium/appium-flutter-driver)|`--source=npm appium-flutter-driver`|iOS, Android|Native|Appium Team/Community||
-|[Flutter Integration](https://github.com/AppiumTestDistribution/appium-flutter-integration-driver)|`--source=npm appium-flutter-integration-driver`|iOS, Android|Native|Community / `@AppiumTestDistribution`||
-|[LG WebOS](https://github.com/headspinio/appium-lg-webos-driver)|`--source=npm appium-lg-webos-driver`|LG TV|Web|HeadSpin||
-|[Linux](https://github.com/fantonglang/appium-linux-driver)|`--source=npm @stdspa/appium-linux-driver`|Linux|Native|`@fantonglang`|Not maintained since 2022|
-|[NovaWindows](https://github.com/AutomateThePlanet/appium-novawindows-driver)|`--source=npm appium-novawindows-driver`|Windows|Native|Community / Automate The Planet||
-|[Roku](https://github.com/headspinio/appium-roku-driver)|`--source=npm @headspinio/appium-roku-driver`|Roku|Native|HeadSpin||
-|[Tizen](https://github.com/Samsung/appium-tizen-driver)|`--source=npm appium-tizen-driver`|Android|Native|Community / Samsung|Not maintained since 2020|
-|[TizenTV](https://github.com/headspinio/appium-tizen-tv-driver)|`--source=npm appium-tizen-tv-driver`|Samsung TV|Web|HeadSpin||
-|[Youi](https://github.com/YOU-i-Labs/appium-youiengine-driver)|`--source=npm appium-youiengine-driver`|iOS, Android, macOS, Linux, tvOS|Native|Community / You.i|Not maintained since 2022|
+### [Espresso](https://github.com/appium/appium-espresso-driver)
+
+```sh
+appium driver install espresso
+```
+
+* Target platform: Android
+* Mode: Native
+
+### [Gecko](https://github.com/appium/appium-gecko-driver)
+
+```sh
+appium driver install gecko
+```
+
+* Target platforms: Desktop and mobile Gecko browsers (Firefox)
+* Mode: Web
+
+### [Mac2](https://github.com/appium/appium-mac2-driver)
+
+```sh
+appium driver install mac2
+```
+
+* Target platform: macOS
+* Mode: Native
+
+### [Safari](https://github.com/appium/appium-safari-driver)
+
+```sh
+appium driver install safari
+```
+
+* Target platforms: Desktop and mobile Safari browser
+* Mode: Web
+
+### [UiAutomator2](https://github.com/appium/appium-uiautomator2-driver)
+
+```sh
+appium driver install uiautomator2
+```
+
+* Target platforms: Android, Android TV, Android Wear
+* Modes: Native, Hybrid, Web
+
+### [Windows](https://github.com/appium/appium-windows-driver)
 
 !!! note
 
-    If you maintain an Appium driver that you would like to be listed in the Appium docs, feel free
-    to make a PR to add it to this section with a link to the driver documentation.
+    Only the Node.js-based driver part is maintained by the Appium team. The server part
+    (WinAppDriver executable) is provided by Microsoft, but has not been maintained since 2022.
+
+```sh
+appium driver install windows
+```
+
+* Target platform: Windows 10 or later
+* Mode: Native
+
+### [XCUITest](https://appium.github.io/appium-xcuitest-driver/)
+
+```sh
+appium driver install xcuitest
+```
+
+* Target platforms: iOS, iPadOS, tvOS
+* Modes: Native, Hybrid, Web
+
+## Other Drivers
+
+These drivers are not maintained by the Appium team and can be used to target other platforms:
+
+### [Flutter](https://github.com/appium/appium-flutter-driver)
+
+```sh
+appium driver install --source=npm appium-flutter-driver
+```
+
+* Target platforms: iOS, Android
+* Mode: Native
+* Supported by: Appium Team / Community
+
+### [Flutter Integration](https://github.com/AppiumTestDistribution/appium-flutter-integration-driver)
+
+```sh
+appium driver install --source=npm appium-flutter-integration-driver
+```
+
+* Target platforms: iOS, Android
+* Mode: Native
+* Supported by: Community / `@AppiumTestDistribution`
+
+### [LG WebOS](https://github.com/headspinio/appium-lg-webos-driver)
+
+```sh
+appium driver install --source=npm appium-lg-webos-driver
+```
+
+* Target platform: LG TV
+* Mode: Web
+* Supported by: HeadSpin
+
+### [Linux](https://github.com/fantonglang/appium-linux-driver)
+
+!!! note
+
+    This driver has not been maintained since 2022 and requires a custom Appium installation
+
+```sh
+git clone https://github.com/fantonglang/appium
+cd appium
+yarn install
+node ./
+```
+
+* Target platform: Linux
+* Mode: Native
+* Supported by: `@fantonglang`
+
+### [NovaWindows](https://github.com/AutomateThePlanet/appium-novawindows-driver)
+
+```sh
+appium driver install --source=npm appium-novawindows-driver
+```
+
+* Target platform: Windows 10 or later
+* Mode: Native
+* Supported by: Community / Automate The Planet
+
+### [Roku](https://github.com/headspinio/appium-roku-driver)
+
+```sh
+appium driver install --source=npm @headspinio/appium-roku-driver
+```
+
+* Target platform: Roku
+* Mode: Native
+* Supported by: HeadSpin
+
+### [Tizen](https://github.com/Samsung/appium-tizen-driver)
+
+!!! note
+
+    This driver has not been maintained since 2020 and is only compatible with Appium 1
+
+```sh
+npm install appium-tizen-driver
+```
+
+* Target platform: Tizen
+* Mode: Native
+* Supported by: Community / Samsung
+
+### [TizenTV](https://github.com/headspinio/appium-tizen-tv-driver)
+
+```sh
+appium driver install --source=npm appium-tizen-tv-driver
+```
+
+* Target platform: Tizen TV
+* Mode: Web
+* Supported by: HeadSpin
+
+### [You.i Engine](https://github.com/YOU-i-Labs/appium-youiengine-driver)
+
+!!! note
+
+    This driver has not been maintained since 2022 and is only compatible with Appium 1
+
+```sh
+npm install appium-youiengine-driver
+```
+
+* Target platforms: iOS, Android, macOS, Linux, tvOS
+* Mode: Native
+* Supported by: Community / You.i

--- a/packages/appium/docs/en/ecosystem/plugins.md
+++ b/packages/appium/docs/en/ecosystem/plugins.md
@@ -24,7 +24,7 @@ appium plugin install execute-driver
 
 ### [Images](https://github.com/appium/appium/tree/master/packages/images-plugin)
 
-Enable image matching and comparison features
+Add support for image matching and comparison features
 
 ```sh title="Install This Plugin"
 appium plugin install images
@@ -32,9 +32,8 @@ appium plugin install images
 
 ### [Inspector](https://github.com/appium/appium-inspector/tree/main/plugins)
 
-Integrate the [Appium Inspector](https://github.com/appium/appium-inspector) directly into your
-Appium server installation, providing a web-based interface for inspecting and interacting with
-your application under test.
+Integrate the [Appium Inspector](https://appium.github.io/appium-inspector/) directly into your
+Appium server installation
 
 ```sh title="Install This Plugin"
 appium plugin install inspector

--- a/packages/appium/docs/en/ecosystem/plugins.md
+++ b/packages/appium/docs/en/ecosystem/plugins.md
@@ -1,7 +1,4 @@
 ---
-hide:
-  - toc
-
 title: Appium Plugins
 ---
 
@@ -9,39 +6,134 @@ Plugins offer various ways to extend or modify Appium's behaviour. They are _com
 and are not needed for standard automation functionality, but you may find them to be useful
 for more specialised automation workflows.
 
-Generally, plugins can be installed using their listed installation key, with the following command:
-```
-appium plugin install <installation key>
-```
+!!! note
 
-### Official Plugins
+    If you maintain an Appium plugin that you would like to be listed here, feel free to create a PR!
+
+## Official Plugins
 
 These plugins are are currently maintained by the Appium team:
 
-|<div style="width:7em">Plugin</div>|<div style="width:8em">Installation Key</div>|Description|
-|---|---|---|
-|[Execute Driver](https://github.com/appium/appium/tree/master/packages/execute-driver-plugin)|`execute-driver`|Run entire batches of commands in a single call to the Appium server|
-|[Images](https://github.com/appium/appium/tree/master/packages/images-plugin)|`images`|Image matching and comparison features|
-|[Inspector](https://github.com/appium/appium-inspector/tree/main/plugins)|`inspector`|Integrate the [Appium Inspector](https://github.com/appium/appium-inspector) directly into your Appium server installation, providing a web-based interface for inspecting and interacting with your application under test.|
-|[Relaxed Caps](https://github.com/appium/appium/tree/master/packages/relaxed-caps-plugin)|`relaxed-caps`|Relax Appium's requirement for vendor prefixes on capabilities|
-|[Storage](https://github.com/appium/appium/tree/master/packages/storage-plugin)|`storage`|Server-side storage with client-side management|
-|[Universal XML](https://github.com/appium/appium/tree/master/packages/universal-xml-plugin)|`universal-xml`|Instead of the standard XML format for iOS and Android, use an XML definition that is the same across both platforms|
+### [Execute Driver](https://github.com/appium/appium/tree/master/packages/execute-driver-plugin)
 
-### Other Plugins
+Run entire batches of commands in a single call to the Appium server
+
+```sh title="Install This Plugin"
+appium plugin install execute-driver
+```
+
+### [Images](https://github.com/appium/appium/tree/master/packages/images-plugin)
+
+Enable image matching and comparison features
+
+```sh title="Install This Plugin"
+appium plugin install images
+```
+
+### [Inspector](https://github.com/appium/appium-inspector/tree/main/plugins)
+
+Integrate the [Appium Inspector](https://github.com/appium/appium-inspector) directly into your
+Appium server installation, providing a web-based interface for inspecting and interacting with
+your application under test.
+
+```sh title="Install This Plugin"
+appium plugin install inspector
+```
+
+### [Relaxed Caps](https://github.com/appium/appium/tree/master/packages/relaxed-caps-plugin)
+
+Relax Appium's requirement for vendor prefixes on capabilities
+
+```sh title="Install This Plugin"
+appium plugin install relaxed-caps
+```
+
+### [Storage](https://github.com/appium/appium/tree/master/packages/storage-plugin)
+
+Add server-side storage with client-side management
+
+```sh title="Install This Plugin"
+appium plugin install storage
+```
+
+### [Universal XML](https://github.com/appium/appium/tree/master/packages/universal-xml-plugin)
+
+Translate the default iOS and Android XML formats into a common format
+
+```sh title="Install This Plugin"
+appium plugin install universal-xml
+```
+
+## Other Plugins
 
 These plugins are not maintained by the Appium team and can provide additional functionality:
 
-|<div style="width:6em">Plugin</div>|<div style="width:19em">Installation Key</div>|Description|<div style="width:13em">Supported By</div>|
-|---|---|---|---|
-|[AltUnity](https://github.com/headspinio/appium-altunity-plugin)|`--source=npm appium-altunity-plugin`|Target Unity games and apps for automation with a new context, via the AltUnityTester framework|HeadSpin|
-|[Device Farm](https://github.com/AppiumTestDistribution/appium-device-farm)|`--source=npm appium-device-farm`|Manage and create driver sessions on connected Android devices and iOS simulators|`@AppiumTestDistribution`|
-|[Gestures](https://github.com/AppiumTestDistribution/appium-gestures-plugin)|`--source=npm appium-gestures-plugin`|Perform basic gestures using W3C Actions|`@AppiumTestDistribution`|
-|[Interceptor](https://github.com/AppiumTestDistribution/appium-interceptor-plugin)|`--source=npm appium-interceptor`|Intercept and mock API requests and responses|`@AppiumTestDistribution`|
-|[OCR](https://github.com/jlipps/appium-ocr-plugin)|`--source=npm appium-ocr-plugin`|Find elements via OCR text|`@jlipps`|
-|[Reporter](https://github.com/AppiumTestDistribution/appium-reporter-plugin)|`--source=npm appium-reporter-plugin`|Generate standalone consolidated HTML reports with screenshots|`@AppiumTestDistribution`|
-|[Wait](https://github.com/AppiumTestDistribution/appium-wait-plugin)|`--source=npm appium-wait-plugin`|Manage global element wait timeouts|`@AppiumTestDistribution`|
+### [AltUnity](https://github.com/headspinio/appium-altunity-plugin)
 
-!!! note
+Target Unity games and apps for automation via the AltUnityTester framework
 
-    If you maintain an Appium plugin that you would like to be listed in the Appium docs, feel free
-    to make a PR to add it to this section with a link to the documentation for the plugin.
+Supported by: HeadSpin
+
+```sh title="Install This Plugin"
+appium plugin install --source=npm appium-altunity-plugin
+```
+
+### [Device Farm](https://github.com/AppiumTestDistribution/appium-device-farm)
+
+Manage and create driver sessions on connected Android devices and iOS simulators
+
+Supported by: `@AppiumTestDistribution`
+
+```sh title="Install This Plugin"
+appium plugin install --source=npm appium-device-farm
+```
+
+### [Gestures](https://github.com/AppiumTestDistribution/appium-gestures-plugin)
+
+Perform basic gestures using W3C Actions
+
+Supported by: `@AppiumTestDistribution`
+
+```sh title="Install This Plugin"
+appium plugin install --source=npm appium-gestures-plugin
+```
+
+### [Interceptor](https://github.com/AppiumTestDistribution/appium-interceptor-plugin)
+
+Intercept and mock API requests and responses
+
+Supported by: `@AppiumTestDistribution`
+
+```sh title="Install This Plugin"
+appium plugin install --source=npm appium-interceptor
+```
+
+### [OCR](https://github.com/jlipps/appium-ocr-plugin)
+
+Find elements via OCR text
+
+Supported by: `@jlipps`
+
+```sh title="Install This Plugin"
+appium plugin install --source=npm appium-ocr-plugin
+```
+
+### [Reporter](https://github.com/AppiumTestDistribution/appium-reporter-plugin)
+
+Generate standalone consolidated HTML reports with screenshots
+
+Supported by: `@AppiumTestDistribution`
+
+```sh title="Install This Plugin"
+appium plugin install --source=npm appium-reporter-plugin
+```
+
+### [Wait](https://github.com/AppiumTestDistribution/appium-wait-plugin)
+
+Manage global element wait timeouts
+
+Supported by: `@AppiumTestDistribution`
+
+```sh title="Install This Plugin"
+appium plugin install --source=npm appium-wait-plugin
+```

--- a/packages/appium/docs/en/ecosystem/tools.md
+++ b/packages/appium/docs/en/ecosystem/tools.md
@@ -51,3 +51,7 @@ It includes commands for installing Appium, its drivers and plugins, as well as 
 prerequisites for iOS or Android emulators or real devices.
 
 Supported by: `@AppiumTestDistribution`
+
+```sh title="Install This Tool"
+npm install -g appium-installer
+```

--- a/packages/appium/docs/en/ecosystem/tools.md
+++ b/packages/appium/docs/en/ecosystem/tools.md
@@ -1,42 +1,53 @@
 ---
-hide:
-  - toc
-
 title: Appium-Related Tools
 ---
 
-There are several Appium tools that have been created to to assist with things not directly related
-to testing, such as Appium installation, test development, and more.
+The Appium ecosystem also includes several tools that have been created to assist with things not
+directly related to running tests, such as Appium installation, test development, and more.
 
-### [Appium Inspector](https://appium.github.io/appium-inspector/latest/)
+!!! note
+
+    If you maintain an Appium tool that you would like to be listed here, feel free to create a PR!
+
+## Official Tools
+
+These tools are currently maintained by the Appium team:
+
+### [Appium Inspector](https://appium.github.io/appium-inspector/)
 
 Appium has a graphical client which can be used to inspect application screenshots, view the
-application hierarchy, run Appium commands, record app interactions, and more. It is very useful
-for Appium test development.
+application hierarchy, search for elements, run Appium commands, record app interactions, and more.
+It can be very useful for Appium test development.
 
-Find downloads and more information on its GitHub page: [Appium Inspector](https://github.com/appium/appium-inspector)
+## Extension Tools
+
+Appium driver or plugin developers can choose to include these tools in their driver/plugin:
 
 ### Appium Doctor
 
-Appium Doctor is a command-line tool built into Appium drivers and plugins.
-The command is expected to be used to validate whether a driver or plugin has all of its prerequisites and other environment details set up correctly
-if the driver/plugin author implemented the `doctor` command.
+The Appium Doctor tool can be used to validate whether all prerequisites and other environment
+details needed for the driver/plugin have been set up correctly. The tool can be accessed via the
+[`doctor` command in the Appium CLI](../cli/extensions.md#doctor):
 
-For example, `uiautomator2` driver provides the `doctor` command below.
-
-```
-appium driver doctor uiautomator2
+```sh
+appium {driver|plugin} doctor <extension-name>
 ```
 
-It shows no result if the driver/plugin author did not implement them.
+It shows no results if the driver/plugin author did not implement Doctor support.
 
-More information on this command can be found in the [Command-Line Usage documentation](../cli/extensions.md#doctor).
-For driver/plugin developers, please read [Building Doctor Checks](../developing/build-doctor-checks.md).
+!!! note
 
-### Other Tools
+    If you maintain an Appium extension and would like to add Appium Doctor support for it, check
+    out the documentation on [Building Doctor Checks](../developing/build-doctor-checks.md).
 
-These tools are not maintained by the Appium team and can be used to assist with other problems:
+## Other Tools
 
-|Name|Description|Supported By|
-|---|---|---|
-|[appium-installer](https://github.com/AppiumTestDistribution/appium-installer)|Help set up an Appium environment for Android and iOS|`@AppiumTestDistribution`|
+These tools are not maintained by the Appium team:
+
+### [Appium Installer](https://github.com/AppiumTestDistribution/appium-installer)
+
+Appium Installer is a command-line tool for simplifying setups of new Appium test environments.
+It includes commands for installing Appium, its drivers and plugins, as well as validating
+prerequisites for iOS or Android emulators or real devices.
+
+Supported by: `@AppiumTestDistribution`


### PR DESCRIPTION
This is an enhancement to the Appium documentation Ecosystem pages.
The current table design used on these pages is not ideal for search and adding extra information, therefore each table row has been changed into a separate section with its own heading. I've also added install/setup commands where possible, to make it easier for users to get started.

Additional changes are as follows:
* Clients page: added language icons
* Drivers page: expanded Target information
* Tools page: rewrote doctor section and moved it to its own category, expanded appium-installer section