### PR TITLE
fix(appium): return bidi webSocketUrl without basePath

### DIFF
--- a/packages/appium/lib/appium.js
+++ b/packages/appium/lib/appium.js
@@ -396,7 +396,7 @@ class AppiumDriver extends DriverCore {
         const {address, port, basePath} = this.args;
         const scheme = `ws${this.server.isSecure() ? 's' : ''}`;
         const host = bidiCommands.determineBiDiHost(address);
-        const bidiUrl = `${scheme}://${host}:${port}${basePath}${BIDI_BASE_PATH}/${innerSessionId}`;
+        const bidiUrl = `${scheme}://${host}:${port}${BIDI_BASE_PATH}/${innerSessionId}`;
         this.log.info(
           `Upstream driver responded with webSocketUrl ${dCaps.webSocketUrl}, will rewrite to ` +
           `${bidiUrl} for response to client`

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -27,7 +27,7 @@ import {
 } from './config';
 import {readConfigFile} from './config-file';
 import {loadExtensions, getActivePlugins, getActiveDrivers} from './extension';
-import {SERVER_SUBCOMMAND, LONG_STACKTRACE_LIMIT} from './constants';
+import {SERVER_SUBCOMMAND, LONG_STACKTRACE_LIMIT, BIDI_BASE_PATH} from './constants';
 import registerNode from './grid-register';
 import {getDefaultsForSchema, validate as validateSchema} from './schema/schema';
 import {
@@ -411,8 +411,8 @@ async function main(args) {
   bidiServer.on('error', appiumDriver.onBidiServerError.bind(appiumDriver));
   try {
     server = await baseServer(serverOpts);
-    server.addWebSocketHandler('/bidi', bidiServer);
-    server.addWebSocketHandler('/bidi/:sessionId', bidiServer);
+    server.addWebSocketHandler(`${BIDI_BASE_PATH}`, bidiServer);
+    server.addWebSocketHandler(`${BIDI_BASE_PATH}/:sessionId`, bidiServer);
   } catch (err) {
     logger.error(
       `Could not configure Appium server. It's possible that a driver or plugin tried ` +


### PR DESCRIPTION
## Proposed changes

If appium is started with `--base-path`, then it's also included into the returned `webSocketUrl`, and then Bidi does not work, as the related code does not take basePath into account.

It seems simpler to remove basePath from the returned `webSocketUrl`, alternatively it can be made working with basePath.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
