### PR TITLE
chore(renovate): remove custom Appium groups

### DIFF
--- a/renovate/README.md
+++ b/renovate/README.md
@@ -46,9 +46,7 @@ Appium extension authors--or anyone else--may use this config as well.
 ### Custom Rules
 
 - Groups (groups updates into single PR):
-  - ESLint-related and [@appium/eslint-config-appium-ts](https://github.com/appium/appium/tree/master/eslint-config-appium-ts)
   - [teen_process](https://github.com/appium/node-teen_process) and its DT types
-  - Appium-scoped (`@appium`) packages. This applies to _other_ repos which depend on Appium, such as official drivers.
 
 ### Additional Config
 

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -18,17 +18,8 @@
       "enabled": false
     },
     {
-      "extends": ["packages:eslint"],
-      "matchPackageNames": ["@appium/eslint-config-appium-ts"],
-      "groupName": "ESLint-related packages"
-    },
-    {
       "matchPackageNames": ["teen_process", "@types/teen_process"],
       "groupName": "teen_process-related packages"
-    },
-    {
-      "matchPackageNames": ["appium", "@appium/**", "!@appium/eslint-config-appium-ts"],
-      "groupName": "Appium-related packages"
     }
   ],
   "semanticCommitScope": "{{#if parentDir}}{{parentDir}}{{else}}deps{{/if}}"


### PR DESCRIPTION
This is another simplification for the Renovate config, removing the custom groups for Appium-related packages:
* Grouping `@appium/eslint-config-appium-ts` with ESLint packages doesn't make much sense, since they do not have the same release schedule
* Appium monorepo packages no longer need to be explicitly grouped since Renovate `42.45.0` (released December 11th), which adds a built-in preset for this (see https://github.com/renovatebot/renovate/pull/39918)

Once `teen_process` is fully migrated to TS, its custom group can also be removed.