### PR TITLE
chore(docutils): remove `chalk`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21048,7 +21048,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/support": "^7.0.4",
-        "chalk": "4.1.2",
         "consola": "3.4.2",
         "diff": "8.0.2",
         "lilconfig": "3.1.3",
@@ -21081,33 +21080,6 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "packages/docutils/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "packages/docutils/node_modules/chalk": {
-      "version": "4.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "packages/docutils/node_modules/cliui": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -21121,20 +21093,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "packages/docutils/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "packages/docutils/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
     },
     "packages/docutils/node_modules/diff": {
       "version": "8.0.2",
@@ -21193,16 +21151,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "packages/docutils/node_modules/supports-color": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "packages/docutils/node_modules/type-fest": {
@@ -22401,7 +22349,6 @@
       "version": "file:packages/docutils",
       "requires": {
         "@appium/support": "^7.0.4",
-        "chalk": "4.1.2",
         "consola": "3.4.2",
         "diff": "8.0.2",
         "lilconfig": "3.1.3",
@@ -22420,19 +22367,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
           "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="
         },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
         "cliui": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -22442,15 +22376,6 @@
             "strip-ansi": "^7.1.0",
             "wrap-ansi": "^9.0.0"
           }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4"
         },
         "diff": {
           "version": "8.0.2",
@@ -22483,12 +22408,6 @@
           "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
           "requires": {
             "ansi-regex": "^6.0.1"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "requires": {
-            "has-flag": "^4.0.0"
           }
         },
         "type-fest": {

--- a/packages/docutils/lib/validate.ts
+++ b/packages/docutils/lib/validate.ts
@@ -5,7 +5,6 @@
  */
 
 import {fs, util} from '@appium/support';
-import chalk from 'chalk';
 import _ from 'lodash';
 import {EventEmitter} from 'node:events';
 import {exec} from 'teen_process';
@@ -21,12 +20,7 @@ import {
   REQUIREMENTS_TXT_PATH,
 } from './constants';
 import {DocutilsError} from './error';
-import {
-  findMkDocsYml,
-  isMkDocsInstalled,
-  readMkDocsYml,
-  findPython,
-} from './fs';
+import {findMkDocsYml, isMkDocsInstalled, readMkDocsYml, findPython} from './fs';
 import {getLogger} from './logger';
 import {MkDocsYml, PipPackage} from './model';
 
@@ -319,7 +313,7 @@ export class DocutilsValidator extends EventEmitter {
       ]));
     } catch {
       return this.fail(
-        `Could not find ${NAME_PIP} installation for Python at ${pythonPath}. Is it installed?`
+        `Could not find ${NAME_PIP} installation for Python at ${pythonPath}. Is it installed?`,
       );
     }
 
@@ -352,7 +346,7 @@ export class DocutilsValidator extends EventEmitter {
           'package',
           missingPackages.length,
         )} could not be found:\n${missingPackages
-          .map((p) => chalk`- {yellow ${p.name}} @ {yellow ${p.version}}`)
+          .map((p) => `- ${p.name} @ ${p.version}`)
           .join('\n')}`,
       );
     }
@@ -364,7 +358,7 @@ export class DocutilsValidator extends EventEmitter {
         )} are installed, but at the wrong version:\n${invalidVersionPackages
           .map(
             ([expected, actual]) =>
-              chalk`- {yellow ${expected.name}} @ {yellow ${expected.version}} (found {red ${actual.version}})`,
+              `- ${expected.name} @ ${expected.version} (found ${actual.version})`,
           )
           .join('\n')}`,
       );

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -49,7 +49,6 @@
   },
   "dependencies": {
     "@appium/support": "^7.0.4",
-    "chalk": "4.1.2",
     "consola": "3.4.2",
     "diff": "8.0.2",
     "lilconfig": "3.1.3",

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -16,7 +16,6 @@
       "matchPackageNames": [
         "@types/supports-color",
         "@types/wrap-ansi",
-        "chalk",
         "env-paths",
         "get-port",
         "get-stream",


### PR DESCRIPTION
This removes the `chalk` dependency, which is only directly used in `@appium/docutils` in two locations. Both locations are part of the dependency validation flow, which I would imagine is not really relevant for most consumers of `docutils`, so removing colors from this output does not really change much.

`chalk` is still present in the monorepo dependency tree, though, so this doesn't really reduce the install bundle size.