### PR TITLE
feat: add W3C printPage endpoint

### DIFF
--- a/packages/appium/docs/en/reference/api/webdriver.md
+++ b/packages/appium/docs/en/reference/api/webdriver.md
@@ -1070,3 +1070,45 @@ identified by `:elementId`.
 #### Response
 
 `string` - a base64-encoded PNG image
+
+### printPage
+
+```
+POST /session/:sessionId/print
+```
+
+> WebDriver documentation: [Print Page](https://w3c.github.io/webdriver/#print-page)
+
+Prints the page by rendering it as a paginated PDF document.
+
+#### Parameters
+
+|<div style="width:7em">Name</div>|Description|<div style="width:9em">Type</div>|Default|
+|--|--|--|--|
+|`orientation?`|Page orientation. Supported values are `portrait` or `landscape`.|string|`portrait`|
+|`scale?`|Page scale. Supported values are in the range `[0.1, 2]`.|number|`1`|
+|`background?`|Whether to include background images|boolean|`false`|
+|`page?`|Object specifying the page width and height|[`PrintPageSize`](#printpagesizeparameter)|`{}`|
+|`margin?`|Object specifying the page margins|[`PrintPageMargins`](#printpagemarginsparameter)|`{}`|
+|`shrinkToFit?`|Whether to resize page contents to match `PrintPageSize.width`|boolean|`true`|
+|`pageRanges?`|Array of pages to be printed, for example, `[1, 4, '8-9']`|array|`[]`|
+
+##### `PrintPageSize`
+
+|Name|Description|Type|Default|
+|--|--|--|--|
+|`width?`|Page width. Must be greater than or equal to `(2.54 / 72)`.|number|`21.59`|
+|`height?`|Page height. Must be greater than or equal to `(2.54 / 72)`.|number|`27.94`|
+
+##### `PrintPageMargins`
+
+|Name|Description|Type|Default|
+|--|--|--|--|
+|`top?`|Page top margin. Must be greater than or equal to `0`.|number|`1`|
+|`bottom?`|Page bottom margin. Must be greater than or equal to `0`.|number|`1`|
+|`left?`|Page left margin. Must be greater than or equal to `0`.|number|`1`|
+|`right?`|Page right margin. Must be greater than or equal to `0`.|number|`1`|
+
+#### Response
+
+`string` - a base64-encoded PDF document

--- a/packages/base-driver/lib/protocol/routes.js
+++ b/packages/base-driver/lib/protocol/routes.js
@@ -232,6 +232,22 @@ export const METHOD_MAP = /** @type {const} */ ({
   '/session/:sessionId/element/:elementId/screenshot': {
     GET: {command: 'getElementScreenshot'},
   },
+  '/session/:sessionId/print': {
+    POST: {
+      command: 'printPage',
+      payloadParams: {
+        optional: [
+          'orientation',
+          'scale',
+          'background',
+          'page',
+          'margin',
+          'shrinkToFit',
+          'pageRanges',
+        ],
+      }
+    }
+  },
   // #endregion
   // #region JSONWP
   // https://www.selenium.dev/documentation/legacy/json_wire_protocol/

--- a/packages/base-driver/test/unit/protocol/routes.spec.js
+++ b/packages/base-driver/test/unit/protocol/routes.spec.js
@@ -41,7 +41,7 @@ describe('Routes', function () {
       }
       let hash = shasum.digest('hex').substring(0, 8);
       // Modify the hash whenever the protocol has intentionally been modified.
-      hash.should.equal('e4d92329');
+      hash.should.equal('f50205cd');
     });
   });
 

--- a/packages/types/lib/commands/webdriver.ts
+++ b/packages/types/lib/commands/webdriver.ts
@@ -440,6 +440,30 @@ export interface IWDClassicCommands {
    * @returns A base64-encoded string representing the PNG image data for the element rect
    */
   getElementScreenshot?(elementId: string): Promise<string>;
+
+  /**
+   * Print the page by rendering it as a PDF document
+   * @see {@link https://w3c.github.io/webdriver/#print-page}
+   *
+   * @param orientation - the orientation of the page ("portrait" or "landscape")
+   * @param scale - the page scale, between 0.1 and 2
+   * @param background - whether to include background images
+   * @param page - the width and height of the printed page
+   * @param margin - the margins of the printed page
+   * @param shrinkToFit - whether to resize page contents to match {@linkcode PrintPageSize.width}
+   * @param pageRanges - array of page numbers and/or page ranges (dash-separated strings) to be printed
+   *
+   * @returns A base64-encoded string representing the PDF document
+   */
+  printPage?(
+    orientation?: string,
+    scale?: number,
+    background?: boolean,
+    page?: PrintPageSize,
+    margin?: PrintPageMargins,
+    shrinkToFit?: boolean,
+    pageRanges?: (number | string)[]
+  ): Promise<string>;
 }
 
 export type NewWindowType = 'tab' | 'window';
@@ -472,4 +496,16 @@ export interface Cookie {
   httpOnly?: boolean;
   expiry?: number;
   sameSite?: 'Lax' | 'Strict';
+}
+
+export interface PrintPageSize {
+  width?: number;
+  height?: number;
+}
+
+export interface PrintPageMargins {
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
 }


### PR DESCRIPTION
## Proposed changes

This PR adds proxy support for the W3C WebDriver [Print Page](https://w3c.github.io/webdriver/#print-page) endpoint, which was missing from the list of supported endpoints.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
