### PR TITLE
chore(deps): update env-paths to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8693,6 +8693,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -21994,12 +21995,24 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "env-paths": "2.2.1",
+        "env-paths": "3.0.0",
         "slugify": "1.6.6"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
+      }
+    },
+    "packages/strongbox/node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/support": {
@@ -22940,8 +22953,15 @@
     "@appium/strongbox": {
       "version": "file:packages/strongbox",
       "requires": {
-        "env-paths": "2.2.1",
+        "env-paths": "3.0.0",
         "slugify": "1.6.6"
+      },
+      "dependencies": {
+        "env-paths": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+          "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="
+        }
       }
     },
     "@appium/support": {
@@ -28677,7 +28697,8 @@
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
     },
     "env-paths": {
-      "version": "2.2.1"
+      "version": "2.2.1",
+      "dev": true
     },
     "envinfo": {
       "version": "7.13.0",

--- a/packages/strongbox/package.json
+++ b/packages/strongbox/package.json
@@ -41,7 +41,7 @@
     "test:e2e": "mocha --exit -t 20s \"test/e2e/**/*.e2e.spec.ts\""
   },
   "dependencies": {
-    "env-paths": "2.2.1",
+    "env-paths": "3.0.0",
     "slugify": "1.6.6"
   },
   "engines": {

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -15,7 +15,6 @@
     {
       "matchPackageNames": [
         "@types/wrap-ansi",
-        "env-paths",
         "get-port",
         "get-stream",
         "log-symbols",


### PR DESCRIPTION
Updates `env-paths` from `v2` to `v3`:
* `v3` required Node 12 and became ESM-only