### PR TITLE
docs: add SeleniumConf & AppiumConf 2026 banner

### DIFF
--- a/packages/appium/docs/overrides/main.html
+++ b/packages/appium/docs/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block announce %}
+    <center>
+    SeleniumConf & AppiumConf returns on May 6-8, 2026! Join us to learn and connect with the community!
+    <a href="https://seleniumconf.com/">Register Now</a>
+    </center>
+{% endblock %}


### PR DESCRIPTION
This banner is added using Material for MkDocs' [announcement bar feature](https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-header/#announcement-bar), which is shown on all pages above the header, and is automatically hidden upon scrolling down:

<img width="1340" height="105" alt="image" src="https://github.com/user-attachments/assets/6cc66275-c3c6-4cb6-9a0e-67a23e8d7c19" />
