### PR TITLE
fix(appium): appium symlink behavior across drivers/plugins installations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "rimraf": "6.1.2",
         "serve-static": "2.2.1",
         "sinon": "21.0.1",
+        "sinon-chai": "4.0.1",
         "sync-monorepo-packages": "1.0.2",
         "teen_process": "4.0.7",
         "ts-node": "10.9.2",
@@ -17396,6 +17397,17 @@
         "url": "https://opencollective.com/sinon"
       }
     },
+    "node_modules/sinon-chai": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-4.0.1.tgz",
+      "integrity": "sha512-xMKEEV3cYHC1G+boyr7QEqi80gHznYsxVdC9CdjP5JnCWz/jPGuXQzJz3PtBcb0CcHAxar15Y5sjLBoAs6a0yA==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR WTFPL)",
+      "peerDependencies": {
+        "chai": "^5.0.0 || ^6.0.0",
+        "sinon": ">=4.0.0"
+      }
+    },
     "node_modules/sinon/node_modules/diff": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
@@ -26095,7 +26107,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
-        "ajv": "^8.0.0"
+        "ajv": "8.17.1"
       }
     },
     "ansi-colors": {
@@ -33952,6 +33964,13 @@
           }
         }
       }
+    },
+    "sinon-chai": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-4.0.1.tgz",
+      "integrity": "sha512-xMKEEV3cYHC1G+boyr7QEqi80gHznYsxVdC9CdjP5JnCWz/jPGuXQzJz3PtBcb0CcHAxar15Y5sjLBoAs6a0yA==",
+      "dev": true,
+      "requires": {}
     },
     "slash": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "rimraf": "6.1.2",
     "serve-static": "2.2.1",
     "sinon": "21.0.1",
+    "sinon-chai": "4.0.1",
     "sync-monorepo-packages": "1.0.2",
     "teen_process": "4.0.7",
     "ts-node": "10.9.2",

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -617,18 +617,6 @@ class ExtensionCliCommand {
         return {pkg, installPath};
       });
 
-      /** @type {Promise<void>[]} */
-      const symlinkInjectionPromises = _.uniq([
-        ...Object.values(this.config.installedExtensions).map((ext) => ext.installPath),
-        installPath,
-      ]).map((instPath) => injectAppiumSymlink.bind(this)(path.join(instPath, 'node_modules')));
-      // After the extension is installed, we try to inject the appium module symlink
-      // into the extension's node_modules folder if it is not there yet.
-      // We also inject the symlink into other installed extensions' node_modules folders
-      // as these might be cleaned up unexpectedly by npm
-      // (see https://github.com/appium/python-client/pull/1177#issuecomment-3419826643).
-      await Promise.all(symlinkInjectionPromises);
-
       return this.getInstallationReceipt({
         pkg,
         installPath,
@@ -1131,14 +1119,39 @@ class ExtensionCliCommand {
 }
 
 /**
+ *
+ * @param {ExtensionConfig<ExtensionType>} driverConfig
+ * @param {ExtensionConfig<ExtensionType>} pluginConfig
+ * @param {import('@appium/types').AppiumLogger} logger
+ */
+export async function injectAppiumSymlinks(driverConfig, pluginConfig, logger) {
+  const installPaths = [
+    ...Object.values(driverConfig.installedExtensions || {}),
+    ...Object.values(pluginConfig.installedExtensions || {})
+  ].map((details) => {
+    if (details.installType === INSTALL_TYPE_NPM) {
+      return details.installPath;
+    }
+  });
+  // After the extension is installed, we try to inject the appium module symlink
+  // into the extension's node_modules folder if it is not there yet.
+  // We also inject the symlink into other installed extensions' node_modules folders
+  // as these might be cleaned up unexpectedly by npm
+  // (see https://github.com/appium/python-client/pull/1177#issuecomment-3419826643).
+  await Promise.all(
+    _.compact(installPaths).map((installPath) => injectAppiumSymlink(path.join(installPath, 'node_modules'), logger))
+  );
+}
+
+/**
  * This is needed to ensure proper module resolution for installed extensions,
  * especially ESM ones.
  *
- * @this {ExtensionCliCommand}
  * @param {string} dstFolder The destination folder where the symlink should be created
+ * @param {import('@appium/types').AppiumLogger} logger
  * @returns {Promise<void>}
  */
-async function injectAppiumSymlink(dstFolder) {
+async function injectAppiumSymlink(dstFolder, logger) {
   let appiumModuleRoot;
   try {
     appiumModuleRoot = getAppiumModuleRoot();
@@ -1148,7 +1161,7 @@ async function injectAppiumSymlink(dstFolder) {
     }
   } catch (error) {
     // This error is not fatal, we may still doing just fine if the module being loaded is a CJS one
-    this.log.info(
+    logger.info(
       `Cannot create a symlink to the appium module '${appiumModuleRoot}' in '${dstFolder}'. ` +
       `Original error: ${error.message}`
     );

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -1127,14 +1127,11 @@ class ExtensionCliCommand {
  * @param {import('@appium/types').AppiumLogger} logger
  */
 export async function injectAppiumSymlinks(driverConfig, pluginConfig, logger) {
-  const installPaths = _.compact([
+  const installPaths = [
     ...Object.values(driverConfig.installedExtensions || {}),
     ...Object.values(pluginConfig.installedExtensions || {})
-  ].map((details) => {
-    if (details.installType === INSTALL_TYPE_NPM) {
-      return details.installPath;
-    }
-  }));
+  ].filter((details) => details.installType === INSTALL_TYPE_NPM)
+   .map((details) => details.installPath);
   // After the extension is installed, we try to inject the appium module symlink
   // into the extension's node_modules folder if it is not there yet.
   // We also inject the symlink into other installed extensions' node_modules folders

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -1119,6 +1119,8 @@ class ExtensionCliCommand {
 }
 
 /**
+ * This is needed to ensure proper module resolution for installed extensions,
+ * especially ESM ones.
  *
  * @param {ExtensionConfig<ExtensionType>} driverConfig
  * @param {ExtensionConfig<ExtensionType>} pluginConfig

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -1127,11 +1127,11 @@ class ExtensionCliCommand {
  * @param {import('@appium/types').AppiumLogger} logger
  */
 export async function injectAppiumSymlinks(driverConfig, pluginConfig, logger) {
-  const installPaths = [
+  const installPaths = _.compact([
     ...Object.values(driverConfig.installedExtensions || {}),
     ...Object.values(pluginConfig.installedExtensions || {})
   ].filter((details) => details.installType === INSTALL_TYPE_NPM)
-   .map((details) => details.installPath);
+   .map((details) => details.installPath));
   // After the extension is installed, we try to inject the appium module symlink
   // into the extension's node_modules folder if it is not there yet.
   // We also inject the symlink into other installed extensions' node_modules folders

--- a/packages/appium/lib/cli/extension-command.js
+++ b/packages/appium/lib/cli/extension-command.js
@@ -1127,21 +1127,21 @@ class ExtensionCliCommand {
  * @param {import('@appium/types').AppiumLogger} logger
  */
 export async function injectAppiumSymlinks(driverConfig, pluginConfig, logger) {
-  const installPaths = [
+  const installPaths = _.compact([
     ...Object.values(driverConfig.installedExtensions || {}),
     ...Object.values(pluginConfig.installedExtensions || {})
   ].map((details) => {
     if (details.installType === INSTALL_TYPE_NPM) {
       return details.installPath;
     }
-  });
+  }));
   // After the extension is installed, we try to inject the appium module symlink
   // into the extension's node_modules folder if it is not there yet.
   // We also inject the symlink into other installed extensions' node_modules folders
   // as these might be cleaned up unexpectedly by npm
   // (see https://github.com/appium/python-client/pull/1177#issuecomment-3419826643).
   await Promise.all(
-    _.compact(installPaths).map((installPath) => injectAppiumSymlink(path.join(installPath, 'node_modules'), logger))
+    installPaths.map((installPath) => injectAppiumSymlink(path.join(installPath, 'node_modules'), logger))
   );
 }
 

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -43,6 +43,7 @@ import {
   isBroadcastIp,
 } from './utils';
 import net from 'node:net';
+import { injectAppiumSymlinks } from './cli/extension-command';
 
 const {resolveAppiumHome} = env;
 /*
@@ -313,6 +314,15 @@ async function init(args) {
       }
       if (isPluginCommandArgs(preConfigArgs)) {
         await runExtensionCommand(preConfigArgs, pluginConfig);
+      }
+
+      if (isDriverCommandArgs(preConfigArgs) || isPluginCommandArgs(preConfigArgs)) {
+        // @ts-ignore The linter suggest using dot
+        const cmd = preConfigArgs.driverCommand || preConfigArgs.pluginCommand;
+        if (cmd === 'install') {
+          logger.info('[debug] =======> doing injection')
+          await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+        }
       }
     }
     return /** @type {InitResult<Cmd>} */ ({});

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -320,7 +320,6 @@ async function init(args) {
         // @ts-ignore The linter suggest using dot
         const cmd = preConfigArgs.driverCommand || preConfigArgs.pluginCommand;
         if (cmd === 'install') {
-          logger.info('[debug] =======> doing injection')
           await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
         }
       }

--- a/packages/appium/test/unit/extension/extension-command.spec.js
+++ b/packages/appium/test/unit/extension/extension-command.spec.js
@@ -1,32 +1,31 @@
 // @ts-check
 import {DriverConfig} from '../../../lib/extension/driver-config';
-import {ExtensionCommand} from '../../../lib/cli/extension-command';
+import {ExtensionCommand, injectAppiumSymlinks} from '../../../lib/cli/extension-command';
 import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 import {FAKE_DRIVER_DIR} from '../../helpers';
 import {Manifest} from '../../../lib/extension/manifest';
+import {fs, system} from '@appium/support';
+import * as utils from '../../../lib/utils';
+import {expect} from 'chai';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
 
 /**
  * Relative path from actual `package.json` of `FakeDriver` for the `fake-stdin` script
  */
 const FAKE_STDIN_SCRIPT = require(`${FAKE_DRIVER_DIR}/package.json`).appium.scripts['fake-stdin'];
 
+/** @type {sinon.SinonSandbox} */
+let sandbox;
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
 describe('ExtensionCommand', function () {
   describe('method', function () {
-    /** @type {ExtensionCommand} */
+    /** @type {ExtensionCommand<any>} */
     let ec;
-
-    /** @type {sinon.SinonSandbox} */
-    let sandbox;
-
-    let expect;
-
-    before(async function () {
-      const chai = await import('chai');
-      const chaiAsPromised = await import('chai-as-promised');
-      chai.use(chaiAsPromised.default);
-      chai.should();
-      expect = chai.expect;
-    });
 
     beforeEach(function () {
       sandbox = sinon.createSandbox();
@@ -35,6 +34,7 @@ describe('ExtensionCommand', function () {
     });
 
     afterEach(function () {
+      sandbox.verify();
       sandbox.restore();
     });
 
@@ -46,18 +46,19 @@ describe('ExtensionCommand', function () {
       // `Promise` + `ChildProcess`, but I didn't want to add the dep.
       it('should respond to stdin', function (done) {
         // we have to fake writing to STDIN because this is an automated test, after all.
-        const proc = ec
+        const proc = /** @type {import('child_process').ChildProcess} */ (ec
           ._runUnbuffered(FAKE_DRIVER_DIR, FAKE_STDIN_SCRIPT, [], {
             stdio: ['pipe', 'inherit', 'inherit'],
-          })
-          .once('exit', (code) => {
-            try {
-              expect(code).to.equal(0);
-              done();
-            } catch (err) {
-              done(err);
-            }
-          });
+          }));
+
+        proc.once('exit', (/** @type {number | null} */ code) => {
+          try {
+            expect(code).to.equal(0);
+            done();
+          } catch (err) {
+            done(err);
+          }
+        });
 
         setTimeout(() => {
           // TS does not understand that `proc.stdin` is not `null`, because it is only a `Writable`
@@ -66,6 +67,329 @@ describe('ExtensionCommand', function () {
           stdin.write('\n');
           stdin.end();
         }, 200);
+      });
+    });
+  });
+
+  describe('injectAppiumSymlinks', function () {
+
+    /** @type {sinon.SinonStub} */
+    let fsExistsStub;
+
+    /** @type {sinon.SinonStub} */
+    let fsSymlinkStub;
+
+    /** @type {sinon.SinonStub} */
+    let getAppiumModuleRootStub;
+
+    /** @type {sinon.SinonStub} */
+    let isWindowsStub;
+
+    /** @type {import('@appium/types').AppiumLogger} */
+    let logger;
+
+    beforeEach(function () {
+      sandbox = sinon.createSandbox();
+      fsExistsStub = sandbox.stub(fs, 'exists');
+      fsSymlinkStub = sandbox.stub(fs, 'symlink');
+      getAppiumModuleRootStub = sandbox.stub(utils, 'getAppiumModuleRoot');
+      isWindowsStub = sandbox.stub(system, 'isWindows');
+      logger = /** @type {any} */ ({
+        info: sandbox.stub(),
+        warn: sandbox.stub(),
+        error: sandbox.stub(),
+        debug: sandbox.stub(),
+      });
+
+      getAppiumModuleRootStub.returns('/path/to/appium');
+      isWindowsStub.returns(false);
+    });
+
+    afterEach(function () {
+      sandbox.verify();
+      sandbox.restore();
+    });
+
+    describe('when there are no installed extensions', function () {
+      it('should not create any symlinks', async function () {
+        const driverConfig = {installedExtensions: {}};
+        const pluginConfig = {installedExtensions: {}};
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.not.have.been.called;
+      });
+    });
+
+    describe('when there are npm-installed drivers', function () {
+      it('should create symlinks for npm-installed drivers', async function () {
+        const driverConfig = {
+          installedExtensions: {
+            'driver-for-test': {
+              installType: 'npm',
+              installPath: '/path/to/driver-for-test',
+            },
+          },
+        };
+        const pluginConfig = {installedExtensions: {}};
+
+        fsExistsStub.withArgs('/path/to/driver-for-test/node_modules').resolves(true);
+        fsExistsStub.withArgs('/path/to/driver-for-test/node_modules/appium').resolves(false);
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsExistsStub).to.have.been.calledWith('/path/to/driver-for-test/node_modules');
+        expect(fsExistsStub).to.have.been.calledWith('/path/to/driver-for-test/node_modules/appium');
+        expect(fsSymlinkStub).to.have.been.calledOnce;
+        expect(fsSymlinkStub).to.have.been.calledWith(
+          '/path/to/appium',
+          '/path/to/driver-for-test/node_modules/appium',
+          'dir'
+        );
+      });
+
+      it('should create junction symlinks on Windows', async function () {
+        isWindowsStub.returns(true);
+        const driverConfig = {
+          installedExtensions: {
+            'driver-for-test': {
+              installType: 'npm',
+              installPath: '/path/to/driver-for-test',
+            },
+          },
+        };
+        const pluginConfig = {installedExtensions: {}};
+
+        fsExistsStub.withArgs('/path/to/driver-for-test/node_modules').resolves(true);
+        fsExistsStub.withArgs('/path/to/driver-for-test/node_modules/appium').resolves(false);
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.have.been.calledWith(
+          '/path/to/appium',
+          '/path/to/driver-for-test/node_modules/appium',
+          'junction'
+        );
+      });
+
+      it('should not create symlinks if node_modules directory does not exist', async function () {
+        const driverConfig = {
+          installedExtensions: {
+            'driver-for-test': {
+              installType: 'npm',
+              installPath: '/path/to/driver-for-test',
+            },
+          },
+        };
+        const pluginConfig = {installedExtensions: {}};
+
+        fsExistsStub.withArgs('/path/to/driver-for-test/node_modules').resolves(false);
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.not.have.been.called;
+      });
+
+      it('should not create symlinks if symlink already exists', async function () {
+        const driverConfig = {
+          installedExtensions: {
+            'driver-for-test': {
+              installType: 'npm',
+              installPath: '/path/to/driver-for-test',
+            },
+          },
+        };
+        const pluginConfig = {installedExtensions: {}};
+
+        fsExistsStub.resolves(true);
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.not.have.been.called;
+      });
+    });
+
+    describe('when there are npm-installed plugins', function () {
+      it('should create symlinks for npm-installed plugins', async function () {
+        const driverConfig = {installedExtensions: {}};
+        const pluginConfig = {
+          installedExtensions: {
+            'plugin-for-test': {
+              installType: 'npm',
+              installPath: '/path/to/plugin-for-test',
+            },
+          },
+        };
+
+        fsExistsStub.withArgs('/path/to/plugin-for-test/node_modules').resolves(true);
+        fsExistsStub.withArgs('/path/to/plugin-for-test/node_modules/appium').resolves(false);
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.have.been.calledOnce;
+        expect(fsSymlinkStub).to.have.been.calledWith(
+          '/path/to/appium',
+          '/path/to/plugin-for-test/node_modules/appium',
+          'dir'
+        );
+      });
+    });
+
+    describe('when there are both drivers and plugins', function () {
+      it('should create symlinks for all npm-installed extensions', async function () {
+        const driverConfig = {
+          installedExtensions: {
+            'driver-for-test': {
+              installType: 'npm',
+              installPath: '/path/to/driver-for-test',
+            },
+          },
+        };
+        const pluginConfig = {
+          installedExtensions: {
+            'plugin-for-test': {
+              installType: 'npm',
+              installPath: '/path/to/plugin-for-test',
+            },
+          },
+        };
+
+        fsExistsStub.resolves(true);
+        fsExistsStub.withArgs('/path/to/driver-for-test/node_modules/appium').resolves(false);
+        fsExistsStub.withArgs('/path/to/plugin-for-test/node_modules/appium').resolves(false);
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.have.been.calledTwice;
+      });
+    });
+
+    describe('when there are non-npm installed extensions', function () {
+      for (const installType of ['git', 'local', 'github']) {
+        it(`should skip ${installType}-installed extensions`, async function () {
+          const driverConfig = {
+            installedExtensions: {
+              [`${installType}-driver`]: {
+                installType,
+                installPath: `/path/to/${installType}-driver`,
+              },
+            },
+          };
+          const pluginConfig = {installedExtensions: {}};
+
+          // @ts-expect-error - partial config for testing
+          await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+          expect(fsSymlinkStub).to.not.have.been.called;
+        });
+      }
+
+      it('should only create symlinks for npm-installed extensions when mixed', async function () {
+        const driverConfig = {
+          installedExtensions: {
+            'npm-driver': {
+              installType: 'npm',
+              installPath: '/path/to/npm-driver',
+            },
+            'git-driver': {
+              installType: 'git',
+              installPath: '/path/to/git-driver',
+            },
+          },
+        };
+        const pluginConfig = {installedExtensions: {}};
+
+        fsExistsStub.resolves(true);
+        fsExistsStub.withArgs('/path/to/npm-driver/node_modules/appium').resolves(false);
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.have.been.calledOnce;
+        expect(fsSymlinkStub).to.have.been.calledWith(
+          '/path/to/appium',
+          '/path/to/npm-driver/node_modules/appium',
+          'dir'
+        );
+      });
+    });
+
+    describe('error handling', function () {
+      it('should log info message when symlink creation fails', async function () {
+        const driverConfig = {
+          installedExtensions: {
+            'driver-for-test': {
+              installType: 'npm',
+              installPath: '/path/to/driver-for-test',
+            },
+          },
+        };
+        const pluginConfig = {installedExtensions: {}};
+
+        fsExistsStub.resolves(true);
+        fsExistsStub.withArgs('/path/to/driver-for-test/node_modules/appium').resolves(false);
+        fsSymlinkStub.rejects(new Error('Permission denied'));
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(logger.info).to.have.been.calledOnce;
+        // @ts-ignore
+        expect(logger.info.args[0][0]).to.match(/Cannot create a symlink/);
+        // @ts-ignore
+        expect(logger.info.args[0][0]).to.match(/Permission denied/);
+      });
+
+      it('should not throw when getAppiumModuleRoot fails', async function () {
+        const driverConfig = {
+          installedExtensions: {
+            'driver-for-test': {
+              installType: 'npm',
+              installPath: '/path/to/driver-for-test',
+            },
+          },
+        };
+        const pluginConfig = {installedExtensions: {}};
+
+        getAppiumModuleRootStub.throws(new Error('Module not found'));
+        fsExistsStub.resolves(true);
+        fsExistsStub.withArgs('/path/to/driver-for-test/node_modules/appium').resolves(false);
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(logger.info).to.have.been.calledOnce;
+        // @ts-ignore
+        expect(logger.info.args[0][0]).to.match(/Cannot create a symlink/);
+      });
+    });
+
+    describe('with null or undefined configs', function () {
+      it('should handle null installedExtensions', async function () {
+        const driverConfig = {installedExtensions: null};
+        const pluginConfig = {installedExtensions: null};
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.not.have.been.called;
+      });
+
+      it('should handle undefined installedExtensions', async function () {
+        const driverConfig = {};
+        const pluginConfig = {};
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.not.have.been.called;
       });
     });
   });

--- a/packages/appium/test/unit/extension/extension-command.spec.js
+++ b/packages/appium/test/unit/extension/extension-command.spec.js
@@ -269,6 +269,28 @@ describe('ExtensionCommand', function () {
 
         expect(fsSymlinkStub).to.have.been.calledTwice;
       });
+
+      it('should not create symlinks for invalid format - no installPath', async function () {
+        const driverConfig = {
+          installedExtensions: {
+            'driver-for-test': {
+              installType: 'npm',
+            },
+          },
+        };
+        const pluginConfig = {
+          installedExtensions: {
+            'plugin-for-test': {
+              installType: 'npm',
+            },
+          },
+        };
+
+        // @ts-expect-error - partial config for testing
+        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+
+        expect(fsSymlinkStub).to.not.have.been.called;
+      });
     });
 
     describe('when there are non-npm installed extensions', function () {


### PR DESCRIPTION
## Proposed changes

This is related to https://github.com/appium/appium/pull/21664. I noticed this issue in https://github.com/appium/ruby_lib_core/actions/runs/20587570810.

The issue occurs in drivers when we install plugins, or plugins when we install drivers.

e.g.
```
appium driver install xcuitest
appium plugin install images  # then, the appium symlink in the node_modules in xcuitest is missing
```

Expected behavior is even after the plugin installation, the symlink to xcuitest should exist.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
