### PR TITLE
chore(deps): remove `source-map-support`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "@types/shell-quote": "1.7.5",
         "@types/sinon": "21.0.0",
         "@types/sinon-chai": "4.0.0",
-        "@types/source-map-support": "0.5.10",
         "@types/supports-color": "8.1.3",
         "@types/teen_process": "2.0.4",
         "@types/which": "3.0.4",
@@ -1959,6 +1958,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3572,6 +3572,7 @@
       "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -4173,6 +4174,7 @@
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -4287,6 +4289,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.3.tgz",
       "integrity": "sha512-gqkrWUsS8hcm0r44yn7/xZeV1ERva/nLgrLxFRUGb7aoNMIJfZJ3AC261zDQuOAKC7MiXai1WCpYc48jAHoShQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -4403,15 +4406,6 @@
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "license": "MIT"
     },
-    "node_modules/@types/source-map-support": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.10.tgz",
-      "integrity": "sha512-tgVP2H469x9zq34Z0m/fgPewGhg/MLClalNOiPIzQlXrSS2YrKu/xCdSCKnEDwkFha51VKEKB6A9wW26/ZNwzA==",
-      "dev": true,
-      "dependencies": {
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/@types/supports-color": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
@@ -4526,6 +4520,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -5482,6 +5477,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5539,6 +5535,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -6877,6 +6874,7 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
       "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8923,6 +8921,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12720,6 +12719,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14060,6 +14060,7 @@
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
       "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
@@ -14962,6 +14963,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -18952,6 +18954,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19512,6 +19515,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19674,6 +19678,7 @@
       "integrity": "sha512-OhuAzBImFPjKNgZ2JwHMfGFUA6NSbRegd1+BPjC1Y0E6X9Y/vJ4zKeGmIMqmlYboj6cMNEwKI+xQisrg4J0HaQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.2.2"
       },
@@ -20861,6 +20866,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "dev": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -20904,7 +20910,6 @@
         "package-changed": "3.0.0",
         "resolve-from": "5.0.0",
         "semver": "7.7.3",
-        "source-map-support": "0.5.21",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
         "winston": "3.19.0",
@@ -20990,7 +20995,6 @@
         "morgan": "1.10.1",
         "path-to-regexp": "8.3.0",
         "serve-favicon": "2.5.1",
-        "source-map-support": "0.5.21",
         "type-fest": "5.3.1"
       },
       "engines": {
@@ -21051,7 +21055,6 @@
         "lodash": "4.17.21",
         "pkg-dir": "5.0.0",
         "read-pkg": "5.2.0",
-        "source-map-support": "0.5.21",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
         "yaml": "2.8.2",
@@ -21285,7 +21288,6 @@
         "get-port": "5.1.1",
         "lodash": "4.17.21",
         "sinon": "21.0.0",
-        "source-map-support": "0.5.21",
         "type-fest": "5.3.1"
       },
       "engines": {
@@ -21341,7 +21343,6 @@
       "dependencies": {
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
-        "source-map-support": "0.5.21",
         "webdriverio": "9.21.0"
       },
       "engines": {
@@ -21876,7 +21877,6 @@
         "asyncbox": "3.0.0",
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
-        "source-map-support": "0.5.21",
         "xpath": "0.0.34"
       },
       "engines": {
@@ -21895,8 +21895,7 @@
         "@appium/base-plugin": "^3.0.5",
         "@appium/support": "^7.0.4",
         "bluebird": "3.7.2",
-        "lodash": "4.17.21",
-        "source-map-support": "0.5.21"
+        "lodash": "4.17.21"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -21915,8 +21914,7 @@
         "@appium/support": "^7.0.4",
         "lodash": "4.17.21",
         "lru-cache": "11.2.4",
-        "sharp": "0.34.5",
-        "source-map-support": "0.5.21"
+        "sharp": "0.34.5"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -21967,8 +21965,7 @@
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
         "opencv-bindings": "4.5.5",
-        "sharp": "0.34.5",
-        "source-map-support": "0.5.21"
+        "sharp": "0.34.5"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -21983,7 +21980,6 @@
         "@appium/types": "^1.1.2",
         "get-port": "5.1.1",
         "log-symbols": "4.1.0",
-        "source-map-support": "0.5.21",
         "teen_process": "3.0.5"
       },
       "engines": {
@@ -22000,8 +21996,7 @@
       "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "lodash": "4.17.21",
-        "source-map-support": "0.5.21"
+        "lodash": "4.17.21"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -22016,8 +22011,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "json-schema": "0.4.0",
-        "source-map-support": "0.5.21"
+        "json-schema": "0.4.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -22035,7 +22029,6 @@
         "lodash": "4.17.21",
         "lru-cache": "11.2.4",
         "rimraf": "6.1.2",
-        "source-map-support": "0.5.21",
         "ws": "8.18.3"
       },
       "engines": {
@@ -22101,7 +22094,6 @@
         "sanitize-filename": "1.6.3",
         "semver": "7.7.3",
         "shell-quote": "1.8.3",
-        "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
@@ -22270,8 +22262,7 @@
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
         "loud-rejection": "2.2.0",
-        "sinon": "21.0.0",
-        "source-map-support": "0.5.21"
+        "sinon": "21.0.0"
       },
       "bin": {
         "android-emu-travis-post": "bin/android-emu-travis-post.sh",
@@ -22332,7 +22323,6 @@
         "@xmldom/xmldom": "0.9.8",
         "fast-xml-parser": "5.3.2",
         "lodash": "4.17.21",
-        "source-map-support": "0.5.21",
         "xpath": "0.0.34"
       },
       "engines": {
@@ -22381,7 +22371,6 @@
         "morgan": "1.10.1",
         "path-to-regexp": "8.3.0",
         "serve-favicon": "2.5.1",
-        "source-map-support": "0.5.21",
         "spdy": "4.0.2",
         "type-fest": "5.3.1"
       },
@@ -22419,7 +22408,6 @@
         "lodash": "4.17.21",
         "pkg-dir": "5.0.0",
         "read-pkg": "5.2.0",
-        "source-map-support": "0.5.21",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
         "yaml": "2.8.2",
@@ -22559,7 +22547,6 @@
         "get-port": "5.1.1",
         "lodash": "4.17.21",
         "sinon": "21.0.0",
-        "source-map-support": "0.5.21",
         "type-fest": "5.3.1"
       },
       "dependencies": {
@@ -22591,7 +22578,6 @@
       "requires": {
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
-        "source-map-support": "0.5.21",
         "webdriverio": "9.21.0"
       },
       "dependencies": {
@@ -22933,7 +22919,6 @@
         "asyncbox": "3.0.0",
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
-        "source-map-support": "0.5.21",
         "xpath": "0.0.34"
       }
     },
@@ -22943,8 +22928,7 @@
         "@appium/base-plugin": "^3.0.5",
         "@appium/support": "^7.0.4",
         "bluebird": "3.7.2",
-        "lodash": "4.17.21",
-        "source-map-support": "0.5.21"
+        "lodash": "4.17.21"
       }
     },
     "@appium/images-plugin": {
@@ -22954,8 +22938,7 @@
         "@appium/support": "^7.0.4",
         "lodash": "4.17.21",
         "lru-cache": "11.2.4",
-        "sharp": "0.34.5",
-        "source-map-support": "0.5.21"
+        "sharp": "0.34.5"
       },
       "dependencies": {
         "lru-cache": {
@@ -22987,8 +22970,7 @@
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
         "opencv-bindings": "4.5.5",
-        "sharp": "0.34.5",
-        "source-map-support": "0.5.21"
+        "sharp": "0.34.5"
       }
     },
     "@appium/plugin-test-support": {
@@ -22997,22 +22979,19 @@
         "@appium/types": "^1.1.2",
         "get-port": "5.1.1",
         "log-symbols": "4.1.0",
-        "source-map-support": "0.5.21",
         "teen_process": "3.0.5"
       }
     },
     "@appium/relaxed-caps-plugin": {
       "version": "file:packages/relaxed-caps-plugin",
       "requires": {
-        "lodash": "4.17.21",
-        "source-map-support": "0.5.21"
+        "lodash": "4.17.21"
       }
     },
     "@appium/schema": {
       "version": "file:packages/schema",
       "requires": {
-        "json-schema": "0.4.0",
-        "source-map-support": "0.5.21"
+        "json-schema": "0.4.0"
       }
     },
     "@appium/storage-plugin": {
@@ -23024,7 +23003,6 @@
         "lodash": "4.17.21",
         "lru-cache": "11.2.4",
         "rimraf": "6.1.2",
-        "source-map-support": "0.5.21",
         "ws": "8.18.3"
       },
       "dependencies": {
@@ -23074,7 +23052,6 @@
         "semver": "7.7.3",
         "sharp": "0.34.5",
         "shell-quote": "1.8.3",
-        "source-map-support": "0.5.21",
         "supports-color": "8.1.1",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
@@ -23170,8 +23147,7 @@
         "bluebird": "3.7.2",
         "lodash": "4.17.21",
         "loud-rejection": "2.2.0",
-        "sinon": "21.0.0",
-        "source-map-support": "0.5.21"
+        "sinon": "21.0.0"
       }
     },
     "@appium/tsconfig": {
@@ -23205,7 +23181,6 @@
         "@xmldom/xmldom": "0.9.8",
         "fast-xml-parser": "5.3.2",
         "lodash": "4.17.21",
-        "source-map-support": "0.5.21",
         "xpath": "0.0.34"
       }
     },
@@ -24208,7 +24183,8 @@
           "version": "4.0.2",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
           "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "rimraf": {
           "version": "4.4.1",
@@ -25266,6 +25242,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
       "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -25712,6 +25689,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -25814,6 +25792,7 @@
       "version": "24.10.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.3.tgz",
       "integrity": "sha512-gqkrWUsS8hcm0r44yn7/xZeV1ERva/nLgrLxFRUGb7aoNMIJfZJ3AC261zDQuOAKC7MiXai1WCpYc48jAHoShQ==",
+      "peer": true,
       "requires": {
         "undici-types": "~7.16.0"
       },
@@ -25922,15 +25901,6 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ=="
     },
-    "@types/source-map-support": {
-      "version": "0.5.10",
-      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.10.tgz",
-      "integrity": "sha512-tgVP2H469x9zq34Z0m/fgPewGhg/MLClalNOiPIzQlXrSS2YrKu/xCdSCKnEDwkFha51VKEKB6A9wW26/ZNwzA==",
-      "dev": true,
-      "requires": {
-        "source-map": "^0.6.0"
-      }
-    },
     "@types/supports-color": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
@@ -26023,6 +25993,7 @@
       "version": "8.49.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -26594,7 +26565,8 @@
     "acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -26629,6 +26601,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -26715,7 +26688,6 @@
         "package-changed": "3.0.0",
         "resolve-from": "5.0.0",
         "semver": "7.7.3",
-        "source-map-support": "0.5.21",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
         "winston": "3.19.0",
@@ -27593,7 +27565,8 @@
     "chai": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.1.tgz",
-      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg=="
+      "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
+      "peer": true
     },
     "chai-as-promised": {
       "version": "8.0.2",
@@ -28936,6 +28909,7 @@
       "version": "9.39.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -31424,7 +31398,8 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
           "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-          "dev": true
+          "dev": true,
+          "peer": true
         },
         "rimraf": {
           "version": "4.4.1",
@@ -32313,6 +32288,7 @@
       "version": "11.7.5",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.7.5.tgz",
       "integrity": "sha512-mTT6RgopEYABzXWFx+GcJ+ZQ32kp4fMf0xvpZIIfSq9Z8lC/++MtcCnQ9t5FP2veYEP95FIYSvW+U9fV4xrlig==",
+      "peer": true,
       "requires": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
@@ -32939,6 +32915,7 @@
       "resolved": "https://registry.npmjs.org/nx/-/nx-21.6.2.tgz",
       "integrity": "sha512-bFZgAsB838vn9kk1vI6a1A9sStKyOA7Q9Ifsx7fYPth3D0GafHKu7X2/YbsC4h1TpmuejkJCPWUw2WtCOQy6IQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@nx/nx-darwin-arm64": "*",
@@ -35597,7 +35574,8 @@
         "picomatch": {
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="
+          "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+          "peer": true
         }
       }
     },
@@ -35967,7 +35945,8 @@
     "typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "peer": true
     },
     "typescript-eslint": {
       "version": "8.49.0",
@@ -36062,6 +36041,7 @@
       "version": "1.7.11",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.7.11.tgz",
       "integrity": "sha512-OhuAzBImFPjKNgZ2JwHMfGFUA6NSbRegd1+BPjC1Y0E6X9Y/vJ4zKeGmIMqmlYboj6cMNEwKI+xQisrg4J0HaQ==",
+      "peer": true,
       "requires": {
         "@unrs/resolver-binding-darwin-arm64": "1.7.11",
         "@unrs/resolver-binding-darwin-x64": "1.7.11",
@@ -36851,7 +36831,8 @@
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "zod-validation-error": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@types/shell-quote": "1.7.5",
     "@types/sinon": "21.0.0",
     "@types/sinon-chai": "4.0.0",
-    "@types/source-map-support": "0.5.10",
     "@types/supports-color": "8.1.3",
     "@types/teen_process": "2.0.4",
     "@types/which": "3.0.4",

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -82,7 +82,6 @@
     "package-changed": "3.0.0",
     "resolve-from": "5.0.0",
     "semver": "7.7.3",
-    "source-map-support": "0.5.21",
     "teen_process": "3.0.5",
     "type-fest": "5.3.1",
     "winston": "3.19.0",

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -61,7 +61,6 @@
     "morgan": "1.10.1",
     "path-to-regexp": "8.3.0",
     "serve-favicon": "2.5.1",
-    "source-map-support": "0.5.21",
     "type-fest": "5.3.1"
   },
   "optionalDependencies": {

--- a/packages/docutils/bin/appium-docs.js
+++ b/packages/docutils/bin/appium-docs.js
@@ -2,7 +2,6 @@
 // @ts-check
 
 'use strict';
-require('source-map-support').install();
 
 const {main} = require('../build/lib/cli');
 const {getLogger} = require('../build/lib/logger');

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -56,7 +56,6 @@
     "lodash": "4.17.21",
     "pkg-dir": "5.0.0",
     "read-pkg": "5.2.0",
-    "source-map-support": "0.5.21",
     "teen_process": "3.0.5",
     "type-fest": "5.3.1",
     "yaml": "2.8.2",

--- a/packages/driver-test-support/package.json
+++ b/packages/driver-test-support/package.json
@@ -49,7 +49,6 @@
     "get-port": "5.1.1",
     "lodash": "4.17.21",
     "sinon": "21.0.0",
-    "source-map-support": "0.5.21",
     "type-fest": "5.3.1"
   },
   "peerDependencies": {

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -40,7 +40,6 @@
   "dependencies": {
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
-    "source-map-support": "0.5.21",
     "webdriverio": "9.21.0"
   },
   "peerDependencies": {

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -46,7 +46,6 @@
     "asyncbox": "3.0.0",
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
-    "source-map-support": "0.5.21",
     "xpath": "0.0.34"
   },
   "peerDependencies": {

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -42,8 +42,7 @@
     "@appium/base-plugin": "^3.0.5",
     "@appium/support": "^7.0.4",
     "bluebird": "3.7.2",
-    "lodash": "4.17.21",
-    "source-map-support": "0.5.21"
+    "lodash": "4.17.21"
   },
   "peerDependencies": {
     "appium": "^3.0.0-beta.0"

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -43,8 +43,7 @@
     "@appium/support": "^7.0.4",
     "lodash": "4.17.21",
     "lru-cache": "11.2.4",
-    "sharp": "0.34.5",
-    "source-map-support": "0.5.21"
+    "sharp": "0.34.5"
   },
   "peerDependencies": {
     "appium": "^3.0.0-beta.0"

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -44,8 +44,7 @@
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
     "opencv-bindings": "4.5.5",
-    "sharp": "0.34.5",
-    "source-map-support": "0.5.21"
+    "sharp": "0.34.5"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",

--- a/packages/plugin-test-support/package.json
+++ b/packages/plugin-test-support/package.json
@@ -44,7 +44,6 @@
     "@appium/types": "^1.1.2",
     "get-port": "5.1.1",
     "log-symbols": "4.1.0",
-    "source-map-support": "0.5.21",
     "teen_process": "3.0.5"
   },
   "peerDependencies": {

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -40,8 +40,7 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.js\""
   },
   "dependencies": {
-    "lodash": "4.17.21",
-    "source-map-support": "0.5.21"
+    "lodash": "4.17.21"
   },
   "peerDependencies": {
     "appium": "^3.0.0-beta.0"

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -38,8 +38,7 @@
     "test": "exit 0"
   },
   "dependencies": {
-    "json-schema": "0.4.0",
-    "source-map-support": "0.5.21"
+    "json-schema": "0.4.0"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",

--- a/packages/storage-plugin/package.json
+++ b/packages/storage-plugin/package.json
@@ -47,7 +47,6 @@
     "lodash": "4.17.21",
     "lru-cache": "11.2.4",
     "rimraf": "6.1.2",
-    "source-map-support": "0.5.21",
     "ws": "8.18.3"
   },
   "peerDependencies": {

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -69,7 +69,6 @@
     "sanitize-filename": "1.6.3",
     "semver": "7.7.3",
     "shell-quote": "1.8.3",
-    "source-map-support": "0.5.21",
     "supports-color": "8.1.1",
     "teen_process": "3.0.5",
     "type-fest": "5.3.1",

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -51,8 +51,7 @@
     "bluebird": "3.7.2",
     "lodash": "4.17.21",
     "loud-rejection": "2.2.0",
-    "sinon": "21.0.0",
-    "source-map-support": "0.5.21"
+    "sinon": "21.0.0"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",

--- a/packages/universal-xml-plugin/package.json
+++ b/packages/universal-xml-plugin/package.json
@@ -40,7 +40,6 @@
     "@xmldom/xmldom": "0.9.8",
     "fast-xml-parser": "5.3.2",
     "lodash": "4.17.21",
-    "source-map-support": "0.5.21",
     "xpath": "0.0.34"
   },
   "peerDependencies": {


### PR DESCRIPTION
See https://github.com/appium/asyncbox/pull/41

The only remaining non-dev instance of `source-map-support` is due to `asyncbox`, whose next version will remove it.