### PR TITLE
chore(storage-plugin): replace rimraf with @appium/support equivalent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10189,6 +10189,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.3.tgz",
       "integrity": "sha512-/g3B0mC+4x724v1TgtBlBtt2hPi/EWptsIAmXUx9Z2rvBYleQcsrmaOzd5LyL50jf/Soi83ZDJmw2+XqvH/EeA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.0",
@@ -10217,6 +10218,7 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
       "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -10226,6 +10228,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.2.tgz",
       "integrity": "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jackspeak": "^4.2.3"
@@ -10238,6 +10241,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
       "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -10250,6 +10254,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
       "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^9.0.0"
@@ -10265,6 +10270,7 @@
       "version": "11.2.6",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
       "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -10274,6 +10280,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.0.tgz",
       "integrity": "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -10289,6 +10296,7 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -10298,6 +10306,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
       "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -16527,6 +16536,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
       "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "glob": "^13.0.0",
@@ -20333,7 +20343,6 @@
         "bluebird": "3.7.2",
         "lodash": "4.17.23",
         "lru-cache": "11.2.6",
-        "rimraf": "6.1.2",
         "ws": "8.19.0"
       },
       "engines": {

--- a/packages/storage-plugin/lib/storage.ts
+++ b/packages/storage-plugin/lib/storage.ts
@@ -5,7 +5,6 @@ import type { Path } from 'path-scurry';
 import path from 'node:path';
 import type { Stats } from 'node:fs';
 import nativeFs from 'node:fs';
-import { rimrafSync } from 'rimraf';
 import { ItemOptions, StorageItem } from './types';
 import AsyncLock from 'async-lock';
 import type { AppiumLogger } from '@appium/types';
@@ -122,7 +121,7 @@ export class Storage {
     this._log.debug(`Cleaning up the '${this._root}' server storage folder`);
 
     if (!this._shouldPreserveRoot && !this._shouldPreserveFiles) {
-      rimrafSync(this._root);
+      fs.rimrafSync(this._root);
       return;
     }
 
@@ -139,7 +138,7 @@ export class Storage {
     }
     if (_.isEmpty(itemNames)) {
       if (!this._shouldPreserveRoot) {
-        rimrafSync(this._root);
+        fs.rimrafSync(this._root);
       }
       return;
     }
@@ -148,10 +147,10 @@ export class Storage {
       (name) => !this._shouldPreserveFiles || _.toLower(name).endsWith(TMP_EXT)
     );
     for (const matchedName of matchedNames) {
-      rimrafSync(path.join(this._root, matchedName));
+      fs.rimrafSync(path.join(this._root, matchedName));
     }
     if (!this._shouldPreserveRoot && _.isEmpty(_.without(itemNames, ...matchedNames))) {
-      rimrafSync(this._root);
+      fs.rimrafSync(this._root);
     }
   }
 

--- a/packages/storage-plugin/package.json
+++ b/packages/storage-plugin/package.json
@@ -45,7 +45,6 @@
     "bluebird": "3.7.2",
     "lodash": "4.17.23",
     "lru-cache": "11.2.6",
-    "rimraf": "6.1.2",
     "ws": "8.19.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
`storage-plugin` has an unnecessary import of `rimraf` for `rimrafSync`, even though the plugin already imports `@appium/support`, which includes a native implementation of `rimrafSync`.