### PR TITLE
docs: add missing supported BiDi commands

### DIFF
--- a/packages/appium/docs/en/reference/api/bidi.md
+++ b/packages/appium/docs/en/reference/api/bidi.md
@@ -1,0 +1,70 @@
+---
+title: WebDriver BiDi Protocol
+---
+<style>
+  ul[data-md-component="toc"] .md-nav {
+    display: none;
+  }
+</style>
+
+The following is a list of [W3C WebDriver BiDi protocol](https://w3c.github.io/webdriver-bidi/)
+commands supported in Appium.
+
+Unlike other protocols that specify URL endpoints, the WebDriver BiDi protocol specifies commands
+sent as a websocket event, that both drivers and clients can emit or listen to.
+
+### `bidiStatus`
+
+```
+session.status
+```
+
+> WebDriver BiDi documentation: [session.status](https://w3c.github.io/webdriver-bidi/#command-session-status)
+
+Retrieves the current status of the Appium server.
+
+#### Response
+
+[`GetStatusResult`](./webdriver.md#response_2)
+
+### `bidiSubscribe`
+
+```
+session.subscribe
+```
+
+> WebDriver BiDi documentation: [session.subscribe](https://w3c.github.io/webdriver-bidi/#command-session-subscribe)
+
+Subscribes to one or more BiDi events.
+
+#### Parameters
+
+|Name|Description|Type|Default|
+|--|--|--|--|
+|`contexts?`|Contexts in which to subscribe to the specified events. By default, the global context scope is applied.|string[]|`['']`|
+|`events`|Names of events to subscribe to|string[]||
+
+#### Response
+
+`null`
+
+### `bidiUnsubscribe`
+
+```
+session.unsubscribe
+```
+
+> WebDriver BiDi documentation: [session.unsubscribe](https://w3c.github.io/webdriver-bidi/#command-session-unsubscribe)
+
+Unsubscribes from one or more BiDi events.
+
+#### Parameters
+
+|Name|Description|Type|Default|
+|--|--|--|--|
+|`contexts?`|Contexts in which to unsubscribe from the specified events. By default, the global scope is applied.|string[]|`['']`|
+|`events`|Names of events to unsubscribe from|string[]||
+
+#### Response
+
+`null`

--- a/packages/appium/docs/en/reference/api/index.md
+++ b/packages/appium/docs/en/reference/api/index.md
@@ -18,6 +18,7 @@ Refer to the documentation of your client for the exact commands used to invoke 
 All endpoint listings are grouped by their protocol, with an additional group for plugin endpoints:
 
 * [WebDriver Protocol](./webdriver.md)
+* [WebDriver BiDi Protocol](./bidi.md)
 * [JSON Wire Protocol](./jsonwp.md)
 * [Appium Protocol](./appium.md)
 * [Other Protocols](./others.md)

--- a/packages/appium/docs/en/reference/api/plugins.md
+++ b/packages/appium/docs/en/reference/api/plugins.md
@@ -143,7 +143,7 @@ Modifies the [`findElements`](./webdriver.md#findelements) endpoint:
 POST /session/:sessionId/actions
 ```
 
-Modifies the `performActions` endpoint:
+Modifies the [`performActions`](./webdriver.md#performactions) endpoint:
 
 * If any action in `actions` includes `origin`, whose value is an image element:
     * Removes the `origin` property

--- a/packages/appium/docs/mkdocs-en.yml
+++ b/packages/appium/docs/mkdocs-en.yml
@@ -45,6 +45,7 @@ nav:
       - API Endpoints:
           - reference/api/index.md
           - reference/api/webdriver.md
+          - reference/api/bidi.md
           - reference/api/jsonwp.md
           - reference/api/appium.md
           - reference/api/others.md


### PR DESCRIPTION
Continuing the implementation of #20210, this PR adds all the implemented WebDriver BiDi commands.
The `bidiNavigate` (`browsingContext.navigate`) command, while defined in `bidi-commands.js`, is not included, since it is not actually defined in the base driver.