### PR TITLE
chore(deps): update read-pkg to v10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4372,7 +4372,9 @@
       "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
-      "version": "2.4.1",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "license": "MIT"
     },
     "node_modules/@types/pluralize": {
@@ -8642,6 +8644,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -10993,6 +10996,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "dev": true,
@@ -11095,6 +11110,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-bun-module": {
@@ -11136,6 +11152,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -11602,6 +11619,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema": {
@@ -12376,6 +12394,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/load-json-file": {
@@ -15531,6 +15550,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -15644,6 +15664,7 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -16294,6 +16315,7 @@
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
@@ -16502,10 +16524,12 @@
     },
     "node_modules/read-pkg/node_modules/hosted-git-info": {
       "version": "2.8.9",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/read-pkg/node_modules/normalize-package-data": {
       "version": "2.5.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^2.1.4",
@@ -16518,12 +16542,14 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
       "version": "0.6.0",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=8"
@@ -16611,6 +16637,7 @@
       "version": "1.22.4",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
       "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -17888,6 +17915,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -18857,7 +18885,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -20253,7 +20280,7 @@
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "package-directory": "8.1.0",
-        "read-pkg": "5.2.0",
+        "read-pkg": "10.0.0",
         "teen_process": "3.0.6",
         "type-fest": "5.3.1",
         "yaml": "2.8.2",
@@ -20309,6 +20336,18 @@
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "license": "MIT"
     },
+    "packages/docutils/node_modules/hosted-git-info": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "packages/docutils/node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -20319,6 +20358,77 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "packages/docutils/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "packages/docutils/node_modules/normalize-package-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "packages/docutils/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/docutils/node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/docutils/node_modules/read-pkg": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
+      "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.4",
+        "normalize-package-data": "^8.0.0",
+        "parse-json": "^8.3.0",
+        "type-fest": "^5.2.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/docutils/node_modules/string-width": {
@@ -21239,7 +21349,7 @@
         "package-directory": "8.1.0",
         "plist": "3.1.0",
         "pluralize": "8.0.0",
-        "read-pkg": "5.2.0",
+        "read-pkg": "10.0.0",
         "resolve-from": "5.0.0",
         "sanitize-filename": "1.6.3",
         "semver": "7.7.3",
@@ -21290,6 +21400,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/support/node_modules/hosted-git-info": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "packages/support/node_modules/is-stream": {
@@ -21345,6 +21467,49 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "packages/support/node_modules/normalize-package-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+      "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^9.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "packages/support/node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/support/node_modules/parse-json/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "packages/support/node_modules/path-scurry": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
@@ -21359,6 +21524,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "packages/support/node_modules/read-pkg": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
+      "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.4",
+        "normalize-package-data": "^8.0.0",
+        "parse-json": "^8.3.0",
+        "type-fest": "^5.2.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/support/node_modules/semver": {
@@ -21596,7 +21780,7 @@
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
         "package-directory": "8.1.0",
-        "read-pkg": "5.2.0",
+        "read-pkg": "10.0.0",
         "teen_process": "3.0.6",
         "type-fest": "5.3.1",
         "yaml": "2.8.2",
@@ -21629,10 +21813,62 @@
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
           "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="
         },
+        "hosted-git-info": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+          "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+          "requires": {
+            "lru-cache": "^11.1.0"
+          }
+        },
         "lilconfig": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
           "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="
+        },
+        "lru-cache": {
+          "version": "11.2.4",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+          "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="
+        },
+        "normalize-package-data": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+          "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+          "requires": {
+            "hosted-git-info": "^9.0.0",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
+          }
+        },
+        "parse-json": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+          "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+          "requires": {
+            "@babel/code-frame": "^7.26.2",
+            "index-to-position": "^1.1.0",
+            "type-fest": "^4.39.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "4.41.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+              "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
+          "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
+          "requires": {
+            "@types/normalize-package-data": "^2.4.4",
+            "normalize-package-data": "^8.0.0",
+            "parse-json": "^8.3.0",
+            "type-fest": "^5.2.0",
+            "unicorn-magic": "^0.3.0"
+          }
         },
         "string-width": {
           "version": "7.2.0",
@@ -22211,7 +22447,7 @@
         "package-directory": "8.1.0",
         "plist": "3.1.0",
         "pluralize": "8.0.0",
-        "read-pkg": "5.2.0",
+        "read-pkg": "10.0.0",
         "resolve-from": "5.0.0",
         "sanitize-filename": "1.6.3",
         "semver": "7.7.3",
@@ -22244,6 +22480,14 @@
             "path-scurry": "^2.0.0"
           }
         },
+        "hosted-git-info": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+          "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+          "requires": {
+            "lru-cache": "^11.1.0"
+          }
+        },
         "is-stream": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
@@ -22272,6 +22516,33 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
           "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
         },
+        "normalize-package-data": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-8.0.0.tgz",
+          "integrity": "sha512-RWk+PI433eESQ7ounYxIp67CYuVsS1uYSonX3kA6ps/3LWfjVQa/ptEg6Y3T6uAMq1mWpX9PQ+qx+QaHpsc7gQ==",
+          "requires": {
+            "hosted-git-info": "^9.0.0",
+            "semver": "^7.3.5",
+            "validate-npm-package-license": "^3.0.4"
+          }
+        },
+        "parse-json": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+          "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+          "requires": {
+            "@babel/code-frame": "^7.26.2",
+            "index-to-position": "^1.1.0",
+            "type-fest": "^4.39.1"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "4.41.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+              "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="
+            }
+          }
+        },
         "path-scurry": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
@@ -22279,6 +22550,18 @@
           "requires": {
             "lru-cache": "^11.0.0",
             "minipass": "^7.1.2"
+          }
+        },
+        "read-pkg": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
+          "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
+          "requires": {
+            "@types/normalize-package-data": "^2.4.4",
+            "normalize-package-data": "^8.0.0",
+            "parse-json": "^8.3.0",
+            "type-fest": "^5.2.0",
+            "unicorn-magic": "^0.3.0"
           }
         },
         "semver": {
@@ -25027,7 +25310,9 @@
       }
     },
     "@types/normalize-package-data": {
-      "version": "2.4.1"
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="
     },
     "@types/pluralize": {
       "version": "0.0.33",
@@ -27895,6 +28180,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -29394,6 +29680,11 @@
       "version": "4.0.0",
       "dev": true
     },
+    "index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="
+    },
     "inflight": {
       "version": "1.0.6",
       "dev": true,
@@ -29465,7 +29756,8 @@
       "dev": true
     },
     "is-arrayish": {
-      "version": "0.2.1"
+      "version": "0.2.1",
+      "dev": true
     },
     "is-bun-module": {
       "version": "2.0.0",
@@ -29494,6 +29786,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "requires": {
         "hasown": "^2.0.2"
       }
@@ -29792,7 +30085,8 @@
       "dev": true
     },
     "json-parse-even-better-errors": {
-      "version": "2.3.1"
+      "version": "2.3.1",
+      "dev": true
     },
     "json-schema": {
       "version": "0.4.0"
@@ -30344,7 +30638,8 @@
       "dev": true
     },
     "lines-and-columns": {
-      "version": "1.2.4"
+      "version": "1.2.4",
+      "dev": true
     },
     "load-json-file": {
       "version": "6.2.0",
@@ -32453,6 +32748,7 @@
     },
     "parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -32524,7 +32820,8 @@
       "version": "3.1.1"
     },
     "path-parse": {
-      "version": "1.0.7"
+      "version": "1.0.7",
+      "dev": true
     },
     "path-scurry": {
       "version": "1.11.1",
@@ -32956,6 +33253,7 @@
     },
     "read-pkg": {
       "version": "5.2.0",
+      "dev": true,
       "requires": {
         "@types/normalize-package-data": "^2.4.0",
         "normalize-package-data": "^2.5.0",
@@ -32964,10 +33262,12 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "2.8.9"
+          "version": "2.8.9",
+          "dev": true
         },
         "normalize-package-data": {
           "version": "2.5.0",
+          "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
@@ -32978,10 +33278,12 @@
         "semver": {
           "version": "5.7.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+          "dev": true
         },
         "type-fest": {
-          "version": "0.6.0"
+          "version": "0.6.0",
+          "dev": true
         }
       }
     },
@@ -33179,6 +33481,7 @@
       "version": "1.22.4",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
       "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -34027,7 +34330,8 @@
       }
     },
     "supports-preserve-symlinks-flag": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "sync-monorepo-packages": {
       "version": "1.0.2",
@@ -34665,8 +34969,7 @@
     "unicorn-magic": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "dev": true
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="
     },
     "unique-filename": {
       "version": "4.0.0",

--- a/packages/docutils/lib/cli/index.ts
+++ b/packages/docutils/lib/cli/index.ts
@@ -10,7 +10,7 @@ import {getLogger} from '../logger';
 
 import {fs} from '@appium/support';
 import _ from 'lodash';
-import {sync as readPkg} from 'read-pkg';
+import {readPackageSync} from 'read-pkg';
 import {hideBin} from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 import {DEFAULT_LOG_LEVEL, LogLevelMap, NAME_BIN} from '../constants';
@@ -18,7 +18,7 @@ import {DocutilsError} from '../error';
 import {build, init, validate} from './command';
 import {findConfig} from './config';
 
-const pkg = readPkg({cwd: fs.findRoot(__dirname)});
+const pkg = readPackageSync({cwd: fs.findRoot(__dirname)});
 const log = getLogger('cli');
 const IMPLICATIONS_FAILED_REGEX = /implications\s+failed:\n\s*(.+)\s->\s(.+)$/i;
 

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -7,7 +7,7 @@ import {fs} from '@appium/support';
 import _ from 'lodash';
 import path from 'node:path';
 import {packageDirectory} from 'package-directory';
-import readPkg, {NormalizedPackageJson, PackageJson} from 'read-pkg';
+import {readPackage, NormalizedPackageJson, PackageJson} from 'read-pkg';
 import {JsonValue} from 'type-fest';
 import * as YAML from 'yaml';
 import {
@@ -118,10 +118,10 @@ async function _readPkgJson(
   const pkgPath = path.join(pkgDir, NAME_PACKAGE_JSON);
   log.debug('Found `package.json` at %s', pkgPath);
   if (normalize) {
-    const pkg = await readPkg({cwd: pkgDir, normalize});
+    const pkg = await readPackage({cwd: pkgDir, normalize});
     return {pkg, pkgPath};
   } else {
-    const pkg = await readPkg({cwd: pkgDir});
+    const pkg = await readPackage({cwd: pkgDir});
     return {pkg, pkgPath};
   }
 }

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -54,7 +54,7 @@
     "lilconfig": "3.1.3",
     "lodash": "4.17.21",
     "package-directory": "8.1.0",
-    "read-pkg": "5.2.0",
+    "read-pkg": "10.0.0",
     "teen_process": "3.0.6",
     "type-fest": "5.3.1",
     "yaml": "2.8.2",

--- a/packages/support/lib/env.js
+++ b/packages/support/lib/env.js
@@ -2,7 +2,7 @@
 import _ from 'lodash';
 import {homedir} from 'os';
 import path from 'path';
-import readPkg from 'read-pkg';
+import {readPackage} from 'read-pkg';
 import * as semver from 'semver';
 
 /**
@@ -96,7 +96,7 @@ export const readPackageInDir = _.memoize(
    * @returns {Promise<import('read-pkg').NormalizedPackageJson|undefined>}
    */
   async function _readPackageInDir(cwd) {
-    return await readPkg({cwd, normalize: true});
+    return await readPackage({cwd, normalize: true});
   }
 );
 

--- a/packages/support/lib/fs.js
+++ b/packages/support/lib/fs.js
@@ -19,7 +19,7 @@ import _ from 'lodash';
 import ncp from 'ncp';
 import {packageDirectorySync} from 'package-directory';
 import path from 'path';
-import readPkg from 'read-pkg';
+import {readPackageSync} from 'read-pkg';
 import sanitize from 'sanitize-filename';
 import which from 'which';
 import log from './logger';
@@ -376,7 +376,7 @@ const fs = {
   readPackageJsonFrom(dir, opts = {}) {
     const cwd = fs.findRoot(dir);
     try {
-      return readPkg.sync(
+      return readPackageSync(
         /** @type {import('read-pkg').NormalizeOptions} */ ({normalize: true, ...opts, cwd})
       );
     } catch (err) {

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -64,7 +64,7 @@
     "package-directory": "8.1.0",
     "plist": "3.1.0",
     "pluralize": "8.0.0",
-    "read-pkg": "5.2.0",
+    "read-pkg": "10.0.0",
     "resolve-from": "5.0.0",
     "sanitize-filename": "1.6.3",
     "semver": "7.7.3",

--- a/packages/support/test/mocks.js
+++ b/packages/support/test/mocks.js
@@ -15,9 +15,9 @@ export function initMocks(sandbox = createSandbox()) {
 
   const MockPkgDir = /** @type {MockPkgDir} */ (sandbox.stub().resolvesArg(0));
 
-  const MockReadPkg = /** @type {MockReadPkg} */ (
-    sandbox.stub().callsFake(async () => MockReadPkg.__pkg)
-  );
+  const MockReadPkg = /** @type {MockReadPkg} */ ({
+    readPackage: sandbox.stub().callsFake(async () => MockReadPkg.__pkg)
+  });
 
   // just an accessible place to put a mock package.json if we need it
   MockReadPkg.__pkg = {
@@ -83,7 +83,8 @@ export function initMocks(sandbox = createSandbox()) {
  */
 
 /**
- * @typedef {sinon.SinonStubbedMember<import('read-pkg')> & {__pkg: import('read-pkg').NormalizedPackageJson}} MockReadPkg
+ * Mocks for `read-pkg` package
+ * @typedef { {readPackage: sinon.SinonStubbedMember<import('read-pkg').readPackage>, __pkg: import('read-pkg').NormalizedPackageJson}} MockReadPkg
  */
 
 /**

--- a/packages/support/test/unit/env.spec.js
+++ b/packages/support/test/unit/env.spec.js
@@ -111,7 +111,7 @@ describe('env', function () {
             // this is needed because the default behavior is `resolvesArg(0)`; `.resolves()`
             // does not override this behavior! I don't know why!
             // .resetBehavior();
-            MockReadPkg.resolves();
+            MockReadPkg.readPackage.resolves();
           });
 
           it('should resolve with DEFAULT_APPIUM_HOME', async function () {
@@ -126,7 +126,7 @@ describe('env', function () {
 
           describe('when `appium` is a dependency which does not resolve to a file path`', function () {
             beforeEach(function () {
-              MockReadPkg.resolves({devDependencies: {appium: '2.0.0-beta.25'}});
+              MockReadPkg.readPackage.resolves({devDependencies: {appium: '2.0.0-beta.25'}});
             });
 
             it('should resolve with the identity', async function () {
@@ -136,7 +136,7 @@ describe('env', function () {
 
           describe('when `appium` is a dependency for version 0.x', function () {
             beforeEach(function () {
-              MockReadPkg.resolves({devDependencies: {appium: '0.9.0'}});
+              MockReadPkg.readPackage.resolves({devDependencies: {appium: '0.9.0'}});
             });
             it('should resolve with DEFAULT_APPIUM_HOME', async function () {
               await expect(env.resolveAppiumHome(appiumHome)).to.eventually.equal(
@@ -147,7 +147,7 @@ describe('env', function () {
 
           describe('when `appium` is a dependency for version 1.x', function () {
             beforeEach(function () {
-              MockReadPkg.resolves({devDependencies: {appium: '1.2.3'}});
+              MockReadPkg.readPackage.resolves({devDependencies: {appium: '1.2.3'}});
             });
 
             it('should resolve with DEFAULT_APPIUM_HOME', async function () {
@@ -162,7 +162,7 @@ describe('env', function () {
       describe('when reading `package.json` causes an exception', function () {
         beforeEach(function () {
           // unclear if this is even possible
-          MockReadPkg.rejects(new Error('on the fritz'));
+          MockReadPkg.readPackage.rejects(new Error('on the fritz'));
         });
 
         it('should resolve with DEFAULT_APPIUM_HOME', async function () {
@@ -189,7 +189,7 @@ describe('env', function () {
   describe('readPackageInDir()', function () {
     it('should delegate to `read-pkg`', async function () {
       await env.readPackageInDir('/somewhere');
-      MockReadPkg.calledWithExactly({
+      MockReadPkg.readPackage.calledWithExactly({
         cwd: '/somewhere',
         normalize: true,
       }).should.be.true;
@@ -244,7 +244,7 @@ describe('env', function () {
 
           describe('when `appium` dep is current`', function () {
             beforeEach(function () {
-              MockReadPkg.resolves({
+              MockReadPkg.readPackage.resolves({
                 devDependencies: {appium: '2.0.0'},
               });
             });
@@ -256,7 +256,7 @@ describe('env', function () {
 
           describe('when `appium` dep is v1.x', function () {
             beforeEach(function () {
-              MockReadPkg.resolves({
+              MockReadPkg.readPackage.resolves({
                 optionalDependencies: {appium: '1.x'},
               });
             });
@@ -267,7 +267,7 @@ describe('env', function () {
 
           describe('when `appium` dep is v0.x', function () {
             beforeEach(function () {
-              MockReadPkg.resolves({
+              MockReadPkg.readPackage.resolves({
                 dependencies: {appium: '0.x'},
               });
             });

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -13,10 +13,7 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
-        "ora",
-        "read-pkg"
-      ],
+      "matchPackageNames": ["ora"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },


### PR DESCRIPTION
Updates `read-pkg` from `v5` to `v10`:
* `v6` required Node 12, became ESM-only, and changed the main exports (default became `readPackageAsync`, default`.sync` became `readPackageSync`)
* `v7` required Node 12.20 and renamed `readPackageAsync` to `readPackage` 
* `v8` required Node 16
* `v9` required Node 18
* `v10` required Node 20