### PR TITLE
chore(deps): update supports-color to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "@types/shell-quote": "1.7.5",
         "@types/sinon": "21.0.0",
         "@types/sinon-chai": "4.0.0",
-        "@types/supports-color": "8.1.3",
         "@types/teen_process": "2.0.4",
         "@types/which": "3.0.4",
         "@types/wrap-ansi": "3.0.0",
@@ -4405,12 +4404,6 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "license": "MIT"
-    },
-    "node_modules/@types/supports-color": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
-      "integrity": "sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==",
-      "dev": true
     },
     "node_modules/@types/teen_process": {
       "version": "2.0.4",
@@ -22042,7 +22035,7 @@
         "sanitize-filename": "1.6.3",
         "semver": "7.7.3",
         "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
+        "supports-color": "10.2.2",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
         "uuid": "13.0.0",
@@ -22141,6 +22134,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/support/node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "packages/support/node_modules/type-fest": {
@@ -22971,7 +22976,7 @@
         "semver": "7.7.3",
         "sharp": "0.34.5",
         "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
+        "supports-color": "10.2.2",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
         "uuid": "13.0.0",
@@ -23025,6 +23030,11 @@
           "version": "7.7.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
           "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
+        },
+        "supports-color": {
+          "version": "10.2.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+          "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="
         },
         "type-fest": {
           "version": "5.3.1",
@@ -25819,12 +25829,6 @@
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ=="
-    },
-    "@types/supports-color": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@types/supports-color/-/supports-color-8.1.3.tgz",
-      "integrity": "sha512-Hy6UMpxhE3j1tLpl27exp1XqHD7n8chAiNPzWfz16LPZoMMoSc4dzLl6w9qijkEb/r5O1ozdu1CWGA2L83ZeZg==",
-      "dev": true
     },
     "@types/teen_process": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@types/shell-quote": "1.7.5",
     "@types/sinon": "21.0.0",
     "@types/sinon-chai": "4.0.0",
-    "@types/supports-color": "8.1.3",
     "@types/teen_process": "2.0.4",
     "@types/which": "3.0.4",
     "@types/wrap-ansi": "3.0.0",

--- a/packages/support/lib/console.js
+++ b/packages/support/lib/console.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import {supportsColor} from 'supports-color';
+import {createSupportsColor} from 'supports-color';
 import {Console as NodeConsole} from 'console';
 import '@colors/colors';
 import symbols from 'log-symbols';
@@ -60,7 +60,7 @@ export class CliConsole {
   constructor({jsonMode = false, useSymbols = true, useColor} = {}) {
     this.#console = new NodeConsole(process.stdout, jsonMode ? new NullWritable() : process.stderr);
     this.#useSymbols = Boolean(useSymbols);
-    this.#useColor = Boolean(useColor ?? supportsColor(process.stderr));
+    this.#useColor = Boolean(useColor ?? createSupportsColor(process.stderr));
   }
 
   /**

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -69,7 +69,7 @@
     "sanitize-filename": "1.6.3",
     "semver": "7.7.3",
     "shell-quote": "1.8.3",
-    "supports-color": "8.1.1",
+    "supports-color": "10.2.2",
     "teen_process": "3.0.5",
     "type-fest": "5.3.1",
     "uuid": "13.0.0",

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -14,7 +14,6 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "@types/supports-color",
         "@types/wrap-ansi",
         "env-paths",
         "get-port",
@@ -23,7 +22,6 @@
         "ora",
         "pkg-dir",
         "read-pkg",
-        "supports-color",
         "wrap-ansi"
       ],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Updates `supports-color` from `v8` to `v10`:
* `v9` required Node 12, became ESM-only, and renamed the `supportsColor` export to `createSupportsColor`
* `v10` required Node 18