### PR TITLE
docs: add missing supported JSONWP & MJSONWP API endpoints

### DIFF
--- a/packages/appium/docs/en/reference/api/appium.md
+++ b/packages/appium/docs/en/reference/api/appium.md
@@ -10,7 +10,7 @@ title: Appium Protocol
 The following is a list of endpoints used in Appium that are defined in the Appium extension of the
 W3C WebDriver protocol.
 
-### `getAppiumSessions`
+### getAppiumSessions
 
 ```
 GET /appium/sessions
@@ -32,7 +32,7 @@ Retrieves information about all active server sessions.
 |`created`|Session creation time (in milliseconds) as a Unix timestamp|number|
 |`id`|Session ID|string|
 
-### `getAppiumSessionCapabilities`
+### getAppiumSessionCapabilities
 
 ```
 GET /session/:sessionId/appium/capabilities
@@ -48,7 +48,7 @@ Retrieves the [session capabilities](../../guides/caps.md).
 |--|--|--|
 |`capabilities`|Session capabilities|object|
 
-### `getSettings`
+### getSettings
 
 ```
 GET /session/:sessionId/appium/settings
@@ -60,7 +60,7 @@ Retrieves the [current session settings](../../guides/settings.md).
 
 `Settings` - an object containing setting names and their values
 
-### `updateSettings`
+### updateSettings
 
 ```
 POST /session/:sessionId/appium/settings
@@ -78,7 +78,7 @@ Updates the specified session settings. Any other previously set settings will r
 
 `null`
 
-### `listCommands`
+### listCommands
 
 ```
 GET /session/:sessionId/appium/commands
@@ -92,7 +92,7 @@ Retrieves the URL endpoints and WebDriver BiDi commands supported in the current
 their origin (base Appium, driver-specific, or plugin-specific). Refer to [the type definition file](https://github.com/appium/appium/blob/master/packages/types/lib/command.ts)
 for a detailed structure of this object.
 
-### `listExtensions`
+### listExtensions
 
 ```
 GET /session/:sessionId/appium/extensions
@@ -106,7 +106,7 @@ Retrieves the [execute methods](../../guides/execute-methods.md) supported in th
 origin (driver-specific or plugin-specific). Refer to [the type definition file](https://github.com/appium/appium/blob/master/packages/types/lib/command.ts)
 for a detailed structure of this object.
 
-### `getLogEvents`
+### getLogEvents
 
 ```
 POST /session/:sessionId/appium/events
@@ -147,7 +147,7 @@ grouped into three categories, as shown by the following example response:
 * Namespaced keys can be added using the `logCustomEvent` endpoint, but may also be provided by
   drivers/plugins. Their value is an array of event times (in milliseconds), as Unix timestamps.
 
-### `logCustomEvent`
+### logCustomEvent
 
 ```
 POST /session/:sessionId/appium/log_event
@@ -166,7 +166,7 @@ Logs a custom event, which can be retrieved using the [`getLogEvents`](#getlogev
 
 `null`
 
-### `getDeviceTime`
+### getDeviceTime
 
 ```
 POST /session/:sessionId/appium/device/system_time
@@ -184,7 +184,7 @@ Retrieves the current system time of the device under test.
 
 `string` - the device time
 
-### `activateApp`
+### activateApp
 
 ```
 POST /session/:sessionId/appium/device/activate_app
@@ -203,7 +203,7 @@ Activates an app on the device under test.
 
 `void`
 
-### `terminateApp`
+### terminateApp
 
 ```
 POST /session/:sessionId/appium/device/terminate_app
@@ -222,7 +222,7 @@ Terminates an app on the device under test.
 
 `void`
 
-### `queryAppState`
+### queryAppState
 
 ```
 POST /session/:sessionId/appium/device/app_state
@@ -248,7 +248,7 @@ Retrieves the state of an app on the device under test.
 |`3`|Running in background|
 |`4`|Running in foreground|
 
-### `installApp`
+### installApp
 
 ```
 POST /session/:sessionId/appium/device/install_app
@@ -267,7 +267,7 @@ Installs an app on the device under test.
 
 `void`
 
-### `removeApp`
+### removeApp
 
 ```
 POST /session/:sessionId/appium/device/remove_app
@@ -286,7 +286,7 @@ Uninstalls an app from the device under test.
 
 `boolean` - `true` if uninstall was successful, otherwise `false`
 
-### `isAppInstalled`
+### isAppInstalled
 
 ```
 POST /session/:sessionId/appium/device/app_installed
@@ -304,7 +304,7 @@ Determines if an app is installed on the device under test.
 
 `boolean` - `true` if app is installed, otherwise `false`
 
-### `hideKeyboard`
+### hideKeyboard
 
 ```
 POST /session/:sessionId/appium/device/hide_keyboard
@@ -326,7 +326,7 @@ Attempts to hide the virtual keyboard on the device under test.
 `boolean` - `true` if the operation was successful, otherwise `false`. Note that some platforms
 may never return a `false` value.
 
-### `isKeyboardShown`
+### isKeyboardShown
 
 ```
 GET /session/:sessionId/appium/device/is_keyboard_shown
@@ -338,7 +338,7 @@ Determines if the virtual keyboard is shown on the device under test.
 
 `boolean` - `true` if the keyboard is shown, otherwise `false`
 
-### `pushFile`
+### pushFile
 
 ```
 POST /session/:sessionId/appium/device/push_file
@@ -357,7 +357,7 @@ Pushes data to a file on the device under test.
 
 `void`
 
-### `pullFile`
+### pullFile
 
 ```
 POST /session/:sessionId/appium/device/pull_file
@@ -375,7 +375,7 @@ Retrieves data from a file on the device under test.
 
 `string` - the Base64-encoded contents of the file
 
-### `pullFolder`
+### pullFolder
 
 ```
 POST /session/:sessionId/appium/device/pull_folder

--- a/packages/appium/docs/en/reference/api/bidi.md
+++ b/packages/appium/docs/en/reference/api/bidi.md
@@ -13,7 +13,7 @@ commands supported in Appium.
 Unlike other protocols that specify URL endpoints, the WebDriver BiDi protocol specifies commands
 sent as a websocket event, that both drivers and clients can emit or listen to.
 
-### `bidiStatus`
+### bidiStatus
 
 ```
 session.status
@@ -27,7 +27,7 @@ Retrieves the current status of the Appium server.
 
 [`GetStatusResult`](./webdriver.md#response_2)
 
-### `bidiSubscribe`
+### bidiSubscribe
 
 ```
 session.subscribe
@@ -48,7 +48,7 @@ Subscribes to one or more BiDi events.
 
 `null`
 
-### `bidiUnsubscribe`
+### bidiUnsubscribe
 
 ```
 session.unsubscribe

--- a/packages/appium/docs/en/reference/api/index.md
+++ b/packages/appium/docs/en/reference/api/index.md
@@ -15,7 +15,7 @@ but may additionally define endpoints of their own. Refer to the documentation o
 The recommended way of calling these API endpoints is through your [Appium client](../../ecosystem/clients.md).
 Refer to the documentation of your client for the exact commands used to invoke specific endpoints.
 
-All endpoint listings are grouped by their protocol, with an additional group for plugin endpoints:
+All endpoints are grouped by their protocol, with an additional group for plugin endpoints:
 
 <div class="grid cards" markdown>
 

--- a/packages/appium/docs/en/reference/api/index.md
+++ b/packages/appium/docs/en/reference/api/index.md
@@ -17,9 +17,14 @@ Refer to the documentation of your client for the exact commands used to invoke 
 
 All endpoint listings are grouped by their protocol, with an additional group for plugin endpoints:
 
-* [WebDriver Protocol](./webdriver.md)
-* [WebDriver BiDi Protocol](./bidi.md)
-* [JSON Wire Protocol](./jsonwp.md)
-* [Appium Protocol](./appium.md)
-* [Other Protocols](./others.md)
-* [Endpoints Used by Official Plugins](./plugins.md)
+<div class="grid cards" markdown>
+
+-   [__WebDriver Protocol__](./webdriver.md)
+-   [__WebDriver BiDi Protocol__](./bidi.md)
+-   [__JSON Wire Protocol__](./jsonwp.md)
+-   [__Mobile JSON Wire Protocol__](./mjsonwp.md)
+-   [__Appium Protocol__](./appium.md)
+-   [__Other Protocols__](./others.md)
+-   [__Endpoints Used by Official Plugins__](./plugins.md)
+
+</div>

--- a/packages/appium/docs/en/reference/api/jsonwp.md
+++ b/packages/appium/docs/en/reference/api/jsonwp.md
@@ -10,7 +10,7 @@ title: JSON Wire Protocol
 The following is a list of legacy [JSON Wire Protocol (JSONWP)](https://www.selenium.dev/documentation/legacy/json_wire_protocol/)
 endpoints used in Appium.
 
-### `getSession`
+### getSession
 
 ```
 GET /session/:sessionId
@@ -18,7 +18,7 @@ GET /session/:sessionId
 
 > JSONWP documentation: [/session/:sessionId](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionid)
 
-Returns the capabilities of the current session.
+Retrieves the capabilities of the current session.
 
 Appium implements a modified version of this endpoint. If the `appium:eventTimings` capability is
 set to `true`, the returned result will additionally include the `events` key, whose value contains
@@ -32,3 +32,183 @@ the event history and timings.
 #### Response
 
 `Capabilities` - an object containing the session capabilities, and the event history (if applicable)
+
+### availableIMEEngines
+
+```
+GET /session/:sessionId/ime/available_engines
+```
+
+> JSONWP documentation: [/session/:sessionId/ime/available_engines](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidimeavailable_engines)
+
+Retrieves all IME (input method editor) engines available on the device under test.
+
+!!! warning "Deprecated"
+
+    In the future, this endpoint will be moved to the [UiAutomator2 and Espresso drivers](../../ecosystem/drivers.md)
+
+#### Response
+
+`string[]` - a list of available IME engines
+
+### getActiveIMEEngine
+
+```
+GET /session/:sessionId/ime/active_engine
+```
+
+> JSONWP documentation: [/session/:sessionId/ime/active_engine](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidimeactive_engine)
+
+Retrieves the name of the active IME engine.
+
+!!! warning "Deprecated"
+
+    In the future, this endpoint will be moved to the UiAutomator2 and Espresso drivers
+
+#### Response
+
+`string` - the name of the active IME engine
+
+### isIMEActivated
+
+```
+GET /session/:sessionId/ime/activated
+```
+
+> JSONWP documentation: [/session/:sessionId/ime/activated](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidimeactivated)
+
+Determines if IME input is available and active.
+
+!!! warning "Deprecated"
+
+    In the future, this endpoint will be moved to the UiAutomator2 and Espresso drivers
+
+#### Response
+
+`boolean` - `true` if IME is active, otherwise `false`
+
+### deactivateIMEEngine
+
+```
+POST /session/:sessionId/ime/deactivate
+```
+
+> JSONWP documentation: [/session/:sessionId/ime/deactivate](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidimedeactivate)
+
+Deactivates the currently active IME engine.
+
+!!! warning "Deprecated"
+
+    In the future, this endpoint will be moved to the UiAutomator2 and Espresso drivers
+
+#### Response
+
+`null`
+
+### activateIMEEngine
+
+```
+POST /session/:sessionId/ime/activate
+```
+
+> JSONWP documentation: [/session/:sessionId/ime/activate](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidimeactivate)
+
+Activates an IME engine.
+
+!!! warning "Deprecated"
+
+    In the future, this endpoint will be moved to the UiAutomator2 and Espresso drivers
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`engine`|Name of the IME engine to activate|string|
+
+#### Response
+
+`null`
+
+### getOrientation
+
+```
+GET /session/:sessionId/orientation
+```
+
+> JSONWP documentation: [/session/:sessionId/orientation](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidorientation)
+
+Retrieves the current orientation of the device under test.
+
+#### Response
+
+`string` - either `PORTRAIT` or `LANDSCAPE`
+
+### setOrientation
+
+```
+POST /session/:sessionId/orientation
+```
+
+> JSONWP documentation: [/session/:sessionId/orientation](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidorientation)
+
+Sets the orientation of the device under test.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`orientation`|New device orientation. Supported values are `PORTRAIT` or `LANDSCAPE`.|string|
+
+#### Response
+
+`null`
+
+### getGeoLocation
+
+```
+GET /session/:sessionId/location
+```
+
+> JSONWP documentation: [/session/:sessionId/location](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidlocation)
+
+Retrieves the current location of the device under test.
+
+!!! warning "Deprecated"
+
+    Please use driver-specific extension methods such as `mobile: getGeoLocation` or
+    `mobile: getSimulatedLocation`
+
+#### Response
+
+`Location` - an object with the following properties:
+
+|Name|Description|Type|
+|--|--|--|
+|`altitude`|Altitude of the device location|number|
+|`latitude`|Latitude of the device location|number|
+|`longitude`|Longitude of the device location|number|
+
+### setGeoLocation
+
+```
+POST /session/:sessionId/location
+```
+
+> JSONWP documentation: [/session/:sessionId/location](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionidlocation)
+
+Sets the current location of the device under test.
+
+!!! warning "Deprecated"
+
+    Please use driver-specific extension methods such as `mobile: setGeoLocation` or
+    `mobile: setSimulatedLocation`
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`location`|New device latitude, longitude and altitude|[`Location`](#response_6)|
+
+#### Response
+
+`null`

--- a/packages/appium/docs/en/reference/api/mjsonwp.md
+++ b/packages/appium/docs/en/reference/api/mjsonwp.md
@@ -1,0 +1,151 @@
+---
+title: Mobile JSON Wire Protocol
+---
+<style>
+  ul[data-md-component="toc"] .md-nav {
+    display: none;
+  }
+</style>
+
+The following is a list of legacy [Mobile JSON Wire Protocol (MJSONWP)](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md)
+endpoints used in Appium.
+
+### getRotation
+
+```
+GET /session/:sessionId/rotation
+```
+
+> MJSONWP documentation: [Device Rotation](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#device-rotation)
+
+Retrieves the current spatial orientation of the device under test.
+
+#### Response
+
+`Rotation` - an object with the following properties:
+
+|Name|Description|Type|
+|--|--|--|
+|`x`|Degrees by which the device is rotated on its X axis|number|
+|`y`|Degrees by which the device is rotated on its Y axis|number|
+|`z`|Degrees by which the device is rotated on its Z axis|number|
+
+### setRotation
+
+```
+POST /session/:sessionId/rotation
+```
+
+> MJSONWP documentation: [Device Rotation](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#device-rotation)
+
+Sets the spatial orientation of the device under test.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`x`|Degrees by which the device is rotated on its X axis|number|
+|`y`|Degrees by which the device is rotated on its Y axis|number|
+|`z`|Degrees by which the device is rotated on its Z axis|number|
+
+#### Response
+
+`null`
+
+### getCurrentContext
+
+```
+GET /session/:sessionId/context
+```
+
+> MJSONWP documentation: [Webviews and Other Contexts](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#webviews-and-other-contexts)
+
+Retrieves the active application context.
+
+#### Response
+
+`string` - the name of the active context
+
+### setContext
+
+```
+POST /session/:sessionId/context
+```
+
+> MJSONWP documentation: [Webviews and Other Contexts](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#webviews-and-other-contexts)
+
+Sets an application context as the active context.
+
+#### Parameters
+
+|Name|Description|Type|
+|--|--|--|
+|`name`|Name of the context to set as the active one|string|
+
+#### Response
+
+`null`
+
+### getContexts
+
+```
+GET /session/:sessionId/contexts
+```
+
+> MJSONWP documentation: [Webviews and Other Contexts](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#webviews-and-other-contexts)
+
+Retrieves all available application contexts.
+
+#### Response
+
+`string[]` - the names of available contexts
+
+### getNetworkConnection
+
+```
+GET /session/:sessionId/network_connection
+```
+
+> MJSONWP documentation: [Device Modes](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#device-modes)
+
+Retrieves the current state of network types (data, Wi-Fi, airplane mode).
+
+!!! warning "Deprecated"
+
+    Please use driver-specific extension methods such as `mobile: getConnectivity`
+
+#### Response
+
+`NetworkConnectionState` - a number indicating the current network state:
+
+|Value|Data|Wi-Fi|Airplane Mode|
+|--|--|--|--|
+|`0`|OFF|OFF|OFF|
+|`1`|OFF|OFF|ON|
+|`2`|OFF|ON|OFF|
+|`4`|ON|OFF|OFF|
+|`6`|ON|ON|OFF|
+
+### setNetworkConnection
+
+```
+POST /session/:sessionId/network_connection
+```
+
+> MJSONWP documentation: [Device Modes](https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#device-modes)
+
+Sets the state of network types (data, Wi-Fi, airplane mode).
+
+!!! warning "Deprecated"
+
+    Please use driver-specific extension methods such as `mobile: setConnectivity`
+
+#### Parameters
+
+|<div style="width:6em">Name</div>|Description|<div style="width:18em">Type</div>|
+|--|--|--|
+|`parameters`|Object containing the `type` key, whose value is the desired network state|`{"type": `[`NetworkConnectionState`](#response_5)`}`|
+
+#### Response
+
+[`NetworkConnectionState`](#response_5) - the new network state

--- a/packages/appium/docs/en/reference/api/others.md
+++ b/packages/appium/docs/en/reference/api/others.md
@@ -19,7 +19,7 @@ vendor-agnostic commands.
 
     Endpoints specified by this protocol are not officially documented.
 
-### `executeCdp`
+### executeCdp
 
 ```
 POST /session/:sessionId/:vendor/cdp/execute
@@ -49,7 +49,7 @@ based on Selenium.
 
     Endpoints specified by this protocol are not officially documented.
 
-### `getLog`
+### getLog
 
 ```
 POST /session/:sessionId/se/log
@@ -76,7 +76,7 @@ Typically a log entry is an object with the following properties:
 |`message`|Contents of the actual log message|string|
 |`timestamp`|Message timestamp (in milliseconds) in Unix format|number|
 
-### `getLogTypes`
+### getLogTypes
 
 ```
 GET /session/:sessionId/se/log/types
@@ -93,7 +93,7 @@ Retrieves the available log types that can be used to call the [`getLog`](#getlo
 The [Web Authentication protocol](https://w3c.github.io/webauthn/) (WebAuthn) is an extension of
 the W3C WebDriver protocol.
 
-### `addVirtualAuthenticator`
+### addVirtualAuthenticator
 
 ```
 POST /session/:sessionId/webauthn/authenticator
@@ -118,7 +118,7 @@ Creates a software [virtual authenticator](https://w3c.github.io/webauthn/#virtu
 
 `string` - the ID of the created authenticator
 
-### `removeVirtualAuthenticator`
+### removeVirtualAuthenticator
 
 ```
 DELETE /session/:sessionId/webauthn/authenticator/:authenticatorId
@@ -132,7 +132,7 @@ Removes the virtual authenticator identified by `:authenticatorId`.
 
 `null`
 
-### `addAuthCredential`
+### addAuthCredential
 
 ```
 POST /session/:sessionId/webauthn/authenticator/:authenticatorId/credential
@@ -158,7 +158,7 @@ into the virtual authenticator identified by `:authenticatorId`.
 
 `null`
 
-### `getAuthCredential`
+### getAuthCredential
 
 ```
 GET /session/:sessionId/webauthn/authenticator/:authenticatorId/credentials
@@ -183,7 +183,7 @@ Retrieves all Public Key Credential Sources stored in the virtual authenticator 
 |`signCount`|Initial value for the signature counter|number|`0`|
 |`userHandle`|User handle associated with the credential, in Base64url encoding|string|`null`|
 
-### `removeAuthCredential`
+### removeAuthCredential
 
 ```
 DELETE /session/:sessionId/webauthn/authenticator/:authenticatorId/credentials/:credentialId
@@ -198,7 +198,7 @@ identified by `:authenticatorId`.
 
 `null`
 
-### `removeAllAuthCredentials`
+### removeAllAuthCredentials
 
 ```
 DELETE /session/:sessionId/webauthn/authenticator/:authenticatorId/credentials
@@ -213,7 +213,7 @@ Removes all Public Key Credential Sources from the virtual authenticator identif
 
 `null`
 
-### `setUserAuthVerified`
+### setUserAuthVerified
 
 ```
 POST /session/:sessionId/webauthn/authenticator/:authenticatorId/uv

--- a/packages/appium/docs/en/reference/api/plugins.md
+++ b/packages/appium/docs/en/reference/api/plugins.md
@@ -11,7 +11,7 @@ The following is a list of endpoints added or modified by official Appium plugin
 
 ## Execute Driver Plugin
 
-### `executeDriverScript`
+### executeDriverScript
 
 ```
 POST /session/:sessionId/appium/execute_driver
@@ -38,7 +38,7 @@ Executes a driver script in a child process.
 
 ## Images Plugin
 
-### `compareImages`
+### compareImages
 
 ```
 POST /session/:sessionId/appium/compare_images
@@ -117,7 +117,7 @@ Compares two images using the specified mode of comparison:
 |`score`|Similarity score between both images in the range `[0.0, 1.0]`|number|
 |`visualization?`|Image of the matcher visualization. Only included if the `visualize` input option was enabled.|Buffer|
 
-### `findElement`
+### findElement
 
 ```
 POST /session/:sessionId/element
@@ -127,7 +127,7 @@ Modifies the [`findElement`](./webdriver.md#findelement) endpoint:
 
 * Adds `-image` to the supported values for the `using` parameter (the location strategy)
 
-### `findElements`
+### findElements
 
 ```
 POST /session/:sessionId/elements
@@ -137,7 +137,7 @@ Modifies the [`findElements`](./webdriver.md#findelements) endpoint:
 
 * Adds `-image` to the supported values for the `using` parameter (the location strategy)
 
-### `performActions`
+### performActions
 
 ```
 POST /session/:sessionId/actions
@@ -151,7 +151,7 @@ Modifies the [`performActions`](./webdriver.md#performactions) endpoint:
 
 ## Relaxed Caps Plugin
 
-### `createSession`
+### createSession
 
 ```
 POST /session
@@ -169,7 +169,7 @@ Modifies the [`createSession`](./webdriver.md#createsession) endpoint:
     All endpoints for this plugin can be invoked without creating a session, allowing you to prepare
     your test environment in advance.
 
-### `addStorageItem`
+### addStorageItem
 
 ```
 POST /storage/add
@@ -205,7 +205,7 @@ Example:
 }
 ```
 
-### `deleteStorageItem`
+### deleteStorageItem
 
 ```
 POST /storage/delete
@@ -224,7 +224,7 @@ Deletes a file in the storage.
 `boolean` - `true` upon successful file deletion, or `false` if the file does not exist in
 the storage 
 
-### `listStorageItems`
+### listStorageItems
 
 ```
 GET /storage/list
@@ -242,7 +242,7 @@ List all files present in the storage.
 |`path`|Full path to the file on the remote file system|string|
 |`size`|File size in bytes|number|
 
-### `resetStorage`
+### resetStorage
 
 ```
 POST /storage/reset
@@ -258,7 +258,7 @@ preserved, and only the incomplete uploads will be stopped.
 
 ## Universal XML Plugin
 
-### `findElement`
+### findElement
 
 ```
 POST /session/:sessionId/element
@@ -268,7 +268,7 @@ Modifies the [`findElement`](./webdriver.md#findelement) endpoint:
 
 * Adds support for universal node/attribute names for the `value` parameter (the selector)
 
-### `findElements`
+### findElements
 
 ```
 POST /session/:sessionId/elements
@@ -278,7 +278,7 @@ Modifies the [`findElements`](./webdriver.md#findelements) endpoint:
 
 * Adds support for universal node/attribute names for the `value` parameter (the selector)
 
-### `getPageSource`
+### getPageSource
 
 ```
 GET /session/:sessionId/source

--- a/packages/appium/docs/en/reference/api/webdriver.md
+++ b/packages/appium/docs/en/reference/api/webdriver.md
@@ -15,7 +15,7 @@ used in Appium.
     Most WebDriver endpoints are not implemented within Appium itself, and are instead proxied
     directly to the driver, which is responsible for the actual endpoint implementation.
 
-### `createSession`
+### createSession
 
 ```
 POST /session
@@ -47,7 +47,7 @@ supported, and any of the 3 parameters can be used to specify the W3C capabiliti
 |`sessionId`|ID of the new session|string|
 |`capabilities`|Capabilities processed by the driver|object|
 
-### `deleteSession`
+### deleteSession
 
 ```
 DELETE /session/:sessionId
@@ -61,7 +61,7 @@ Closes the current session.
 
 `null`
 
-### `getStatus`
+### getStatus
 
 ```
 GET /status
@@ -81,7 +81,7 @@ Retrieves the current status of the Appium server.
 |`message`|Explanation of the `ready` value|string|
 |`ready`|Whether the server is able to create new sessions|boolean|
 
-### `getTimeouts`
+### getTimeouts
 
 ```
 GET /session/:sessionId/timeouts
@@ -100,7 +100,7 @@ Retrieves the timeout values of the current session.
 |`command`|Command timeout|number|
 |`implicit`|Implicit wait timeout|number|
 
-### `timeouts`
+### timeouts
 
 ```
 POST /session/:sessionId/timeouts
@@ -122,7 +122,7 @@ Sets the timeout values of the current session.
 
 `null`
 
-### `setUrl`
+### setUrl
 
 ```
 POST /session/:sessionId/url
@@ -142,7 +142,7 @@ Navigates the current top-level browsing context to the specified URL.
 
 `null`
 
-### `getUrl`
+### getUrl
 
 ```
 GET /session/:sessionId/url
@@ -156,7 +156,7 @@ Retrieves the URL of the current top-level browsing context.
 
 `string` - the current URL
 
-### `back`
+### back
 
 ```
 POST /session/:sessionId/back
@@ -170,7 +170,7 @@ Navigates backwards in the browser history, if possible.
 
 `null`
 
-### `forward`
+### forward
 
 ```
 POST /session/:sessionId/forward
@@ -184,7 +184,7 @@ Navigates forwards in the browser history, if possible.
 
 `null`
 
-### `refresh`
+### refresh
 
 ```
 POST /session/:sessionId/refresh
@@ -198,7 +198,7 @@ Reloads the window of the current top-level browsing context.
 
 `null`
 
-### `title`
+### title
 
 ```
 GET /session/:sessionId/title
@@ -212,7 +212,7 @@ Retrieves the window title of the top-level browsing context.
 
 `string` - the page title
 
-### `getWindowHandle`
+### getWindowHandle
 
 ```
 GET /session/:sessionId/window
@@ -226,7 +226,7 @@ Retrieves the window handle of the top-level browsing context.
 
 `string` - the window handle identifier
 
-### `closeWindow`
+### closeWindow
 
 ```
 DELETE /session/:sessionId/window
@@ -240,7 +240,7 @@ Closes the current top-level browsing context.
 
 `string[]` - an array of zero or more remaining window handle identifiers
 
-### `setWindow`
+### setWindow
 
 ```
 POST /session/:sessionId/window
@@ -260,7 +260,7 @@ Selects the top-level browsing context.
 
 `null`
 
-### `getWindowHandles`
+### getWindowHandles
 
 ```
 GET /session/:sessionId/window/handles
@@ -274,7 +274,7 @@ Retrieves a list of window handles for every top-level browsing context.
 
 `string[]` - an array of zero or more window handle identifiers
 
-### `createNewWindow`
+### createNewWindow
 
 ```
 POST /session/:sessionId/window/new
@@ -300,7 +300,7 @@ Creates a new window or tab.
 |`type`|Type of the created window (`window` or `tab`)|string|
 
 
-### `setFrame`
+### setFrame
 
 ```
 POST /session/:sessionId/frame
@@ -320,7 +320,7 @@ Selects the top-level or child browsing context as the current browsing context.
 
 `null`
 
-### `switchToParentFrame`
+### switchToParentFrame
 
 ```
 POST /session/:sessionId/frame/parent
@@ -334,7 +334,7 @@ Sets the current browsing context to the parent of the current browsing context.
 
 `null`
 
-### `getWindowRect`
+### getWindowRect
 
 ```
 GET /session/:sessionId/window/rect
@@ -355,7 +355,7 @@ Retrieves the size and position of the current window.
 |`x`|X-axis position of the top-left corner of the window|number|
 |`y`|Y-axis position of the top-left corner of the window|number|
 
-### `setWindowRect`
+### setWindowRect
 
 ```
 POST /session/:sessionId/window/rect
@@ -378,7 +378,7 @@ Sets the size and/or position of the current window.
 
 [`Rect`](#response_18) - the new window size
 
-### `maximizeWindow`
+### maximizeWindow
 
 ```
 POST /session/:sessionId/window/maximize
@@ -392,7 +392,7 @@ Maximizes the current window.
 
 [`Rect`](#response_18) - the new window size
 
-### `minimizeWindow`
+### minimizeWindow
 
 ```
 POST /session/:sessionId/window/minimize
@@ -406,7 +406,7 @@ Minimizes the current window.
 
 [`Rect`](#response_18) - the new window size
 
-### `fullScreenWindow`
+### fullScreenWindow
 
 ```
 POST /session/:sessionId/window/fullscreen
@@ -420,7 +420,7 @@ Makes the current window fullscreen.
 
 [`Rect`](#response_18) - the new window size
 
-### `active`
+### active
 
 ```
 GET /session/:sessionId/element/active
@@ -439,7 +439,7 @@ Retrieves the currently focused element.
 |`element-6066-11e4-a52e-4f735466cecf`|Element ID|string|
 |`ELEMENT`|Element ID (same value as `element-6066-11e4-a52e-4f735466cecf`). This key was used in the legacy Mobile JSON Wire Protocol (MJSONWP).|string|
 
-### `elementShadowRoot`
+### elementShadowRoot
 
 ```
 GET /session/:sessionId/element/:elementId/shadow
@@ -457,7 +457,7 @@ Retrieves the shadow root of the element identified by `:elementId`.
 |--|--|--|
 |`shadow-6066-11e4-a52e-4f735466cecf`|Shadow root ID|string|
 
-### `findElement`
+### findElement
 
 ```
 POST /session/:sessionId/element
@@ -479,7 +479,7 @@ location strategy, starting from the root node.
 
 [`Element`](#response_23)
 
-### `findElements`
+### findElements
 
 ```
 POST /session/:sessionId/elements
@@ -501,7 +501,7 @@ strategy, starting from the root node.
 
 `Element[]` - an array containing zero or more [`Element` objects](#response_23)
 
-### `findElementFromElement`
+### findElementFromElement
 
 ```
 POST /session/:sessionId/element/:elementId/element
@@ -523,7 +523,7 @@ location strategy, starting from the element node identified by `:elementId`.
 
 [`Element`](#response_23)
 
-### `findElementsFromElement`
+### findElementsFromElement
 
 ```
 POST /session/:sessionId/element/:elementId/elements
@@ -545,7 +545,7 @@ strategy, starting from the element node identified by `:elementId`.
 
 [`Element[]`](#response_26)
 
-### `findElementFromShadowRoot`
+### findElementFromShadowRoot
 
 ```
 POST /session/:sessionId/shadow/:shadowId/element
@@ -567,7 +567,7 @@ location strategy, starting from the shadow root node identified by `:shadowId`.
 
 [`Element`](#response_23)
 
-### `findElementsFromShadowRoot`
+### findElementsFromShadowRoot
 
 ```
 POST /session/:sessionId/shadow/:shadowId/elements
@@ -589,7 +589,7 @@ strategy, starting from the shadow root node identified by `:shadowId`.
 
 [`Element[]`](#response_26)
 
-### `elementSelected`
+### elementSelected
 
 ```
 GET /session/:sessionId/element/:elementId/selected
@@ -604,7 +604,7 @@ relevant to certain element types, such as checkboxes, radio buttons, or options
 
 `boolean` - `true` if the element is selected, otherwise `false`
 
-### `elementDisplayed`
+### elementDisplayed
 
 ```
 GET /session/:sessionId/element/:elementId/displayed
@@ -618,7 +618,7 @@ Determines if the element identified by `:elementId` is currently displayed.
 
 `boolean` - `true` if the element is displayed, otherwise `false`
 
-### `getAttribute`
+### getAttribute
 
 ```
 GET /session/:sessionId/element/:elementId/attribute/:name
@@ -632,7 +632,7 @@ Retrieves the value of the `:name` attribute for the element identified by `:ele
 
 `string` - the attribute value, or `null` if the attribute does not exist
 
-### `getProperty`
+### getProperty
 
 ```
 GET /session/:sessionId/element/:elementId/property/:name
@@ -646,7 +646,7 @@ Retrieves the value of the `:name` property for the element identified by `:elem
 
 `string` - the property value, or `null` if the property does not exist
 
-### `getCssProperty`
+### getCssProperty
 
 ```
 GET /session/:sessionId/element/:elementId/css/:propertyName
@@ -661,7 +661,7 @@ Retrieves the value of the `:propertyName` computed CSS property for the element
 
 `string` - the CSS property value, or `null` if the property does not exist
 
-### `getText`
+### getText
 
 ```
 GET /session/:sessionId/element/:elementId/text
@@ -676,7 +676,7 @@ elements (if any).
 
 `string` - the element text (including its child elements)
 
-### `getName`
+### getName
 
 ```
 GET /session/:sessionId/element/:elementId/name
@@ -690,7 +690,7 @@ Retrieves the tag name of the element identified by `:elementId`.
 
 `string` - the element tag name
 
-### `getElementRect`
+### getElementRect
 
 ```
 GET /session/:sessionId/element/:elementId/rect
@@ -704,7 +704,7 @@ Retrieves the dimensions and coordinates of the element identified by `:elementI
 
 [`Rect`](#response_18)
 
-### `elementEnabled`
+### elementEnabled
 
 ```
 GET /session/:sessionId/element/:elementId/enabled
@@ -719,7 +719,7 @@ relevant to certain element types, such as buttons, input fields, checkboxes, et
 
 `boolean` - `true` if the element is enabled, otherwise `false`
 
-### `getComputedRole`
+### getComputedRole
 
 ```
 GET /session/:sessionId/element/:elementId/computedrole
@@ -734,7 +734,7 @@ identified by `:elementId`.
 
 `string` - the element computed role
 
-### `getComputedLabel`
+### getComputedLabel
 
 ```
 GET /session/:sessionId/element/:elementId/computedlabel
@@ -749,7 +749,7 @@ element identified by `:elementId`.
 
 `string` - the element accessible name
 
-### `click`
+### click
 
 ```
 POST /session/:sessionId/element/:elementId/click
@@ -763,7 +763,7 @@ Clicks on the identified by `:elementId`.
 
 `null`
 
-### `clear`
+### clear
 
 ```
 POST /session/:sessionId/element/:elementId/clear
@@ -778,7 +778,7 @@ such as input fields.
 
 `null`
 
-### `setValue`
+### setValue
 
 ```
 POST /session/:sessionId/element/:elementId/value
@@ -799,7 +799,7 @@ keyboard-interactable element types, such as input fields.
 
 `null`
 
-### `getPageSource`
+### getPageSource
 
 ```
 GET /session/:sessionId/source
@@ -813,7 +813,7 @@ Retrieves the page/application source of the current browsing context in HTML/XM
 
 `string` - the DOM of the current browsing context
 
-### `execute`
+### execute
 
 ```
 POST /session/:sessionId/execute/sync
@@ -834,7 +834,7 @@ Executes synchronous JavaScript code in the current browsing context.
 
 `any` - the result of the script execution
 
-### `executeAsync`
+### executeAsync
 
 ```
 POST /session/:sessionId/execute/async
@@ -859,7 +859,7 @@ passed to this completion function is returned as the endpoint response.
 
 `any` - the result returned by the completion function of the script
 
-### `getCookies`
+### getCookies
 
 ```
 GET /session/:sessionId/cookie
@@ -873,7 +873,7 @@ Retrieves all cookies of the current browsing context.
 
 `Cookie[]` - an array containing zero or more [`Cookie` objects](#response_49)
 
-### `getCookie`
+### getCookie
 
 ```
 GET /session/:sessionId/cookie/:name
@@ -898,7 +898,7 @@ Retrieves a cookie with the name identified by `:name` from the current browsing
 |`secure?`|Whether the cookie is a secure cookie|boolean|
 |`value`|Cookie value|string|
 
-### `setCookie`
+### setCookie
 
 ```
 POST /session/:sessionId/cookie
@@ -918,7 +918,7 @@ Adds a cookie to the cookie store of the current browsing context.
 
 `null`
 
-### `deleteCookie`
+### deleteCookie
 
 ```
 DELETE /session/:sessionId/cookie/:name
@@ -932,7 +932,7 @@ Deletes a cookie with the name identified by `:name` from the current browsing c
 
 `null`
 
-### `deleteCookies`
+### deleteCookies
 
 ```
 DELETE /session/:sessionId/cookie
@@ -946,7 +946,7 @@ Deletes all cookies from the current browsing context.
 
 `null`
 
-### `performActions`
+### performActions
 
 ```
 POST /session/:sessionId/actions
@@ -966,7 +966,7 @@ Performs a sequence of [actions](https://w3c.github.io/webdriver/#actions).
 
 `null`
 
-### `releaseActions`
+### releaseActions
 
 ```
 DELETE /session/:sessionId/actions
@@ -980,7 +980,7 @@ Releases all currently depressed keys and pointer buttons.
 
 `null`
 
-### `postDismissAlert`
+### postDismissAlert
 
 ```
 POST /session/:sessionId/alert/dismiss
@@ -994,7 +994,7 @@ Dismisses the currently displayed user prompt.
 
 `null`
 
-### `postAcceptAlert`
+### postAcceptAlert
 
 ```
 POST /session/:sessionId/alert/accept
@@ -1008,7 +1008,7 @@ Accepts the currently displayed user prompt.
 
 `null`
 
-### `getAlertText`
+### getAlertText
 
 ```
 GET /session/:sessionId/alert/text
@@ -1022,7 +1022,7 @@ Retrieves the text of the currently displayed user prompt.
 
 `string` - prompt text
 
-### `setAlertText`
+### setAlertText
 
 ```
 POST /session/:sessionId/alert/text
@@ -1042,7 +1042,7 @@ Sets the text of the currently displayed user prompt.
 
 `null`
 
-### `getScreenshot`
+### getScreenshot
 
 ```
 GET /session/:sessionId/screenshot
@@ -1056,7 +1056,7 @@ Takes a screenshot of the current browsing context.
 
 `string` - a base64-encoded PNG image
 
-### `getElementScreenshot`
+### getElementScreenshot
 
 ```
 GET /session/:sessionId/element/:elementId/screenshot

--- a/packages/appium/docs/mkdocs-en.yml
+++ b/packages/appium/docs/mkdocs-en.yml
@@ -47,6 +47,7 @@ nav:
           - reference/api/webdriver.md
           - reference/api/bidi.md
           - reference/api/jsonwp.md
+          - reference/api/mjsonwp.md
           - reference/api/appium.md
           - reference/api/others.md
           - reference/api/plugins.md


### PR DESCRIPTION
Finishing the implementation of #20210, this PR adds all the implemented JSONWP and MJSONWP endpoints that are missing from the docs.
The only remaining undocumented endpoint now is `/session/:sessionId/receive_async_response`, to which I could not find a reference in any protocol, and its Appium protocol version was removed in Appium 3 anyway.

Resolves #20210.