### PR TITLE
chore(deps): update ora to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6312,6 +6312,7 @@
     },
     "node_modules/bl": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -7010,6 +7011,7 @@
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
@@ -7020,6 +7022,7 @@
     },
     "node_modules/cli-spinners": {
       "version": "2.7.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8076,6 +8079,7 @@
     },
     "node_modules/defaults": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
@@ -8086,6 +8090,7 @@
     },
     "node_modules/defaults/node_modules/clone": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
@@ -11283,6 +11288,7 @@
     },
     "node_modules/is-interactive": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13346,9 +13352,22 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -14859,6 +14878,7 @@
     },
     "node_modules/onetime": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -14910,6 +14930,7 @@
     },
     "node_modules/ora": {
       "version": "5.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bl": "^4.1.0",
@@ -14931,6 +14952,7 @@
     },
     "node_modules/ora/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -14944,6 +14966,7 @@
     },
     "node_modules/ora/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -14958,6 +14981,7 @@
     },
     "node_modules/ora/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -14968,12 +14992,14 @@
     },
     "node_modules/ora/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ora/node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
       "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -14988,6 +15014,7 @@
     },
     "node_modules/ora/node_modules/supports-color": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -16683,6 +16710,7 @@
     },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -17627,6 +17655,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/stream-browserify": {
@@ -19185,6 +19225,7 @@
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
@@ -20113,7 +20154,7 @@
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "lru-cache": "11.2.4",
-        "ora": "5.4.1",
+        "ora": "9.0.0",
         "package-changed": "3.0.0",
         "resolve-from": "5.0.0",
         "semver": "7.7.3",
@@ -20130,6 +20171,81 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
+      }
+    },
+    "packages/appium/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/appium/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "packages/appium/node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/appium/node_modules/cli-spinners": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.3.0.tgz",
+      "integrity": "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/appium/node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/appium/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/appium/node_modules/lilconfig": {
@@ -20153,6 +20269,60 @@
         "node": "20 || >=22"
       }
     },
+    "packages/appium/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/appium/node_modules/ora": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
+      "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.2.2",
+        "string-width": "^8.1.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/appium/node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/appium/node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -20163,6 +20333,49 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "packages/appium/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/appium/node_modules/string-width": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/appium/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "packages/appium/node_modules/type-fest": {
@@ -25923,7 +26136,7 @@
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "lru-cache": "11.2.4",
-        "ora": "5.4.1",
+        "ora": "9.0.0",
         "package-changed": "3.0.0",
         "resolve-from": "5.0.0",
         "semver": "7.7.3",
@@ -25935,6 +26148,39 @@
         "yaml": "2.8.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+          "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
+        },
+        "chalk": {
+          "version": "5.6.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+          "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
+        },
+        "cli-cursor": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+          "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+          "requires": {
+            "restore-cursor": "^5.0.0"
+          }
+        },
+        "cli-spinners": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.3.0.tgz",
+          "integrity": "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ=="
+        },
+        "is-interactive": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+          "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="
+        },
+        "is-unicode-supported": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+          "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="
+        },
         "lilconfig": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -25945,10 +26191,65 @@
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
           "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="
         },
+        "onetime": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+          "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+          "requires": {
+            "mimic-function": "^5.0.0"
+          }
+        },
+        "ora": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
+          "integrity": "sha512-m0pg2zscbYgWbqRR6ABga5c3sZdEon7bSgjnlXC64kxtxLOyjRcbbUkLj7HFyy/FTD+P2xdBWu8snGhYI0jc4A==",
+          "requires": {
+            "chalk": "^5.6.2",
+            "cli-cursor": "^5.0.0",
+            "cli-spinners": "^3.2.0",
+            "is-interactive": "^2.0.0",
+            "is-unicode-supported": "^2.1.0",
+            "log-symbols": "^7.0.1",
+            "stdin-discarder": "^0.2.2",
+            "string-width": "^8.1.0",
+            "strip-ansi": "^7.1.2"
+          }
+        },
+        "restore-cursor": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+          "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+          "requires": {
+            "onetime": "^7.0.0",
+            "signal-exit": "^4.1.0"
+          }
+        },
         "semver": {
           "version": "7.7.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
           "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="
+        },
+        "string-width": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+          "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+          "requires": {
+            "get-east-asian-width": "^1.3.0",
+            "strip-ansi": "^7.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+          "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
         },
         "type-fest": {
           "version": "5.3.1",
@@ -26366,6 +26667,7 @@
     },
     "bl": {
       "version": "4.1.0",
+      "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -26836,12 +27138,14 @@
     },
     "cli-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "restore-cursor": "^3.1.0"
       }
     },
     "cli-spinners": {
-      "version": "2.7.0"
+      "version": "2.7.0",
+      "dev": true
     },
     "cli-width": {
       "version": "4.1.0",
@@ -27533,12 +27837,14 @@
     },
     "defaults": {
       "version": "1.0.4",
+      "dev": true,
       "requires": {
         "clone": "^1.0.2"
       },
       "dependencies": {
         "clone": {
-          "version": "1.0.4"
+          "version": "1.0.4",
+          "dev": true
         }
       }
     },
@@ -29596,7 +29902,8 @@
       }
     },
     "is-interactive": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -31000,7 +31307,13 @@
       }
     },
     "mimic-fn": {
-      "version": "2.1.0"
+      "version": "2.1.0",
+      "dev": true
+    },
+    "mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="
     },
     "min-indent": {
       "version": "1.0.1",
@@ -32036,6 +32349,7 @@
     },
     "onetime": {
       "version": "5.1.2",
+      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -32069,6 +32383,7 @@
     },
     "ora": {
       "version": "5.4.1",
+      "dev": true,
       "requires": {
         "bl": "^4.1.0",
         "chalk": "^4.1.0",
@@ -32083,12 +32398,14 @@
       "dependencies": {
         "ansi-styles": {
           "version": "4.3.0",
+          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
           "version": "4.1.2",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -32096,17 +32413,20 @@
         },
         "color-convert": {
           "version": "2.0.1",
+          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
         },
         "color-name": {
-          "version": "1.1.4"
+          "version": "1.1.4",
+          "dev": true
         },
         "log-symbols": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
           "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "dev": true,
           "requires": {
             "chalk": "^4.1.0",
             "is-unicode-supported": "^0.1.0"
@@ -32114,6 +32434,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
+          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -33235,6 +33556,7 @@
     },
     "restore-cursor": {
       "version": "3.1.0",
+      "dev": true,
       "requires": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -33845,6 +34167,11 @@
     },
     "statuses": {
       "version": "2.0.1"
+    },
+    "stdin-discarder": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
+      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="
     },
     "stream-browserify": {
       "version": "2.0.2",
@@ -34899,6 +35226,7 @@
     },
     "wcwidth": {
       "version": "1.0.1",
+      "dev": true,
       "requires": {
         "defaults": "^1.0.3"
       }

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -78,7 +78,7 @@
     "lilconfig": "3.1.3",
     "lodash": "4.17.21",
     "lru-cache": "11.2.4",
-    "ora": "5.4.1",
+    "ora": "9.0.0",
     "package-changed": "3.0.0",
     "resolve-from": "5.0.0",
     "semver": "7.7.3",

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -15,7 +15,6 @@
     {
       "matchPackageNames": [
         "@types/wrap-ansi",
-        "ora",
         "read-pkg",
         "wrap-ansi"
       ],


### PR DESCRIPTION
Updates `ora` from `v5` to `v9`:
* `v6` required Node 12.20, became ESM-only, and changed some properties not used in this repo
* `v7` required Node 16
* `v8` required Node 18
* `v9` required Node 20