### PR TITLE
feat: add inspector to plugins installed via `appium setup`

### DIFF
--- a/packages/appium/docs/en/reference/cli/setup.md
+++ b/packages/appium/docs/en/reference/cli/setup.md
@@ -20,7 +20,7 @@ mentioned below.
 Installs the following extensions for browser webview testing:
 
 * Drivers: `safari`[^1], `gecko`, `chromium`
-* Plugins: `images`
+* Plugins: `images`, `inspector`
 
 #### Usage
 
@@ -33,7 +33,7 @@ appium setup browser
 Installs the following extensions for desktop application testing:
 
 * Drivers: `mac2`[^1], `windows`[^2]
-* Plugins: `images`
+* Plugins: `images`, `inspector`
 
 #### Usage
 
@@ -46,7 +46,7 @@ appium setup desktop
 Installs the following extensions for mobile testing:
 
 * Drivers: `uiautomator2`, `xcuitest`[^1], `espresso`
-* Plugins: `images`
+* Plugins: `images`, `inspector`
 
 #### Usage
 

--- a/packages/appium/lib/cli/setup-command.js
+++ b/packages/appium/lib/cli/setup-command.js
@@ -34,7 +34,7 @@ const DRIVERS_ONLY_WINDOWS = ['windows'];
 /**
  * Plugin names listed in KNOWN_PLUGINS to install by default.
  */
-export const DEFAULT_PLUGINS = ['images'];
+export const DEFAULT_PLUGINS = ['images', 'inspector'];
 
 /**
  * Return a list of drivers available for current host platform.


### PR DESCRIPTION
## Proposed changes

This adds the `inspector` plugin to the list of plugins installed when using the `appium setup` CLI command.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
