### PR TITLE
chore(deps): remove @types/uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "@types/source-map-support": "0.5.10",
         "@types/supports-color": "8.1.3",
         "@types/teen_process": "2.0.4",
-        "@types/uuid": "11.0.0",
         "@types/which": "3.0.4",
         "@types/wrap-ansi": "3.0.0",
         "@types/ws": "8.18.1",
@@ -4126,17 +4125,6 @@
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@types/which": {
       "version": "3.0.4",
@@ -26169,15 +26157,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
-    "@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "dev": true,
-      "requires": {
-        "uuid": "*"
-      }
     },
     "@types/which": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "@types/source-map-support": "0.5.10",
     "@types/supports-color": "8.1.3",
     "@types/teen_process": "2.0.4",
-    "@types/uuid": "11.0.0",
     "@types/which": "3.0.4",
     "@types/wrap-ansi": "3.0.0",
     "@types/ws": "8.18.1",


### PR DESCRIPTION
`uuid` already includes built-in types since version 11, so this package is not needed.