### PR TITLE
fix(appium): Fix CLI arguments normalization

### DIFF
--- a/packages/appium/lib/cli/parser.js
+++ b/packages/appium/lib/cli/parser.js
@@ -14,7 +14,7 @@ import {
   SERVER_SUBCOMMAND,
   SETUP_SUBCOMMAND
 } from '../constants';
-import {finalizeSchema, getArgSpec, hasArgSpec} from '../schema';
+import {finalizeSchema, getAllArgSpecs, getArgSpec, hasArgSpec} from '../schema';
 import {rootDir} from '../config';
 import {getExtensionArgs, getServerArgs} from './args';
 import {
@@ -156,6 +156,25 @@ class ArgParser {
         process.exit(1);
       }
     }
+  }
+
+  /**
+   * Normalize hyphenated server arg keys (e.g. "log-level") to dest form (e.g. "loglevel").
+   * Use when server args come from programmatic init rather than the CLI, so they match
+   * the shape produced by parseArgs() / _transformParsedArgs().
+   * Mutates the given object.
+   *
+   * @param {object} obj - Object that may contain server args with schema property names
+   * @returns {object} The same object with keys normalized
+   */
+  static normalizeServerArgs(obj) {
+    for (const spec of getAllArgSpecs().values()) {
+      if (!spec.extType && obj[spec.name] !== undefined && spec.rawDest !== spec.name) {
+        obj[spec.rawDest] = obj[spec.name] ?? obj[spec.rawDest];
+        delete obj[spec.name];
+      }
+    }
+    return obj;
   }
 
   /**

--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -211,12 +211,17 @@ async function createTransports(args) {
   let consoleLogLevel;
   /** @type {string} */
   let fileLogLevel;
-  if (args.loglevel && args.loglevel.match(':')) {
+
+  // Server args are normalized in main so we only see dest form (`loglevel`).
+  // Fall back to schema default so Winston never sees undefined.
+  const rawLogLevel = args.loglevel ?? 'debug';
+
+  if (rawLogLevel && rawLogLevel.includes(':')) {
     // --log-level arg can optionally provide diff logging levels for console and file, separated by a colon
-    const lvlPair = args.loglevel.split(':');
+    const lvlPair = rawLogLevel.split(':');
     [consoleLogLevel, fileLogLevel] = lvlPair;
   } else {
-    consoleLogLevel = fileLogLevel = args.loglevel;
+    consoleLogLevel = fileLogLevel = rawLogLevel;
   }
 
   transports.push(createConsoleTransport(args, consoleLogLevel));

--- a/packages/appium/lib/main.js
+++ b/packages/appium/lib/main.js
@@ -13,7 +13,7 @@ import _ from 'lodash';
 import {AppiumDriver} from './appium';
 import {runExtensionCommand} from './cli/extension';
 import { runSetupCommand } from './cli/setup-command';
-import {getParser} from './cli/parser';
+import {getParser, ArgParser} from './cli/parser';
 import {
   APPIUM_VER,
   checkNodeOk,
@@ -211,6 +211,8 @@ async function init(args) {
       delete args.throwInsteadOfExit;
     }
     preConfigArgs = {...args, subcommand: args.subcommand ?? SERVER_SUBCOMMAND};
+    // Normalize hyphenated keys to dest form so programmatic args match CLI shape
+    ArgParser.normalizeServerArgs(preConfigArgs);
   } else {
     // otherwise parse from CLI
     preConfigArgs = /** @type {Args<Cmd, SubCmd>} */ (parser.parseArgs());

--- a/packages/appium/lib/schema/cli-args.js
+++ b/packages/appium/lib/schema/cli-args.js
@@ -112,6 +112,12 @@ function subSchemaToArgDef(subSchema, argSpec) {
     help: makeDescription(subSchema),
   };
 
+  // argparse infers dest from the option string (e.g. --log-level → log_level).
+  // We need schema dest (e.g. loglevel) so merged server args and logsink use the right key.
+  if (!argSpec.extType) {
+    argOpts.dest = argSpec.rawDest;
+  }
+
   /**
    * Generally we will provide a `type` to `argparse` as a function which
    * validates using ajv (which is much more full-featured than what `argparse`

--- a/packages/appium/test/unit/parser.spec.ts
+++ b/packages/appium/test/unit/parser.spec.ts
@@ -112,10 +112,7 @@ describe('parser', function () {
       });
 
       it('should parse --allow-insecure correctly', function () {
-        // With explicit dest, optional args may be present as undefined when not passed
-        expect(p.parseArgs([])).to.satisfy(
-          (obj) => obj.allowInsecure === undefined || _.isEqual(obj.allowInsecure, [])
-        );
+        expect(p.parseArgs([])).to.satisfy((obj) => obj.allowInsecure === undefined);
         expect(p.parseArgs(['--allow-insecure', '']).allowInsecure).to.eql([]);
         expect(p.parseArgs(['--allow-insecure', '*:foo']).allowInsecure).to.eql(['*:foo']);
         expect(p.parseArgs(['--allow-insecure', '*:foo,*:bar']).allowInsecure).to.eql(['*:foo', '*:bar']);
@@ -135,10 +132,7 @@ describe('parser', function () {
       });
 
       it('should parse --deny-insecure correctly', function () {
-        // With explicit dest, optional args may be present as undefined when not passed
-        expect(p.parseArgs([])).to.satisfy(
-          (obj) => obj.denyInsecure === undefined || _.isEqual(obj.denyInsecure, [])
-        );
+        expect(p.parseArgs([])).to.satisfy((obj) => obj.denyInsecure === undefined);
         expect(p.parseArgs(['--deny-insecure', '']).denyInsecure).to.eql([]);
         expect(p.parseArgs(['--deny-insecure', '*:foo']).denyInsecure).to.eql(['*:foo']);
         expect(p.parseArgs(['--deny-insecure', '*:foo,*:bar']).denyInsecure).to.eql(['*:foo', '*:bar']);


### PR DESCRIPTION
https://github.com/appium/appium/issues/21940#issuecomment-3876771876


The root cause was missing dest for schema-derived server args in the CLI parser, which made --log-level end up under log_level instead of loglevel. Setting dest for server args fixes the CLI behavior; normalization in main remains for programmatic callers.