### PR TITLE
docs(appium): Update Selenium Grid guide to address breaking changes to 4.35 relay behaviour

### DIFF
--- a/packages/appium/docs/en/guides/grid.md
+++ b/packages/appium/docs/en/guides/grid.md
@@ -22,9 +22,11 @@ server:
   use-drivers:
     - xcuitest
   default-capabilities:
-    wdaLocalPort: 8100
-    mjpegServerPort: 9100
-    mjpegScreenshotUrl: "http://localhost:9100"
+    appium:wdaLocalPort: 8100
+    appium:mjpegServerPort: 9100
+    appium:mjpegScreenshotUrl: "http://localhost:9100"
+    appium:platformVersion: "26.0"
+    appium:deviceName: "iPhone 17"
 ```
 
 In the above YAML config file, we specify the Appium server port, the driver used, and parameters
@@ -39,9 +41,11 @@ server:
   use-drivers:
     - xcuitest
   default-capabilities:
-    wdaLocalPort: 8110
-    mjpegServerPort: 9110
-    mjpegScreenshotUrl: "http://localhost:9110"
+    appium:wdaLocalPort: 8110
+    appium:mjpegServerPort: 9110
+    appium:mjpegScreenshotUrl: "http://localhost:9110"
+    appium:platformVersion: "26.0"
+    appium:deviceName: "iPhone 16"
 ```
 
 ### Define the Grid node configs
@@ -60,11 +64,15 @@ port = 5555
 [node]
 detect-drivers = false
 
+[events]
+publish = "tcp://HUB_IP_ADDRESS:4442"
+subscribe = "tcp://HUB_IP_ADDRESS:4443"
+
 [relay]
 url = "http://localhost:4723"
 status-endpoint = "/status"
 configs = [
-    "1", "{\"platformName\": \"iOS\", \"appium:platformVersion\": \"15.5\", \"appium:deviceName\": \"iPhone 13\", \"appium:automationName\": \"XCUITest\"}"
+    "1", "{\"platformName\": \"iOS\", \"appium:automationName\": \"XCUITest\"}"
 ]
 ```
 
@@ -76,11 +84,15 @@ port = 5565
 [node]
 detect-drivers = false
 
+[events]
+publish = "tcp://HUB_IP_ADDRESS:4442"
+subscribe = "tcp://HUB_IP_ADDRESS:4443"
+
 [relay]
 url = "http://localhost:4733"
 status-endpoint = "/status"
 configs = [
-    "1", "{\"platformName\": \"iOS\", \"appium:platformVersion\": \"15.5\", \"appium:deviceName\": \"iPhone 12\", \"appium:automationName\": \"XCUITest\"}"
+    "1", "{\"platformName\": \"iOS\", \"appium:automationName\": \"XCUITest\"}"
 ]
 ```
 


### PR DESCRIPTION
## Proposed changes

Selenium Grid 4 is currently on version 4.38, in 4.35 there was a change to the relay mechanism (I believe it to be this line in the release notes `[grid] Restructuring classes have stateful data and improve Node health checks in LocalDistributor (#16151)`). This has led to the capabilities `deviceName` and `platformVersion` no longer being matched and merged into Appium server Caps if they are specified in the node config file.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
