### PR TITLE
docs(appium): add missing verbose flag for CLI list command

### DIFF
--- a/packages/appium/docs/en/reference/cli/extensions.md
+++ b/packages/appium/docs/en/reference/cli/extensions.md
@@ -134,6 +134,7 @@ appium {driver|plugin} list
 |`--installed`|Only list all installed extensions|boolean|
 |`--json`|Return the result in JSON format|boolean|
 |`--updates`|List all extensions along with information on whether newer versions are available. Only supported for extensions installed via `npm`.|boolean|
+|`--verbose`|Show additional details for each extension|boolean|
 
 #### Example
 


### PR DESCRIPTION
I checked `lib/cli/args.js` and it seems this was the only missing flag. I guess there's also `--shell` but it didn't seem to do anything for me, so it can probably be omitted.