### PR TITLE
chore(deps): update asyncbox to v6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@types/ws": "8.18.1",
         "@types/xmldom": "0.1.34",
         "@types/yargs": "17.0.35",
-        "asyncbox": "5.0.0",
+        "asyncbox": "6.0.0",
         "chai": "6.2.2",
         "chai-as-promised": "8.0.2",
         "conventional-changelog-conventionalcommits": "7.0.2",
@@ -6141,9 +6141,9 @@
       "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="
     },
     "node_modules/asyncbox": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-5.0.0.tgz",
-      "integrity": "sha512-F2D847Y1W4mJMBLvwN+1+l7dsS9uBq+Q9U3RqSih+zZ9d810/vMr0PXPF5OUGERtVVTXM6hVW80yFa3MXyIo7Q==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/asyncbox/-/asyncbox-6.0.0.tgz",
+      "integrity": "sha512-ZX00uaxQrEDGWh+hJpG83bn5u4ZBr3+PMhMvbF+A5oTryyoAHyBXDOU6AJdzN+nbQUXj5YoaEXlJPxmyw9xESg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bluebird": "^3.5.1",
@@ -20628,7 +20628,6 @@
         "ajv-formats": "3.0.1",
         "argparse": "2.0.1",
         "async-lock": "1.4.1",
-        "asyncbox": "5.0.0",
         "axios": "1.13.2",
         "bluebird": "3.7.2",
         "lilconfig": "3.1.3",
@@ -20709,7 +20708,7 @@
         "@appium/types": "^1.1.2",
         "@colors/colors": "1.6.0",
         "async-lock": "1.4.1",
-        "asyncbox": "5.0.0",
+        "asyncbox": "6.0.0",
         "axios": "1.13.2",
         "bluebird": "3.7.2",
         "body-parser": "2.2.2",
@@ -21623,7 +21622,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "0.9.8",
-        "asyncbox": "5.0.0",
         "bluebird": "3.7.2",
         "lodash": "4.17.23",
         "xpath": "0.0.34"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "@types/ws": "8.18.1",
     "@types/xmldom": "0.1.34",
     "@types/yargs": "17.0.35",
-    "asyncbox": "5.0.0",
+    "asyncbox": "6.0.0",
     "chai": "6.2.2",
     "chai-as-promised": "8.0.2",
     "conventional-changelog-conventionalcommits": "7.0.2",

--- a/packages/appium/index.js
+++ b/packages/appium/index.js
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 
-const {asyncify} = require('asyncbox');
-
 const appium = require('./build/lib/main.js');
 
 if (require.main === module) {
-  asyncify(appium.main);
+  appium.main();
 }
 
 module.exports = appium;

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -9,7 +9,6 @@ import {
   normalizeBasePath,
 } from '@appium/base-driver';
 import {util, env} from '@appium/support';
-import {asyncify} from 'asyncbox';
 import _ from 'lodash';
 import {AppiumDriver} from './appium';
 import {runExtensionCommand} from './cli/extension';
@@ -490,7 +489,7 @@ async function main(args) {
 // (more specifically, `build/lib/main.js`)
 // the executable is now `../index.js`, so that module will typically be `require.main`.
 if (require.main === module) {
-  asyncify(main);
+  main();
 }
 
 // everything below here is intended to be a public API.

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -72,7 +72,6 @@
     "ajv-formats": "3.0.1",
     "argparse": "2.0.1",
     "async-lock": "1.4.1",
-    "asyncbox": "5.0.0",
     "axios": "1.13.2",
     "bluebird": "3.7.2",
     "lilconfig": "3.1.3",

--- a/packages/appium/scripts/parse-yml-commands.js
+++ b/packages/appium/scripts/parse-yml-commands.js
@@ -7,7 +7,6 @@ const yaml = require('yaml');
 const {fs, util, logger} = require('@appium/support');
 const Handlebars = require('handlebars');
 const _ = require('lodash');
-const {asyncify} = require('asyncbox');
 
 const log = logger.getLogger('YamlParser');
 
@@ -417,4 +416,4 @@ async function main() {
   await generateCommandIndex();
 }
 
-asyncify(main);
+main();

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -48,7 +48,7 @@
     "@appium/types": "^1.1.2",
     "@colors/colors": "1.6.0",
     "async-lock": "1.4.1",
-    "asyncbox": "5.0.0",
+    "asyncbox": "6.0.0",
     "axios": "1.13.2",
     "bluebird": "3.7.2",
     "body-parser": "2.2.2",

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "@xmldom/xmldom": "0.9.8",
-    "asyncbox": "5.0.0",
     "bluebird": "3.7.2",
     "lodash": "4.17.23",
     "xpath": "0.0.34"


### PR DESCRIPTION
Replaces #21879 

These changes also allowed to completely remove the `asyncbox` dependency for the main `appium` module, and I've also removed it for `fake-driver`, which does not use it at all.