### PR TITLE
chore(deps): update get-port to v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "eslint-plugin-mocha": "11.2.0",
         "eslint-plugin-promise": "7.2.1",
         "finalhandler": "2.1.1",
-        "get-port": "5.1.1",
+        "get-port": "7.1.0",
         "json-schema-to-typescript": "15.0.4",
         "lerna": "9.0.3",
         "log-symbols": "4.1.0",
@@ -5294,19 +5294,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@wdio/utils/node_modules/get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@wdio/utils/node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -10382,10 +10369,12 @@
       }
     },
     "node_modules/get-port": {
-      "version": "5.1.1",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12552,6 +12541,19 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/lerna/node_modules/get-port": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lerna/node_modules/get-stream": {
@@ -21227,7 +21229,7 @@
         "bluebird": "3.7.2",
         "chai": "6.2.1",
         "chai-as-promised": "8.0.2",
-        "get-port": "5.1.1",
+        "get-port": "7.1.0",
         "lodash": "4.17.21",
         "sinon": "21.0.0",
         "type-fest": "5.3.1"
@@ -21536,18 +21538,6 @@
       },
       "engines": {
         "node": "^16.13 || >=18 || >=20"
-      }
-    },
-    "packages/execute-driver-plugin/node_modules/get-port": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/execute-driver-plugin/node_modules/glob": {
@@ -21920,7 +21910,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/types": "^1.1.2",
-        "get-port": "5.1.1",
+        "get-port": "7.1.0",
         "log-symbols": "4.1.0",
         "teen_process": "3.0.5"
       },
@@ -22481,7 +22471,7 @@
         "bluebird": "3.7.2",
         "chai": "6.2.1",
         "chai-as-promised": "8.0.2",
-        "get-port": "5.1.1",
+        "get-port": "7.1.0",
         "lodash": "4.17.21",
         "sinon": "21.0.0",
         "type-fest": "5.3.1"
@@ -22676,11 +22666,6 @@
             "tar-fs": "^3.0.6",
             "which": "^4.0.0"
           }
-        },
-        "get-port": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-          "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw=="
         },
         "glob": {
           "version": "10.5.0",
@@ -22914,7 +22899,7 @@
       "version": "file:packages/plugin-test-support",
       "requires": {
         "@appium/types": "^1.1.2",
-        "get-port": "5.1.1",
+        "get-port": "7.1.0",
         "log-symbols": "4.1.0",
         "teen_process": "3.0.5"
       }
@@ -26390,12 +26375,6 @@
           "integrity": "sha512-G7Cqgaelq68XHJNGlZ7lrNQyhZGsFqpwtGFexqUv4IQdjKoSYF7ipZ9UuTJZUSQXFj/XaoBLuEVIVqr8EJngEQ==",
           "dev": true
         },
-        "get-port": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
-          "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
-          "dev": true
-        },
         "split2": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -29799,7 +29778,9 @@
       }
     },
     "get-port": {
-      "version": "5.1.1"
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw=="
     },
     "get-proto": {
       "version": "1.0.1",
@@ -31236,6 +31217,12 @@
           "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
           "dev": true,
           "requires": {}
+        },
+        "get-port": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
+          "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
+          "dev": true
         },
         "get-stream": {
           "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "eslint-plugin-mocha": "11.2.0",
     "eslint-plugin-promise": "7.2.1",
     "finalhandler": "2.1.1",
-    "get-port": "5.1.1",
+    "get-port": "7.1.0",
     "json-schema-to-typescript": "15.0.4",
     "lerna": "9.0.3",
     "log-symbols": "4.1.0",

--- a/packages/driver-test-support/package.json
+++ b/packages/driver-test-support/package.json
@@ -46,7 +46,7 @@
     "bluebird": "3.7.2",
     "chai": "6.2.1",
     "chai-as-promised": "8.0.2",
-    "get-port": "5.1.1",
+    "get-port": "7.1.0",
     "lodash": "4.17.21",
     "sinon": "21.0.0",
     "type-fest": "5.3.1"

--- a/packages/plugin-test-support/package.json
+++ b/packages/plugin-test-support/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@appium/types": "^1.1.2",
-    "get-port": "5.1.1",
+    "get-port": "7.1.0",
     "log-symbols": "4.1.0",
     "teen_process": "3.0.5"
   },

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -15,7 +15,6 @@
     {
       "matchPackageNames": [
         "@types/wrap-ansi",
-        "get-port",
         "get-stream",
         "log-symbols",
         "ora",


### PR DESCRIPTION
Updates `get-port` from `v5` to `v7`:
* v6 required Node 12.20, became ESM-only, and changed a method that isn't used in Appium
* v7 required Node 16

