### PR TITLE
feat(docutils): add 3 Material for MkDocs features

### DIFF
--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -75,8 +75,11 @@ theme:
     - content.action.edit
     - content.code.annotate
     - content.code.copy
+    - content.footnote.tooltips
     - content.tabs.link
+    - content.tooltips
     - navigation.indexes
+    - navigation.path
     - navigation.sections
     - navigation.tabs
     - navigation.top


### PR DESCRIPTION
This enables a few features from Material for MkDocs:
* [Improved tooltips](https://squidfunk.github.io/mkdocs-material/reference/tooltips/#improved-tooltips)
* [Footnote tooltips](https://squidfunk.github.io/mkdocs-material/reference/footnotes/#footnote-tooltips)
* [Navigation paths (breadcrumbs)
](https://squidfunk.github.io/mkdocs-material/setup/setting-up-navigation/#navigation-path)

There is also [the ability to stay on page when switching languages](https://squidfunk.github.io/mkdocs-material/setup/changing-the-language/#stay-on-page), which was automatically enabled upon updating to `mkdocs-material` `9.7.0` (#21710).

Furthermore, it is worth noting that Material for MkDocs is now in maintenance mode. We should look into switching to its replacement [Zensical](https://zensical.org/), once it has all the features we use (namely, support for `mkdocs-redirects`).