### PR TITLE
fix(scripts): properly import log-symbols in scripts

### DIFF
--- a/packages/schema/scripts/generate-schema-json.js
+++ b/packages/schema/scripts/generate-schema-json.js
@@ -10,6 +10,7 @@
 const path = require('path');
 const {writeFile, mkdir} = require('fs').promises;
 const logSymbols = require('log-symbols');
+const {error, info, success} = logSymbols.default;
 
 /**
  * `@appium/schema` package root.
@@ -43,7 +44,7 @@ async function write() {
     ({AppiumConfigJsonSchema: schema} = require(SCHEMA_SRC));
   } catch {
     throw new Error(
-      `${logSymbols.error} Failed to read ${SCHEMA_SRC}; did you execute \`npm run build\` first?`
+      `${error} Failed to read ${SCHEMA_SRC}; did you execute \`npm run build\` first?`
     );
   }
 
@@ -52,9 +53,9 @@ async function write() {
   try {
     await mkdir(OUTPUT_DIR, {recursive: true});
     await writeFile(OUTPUT_PATH, json);
-    console.log(`${logSymbols.info} Wrote JSON schema to ${OUTPUT_PATH}`);
+    console.log(`${info} Wrote JSON schema to ${OUTPUT_PATH}`);
   } catch (err) {
-    throw new Error(`${logSymbols.error} Failed to write JSON schema to ${OUTPUT_PATH}: ${err.message}`);
+    throw new Error(`${error} Failed to write JSON schema to ${OUTPUT_PATH}: ${err.message}`);
   }
 }
 
@@ -66,7 +67,7 @@ async function main() {
     process.exitCode = 1;
     return;
   }
-  console.log(`${logSymbols.success} Done.`);
+  console.log(`${success} Done.`);
 }
 
 if (require.main === module) {

--- a/packages/types/scripts/generate-schema-types.js
+++ b/packages/types/scripts/generate-schema-types.js
@@ -9,6 +9,7 @@ const {compileFromFile} = require('json-schema-to-typescript');
 const path = require('path');
 const {promises: fs} = require('fs');
 const logSymbols = require('log-symbols');
+const {error, info, success} = logSymbols.default;
 
 /**
  * Path to `@appium/types` package root
@@ -41,16 +42,16 @@ async function main() {
       ts = await compileFromFile(JSON_SCHEMA_PATH);
     } catch (err) {
       throw new Error(
-        `${logSymbols.error} Could not convert Appium schema JSON to TypeScript: ${err.message}. Does it exist?`
+        `${error} Could not convert Appium schema JSON to TypeScript: ${err.message}. Does it exist?`
       );
     }
     try {
       await fs.writeFile(OUTPUT_PATH, ts);
     } catch (err) {
-      throw new Error(`${logSymbols.error} Could not write Appium schema declaration file: ${err.message}`);
+      throw new Error(`${error} Could not write Appium schema declaration file: ${err.message}`);
     }
-    console.log(`${logSymbols.info} Wrote %s`, OUTPUT_PATH);
-    console.log(`${logSymbols.success} Done.`);
+    console.log(`${info} Wrote %s`, OUTPUT_PATH);
+    console.log(`${success} Done.`);
   } catch (err) {
     console.error(err.message);
     process.exitCode = 1;


### PR DESCRIPTION
The recent update to `log-symbols` `v7` broke the symbols for script files (files with ES6 imports were not affected):
<img width="297" height="77" alt="symbols-old" src="https://github.com/user-attachments/assets/33baa899-db8a-4e18-a2dd-8edfae68adb0" />

This PR fixes the imports, plus the symbols are now colored (which was not the case with `log-symbols` `v4`):
<img width="294" height="77" alt="symbols-new" src="https://github.com/user-attachments/assets/9c907fb6-2358-492f-a959-3f413315b2f6" />
