### PR TITLE
fix(base-driver): normalize sessionId to avoid string[] type errors

### DIFF
--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -297,6 +297,10 @@ export function routeConfiguringFunction(driver: Core<any>): RouteConfiguringFun
   };
 }
 
+function normalizeSessionId(id: string | string[] | undefined): string | undefined {
+  return Array.isArray(id) ? id[0] : id;
+}
+
 function buildHandler(
   app: Application,
   method: string,
@@ -306,17 +310,18 @@ function buildHandler(
   isSessCmd: boolean
 ): void {
   const asyncHandler = async (req: Request, res: Response) => {
+    const sessionId = normalizeSessionId(req.params.sessionId);
     let jsonObj = req.body;
     let httpResBody = {} as any;
     let httpStatus = 200;
     let newSessionId: string | undefined;
-    let currentProtocol = extractProtocol(driver, req.params.sessionId);
+    let currentProtocol = extractProtocol(driver, sessionId ?? null);
 
     try {
       // if the route accessed is deprecated, log a warning
       if (spec.deprecated && spec.command && !deprecatedCommandsLogged.has(spec.command)) {
         deprecatedCommandsLogged.add(spec.command);
-        getLogger(driver, req.params.sessionId).warn(
+        getLogger(driver, sessionId ?? null).warn(
           `The ${method} ${path} endpoint has been deprecated and will be removed in a future ` +
             `version of Appium or your driver/plugin. Please use a different endpoint or contact the ` +
             `driver/plugin author to add explicit support for the endpoint before it is removed`
@@ -325,7 +330,7 @@ function buildHandler(
 
       // if this is a session command but we don't have a session,
       // error out early (especially before proxying)
-      if (isSessCmd && !driver.sessionExists(req.params.sessionId)) {
+      if (isSessCmd && !driver.sessionExists(sessionId)) {
         throw new errors.NoSuchDriverError();
       }
 
@@ -341,12 +346,12 @@ function buildHandler(
       if (isSessCmd && !spec.neverProxy && spec.command && driverShouldDoJwpProxy(driver, req, spec.command)) {
         if (
           !('pluginsToHandleCmd' in driver) || !_.isFunction(driver.pluginsToHandleCmd) ||
-          driver.pluginsToHandleCmd(spec.command, req.params.sessionId).length === 0
+          driver.pluginsToHandleCmd(spec.command, sessionId ?? null).length === 0
         ) {
           await doJwpProxy(driver as BaseDriver<any>, req, res);
           return;
         }
-        getLogger(driver, req.params.sessionId).debug(
+        getLogger(driver, sessionId ?? null).debug(
           `Would have proxied ` +
             `command directly, but a plugin exists which might require its value, so will let ` +
             `its value be collected internally and made part of plugin chain`
@@ -393,7 +398,7 @@ function buildHandler(
       }
 
       // run the driver command wrapped inside the argument validators
-      getLogger(driver, req.params.sessionId).debug(
+      getLogger(driver, sessionId ?? null).debug(
         `Calling %s.%s() with args: %s`,
         driver.constructor.name, spec.command,
         logger.markSensitive(_.truncate(JSON.stringify(args), {length: MAX_LOG_BODY_LENGTH}))
@@ -409,7 +414,7 @@ function buildHandler(
       driverRes = await (driver as BaseDriver<any>).executeCommand(spec.command, ...args);
 
       // Get the protocol after executeCommand
-      currentProtocol = extractProtocol(driver, req.params.sessionId) || currentProtocol;
+      currentProtocol = extractProtocol(driver, sessionId ?? null) || currentProtocol;
 
       // If `executeCommand` was overridden and the method returns an object
       // with a protocol and value/error property, re-assign the protocol
@@ -440,12 +445,12 @@ function buildHandler(
 
       // delete should not return anything even if successful
       if (spec.command === DELETE_SESSION_COMMAND) {
-        getLogger(driver, req.params.sessionId).debug(
+        getLogger(driver, sessionId ?? null).debug(
           `Received response: ${_.truncate(JSON.stringify(driverRes), {
             length: MAX_LOG_BODY_LENGTH,
           })}`
         );
-        getLogger(driver, req.params.sessionId).debug('But deleting session, so not returning');
+        getLogger(driver, sessionId ?? null).debug('But deleting session, so not returning');
         driverRes = null;
       }
 
@@ -467,7 +472,7 @@ function buildHandler(
       }
 
       httpResBody.value = driverRes;
-      getLogger(driver, req.params.sessionId || newSessionId).debug(
+      getLogger(driver, sessionId ?? newSessionId ?? null).debug(
         `Responding ` +
           `to client with driver.${spec.command}() result: ${_.truncate(JSON.stringify(driverRes), {
             length: MAX_LOG_BODY_LENGTH,
@@ -480,7 +485,7 @@ function buildHandler(
       if (err instanceof Error || (_.has(err, 'stack') && _.has(err, 'message'))) {
         actualErr = err;
       } else {
-        getLogger(driver, req.params.sessionId || newSessionId).warn(
+        getLogger(driver, sessionId ?? newSessionId ?? null).warn(
           'The thrown error object does not seem to be a valid instance of the Error class. This ' +
             'might be a genuine bug of a driver or a plugin.'
         );
@@ -488,7 +493,7 @@ function buildHandler(
       }
 
       currentProtocol =
-        currentProtocol || extractProtocol(driver, req.params.sessionId || newSessionId);
+        currentProtocol || extractProtocol(driver, (sessionId ?? newSessionId) ?? null);
 
       let errMsg = err.stacktrace || err.stack;
       if (!_.includes(errMsg, err.message)) {
@@ -499,7 +504,7 @@ function buildHandler(
       if (isErrorType(err, errors.ProxyRequestError)) {
         actualErr = err.getActualError();
       } else {
-        getLogger(driver, req.params.sessionId || newSessionId).debug(
+        getLogger(driver, sessionId ?? newSessionId ?? null).debug(
           `Encountered internal error running command: ${errMsg}`
         );
       }
@@ -526,8 +531,14 @@ function buildHandler(
 }
 
 export function driverShouldDoJwpProxy(driver: Core<any>, req: import('express').Request, command: string): boolean {
+  const sessionId = normalizeSessionId(req.params.sessionId);
+
+  if (!sessionId) {
+    return false;
+  }
+  
   // drivers need to explicitly say when the proxy is active
-  if (!driver.proxyActive(req.params.sessionId)) {
+  if (!driver.proxyActive(sessionId)) {
     return false;
   }
 
@@ -539,7 +550,7 @@ export function driverShouldDoJwpProxy(driver: Core<any>, req: import('express')
 
   // validate avoidance schema, and say we shouldn't proxy if anything in the
   // avoid list matches our req
-  if (driver.proxyRouteIsAvoided(req.params.sessionId, req.method, req.originalUrl, req.body)) {
+  if (driver.proxyRouteIsAvoided(sessionId, req.method, req.originalUrl, req.body)) {
     return false;
   }
 
@@ -547,16 +558,21 @@ export function driverShouldDoJwpProxy(driver: Core<any>, req: import('express')
 }
 
 async function doJwpProxy(driver: BaseDriver<any>, req: Request, res: Response): Promise<void> {
-  getLogger(driver, req.params.sessionId).info(
+  const sessionId = normalizeSessionId(req.params.sessionId);
+  if (!sessionId) {
+    throw new errors.NoSuchDriverError();
+  }
+
+  getLogger(driver, sessionId).info(
     'Driver proxy active, passing request on via HTTP proxy'
   );
 
   // check that the inner driver has a proxy function
-  if (!driver.canProxy(req.params.sessionId)) {
+  if (!driver.canProxy(sessionId)) {
     throw new Error('Trying to proxy to a server but the driver is unable to proxy');
   }
   try {
-    await driver.executeCommand('proxyReqRes', req, res, req.params.sessionId);
+    await driver.executeCommand('proxyReqRes', req, res, sessionId);
   } catch (err) {
     if (isErrorType(err, errors.ProxyRequestError)) {
       throw err;


### PR DESCRIPTION
Changes
This PR fixes TypeScript build failures in protocol.ts caused by req.params.sessionId being typed as string | string[]. Several internal calls expect a plain string, which caused the monorepo build to fail on a clean install.

A helper function (normalizeSessionId) is introduced to normalize the value, and all internal uses inside asyncHandler now use the normalized version.

Types of changes
Bugfix (nonbreaking change which fixes an issue)

Checklist
I have tested the changes locally with npm run build

I ensured no unrelated changes are included

I have followed the code style and conventions of the project
