### PR TITLE
docs: add missing WebDriver standard API endpoints

### DIFF
--- a/packages/appium/docs/en/reference/api/webdriver.md
+++ b/packages/appium/docs/en/reference/api/webdriver.md
@@ -954,13 +954,13 @@ POST /session/:sessionId/actions
 
 > WebDriver documentation: [Perform Actions](https://w3c.github.io/webdriver/#perform-actions)
 
-Performs a sequence of actions.
+Performs a sequence of [actions](https://w3c.github.io/webdriver/#actions).
 
 #### Parameters
 
 |Name|Description|Type|
 |--|--|--|
-|`actions`|Array of action objects|object[]|
+|`actions`|Array of action objects|`ActionSequence[]`|
 
 #### Response
 
@@ -974,7 +974,7 @@ DELETE /session/:sessionId/actions
 
 > WebDriver documentation: [Release Actions](https://w3c.github.io/webdriver/#release-actions)
 
-Releases all actions.
+Releases all currently depressed keys and pointer buttons.
 
 #### Response
 
@@ -988,7 +988,7 @@ POST /session/:sessionId/alert/dismiss
 
 > WebDriver documentation: [Dismiss Alert](https://w3c.github.io/webdriver/#dismiss-alert)
 
-Dismisses the currently displayed alert dialog.
+Dismisses the currently displayed user prompt.
 
 #### Response
 
@@ -1002,7 +1002,7 @@ POST /session/:sessionId/alert/accept
 
 > WebDriver documentation: [Accept Alert](https://w3c.github.io/webdriver/#accept-alert)
 
-Accepts the currently displayed alert dialog.
+Accepts the currently displayed user prompt.
 
 #### Response
 
@@ -1016,11 +1016,11 @@ GET /session/:sessionId/alert/text
 
 > WebDriver documentation: [Get Alert Text](https://w3c.github.io/webdriver/#get-alert-text)
 
-Gets the text of the currently displayed alert dialog.
+Retrieves the text of the currently displayed user prompt.
 
 #### Response
 
-`string` - alert text
+`string` - prompt text
 
 ### `setAlertText`
 
@@ -1028,9 +1028,9 @@ Gets the text of the currently displayed alert dialog.
 POST /session/:sessionId/alert/text
 ```
 
-> WebDriver documentation: [Set Alert Text](https://w3c.github.io/webdriver/#set-alert-text)
+> WebDriver documentation: [Send Alert Text](https://w3c.github.io/webdriver/#send-alert-text)
 
-Sets the text of the currently displayed alert dialog.
+Sets the text of the currently displayed user prompt.
 
 #### Parameters
 
@@ -1064,13 +1064,8 @@ GET /session/:sessionId/element/:elementId/screenshot
 
 > WebDriver documentation: [Take Element Screenshot](https://w3c.github.io/webdriver/#take-element-screenshot)
 
-Takes a screenshot of the specified element.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Takes a screenshot of the visible region encompassed by the bounding rectangle of the element
+identified by `:elementId`.
 
 #### Response
 

--- a/packages/appium/docs/en/reference/api/webdriver.md
+++ b/packages/appium/docs/en/reference/api/webdriver.md
@@ -12,7 +12,8 @@ used in Appium.
 
 !!! note
 
-    Drivers or plugins may implement modified versions of these endpoints.
+    Most WebDriver endpoints have no implementation within Appium, and are proxied directly to the
+    receiving driver.
 
 ### `createSession`
 
@@ -597,7 +598,7 @@ GET /session/:sessionId/element/:elementId/selected
 > WebDriver documentation: [Is Element Selected](https://w3c.github.io/webdriver/#is-element-selected)
 
 Determines if the element identified by `:elementId` is currently selected. This property is only
-relevant to certain elements types, such as checkboxes, radio buttons, or options.
+relevant to certain element types, such as checkboxes, radio buttons, or options.
 
 #### Response
 
@@ -712,7 +713,7 @@ GET /session/:sessionId/element/:elementId/enabled
 > WebDriver documentation: [Is Element Enabled](https://w3c.github.io/webdriver/#is-element-enabled)
 
 Determines if the element identified by `:elementId` is currently enabled. This property is only
-relevant to certain elements types, such as buttons, input fields, checkboxes, etc.
+relevant to certain element types, such as buttons, input fields, checkboxes, etc.
 
 #### Response
 
@@ -756,13 +757,7 @@ POST /session/:sessionId/element/:elementId/click
 
 > WebDriver documentation: [Element Click](https://w3c.github.io/webdriver/#element-click)
 
-Clicks on the specified element.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element to click|string|
+Clicks on the identified by `:elementId`.
 
 #### Response
 
@@ -774,15 +769,10 @@ Clicks on the specified element.
 POST /session/:sessionId/element/:elementId/clear
 ```
 
-> WebDriver documentation: [Clear Element](https://w3c.github.io/webdriver/#clear-element)
+> WebDriver documentation: [Element Clear](https://w3c.github.io/webdriver/#element-clear)
 
-Clears a text element's value.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Clears the identified by `:elementId`. This functionality is only relevant to certain element types,
+such as input fields.
 
 #### Response
 
@@ -796,13 +786,13 @@ POST /session/:sessionId/element/:elementId/value
 
 > WebDriver documentation: [Element Send Keys](https://w3c.github.io/webdriver/#element-send-keys)
 
-Sends a sequence of key strokes to the specified element.
+Sends keys to the element the identified by `:elementId`. This functionality is only relevant to
+keyboard-interactable element types, such as input fields.
 
 #### Parameters
 
 |Name|Description|Type|
 |--|--|--|
-|`elementId`|ID of the element|string|
 |`text`|Text to send|string|
 
 #### Response
@@ -831,14 +821,14 @@ POST /session/:sessionId/execute/sync
 
 > WebDriver documentation: [Execute Script](https://w3c.github.io/webdriver/#execute-script)
 
-Executes a synchronous JavaScript script in the current browsing context.
+Executes synchronous JavaScript code in the current browsing context.
 
 #### Parameters
 
 |Name|Description|Type|
 |--|--|--|
-|`script`|The script to execute|string|
-|`args`|Arguments for the script|array|
+|`script`|Script function to execute|string|
+|`args`|Arguments passed to the script|array|
 
 #### Response
 
@@ -852,18 +842,22 @@ POST /session/:sessionId/execute/async
 
 > WebDriver documentation: [Execute Async Script](https://w3c.github.io/webdriver/#execute-async-script)
 
-Executes an asynchronous JavaScript script in the current browsing context.
+Executes asynchronous JavaScript code in the current browsing context.
+
+The `script` function is provided an additional argument (applied after `args`), which is a
+function that can be invoked (within `script`) to trigger script completion. The first argument
+passed to this completion function is returned as the endpoint response.
 
 #### Parameters
 
 |Name|Description|Type|
 |--|--|--|
-|`script`|The script to execute|string|
+|`script`|Script function to execute|string|
 |`args`|Arguments for the script|array|
 
 #### Response
 
-`any` - the result of the script execution
+`any` - the result returned by the completion function of the script
 
 ### `getCookies`
 
@@ -873,11 +867,11 @@ GET /session/:sessionId/cookie
 
 > WebDriver documentation: [Get Cookies](https://w3c.github.io/webdriver/#get-cookies)
 
-Retrieves all cookies visible to the current page.
+Retrieves all cookies of the current browsing context.
 
 #### Response
 
-`object[]` - array of cookie objects
+`Cookie[]` - an array containing zero or more [`Cookie` objects](#response_49)
 
 ### `getCookie`
 
@@ -887,17 +881,22 @@ GET /session/:sessionId/cookie/:name
 
 > WebDriver documentation: [Get Named Cookie](https://w3c.github.io/webdriver/#get-named-cookie)
 
-Retrieves a cookie by name.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`name`|Name of the cookie|string|
+Retrieves a cookie with the name identified by `:name` from the current browsing context.
 
 #### Response
 
-`object` - cookie object
+`Cookie` - an object with the following properties:
+
+|Name|Description|Type|
+|--|--|--|
+|`domain?`|Cookie domain|string|
+|`expiry?`|Cookie expiration time (in seconds) as a Unix timestamp|number|
+|`httpOnly?`|Whether the cookie is an HTTP only cookie|boolean|
+|`name`|Cookie name|string|
+|`path?`|Cookie path|string|
+|`sameSite?`|SameSite policy type of the cookie (either `Lax` or `Strict`)|string|
+|`secure?`|Whether the cookie is a secure cookie|boolean|
+|`value`|Cookie value|string|
 
 ### `setCookie`
 
@@ -907,13 +906,13 @@ POST /session/:sessionId/cookie
 
 > WebDriver documentation: [Add Cookie](https://w3c.github.io/webdriver/#add-cookie)
 
-Sets a cookie.
+Adds a cookie to the cookie store of the current browsing context.
 
 #### Parameters
 
 |Name|Description|Type|
 |--|--|--|
-|`cookie`|Cookie object to set|object|
+|`cookie`|Cookie object to add|[`Cookie`](#response_49)|
 
 #### Response
 
@@ -927,13 +926,7 @@ DELETE /session/:sessionId/cookie/:name
 
 > WebDriver documentation: [Delete Cookie](https://w3c.github.io/webdriver/#delete-cookie)
 
-Deletes a cookie by name.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`name`|Name of the cookie|string|
+Deletes a cookie with the name identified by `:name` from the current browsing context.
 
 #### Response
 
@@ -947,12 +940,11 @@ DELETE /session/:sessionId/cookie
 
 > WebDriver documentation: [Delete All Cookies](https://w3c.github.io/webdriver/#delete-all-cookies)
 
-Deletes all cookies visible to the current page.
+Deletes all cookies from the current browsing context.
 
 #### Response
 
 `null`
-
 
 ### `performActions`
 

--- a/packages/appium/docs/en/reference/api/webdriver.md
+++ b/packages/appium/docs/en/reference/api/webdriver.md
@@ -10,10 +10,10 @@ title: WebDriver Protocol
 The following is a list of [W3C WebDriver protocol](https://w3c.github.io/webdriver/) endpoints
 used in Appium.
 
-!!! note
+!!! info
 
-    Most WebDriver endpoints have no implementation within Appium, and are proxied directly to the
-    receiving driver.
+    Most WebDriver endpoints are not implemented within Appium itself, and are instead proxied
+    directly to the driver, which is responsible for the actual endpoint implementation.
 
 ### `createSession`
 

--- a/packages/appium/docs/en/reference/api/webdriver.md
+++ b/packages/appium/docs/en/reference/api/webdriver.md
@@ -117,6 +117,326 @@ Sets the timeout values of the current session.
 
 `null`
 
+### `setUrl`
+
+```
+POST /session/:sessionId/url
+```
+
+> WebDriver documentation: [Navigate To](https://w3c.github.io/webdriver/#navigate-to)
+
+Navigates the current top-level browsing context to the specified URL.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`url`|The URL to navigate to|string|
+
+#### Response
+
+`null`
+
+### `getUrl`
+
+```
+GET /session/:sessionId/url
+```
+
+> WebDriver documentation: [Get Current URL](https://w3c.github.io/webdriver/#get-current-url)
+
+Retrieves the URL of the current top-level browsing context.
+
+#### Response
+
+`string` - the current URL
+
+### `back`
+
+```
+POST /session/:sessionId/back
+```
+
+> WebDriver documentation: [Back](https://w3c.github.io/webdriver/#back)
+
+Navigates backwards in the browser history, if possible.
+
+#### Response
+
+`null`
+
+### `forward`
+
+```
+POST /session/:sessionId/forward
+```
+
+> WebDriver documentation: [Forward](https://w3c.github.io/webdriver/#forward)
+
+Navigates forwards in the browser history, if possible.
+
+#### Response
+
+`null`
+
+### `refresh`
+
+```
+POST /session/:sessionId/refresh
+```
+
+> WebDriver documentation: [Refresh](https://w3c.github.io/webdriver/#refresh)
+
+Reloads the window of the current top-level browsing context.
+
+#### Response
+
+`null`
+
+### `title`
+
+```
+GET /session/:sessionId/title
+```
+
+> WebDriver documentation: [Get Title](https://w3c.github.io/webdriver/#get-title)
+
+Retrieves the window title of the top-level browsing context.
+
+#### Response
+
+`string` - the page title
+
+### `getWindowHandle`
+
+```
+GET /session/:sessionId/window
+```
+
+> WebDriver documentation: [Get Window Handle](https://w3c.github.io/webdriver/#get-window-handle)
+
+Retrieves the window handle of the top-level browsing context.
+
+#### Response
+
+`string` - the window handle identifier
+
+### `closeWindow`
+
+```
+DELETE /session/:sessionId/window
+```
+
+> WebDriver documentation: [Close Window](https://w3c.github.io/webdriver/#close-window)
+
+Closes the current top-level browsing context.
+
+#### Response
+
+`string[]` - an array of zero or more remaining window handle identifiers
+
+### `setWindow`
+
+```
+POST /session/:sessionId/window
+```
+
+> WebDriver documentation: [Switch To Window](https://w3c.github.io/webdriver/#switch-to-window)
+
+Selects the top-level browsing context.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`handle`|Identifier for the window to switch to|string|
+
+#### Response
+
+`null`
+
+### `getWindowHandles`
+
+```
+GET /session/:sessionId/window/handles
+```
+
+> WebDriver documentation: [Get Window Handles](https://w3c.github.io/webdriver/#get-window-handles)
+
+Retrieves a list of window handles for every top-level browsing context.
+
+#### Response
+
+`string[]` - an array of zero or more window handle identifiers
+
+### `createNewWindow`
+
+```
+POST /session/:sessionId/window/new
+```
+
+> WebDriver documentation: [New Window](https://w3c.github.io/webdriver/#new-window)
+
+Creates a new window or tab.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`type?`|Type of window to create (`window` or `tab`)|string|
+
+#### Response
+
+`object` - window handle and type
+
+
+### `setFrame`
+
+```
+POST /session/:sessionId/frame
+```
+
+> WebDriver documentation: [Switch To Frame](https://w3c.github.io/webdriver/#switch-to-frame)
+
+Changes focus to another frame on the page.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`id`|Identifier for the frame (index, element, or null)|number \| string \| object|
+
+#### Response
+
+`null`
+
+### `switchToParentFrame`
+
+```
+POST /session/:sessionId/frame/parent
+```
+
+> WebDriver documentation: [Switch To Parent Frame](https://w3c.github.io/webdriver/#switch-to-parent-frame)
+
+Changes focus to the parent frame.
+
+#### Response
+
+`null`
+
+### `getWindowRect`
+
+```
+GET /session/:sessionId/window/rect
+```
+
+> WebDriver documentation: [Get Window Rect](https://w3c.github.io/webdriver/#get-window-rect)
+
+Retrieves the size and position of the current window.
+
+#### Response
+
+`object` - an object with `x`, `y`, `width`, and `height` properties
+
+### `setWindowRect`
+
+```
+POST /session/:sessionId/window/rect
+```
+
+> WebDriver documentation: [Set Window Rect](https://w3c.github.io/webdriver/#set-window-rect)
+
+Sets the size and/or position of the current window.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`x?`|X coordinate of the window|number|
+|`y?`|Y coordinate of the window|number|
+|`width?`|Width of the window|number|
+|`height?`|Height of the window|number|
+
+#### Response
+
+`object` - an object with `x`, `y`, `width`, and `height` properties
+
+### `maximizeWindow`
+
+```
+POST /session/:sessionId/window/maximize
+```
+
+> WebDriver documentation: [Maximize Window](https://w3c.github.io/webdriver/#maximize-window)
+
+Maximizes the current window.
+
+#### Response
+
+`object` - window rect information
+
+### `minimizeWindow`
+
+```
+POST /session/:sessionId/window/minimize
+```
+
+> WebDriver documentation: [Minimize Window](https://w3c.github.io/webdriver/#minimize-window)
+
+Minimizes the current window.
+
+#### Response
+
+`object` - window rect information
+
+### `fullScreenWindow`
+
+```
+POST /session/:sessionId/window/fullscreen
+```
+
+> WebDriver documentation: [Fullscreen Window](https://w3c.github.io/webdriver/#fullscreen-window)
+
+Makes the current window fullscreen.
+
+#### Response
+
+`object` - window rect information
+
+### `active`
+
+```
+GET /session/:sessionId/element/active
+```
+
+> WebDriver documentation: [Get Active Element](https://w3c.github.io/webdriver/#get-active-element)
+
+Retrieves the element on the page that currently has focus.
+
+#### Response
+
+[`Element`](#response_5)
+
+### `elementShadowRoot`
+
+```
+GET /session/:sessionId/element/:elementId/shadow
+```
+
+> WebDriver documentation: [Get Shadow Root](https://w3c.github.io/webdriver/#get-shadow-root)
+
+Retrieves the shadow root of the specified element.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`object` - shadow root object
+
 ### `findElement`
 
 ```
@@ -254,6 +574,290 @@ strategy, starting from the shadow root node identified by `:shadowId`.
 
 [`Element[]`](#response_6)
 
+### `elementSelected`
+
+```
+GET /session/:sessionId/element/:elementId/selected
+```
+
+> WebDriver documentation: [Is Element Selected](https://w3c.github.io/webdriver/#is-element-selected)
+
+Determines if an element is currently selected.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`boolean`
+
+### `elementDisplayed`
+
+```
+GET /session/:sessionId/element/:elementId/displayed
+```
+
+> WebDriver documentation: [Element Displayedness](https://w3c.github.io/webdriver/#element-displayedness)
+
+Determines if an element is currently displayed.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`boolean`
+
+### `getAttribute`
+
+```
+GET /session/:sessionId/element/:elementId/attribute/:name
+```
+
+> WebDriver documentation: [Get Element Attribute](https://w3c.github.io/webdriver/#get-element-attribute)
+
+Gets the value of an element's attribute.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+|`name`|Attribute name|string|
+
+#### Response
+
+`string` - attribute value
+
+### `getProperty`
+
+```
+GET /session/:sessionId/element/:elementId/property/:name
+```
+
+> WebDriver documentation: [Get Element Property](https://w3c.github.io/webdriver/#get-element-property)
+
+Gets the value of an element's property.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+|`name`|Property name|string|
+
+#### Response
+
+`string` - property value
+
+### `getCssProperty`
+
+```
+GET /session/:sessionId/element/:elementId/css/:propertyName
+```
+
+> WebDriver documentation: [Get Element CSS Value](https://w3c.github.io/webdriver/#get-element-css-value)
+
+Queries the value of an element's computed CSS property.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+|`propertyName`|CSS property name|string|
+
+#### Response
+
+`string` - CSS property value
+
+### `getText`
+
+```
+GET /session/:sessionId/element/:elementId/text
+```
+
+> WebDriver documentation: [Get Element Text](https://w3c.github.io/webdriver/#get-element-text)
+
+Returns the visible text for the specified element.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`string` - visible text
+
+### `getName`
+
+```
+GET /session/:sessionId/element/:elementId/name
+```
+
+> WebDriver documentation: [Get Element Tag Name](https://w3c.github.io/webdriver/#get-element-tag-name)
+
+Queries for an element's tag name.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`string` - tag name
+
+### `getElementRect`
+
+```
+GET /session/:sessionId/element/:elementId/rect
+```
+
+> WebDriver documentation: [Get Element Rect](https://w3c.github.io/webdriver/#get-element-rect)
+
+Retrieves the dimensions and coordinates of the specified element.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`object` - an object with `x`, `y`, `width`, and `height` properties
+
+### `elementEnabled`
+
+```
+GET /session/:sessionId/element/:elementId/enabled
+```
+
+> WebDriver documentation: [Is Element Enabled](https://w3c.github.io/webdriver/#is-element-enabled)
+
+Determines if an element is currently enabled.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`boolean`
+
+### `getComputedRole`
+
+```
+GET /session/:sessionId/element/:elementId/computedrole
+```
+
+> WebDriver documentation: [Get Computed Role](https://www.w3.org/TR/webdriver2/#get-computed-role)
+
+Gets the computed role of the element.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`string` - computed role
+
+### `getComputedLabel`
+
+```
+GET /session/:sessionId/element/:elementId/computedlabel
+```
+
+> WebDriver documentation: [Get Computed Label](https://www.w3.org/TR/webdriver2/#get-computed-label)
+
+Gets the computed label of the element.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`string` - computed label
+
+### `click`
+
+```
+POST /session/:sessionId/element/:elementId/click
+```
+
+> WebDriver documentation: [Element Click](https://w3c.github.io/webdriver/#element-click)
+
+Clicks on the specified element.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element to click|string|
+
+#### Response
+
+`null`
+
+### `clear`
+
+```
+POST /session/:sessionId/element/:elementId/clear
+```
+
+> WebDriver documentation: [Clear Element](https://w3c.github.io/webdriver/#clear-element)
+
+Clears a text element's value.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`null`
+
+### `setValue`
+
+```
+POST /session/:sessionId/element/:elementId/value
+```
+
+> WebDriver documentation: [Element Send Keys](https://w3c.github.io/webdriver/#element-send-keys)
+
+Sends a sequence of key strokes to the specified element.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+|`text`|Text to send|string|
+
+#### Response
+
+`null`
+
 ### `getPageSource`
 
 ```
@@ -267,3 +871,264 @@ Retrieves the page/application source of the current browsing context in HTML/XM
 #### Response
 
 `string` - the DOM of the current browsing context
+
+### `execute`
+
+```
+POST /session/:sessionId/execute/sync
+```
+
+> WebDriver documentation: [Execute Script](https://w3c.github.io/webdriver/#execute-script)
+
+Executes a synchronous JavaScript script in the current browsing context.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`script`|The script to execute|string|
+|`args`|Arguments for the script|array|
+
+#### Response
+
+`any` - the result of the script execution
+
+### `executeAsync`
+
+```
+POST /session/:sessionId/execute/async
+```
+
+> WebDriver documentation: [Execute Async Script](https://w3c.github.io/webdriver/#execute-async-script)
+
+Executes an asynchronous JavaScript script in the current browsing context.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`script`|The script to execute|string|
+|`args`|Arguments for the script|array|
+
+#### Response
+
+`any` - the result of the script execution
+
+### `getCookies`
+
+```
+GET /session/:sessionId/cookie
+```
+
+> WebDriver documentation: [Get Cookies](https://w3c.github.io/webdriver/#get-cookies)
+
+Retrieves all cookies visible to the current page.
+
+#### Response
+
+`object[]` - array of cookie objects
+
+### `getCookie`
+
+```
+GET /session/:sessionId/cookie/:name
+```
+
+> WebDriver documentation: [Get Named Cookie](https://w3c.github.io/webdriver/#get-named-cookie)
+
+Retrieves a cookie by name.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`name`|Name of the cookie|string|
+
+#### Response
+
+`object` - cookie object
+
+### `setCookie`
+
+```
+POST /session/:sessionId/cookie
+```
+
+> WebDriver documentation: [Add Cookie](https://w3c.github.io/webdriver/#add-cookie)
+
+Sets a cookie.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`cookie`|Cookie object to set|object|
+
+#### Response
+
+`null`
+
+### `deleteCookie`
+
+```
+DELETE /session/:sessionId/cookie/:name
+```
+
+> WebDriver documentation: [Delete Cookie](https://w3c.github.io/webdriver/#delete-cookie)
+
+Deletes a cookie by name.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`name`|Name of the cookie|string|
+
+#### Response
+
+`null`
+
+### `deleteCookies`
+
+```
+DELETE /session/:sessionId/cookie
+```
+
+> WebDriver documentation: [Delete All Cookies](https://w3c.github.io/webdriver/#delete-all-cookies)
+
+Deletes all cookies visible to the current page.
+
+#### Response
+
+`null`
+
+
+### `performActions`
+
+```
+POST /session/:sessionId/actions
+```
+
+> WebDriver documentation: [Perform Actions](https://w3c.github.io/webdriver/#perform-actions)
+
+Performs a sequence of actions.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`actions`|Array of action objects|object[]|
+
+#### Response
+
+`null`
+
+### `releaseActions`
+
+```
+DELETE /session/:sessionId/actions
+```
+
+> WebDriver documentation: [Release Actions](https://w3c.github.io/webdriver/#release-actions)
+
+Releases all actions.
+
+#### Response
+
+`null`
+
+### `postDismissAlert`
+
+```
+POST /session/:sessionId/alert/dismiss
+```
+
+> WebDriver documentation: [Dismiss Alert](https://w3c.github.io/webdriver/#dismiss-alert)
+
+Dismisses the currently displayed alert dialog.
+
+#### Response
+
+`null`
+
+### `postAcceptAlert`
+
+```
+POST /session/:sessionId/alert/accept
+```
+
+> WebDriver documentation: [Accept Alert](https://w3c.github.io/webdriver/#accept-alert)
+
+Accepts the currently displayed alert dialog.
+
+#### Response
+
+`null`
+
+### `getAlertText`
+
+```
+GET /session/:sessionId/alert/text
+```
+
+> WebDriver documentation: [Get Alert Text](https://w3c.github.io/webdriver/#get-alert-text)
+
+Gets the text of the currently displayed alert dialog.
+
+#### Response
+
+`string` - alert text
+
+### `setAlertText`
+
+```
+POST /session/:sessionId/alert/text
+```
+
+> WebDriver documentation: [Set Alert Text](https://w3c.github.io/webdriver/#set-alert-text)
+
+Sets the text of the currently displayed alert dialog.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`text`|Text to set|string|
+
+#### Response
+
+`null`
+
+### `getScreenshot`
+
+```
+GET /session/:sessionId/screenshot
+```
+
+> WebDriver documentation: [Take Screenshot](https://w3c.github.io/webdriver/#take-screenshot)
+
+Takes a screenshot of the current browsing context.
+
+#### Response
+
+`string` - a base64-encoded PNG image
+
+### `getElementScreenshot`
+
+```
+GET /session/:sessionId/element/:elementId/screenshot
+```
+
+> WebDriver documentation: [Take Element Screenshot](https://w3c.github.io/webdriver/#take-element-screenshot)
+
+Takes a screenshot of the specified element.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`elementId`|ID of the element|string|
+
+#### Response
+
+`string` - a base64-encoded PNG image

--- a/packages/appium/docs/en/reference/api/webdriver.md
+++ b/packages/appium/docs/en/reference/api/webdriver.md
@@ -283,11 +283,16 @@ Creates a new window or tab.
 
 |Name|Description|Type|
 |--|--|--|
-|`type?`|Type of window to create (`window` or `tab`)|string|
+|`type`|Type of window to create (`window` or `tab`)|string|
 
 #### Response
 
-`object` - window handle and type
+`NewWindow` -  an object with the following properties:
+
+|Name|Description|Type|
+|--|--|--|
+|`handle`|ID of the created window handle|string|
+|`type`|Type of the created window (`window` or `tab`)|string|
 
 
 ### `setFrame`
@@ -298,13 +303,13 @@ POST /session/:sessionId/frame
 
 > WebDriver documentation: [Switch To Frame](https://w3c.github.io/webdriver/#switch-to-frame)
 
-Changes focus to another frame on the page.
+Selects the top-level or child browsing context as the current browsing context.
 
 #### Parameters
 
 |Name|Description|Type|
 |--|--|--|
-|`id`|Identifier for the frame (index, element, or null)|number \| string \| object|
+|`id`|Identifier for the frame|null, number, or [`Element`](#response_23)|
 
 #### Response
 
@@ -318,7 +323,7 @@ POST /session/:sessionId/frame/parent
 
 > WebDriver documentation: [Switch To Parent Frame](https://w3c.github.io/webdriver/#switch-to-parent-frame)
 
-Changes focus to the parent frame.
+Sets the current browsing context to the parent of the current browsing context.
 
 #### Response
 
@@ -336,7 +341,14 @@ Retrieves the size and position of the current window.
 
 #### Response
 
-`object` - an object with `x`, `y`, `width`, and `height` properties
+`Rect` -  an object with the following properties:
+
+|Name|Description|Type|
+|--|--|--|
+|`height`|Window height|number|
+|`width`|Window width|number|
+|`x`|X-axis position of the top-left corner of the window|number|
+|`y`|Y-axis position of the top-left corner of the window|number|
 
 ### `setWindowRect`
 
@@ -352,14 +364,14 @@ Sets the size and/or position of the current window.
 
 |Name|Description|Type|
 |--|--|--|
-|`x?`|X coordinate of the window|number|
-|`y?`|Y coordinate of the window|number|
-|`width?`|Width of the window|number|
-|`height?`|Height of the window|number|
+|`height?`|Window height|number|
+|`width?`|Window width|number|
+|`x?`|X-axis position of the top-left corner of the window|number|
+|`y?`|Y-axis position of the top-left corner of the window|number|
 
 #### Response
 
-`object` - an object with `x`, `y`, `width`, and `height` properties
+[`Rect`](#response_18) - the new window size
 
 ### `maximizeWindow`
 
@@ -373,7 +385,7 @@ Maximizes the current window.
 
 #### Response
 
-`object` - window rect information
+[`Rect`](#response_18) - the new window size
 
 ### `minimizeWindow`
 
@@ -387,7 +399,7 @@ Minimizes the current window.
 
 #### Response
 
-`object` - window rect information
+[`Rect`](#response_18) - the new window size
 
 ### `fullScreenWindow`
 
@@ -401,7 +413,7 @@ Makes the current window fullscreen.
 
 #### Response
 
-`object` - window rect information
+[`Rect`](#response_18) - the new window size
 
 ### `active`
 
@@ -411,11 +423,16 @@ GET /session/:sessionId/element/active
 
 > WebDriver documentation: [Get Active Element](https://w3c.github.io/webdriver/#get-active-element)
 
-Retrieves the element on the page that currently has focus.
+Retrieves the currently focused element.
 
 #### Response
 
-[`Element`](#response_5)
+`Element` - an object with the following properties:
+
+|Name|Description|Type|
+|--|--|--|
+|`element-6066-11e4-a52e-4f735466cecf`|Element ID|string|
+|`ELEMENT`|Element ID (same value as `element-6066-11e4-a52e-4f735466cecf`). This key was used in the legacy Mobile JSON Wire Protocol (MJSONWP).|string|
 
 ### `elementShadowRoot`
 
@@ -425,17 +442,15 @@ GET /session/:sessionId/element/:elementId/shadow
 
 > WebDriver documentation: [Get Shadow Root](https://w3c.github.io/webdriver/#get-shadow-root)
 
-Retrieves the shadow root of the specified element.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Retrieves the shadow root of the element identified by `:elementId`.
 
 #### Response
 
-`object` - shadow root object
+`ShadowElement` - an object with the following properties:
+
+|Name|Description|Type|
+|--|--|--|
+|`shadow-6066-11e4-a52e-4f735466cecf`|Shadow root ID|string|
 
 ### `findElement`
 
@@ -457,12 +472,7 @@ location strategy, starting from the root node.
 
 #### Response
 
-`Element` - an object with the following properties:
-
-|Name|Description|Type|
-|--|--|--|
-|`element-6066-11e4-a52e-4f735466cecf`|The element ID|string|
-|`ELEMENT`|The element ID used in the legacy Mobile JSON Wire Protocol (MJSONWP). Has the same value as `element-6066-11e4-a52e-4f735466cecf`.|string|
+[`Element`](#response_23)
 
 ### `findElements`
 
@@ -484,7 +494,7 @@ strategy, starting from the root node.
 
 #### Response
 
-`Element[]` - an array containing zero or more [`Element` objects](#response_5)
+`Element[]` - an array containing zero or more [`Element` objects](#response_23)
 
 ### `findElementFromElement`
 
@@ -506,7 +516,7 @@ location strategy, starting from the element node identified by `:elementId`.
 
 #### Response
 
-[`Element`](#response_5)
+[`Element`](#response_23)
 
 ### `findElementsFromElement`
 
@@ -528,7 +538,7 @@ strategy, starting from the element node identified by `:elementId`.
 
 #### Response
 
-[`Element[]`](#response_6)
+[`Element[]`](#response_26)
 
 ### `findElementFromShadowRoot`
 
@@ -550,7 +560,7 @@ location strategy, starting from the shadow root node identified by `:shadowId`.
 
 #### Response
 
-[`Element`](#response_5)
+[`Element`](#response_23)
 
 ### `findElementsFromShadowRoot`
 
@@ -572,7 +582,7 @@ strategy, starting from the shadow root node identified by `:shadowId`.
 
 #### Response
 
-[`Element[]`](#response_6)
+[`Element[]`](#response_26)
 
 ### `elementSelected`
 

--- a/packages/appium/docs/en/reference/api/webdriver.md
+++ b/packages/appium/docs/en/reference/api/webdriver.md
@@ -10,6 +10,10 @@ title: WebDriver Protocol
 The following is a list of [W3C WebDriver protocol](https://w3c.github.io/webdriver/) endpoints
 used in Appium.
 
+!!! note
+
+    Drivers or plugins may implement modified versions of these endpoints.
+
 ### `createSession`
 
 ```
@@ -131,7 +135,7 @@ Navigates the current top-level browsing context to the specified URL.
 
 |Name|Description|Type|
 |--|--|--|
-|`url`|The URL to navigate to|string|
+|`url`|URL to navigate to|string|
 
 #### Response
 
@@ -592,17 +596,12 @@ GET /session/:sessionId/element/:elementId/selected
 
 > WebDriver documentation: [Is Element Selected](https://w3c.github.io/webdriver/#is-element-selected)
 
-Determines if an element is currently selected.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Determines if the element identified by `:elementId` is currently selected. This property is only
+relevant to certain elements types, such as checkboxes, radio buttons, or options.
 
 #### Response
 
-`boolean`
+`boolean` - `true` if the element is selected, otherwise `false`
 
 ### `elementDisplayed`
 
@@ -612,17 +611,11 @@ GET /session/:sessionId/element/:elementId/displayed
 
 > WebDriver documentation: [Element Displayedness](https://w3c.github.io/webdriver/#element-displayedness)
 
-Determines if an element is currently displayed.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Determines if the element identified by `:elementId` is currently displayed.
 
 #### Response
 
-`boolean`
+`boolean` - `true` if the element is displayed, otherwise `false`
 
 ### `getAttribute`
 
@@ -632,18 +625,11 @@ GET /session/:sessionId/element/:elementId/attribute/:name
 
 > WebDriver documentation: [Get Element Attribute](https://w3c.github.io/webdriver/#get-element-attribute)
 
-Gets the value of an element's attribute.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
-|`name`|Attribute name|string|
+Retrieves the value of the `:name` attribute for the element identified by `:elementId`.
 
 #### Response
 
-`string` - attribute value
+`string` - the attribute value, or `null` if the attribute does not exist
 
 ### `getProperty`
 
@@ -653,18 +639,11 @@ GET /session/:sessionId/element/:elementId/property/:name
 
 > WebDriver documentation: [Get Element Property](https://w3c.github.io/webdriver/#get-element-property)
 
-Gets the value of an element's property.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
-|`name`|Property name|string|
+Retrieves the value of the `:name` property for the element identified by `:elementId`.
 
 #### Response
 
-`string` - property value
+`string` - the property value, or `null` if the property does not exist
 
 ### `getCssProperty`
 
@@ -674,18 +653,12 @@ GET /session/:sessionId/element/:elementId/css/:propertyName
 
 > WebDriver documentation: [Get Element CSS Value](https://w3c.github.io/webdriver/#get-element-css-value)
 
-Queries the value of an element's computed CSS property.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
-|`propertyName`|CSS property name|string|
+Retrieves the value of the `:propertyName` computed CSS property for the element identified by
+`:elementId`.
 
 #### Response
 
-`string` - CSS property value
+`string` - the CSS property value, or `null` if the property does not exist
 
 ### `getText`
 
@@ -695,17 +668,12 @@ GET /session/:sessionId/element/:elementId/text
 
 > WebDriver documentation: [Get Element Text](https://w3c.github.io/webdriver/#get-element-text)
 
-Returns the visible text for the specified element.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Retrieves the text of the element identified by `:elementId`, as well as the text of its child
+elements (if any).
 
 #### Response
 
-`string` - visible text
+`string` - the element text (including its child elements)
 
 ### `getName`
 
@@ -715,17 +683,11 @@ GET /session/:sessionId/element/:elementId/name
 
 > WebDriver documentation: [Get Element Tag Name](https://w3c.github.io/webdriver/#get-element-tag-name)
 
-Queries for an element's tag name.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Retrieves the tag name of the element identified by `:elementId`.
 
 #### Response
 
-`string` - tag name
+`string` - the element tag name
 
 ### `getElementRect`
 
@@ -735,17 +697,11 @@ GET /session/:sessionId/element/:elementId/rect
 
 > WebDriver documentation: [Get Element Rect](https://w3c.github.io/webdriver/#get-element-rect)
 
-Retrieves the dimensions and coordinates of the specified element.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Retrieves the dimensions and coordinates of the element identified by `:elementId`.
 
 #### Response
 
-`object` - an object with `x`, `y`, `width`, and `height` properties
+[`Rect`](#response_18)
 
 ### `elementEnabled`
 
@@ -755,17 +711,12 @@ GET /session/:sessionId/element/:elementId/enabled
 
 > WebDriver documentation: [Is Element Enabled](https://w3c.github.io/webdriver/#is-element-enabled)
 
-Determines if an element is currently enabled.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Determines if the element identified by `:elementId` is currently enabled. This property is only
+relevant to certain elements types, such as buttons, input fields, checkboxes, etc.
 
 #### Response
 
-`boolean`
+`boolean` - `true` if the element is enabled, otherwise `false`
 
 ### `getComputedRole`
 
@@ -773,19 +724,14 @@ Determines if an element is currently enabled.
 GET /session/:sessionId/element/:elementId/computedrole
 ```
 
-> WebDriver documentation: [Get Computed Role](https://www.w3.org/TR/webdriver2/#get-computed-role)
+> WebDriver documentation: [Get Computed Role](https://w3c.github.io/webdriver/#get-computed-role)
 
-Gets the computed role of the element.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Retrieves the computed [WAI-ARIA](https://w3c.github.io/aria/#introroles) role of the element
+identified by `:elementId`.
 
 #### Response
 
-`string` - computed role
+`string` - the element computed role
 
 ### `getComputedLabel`
 
@@ -793,19 +739,14 @@ Gets the computed role of the element.
 GET /session/:sessionId/element/:elementId/computedlabel
 ```
 
-> WebDriver documentation: [Get Computed Label](https://www.w3.org/TR/webdriver2/#get-computed-label)
+> WebDriver documentation: [Get Computed Label](https://w3c.github.io/webdriver/#get-computed-label)
 
-Gets the computed label of the element.
-
-#### Parameters
-
-|Name|Description|Type|
-|--|--|--|
-|`elementId`|ID of the element|string|
+Retrieves the [accessible name](https://w3c.github.io/accname/#dfn-accessible-name) of the
+element identified by `:elementId`.
 
 #### Response
 
-`string` - computed label
+`string` - the element accessible name
 
 ### `click`
 


### PR DESCRIPTION
This is the first of several PRs related to #20210, aiming to document all endpoints defined in base-driver's `routes.js` file.

This PR adds all the implemented WebDriver standard endpoints that are missing from the docs.