### PR TITLE
test(appium): Fix BiDi test

### DIFF
--- a/packages/appium/test/e2e/driver.e2e.spec.ts
+++ b/packages/appium/test/e2e/driver.e2e.spec.ts
@@ -581,7 +581,7 @@ describe('FakeDriver via HTTP', function () {
     });
 
     it('should interpret the bidi protocol and let the driver handle it by command', async function () {
-      expect(await driver.getUrl()).to.be.falsy;
+      expect(await driver.getUrl()).to.not.be.ok;
 
       await driver.browsingContextNavigate({
         context: 'foo',
@@ -644,7 +644,7 @@ describe('FakeDriver via HTTP', function () {
     });
 
     it('should interpret the bidi protocol and let the driver handle it by command', async function () {
-      expect(await driver.getUrl()).to.be.falsy;
+      expect(await driver.getUrl()).to.not.be.ok;
 
       await driver.browsingContextNavigate({
         context: 'foo',
@@ -731,7 +731,7 @@ describe('Bidi over SSL', function () {
   });
 
   it('should still run bidi over ssl', async function () {
-    expect(await driver.getUrl()).to.be.falsy;
+    expect(await driver.getUrl()).to.not.be.ok;
 
     await driver.browsingContextNavigate({
       context: 'foo',

--- a/packages/appium/test/e2e/driver.e2e.spec.ts
+++ b/packages/appium/test/e2e/driver.e2e.spec.ts
@@ -581,7 +581,7 @@ describe('FakeDriver via HTTP', function () {
     });
 
     it('should interpret the bidi protocol and let the driver handle it by command', async function () {
-      expect(await driver.getUrl()).to.not.exist;
+      expect(await driver.getUrl()).to.be.falsy;
 
       await driver.browsingContextNavigate({
         context: 'foo',
@@ -644,7 +644,7 @@ describe('FakeDriver via HTTP', function () {
     });
 
     it('should interpret the bidi protocol and let the driver handle it by command', async function () {
-      expect(await driver.getUrl()).to.not.exist;
+      expect(await driver.getUrl()).to.be.falsy;
 
       await driver.browsingContextNavigate({
         context: 'foo',
@@ -731,7 +731,7 @@ describe('Bidi over SSL', function () {
   });
 
   it('should still run bidi over ssl', async function () {
-    expect(await driver.getUrl()).to.not.exist;
+    expect(await driver.getUrl()).to.be.falsy;
 
     await driver.browsingContextNavigate({
       context: 'foo',


### PR DESCRIPTION
This fix is related to https://github.com/appium/appium/pull/21935

According to the spec getUrl is not allowed to return null/undefined, so we return an empty string instead