### PR TITLE
chore(deps): remove vulnerable axios versions from lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5798,7 +5798,6 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
       "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -21078,17 +21077,6 @@
         "npm": ">=10"
       }
     },
-    "packages/appium/node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "packages/appium/node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -21156,17 +21144,6 @@
       },
       "optionalDependencies": {
         "spdy": "4.0.2"
-      }
-    },
-    "packages/base-driver/node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/base-driver/node_modules/body-parser": {
@@ -21580,17 +21557,6 @@
       "peerDependencies": {
         "appium": "^3.0.0-beta.0",
         "mocha": "*"
-      }
-    },
-    "packages/driver-test-support/node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "packages/driver-test-support/node_modules/type-fest": {
@@ -22413,17 +22379,6 @@
         "sharp": "0.34.4"
       }
     },
-    "packages/support/node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "packages/support/node_modules/glob": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
@@ -22701,15 +22656,6 @@
         "type-fest": "5.0.1"
       },
       "dependencies": {
-        "axios": {
-          "version": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-          "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
         "body-parser": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -22963,15 +22909,6 @@
         "type-fest": "5.0.1"
       },
       "dependencies": {
-        "axios": {
-          "version": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-          "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
         "type-fest": {
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.0.1.tgz",
@@ -23492,15 +23429,6 @@
         "yauzl": "3.2.0"
       },
       "dependencies": {
-        "axios": {
-          "version": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-          "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
         "glob": {
           "version": "11.0.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
@@ -26974,15 +26902,6 @@
         "yaml": "2.8.1"
       },
       "dependencies": {
-        "axios": {
-          "version": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-          "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
         "lilconfig": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -27326,7 +27245,6 @@
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
       "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
-      "dev": true,
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",


### PR DESCRIPTION
Running `npm i` on the current master returns 1 vulnerability due to `axios`, even though all `package.json` files explicitly specify non-vulnerable versions. This is a manual adjustment of the lockfile to ensure only non-vulnerable versions are used.