### PR TITLE
chore(deps): remove wrap-ansi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "@types/sinon-chai": "4.0.0",
         "@types/teen_process": "2.0.4",
         "@types/which": "3.0.4",
-        "@types/wrap-ansi": "3.0.0",
         "@types/ws": "8.18.1",
         "@types/xmldom": "0.1.34",
         "@types/yargs": "17.0.35",
@@ -4497,11 +4496,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/which/-/which-3.0.4.tgz",
       "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/wrap-ansi": {
-      "version": "3.0.0",
       "dev": true,
       "license": "MIT"
     },
@@ -20120,7 +20114,6 @@
         "teen_process": "3.0.6",
         "type-fest": "5.3.1",
         "winston": "3.19.0",
-        "wrap-ansi": "7.0.0",
         "ws": "8.18.3",
         "yaml": "2.8.2"
       },
@@ -25150,10 +25143,6 @@
       "integrity": "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==",
       "dev": true
     },
-    "@types/wrap-ansi": {
-      "version": "3.0.0",
-      "dev": true
-    },
     "@types/ws": {
       "version": "8.18.1",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -25930,7 +25919,6 @@
         "teen_process": "3.0.6",
         "type-fest": "5.3.1",
         "winston": "3.19.0",
-        "wrap-ansi": "7.0.0",
         "ws": "8.18.3",
         "yaml": "2.8.2"
       },

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "@types/sinon-chai": "4.0.0",
     "@types/teen_process": "2.0.4",
     "@types/which": "3.0.4",
-    "@types/wrap-ansi": "3.0.0",
     "@types/ws": "8.18.1",
     "@types/xmldom": "0.1.34",
     "@types/yargs": "17.0.35",

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -85,7 +85,6 @@
     "teen_process": "3.0.6",
     "type-fest": "5.3.1",
     "winston": "3.19.0",
-    "wrap-ansi": "7.0.0",
     "ws": "8.18.3",
     "yaml": "2.8.2"
   },

--- a/packages/appium/scripts/autoinstall-extensions.js
+++ b/packages/appium/scripts/autoinstall-extensions.js
@@ -39,11 +39,6 @@ let PLUGIN_TYPE;
 let loadExtensions;
 
 const _ = require('lodash');
-const wrap = _.partial(
-  require('wrap-ansi'),
-  _,
-  process.stderr.columns ?? process.stdout.columns ?? 80
-);
 const ora = require('ora');
 
 /** @type {typeof import('@appium/support').env} */
@@ -54,7 +49,7 @@ let util;
 let logger;
 
 function log(message) {
-  console.error(wrap(`[Appium] ${message}`));
+  console.error(`[Appium] ${message}`);
 }
 
 /**
@@ -118,9 +113,12 @@ async function main() {
   }).start();
 
   if (!driverEnv && !pluginEnv) {
-    spinner.succeed(
-      wrap(`No drivers or plugins to automatically install.
-      If desired, provide arguments with comma-separated values "--drivers=<known_driver>[,known_driver...]" and/or "--plugins=<known_plugin>[,known_plugin...]" to the "npm install appium" command. The specified extensions will be installed automatically with Appium.  Note: to see the list of known extensions, run "appium <driver|plugin> list".`)
+    spinner.succeed('No drivers or plugins to automatically install.');
+    log(
+      'If desired, provide the argument "--drivers=<driver_name>[,<driver_name>...]" and/or ' +
+      '"--plugins=<plugin_name>[,<plugin_name>...]" to the "npm install appium" command. ' +
+      'The specified extensions will be installed automatically alongside Appium. ' +
+      'For a list of known extensions, run "appium <driver|plugin> list".'
     );
     return;
   }

--- a/packages/appium/scripts/autoinstall-extensions.js
+++ b/packages/appium/scripts/autoinstall-extensions.js
@@ -38,7 +38,6 @@ let PLUGIN_TYPE;
 /** @type {typeof import('../lib/extension').loadExtensions} */
 let loadExtensions;
 
-const _ = require('lodash');
 const ora = require('ora');
 
 /** @type {typeof import('@appium/support').env} */

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -14,10 +14,8 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "@types/wrap-ansi",
         "ora",
-        "read-pkg",
-        "wrap-ansi"
+        "read-pkg"
       ],
       "matchUpdateTypes": ["major"],
       "enabled": false


### PR DESCRIPTION
This removes the `wrap-ansi` dependency (along with its types). It was only used in one script, and none of the other loggers apply this kind of line-wrapping, so I do not see much point in using it here.