### PR TITLE
chore(deps): update pkg-dir to v8 and rename it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9914,6 +9914,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/flat": {
       "version": "5.0.2",
       "license": "BSD-3-Clause",
@@ -15731,6 +15743,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/package-directory": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/package-directory/-/package-directory-8.1.0.tgz",
+      "integrity": "sha512-qHKRW0pw3lYdZMQVkjDBqh8HlamH/LCww2PH7OWEp4Qrt3SFeYMNpnJrQzlSnGrDD5zGR51XqBh7FnNCdVNEHA==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -16274,16 +16301,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "5.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/plist": {
@@ -21055,7 +21072,7 @@
         "diff": "8.0.2",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
-        "pkg-dir": "5.0.0",
+        "package-directory": "8.1.0",
         "read-pkg": "5.2.0",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
@@ -22037,7 +22054,7 @@
         "log-symbols": "4.1.0",
         "moment": "2.30.1",
         "ncp": "2.0.0",
-        "pkg-dir": "5.0.0",
+        "package-directory": "8.1.0",
         "plist": "3.1.0",
         "pluralize": "8.0.0",
         "read-pkg": "5.2.0",
@@ -22396,7 +22413,7 @@
         "diff": "8.0.2",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
-        "pkg-dir": "5.0.0",
+        "package-directory": "8.1.0",
         "read-pkg": "5.2.0",
         "teen_process": "3.0.5",
         "type-fest": "5.3.1",
@@ -23007,7 +23024,7 @@
         "log-symbols": "4.1.0",
         "moment": "2.30.1",
         "ncp": "2.0.0",
-        "pkg-dir": "5.0.0",
+        "package-directory": "8.1.0",
         "plist": "3.1.0",
         "pluralize": "8.0.0",
         "read-pkg": "5.2.0",
@@ -29529,6 +29546,11 @@
         "path-exists": "^4.0.0"
       }
     },
+    "find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ=="
+    },
     "flat": {
       "version": "5.0.2"
     },
@@ -33385,6 +33407,14 @@
         }
       }
     },
+    "package-directory": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/package-directory/-/package-directory-8.1.0.tgz",
+      "integrity": "sha512-qHKRW0pw3lYdZMQVkjDBqh8HlamH/LCww2PH7OWEp4Qrt3SFeYMNpnJrQzlSnGrDD5zGR51XqBh7FnNCdVNEHA==",
+      "requires": {
+        "find-up-simple": "^1.0.0"
+      }
+    },
     "package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -33753,12 +33783,6 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
       "integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
       "dev": true
-    },
-    "pkg-dir": {
-      "version": "5.0.0",
-      "requires": {
-        "find-up": "^5.0.0"
-      }
     },
     "plist": {
       "version": "3.1.0",

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -6,7 +6,7 @@
 import {fs} from '@appium/support';
 import _ from 'lodash';
 import path from 'node:path';
-import _pkgDir from 'pkg-dir';
+import {packageDirectory} from 'package-directory';
 import readPkg, {NormalizedPackageJson, PackageJson} from 'read-pkg';
 import {JsonValue} from 'type-fest';
 import * as YAML from 'yaml';
@@ -30,7 +30,7 @@ const log = getLogger('fs');
  *
  * Caches result
  */
-const findPkgDir = _.memoize(_pkgDir);
+const findPkgDir = _.memoize(packageDirectory);
 
 /**
  * Stringifies a thing into a YAML
@@ -75,7 +75,7 @@ export async function findInPkgDir(
   filename: string,
   cwd = process.cwd(),
 ): Promise<string | undefined> {
-  const pkgDir = await findPkgDir(cwd);
+  const pkgDir = await findPkgDir({cwd});
   if (!pkgDir) {
     return;
   }
@@ -109,7 +109,7 @@ async function _readPkgJson(
   cwd: string,
   normalize?: boolean,
 ): Promise<{pkgPath: string; pkg: PackageJson | NormalizedPackageJson}> {
-  const pkgDir = await findPkgDir(cwd);
+  const pkgDir = await findPkgDir({cwd});
   if (!pkgDir) {
     throw new DocutilsError(
       `Could not find a ${NAME_PACKAGE_JSON} near ${cwd}; please create it before using this utility`,

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -5,6 +5,7 @@
 
 import {fs} from '@appium/support';
 import _ from 'lodash';
+import crypto from 'node:crypto';
 import path from 'node:path';
 import {packageDirectory} from 'package-directory';
 import readPkg, {NormalizedPackageJson, PackageJson} from 'read-pkg';
@@ -30,7 +31,7 @@ const log = getLogger('fs');
  *
  * Caches result
  */
-const findPkgDir = _.memoize(packageDirectory);
+const findPkgDir = _.memoize(packageDirectory, (opts) => opts?.cwd ?? crypto.randomUUID());
 
 /**
  * Stringifies a thing into a YAML

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -5,7 +5,6 @@
 
 import {fs} from '@appium/support';
 import _ from 'lodash';
-import crypto from 'node:crypto';
 import path from 'node:path';
 import {packageDirectory} from 'package-directory';
 import readPkg, {NormalizedPackageJson, PackageJson} from 'read-pkg';
@@ -31,7 +30,7 @@ const log = getLogger('fs');
  *
  * Caches result
  */
-const findPkgDir = _.memoize(packageDirectory, (opts) => opts?.cwd ?? crypto.randomUUID());
+const findPkgDir = _.memoize(packageDirectory, (opts) => opts?.cwd);
 
 /**
  * Stringifies a thing into a YAML

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -53,7 +53,7 @@
     "diff": "8.0.2",
     "lilconfig": "3.1.3",
     "lodash": "4.17.21",
-    "pkg-dir": "5.0.0",
+    "package-directory": "8.1.0",
     "read-pkg": "5.2.0",
     "teen_process": "3.0.5",
     "type-fest": "5.3.1",

--- a/packages/support/lib/fs.js
+++ b/packages/support/lib/fs.js
@@ -31,7 +31,7 @@ const ncpAsync =
   /** @type {(source: string, dest: string, opts: ncp.Options|undefined) => B<void>} */ (
     B.promisify(ncp)
   );
-const findRootCached = _.memoize(packageDirectorySync);
+const findRootCached = _.memoize(packageDirectorySync, (opts) => opts?.cwd ?? crypto.randomUUID());
 
 const fs = {
   /**

--- a/packages/support/lib/fs.js
+++ b/packages/support/lib/fs.js
@@ -31,7 +31,7 @@ const ncpAsync =
   /** @type {(source: string, dest: string, opts: ncp.Options|undefined) => B<void>} */ (
     B.promisify(ncp)
   );
-const findRootCached = _.memoize(packageDirectorySync, (opts) => opts?.cwd ?? crypto.randomUUID());
+const findRootCached = _.memoize(packageDirectorySync, (opts) => opts?.cwd);
 
 const fs = {
   /**

--- a/packages/support/lib/fs.js
+++ b/packages/support/lib/fs.js
@@ -17,8 +17,8 @@ import { glob } from 'glob';
 import klaw from 'klaw';
 import _ from 'lodash';
 import ncp from 'ncp';
+import {packageDirectorySync} from 'package-directory';
 import path from 'path';
-import pkgDir from 'pkg-dir';
 import readPkg from 'read-pkg';
 import sanitize from 'sanitize-filename';
 import which from 'which';
@@ -31,7 +31,7 @@ const ncpAsync =
   /** @type {(source: string, dest: string, opts: ncp.Options|undefined) => B<void>} */ (
     B.promisify(ncp)
   );
-const findRootCached = _.memoize(pkgDir.sync);
+const findRootCached = _.memoize(packageDirectorySync);
 
 const fs = {
   /**
@@ -395,7 +395,7 @@ const fs = {
     if (!dir || !path.isAbsolute(dir)) {
       throw new TypeError('`findRoot()` must be provided a non-empty, absolute path');
     }
-    const result = findRootCached(dir);
+    const result = findRootCached({cwd: dir});
     if (!result) {
       throw new Error(`\`findRoot()\` could not find \`package.json\` from ${dir}`);
     }

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -61,7 +61,7 @@
     "log-symbols": "4.1.0",
     "moment": "2.30.1",
     "ncp": "2.0.0",
-    "pkg-dir": "5.0.0",
+    "package-directory": "8.1.0",
     "plist": "3.1.0",
     "pluralize": "8.0.0",
     "read-pkg": "5.2.0",

--- a/packages/support/test/mocks.js
+++ b/packages/support/test/mocks.js
@@ -47,7 +47,7 @@ export function initMocks(sandbox = createSandbox()) {
   const overrides = {
     'resolve-from': MockResolveFrom,
     'read-pkg': MockReadPkg,
-    'pkg-dir': MockPkgDir,
+    'package-directory': MockPkgDir,
     teen_process: MockTeenProcess,
     fs: MockFs,
   };
@@ -69,8 +69,8 @@ export function initMocks(sandbox = createSandbox()) {
  */
 
 /**
- * Mocks for `pkg-dir` package
- * @typedef {sinon.SinonStubbedMember<import('pkg-dir')>} MockPkgDir
+ * Mocks for `package-directory` package
+ * @typedef {sinon.SinonStubbedMember<import('package-directory').packageDirectory>} MockPkgDir
  */
 
 /**
@@ -80,7 +80,7 @@ export function initMocks(sandbox = createSandbox()) {
 
 /**
  * For passing into `rewiremock.proxy()`.
- * @typedef { {'resolve-from': MockResolveFrom, 'pkg-dir': MockPkgDir, 'read-pkg': MockReadPkg, 'teen_process': MockTeenProcess, fs: MockFs} } Overrides
+ * @typedef { {'resolve-from': MockResolveFrom, 'package-directory': MockPkgDir, 'read-pkg': MockReadPkg, 'teen_process': MockTeenProcess, fs: MockFs} } Overrides
  */
 
 /**

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -17,7 +17,6 @@
         "@types/wrap-ansi",
         "log-symbols",
         "ora",
-        "pkg-dir",
         "read-pkg",
         "wrap-ansi"
       ],


### PR DESCRIPTION
Updates `pkg-dir` from `v5` to `v8`:
* `v6` required Node 12, became ESM-only, and changed from default export to named exports
* `v7` required Node 14
* `v8` required Node 18
* `v8.1.0` renamed the package to `package-directory`