### PR TITLE
feat(docutils): enable section index pages

### DIFF
--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -76,6 +76,7 @@ theme:
     - content.code.annotate
     - content.code.copy
     - content.tabs.link
+    - navigation.indexes
     - navigation.sections
     - navigation.tabs
     - navigation.top


### PR DESCRIPTION
This adds a small documentation feature where section indices can have their own pages.
Since we use more than one overview page, this is fairly useful, as it removes the overview page's dedicated entry in the sidebar nav, making navigation more intuitive.

Reference: https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#section-index-pages