### PR TITLE
feat(base-driver): add ability to supply custom headers for proxy

### DIFF
--- a/packages/base-driver/lib/jsonwp-proxy/proxy.js
+++ b/packages/base-driver/lib/jsonwp-proxy/proxy.js
@@ -34,6 +34,7 @@ const ALLOWED_OPTS = [
   'timeout',
   'log',
   'keepAlive',
+  'headers',
 ];
 
 export class JWProxy {
@@ -51,6 +52,8 @@ export class JWProxy {
   sessionId;
   /** @type {number} */
   timeout;
+  /** @type {import('@appium/types').HTTPHeaders | undefined} */
+  headers;
   /** @type {Protocol | null | undefined} */
   _downstreamProtocol;
   /** @type {ProxyRequest[]} */
@@ -192,6 +195,7 @@ export class JWProxy {
         'content-type': 'application/json; charset=utf-8',
         'user-agent': 'appium',
         accept: 'application/json, */*',
+        ...(this.headers ?? {}),
       },
       proxy: false,
       timeout: this.timeout,

--- a/packages/types/lib/http.ts
+++ b/packages/types/lib/http.ts
@@ -91,6 +91,14 @@ export interface ProxyOptions {
    * @default true
    */
   keepAlive?: boolean;
+  /**
+   * Additional HTTP headers to send to the downstream server on every request.
+   *
+   * These headers are merged into the default headers Appium uses
+   * (`content-type`, `user-agent`, `accept`). If a header provided here
+   * has the same name as a default header, the value provided here wins.
+   */
+  headers?: HTTPHeaders;
 }
 
 export type HTTPBody<T = any> = T;


### PR DESCRIPTION
## Proposed changes

Remote servers may be behind authentication and it's industry-standard to provide tokens via headers.

The main example we need this is that the appium-xcuitest-driver needs to make calls to WebDriverAgent server that is behind a gateway that checks for `Authorization` header.

I'll follow up with a change in `WebDriverAgent` project to make it pass through the authorization header from client to this proxy object.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
