### PR TITLE
feat(appium): Add repository links for extensions list

### DIFF
--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -218,7 +218,7 @@ class ExtensionCliCommand {
       for (const data of _.values(listData)) {
         const repoUrl = await this._getRepositoryUrl(data);
         if (repoUrl) {
-          /** @type {any} */ (data).repositoryUrl = repoUrl;
+          data.repositoryUrl = repoUrl;
         }
       }
     });
@@ -237,8 +237,8 @@ class ExtensionCliCommand {
     /** @type {Record<string, string>} */
     const repoUrlMap = {};
     for (const [name, data] of _.toPairs(listData)) {
-      if (/** @type {any} */ (data).repositoryUrl) {
-        repoUrlMap[name] = /** @type {any} */ (data).repositoryUrl;
+      if (data.repositoryUrl) {
+        repoUrlMap[name] = data.repositoryUrl;
       }
     }
 
@@ -1235,6 +1235,7 @@ export {ExtensionCliCommand as ExtensionCommand};
  * @property {string|null} unsafeUpdateVersion - Same as above, but a major version bump
  * @property {string} [updateError] - Update check error message (if present)
  * @property {boolean} [devMode] - If Appium is run from an extension's working copy
+ * @property {string} [repositoryUrl] - Repository URL for the extension (if available)
  */
 
 /**

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -97,6 +97,7 @@ class ExtensionCliCommand {
    * For TS to understand that a function throws an exception, it must actually throw an exception--
    * in other words, _calling_ a function which is guaranteed to throw an exception is not enough--
    * nor is something like `@returns {never}` which does not imply a thrown exception.
+   *
    * @param {string} message
    * @protected
    * @throws {Error}
@@ -122,6 +123,7 @@ class ExtensionCliCommand {
 
   /**
    * List extensions
+   *
    * @template {ExtensionType} ExtType
    * @param {ListOptions} opts
    * @return {Promise<ExtensionList<ExtType>>} map of extension names to extension data
@@ -131,17 +133,15 @@ class ExtensionCliCommand {
 
     const lsMsg =
       `Listing ${showInstalled ? 'installed' : 'available'} ${this.type}s` +
-      (verbose ? ' (verbose mode)' : '(rerun with --verbose for more info)');
+      (verbose ? ' (verbose mode)' : ' (rerun with --verbose for more info)');
     await this._checkForUpdates(listData, showUpdates, lsMsg);
 
     if (this.isJsonOutput) {
-      // Fetch repository URLs for all extensions (needed for JSON output)
       await this._addRepositoryUrlsToListData(listData);
       return listData;
     }
 
     if (verbose) {
-      // Fetch repository URLs for all extensions (needed for verbose output)
       await this._addRepositoryUrlsToListData(listData);
       this.log.log(inspect(listData, {colors: true, depth: null}));
       return listData;
@@ -152,6 +152,7 @@ class ExtensionCliCommand {
 
   /**
    * Build the initial list data structure from installed and known extensions
+   *
    * @template {ExtensionType} ExtType
    * @param {boolean} showInstalled
    * @returns {ExtensionList<ExtType>}
@@ -180,6 +181,7 @@ class ExtensionCliCommand {
 
   /**
    * Check for available updates for installed extensions
+   *
    * @template {ExtensionType} ExtType
    * @param {ExtensionList<ExtType>} listData
    * @param {boolean} showUpdates
@@ -188,10 +190,12 @@ class ExtensionCliCommand {
    * @private
    */
   async _checkForUpdates(listData, showUpdates, lsMsg) {
-    if (!showUpdates) {
-      return;
-    }
     await spinWith(this.isJsonOutput, lsMsg, async () => {
+      // We'd like to still show lsMsg even if showUpdates is false
+      if (!showUpdates) {
+        return;
+      }
+
       // Filter to only extensions that need update checks (installed npm packages)
       const extensionsToCheck = _.toPairs(listData).filter(
         ([, data]) => data.installed && data.installType === INSTALL_TYPE_NPM
@@ -216,6 +220,7 @@ class ExtensionCliCommand {
 
   /**
    * Add repository URLs to list data for all extensions
+   *
    * @template {ExtensionType} ExtType
    * @param {ExtensionList<ExtType>} listData
    * @returns {Promise<void>}
@@ -238,6 +243,7 @@ class ExtensionCliCommand {
 
   /**
    * Display normal formatted output
+   *
    * @template {ExtensionType} ExtType
    * @param {ExtensionList<ExtType>} listData
    * @param {boolean} showUpdates
@@ -255,6 +261,7 @@ class ExtensionCliCommand {
 
   /**
    * Format a single extension line for display
+   *
    * @template {ExtensionType} ExtType
    * @param {string} name
    * @param {ExtensionListData<ExtType>} data
@@ -274,6 +281,7 @@ class ExtensionCliCommand {
 
   /**
    * Format installation status text
+   *
    * @template {ExtensionType} ExtType
    * @param {InstalledExtensionListData<ExtType>} data
    * @returns {string}
@@ -301,6 +309,7 @@ class ExtensionCliCommand {
 
   /**
    * Format update information text
+   *
    * @template {ExtensionType} ExtType
    * @param {InstalledExtensionListData<ExtType>} data
    * @returns {string}
@@ -326,6 +335,7 @@ class ExtensionCliCommand {
 
   /**
    * Get repository URL from package data
+   *
    * @template {ExtensionType} ExtType
    * @param {ExtensionListData<ExtType>} data
    * @returns {Promise<string|null>}
@@ -345,6 +355,7 @@ class ExtensionCliCommand {
 
   /**
    * Get repository URL from installed extension's package.json
+   *
    * @template {ExtensionType} ExtType
    * @param {InstalledExtensionListData<ExtType>} data
    * @returns {Promise<string|null>}
@@ -372,6 +383,7 @@ class ExtensionCliCommand {
 
   /**
    * Get repository URL from npm for a package name
+   *
    * @param {string} pkgName
    * @returns {Promise<string|null>}
    * @private

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -129,7 +129,9 @@ class ExtensionCliCommand {
   async list({showInstalled, showUpdates, verbose = false}) {
     const listData = this._buildListData(showInstalled);
 
-    const lsMsg = `Listing ${showInstalled ? 'installed' : 'available'} ${this.type}s${verbose ? ' (verbose mode)' : ''}`;
+    const lsMsg =
+      `Listing ${showInstalled ? 'installed' : 'available'} ${this.type}s` +
+      (verbose ? ' (verbose mode)' : '');
     await this._checkForUpdates(listData, showUpdates, lsMsg);
 
     // Fetch repository URLs for all extensions (needed for both JSON and display output)
@@ -144,7 +146,7 @@ class ExtensionCliCommand {
       return listData;
     }
 
-    return await this._displayNormalOutput(listData, showUpdates);
+    return await this._displayNormalListOutput(listData, showUpdates);
   }
 
   /**
@@ -241,7 +243,7 @@ class ExtensionCliCommand {
    * @returns {Promise<ExtensionList<ExtType>>}
    * @private
    */
-  async _displayNormalOutput(listData, showUpdates) {
+  async _displayNormalListOutput(listData, showUpdates) {
     for (const [name, data] of _.toPairs(listData)) {
       const line = await this._formatExtensionLine(name, data, showUpdates);
       this.log.log(line);
@@ -354,7 +356,6 @@ class ExtensionCliCommand {
     }
     return txt;
   }
-
 
   /**
    * Get repository URL from package data

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -215,7 +215,7 @@ class ExtensionCliCommand {
    */
   async _addRepositoryUrlsToListData(listData) {
     await spinWith(this.isJsonOutput, 'Fetching repository information', async () => {
-      for (const [, data] of _.toPairs(listData)) {
+      for (const data of _.values(listData)) {
         const repoUrl = await this._getRepositoryUrl(data);
         if (repoUrl) {
           /** @type {any} */ (data).repositoryUrl = repoUrl;

--- a/packages/appium/lib/cli/utils.js
+++ b/packages/appium/lib/cli/utils.js
@@ -54,20 +54,6 @@ export async function spinWith(json, msg, fn) {
   }
 }
 
-/**
- * Create a clickable terminal link using OSC 8 escape sequence
- * @param {string} url - The URL to link to
- * @param {string} text - The text to display
- * @returns {string} The formatted link or plain text if terminal doesn't support links
- */
-export function createTerminalLink(url, text) {
-  if (process.stdout.isTTY && process.env.TERM && !process.env.NO_COLOR) {
-    // OSC 8 escape sequence for hyperlinks
-    return `\u001b]8;;${url}\u001b\\${text}\u001b]8;;\u001b\\`;
-  }
-  return text;
-}
-
 export class RingBuffer {
   constructor(size = 50) {
     this.size = size;

--- a/packages/appium/lib/cli/utils.js
+++ b/packages/appium/lib/cli/utils.js
@@ -54,6 +54,20 @@ export async function spinWith(json, msg, fn) {
   }
 }
 
+/**
+ * Create a clickable terminal link using OSC 8 escape sequence
+ * @param {string} url - The URL to link to
+ * @param {string} text - The text to display
+ * @returns {string} The formatted link or plain text if terminal doesn't support links
+ */
+export function createTerminalLink(url, text) {
+  if (process.stdout.isTTY && process.env.TERM && !process.env.NO_COLOR) {
+    // OSC 8 escape sequence for hyperlinks
+    return `\u001b]8;;${url}\u001b\\${text}\u001b]8;;\u001b\\`;
+  }
+  return text;
+}
+
 export class RingBuffer {
   constructor(size = 50) {
     this.size = size;

--- a/packages/appium/test/e2e/cli-driver.e2e.spec.js
+++ b/packages/appium/test/e2e/cli-driver.e2e.spec.js
@@ -98,10 +98,12 @@ describe('Driver CLI', function () {
     it('should list available drivers in json format', async function () {
       const driverData = await runList();
       for (const d of Object.keys(KNOWN_DRIVERS)) {
-        driverData[d].should.eql({
-          installed: false,
-          pkgName: KNOWN_DRIVERS[d],
-        });
+        driverData[d].should.have.property('installed', false);
+        driverData[d].should.have.property('pkgName', KNOWN_DRIVERS[d]);
+        // repositoryUrl may be present if available
+        if (driverData[d].repositoryUrl) {
+          driverData[d].repositoryUrl.should.be.a('string');
+        }
       }
     });
 
@@ -179,6 +181,8 @@ describe('Driver CLI', function () {
       const list = await runList(['--installed']);
       // @ts-ignore
       delete list.uiautomator2.installed;
+      // @ts-ignore
+      delete list.uiautomator2.repositoryUrl;
       list.should.eql(ret);
     });
 
@@ -190,6 +194,8 @@ describe('Driver CLI', function () {
       const list = await runList(['--installed']);
       // @ts-ignore
       delete list.fake.installed;
+      // @ts-ignore
+      delete list.fake.repositoryUrl;
       list.should.eql(ret);
     });
 
@@ -223,6 +229,8 @@ describe('Driver CLI', function () {
       const list = await runList(['--installed']);
       // @ts-ignore
       delete list.fake.installed;
+      // @ts-ignore
+      delete list.fake.repositoryUrl;
       list.should.eql(ret);
     });
 
@@ -245,6 +253,8 @@ describe('Driver CLI', function () {
       const list = await runList(['--installed']);
       // @ts-ignore
       delete list.fake.installed;
+      // @ts-ignore
+      delete list.fake.repositoryUrl;
       list.should.eql(ret);
     });
 
@@ -262,6 +272,8 @@ describe('Driver CLI', function () {
       const list = await runList(['--installed', '--json']);
       // @ts-ignore
       delete list.fake.installed;
+      // @ts-ignore
+      delete list.fake.repositoryUrl;
       list.should.eql(ret);
     });
 
@@ -284,6 +296,8 @@ describe('Driver CLI', function () {
       const list = await runList(['--installed']);
       // @ts-ignore
       delete list.fake.installed;
+      // @ts-ignore
+      delete list.fake.repositoryUrl;
       list.should.eql(ret);
     });
 


### PR DESCRIPTION
## Proposed changes

Addresses https://github.com/appium/appium/issues/16798

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Github links are now included into both detailed and normal list output. The normal output looks like:

```
- xcuitest@10.1.6 [installed (linked from /Users/test/code/appium-xcuitest-driver)] https://github.com/appium/appium-xcuitest-driver
- gecko@2.0.6 [installed (linked from /Users/test/code/appium-geckodriver)] https://github.com/appium/appium-geckodriver
- uiautomator2@6.0.2 [installed (linked from /Users/test/code/appium-uiautomator2-driver)] https://github.com/appium/appium-uiautomator2-driver
- espresso (appium-espresso-driver) [not installed] https://github.com/appium/appium-espresso-driver
- mac2 (appium-mac2-driver) [not installed] https://github.com/appium/appium-mac2-driver
- windows (appium-windows-driver) [not installed] https://github.com/appium/appium-windows-driver
- safari (appium-safari-driver) [not installed] https://github.com/appium/appium-safari-driver
- chromium (appium-chromium-driver) [not installed] https://github.com/appium/appium-chromium-driver
```
