### PR TITLE
chore(deps): update get-stream to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3811,6 +3811,12 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "license": "MIT"
     },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT"
+    },
     "node_modules/@sidvind/better-ajv-errors": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@sidvind/better-ajv-errors/-/better-ajv-errors-4.0.1.tgz",
@@ -10395,6 +10401,7 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -22021,7 +22028,7 @@
         "bplist-creator": "0.1.1",
         "bplist-parser": "0.3.2",
         "form-data": "4.0.5",
-        "get-stream": "6.0.1",
+        "get-stream": "9.0.1",
         "glob": "13.0.0",
         "jsftp": "2.1.3",
         "klaw": "4.1.0",
@@ -22053,6 +22060,22 @@
         "sharp": "0.34.5"
       }
     },
+    "packages/support/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/support/node_modules/glob": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
@@ -22068,6 +22091,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/support/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/support/node_modules/isexe": {
@@ -22963,7 +22998,7 @@
         "bplist-creator": "0.1.1",
         "bplist-parser": "0.3.2",
         "form-data": "4.0.5",
-        "get-stream": "6.0.1",
+        "get-stream": "9.0.1",
         "glob": "13.0.0",
         "jsftp": "2.1.3",
         "klaw": "4.1.0",
@@ -22989,6 +23024,15 @@
         "yauzl": "3.2.0"
       },
       "dependencies": {
+        "get-stream": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+          "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+          "requires": {
+            "@sec-ant/readable-stream": "^0.4.1",
+            "is-stream": "^4.0.1"
+          }
+        },
         "glob": {
           "version": "13.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
@@ -22998,6 +23042,11 @@
             "minipass": "^7.1.2",
             "path-scurry": "^2.0.0"
           }
+        },
+        "is-stream": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+          "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A=="
         },
         "isexe": {
           "version": "3.1.1",
@@ -25339,6 +25388,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="
+    },
+    "@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="
     },
     "@sidvind/better-ajv-errors": {
       "version": "4.0.1",
@@ -29792,7 +29846,8 @@
       }
     },
     "get-stream": {
-      "version": "6.0.1"
+      "version": "6.0.1",
+      "dev": true
     },
     "get-symbol-description": {
       "version": "1.1.0",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -52,7 +52,7 @@
     "bplist-creator": "0.1.1",
     "bplist-parser": "0.3.2",
     "form-data": "4.0.5",
-    "get-stream": "6.0.1",
+    "get-stream": "9.0.1",
     "glob": "13.0.0",
     "jsftp": "2.1.3",
     "klaw": "4.1.0",

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -15,7 +15,6 @@
     {
       "matchPackageNames": [
         "@types/wrap-ansi",
-        "get-stream",
         "log-symbols",
         "ora",
         "pkg-dir",


### PR DESCRIPTION
Updates `get-stream` from `v6` to `v9`:
* `v7` required Node 16, became ESM-only, and removed/renamed some options that aren't used in Appium
* `v8` removed the `encoding` option, which isn't used in Appium
* `v9` required Node 18