### PR TITLE
fix: Move @appium/types to dev dependencies for various packages

### DIFF
--- a/packages/driver-test-support/package.json
+++ b/packages/driver-test-support/package.json
@@ -42,7 +42,6 @@
   },
   "types": "./build/lib/index.d.ts",
   "dependencies": {
-    "@appium/types": "^1.2.0",
     "axios": "1.13.4",
     "bluebird": "3.7.2",
     "chai": "6.2.2",
@@ -51,6 +50,9 @@
     "lodash": "4.17.23",
     "sinon": "21.0.1",
     "type-fest": "5.4.3"
+  },
+  "devDependencies": {
+    "@appium/types": "^1.2.0"
   },
   "peerDependencies": {
     "appium": "^3.0.0-beta.0",

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -41,11 +41,11 @@
   "dependencies": {
     "@appium/base-plugin": "^3.0.6",
     "@appium/support": "^7.0.5",
-    "@appium/types": "^1.2.0",
     "bluebird": "3.7.2",
     "lodash": "4.17.23"
   },
   "devDependencies": {
+    "@appium/types": "^1.2.0",
     "express": "5.2.1"
   },
   "peerDependencies": {

--- a/packages/plugin-test-support/package.json
+++ b/packages/plugin-test-support/package.json
@@ -38,8 +38,10 @@
     "test:smoke": "node ./build/lib/index.js --smoke-test",
     "test:unit": "exit 0"
   },
+  "devDependencies": {
+    "@appium/types": "^1.2.0"
+  },
   "dependencies": {
-    "@appium/types": "^1.2.0",
     "get-port": "7.1.0",
     "log-symbols": "7.0.1",
     "teen_process": "4.0.9"

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -39,8 +39,10 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.*ts\""
   },
   "dependencies": {
-    "@appium/types": "^1.2.0",
     "lodash": "4.17.23"
+  },
+  "devDependencies": {
+    "@appium/types": "^1.2.0"
   },
   "peerDependencies": {
     "appium": "^3.0.0-beta.0"


### PR DESCRIPTION
there is no need to keep them in `dependencies` section as they are only used to build the package