### PR TITLE
chore(support): replace moment with native Date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13703,14 +13703,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/morgan": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
@@ -20404,7 +20396,6 @@
         "lockfile": "1.0.4",
         "lodash": "4.17.23",
         "log-symbols": "7.0.1",
-        "moment": "2.30.1",
         "ncp": "2.0.0",
         "package-directory": "8.2.0",
         "plist": "3.1.0",

--- a/packages/support/lib/logging.js
+++ b/packages/support/lib/logging.js
@@ -1,11 +1,9 @@
 import globalLog, { markSensitive as _markSensitive } from '@appium/logger';
 import _ from 'lodash';
-import moment from 'moment';
 
 /** @type {import('@appium/types').AppiumLoggerLevel[]} */
 export const LEVELS = ['silly', 'verbose', 'debug', 'info', 'http', 'warn', 'error'];
 const MAX_LOG_RECORDS_COUNT = 3000;
-const PREFIX_TIMESTAMP_FORMAT = 'HH-mm-ss:SSS';
 // mock log object is used in testing mode to silence the output
 const MOCK_LOG = {
   unwrap: () => ({
@@ -132,7 +130,15 @@ function getFinalPrefix(prefix, shouldLogTimestamp = false) {
   if (!shouldLogTimestamp) {
     return result;
   }
-  const formattedTimestamp = `[${moment().format(PREFIX_TIMESTAMP_FORMAT)}]`;
+  // Format the timestamp as HH-mm-ss:SSS
+  const now = new Date();
+  const pad = (n, z = 2) => String(n).padStart(z, '0');
+  const formattedTimestamp = `[${
+    pad(now.getHours()) + '-' +
+    pad(now.getMinutes()) + '-' +
+    pad(now.getSeconds()) + ':' +
+    pad(now.getMilliseconds(), 3)
+  }]`;
   return result ? `${formattedTimestamp} ${result}` : formattedTimestamp;
 }
 

--- a/packages/support/lib/logging.js
+++ b/packages/support/lib/logging.js
@@ -133,12 +133,8 @@ function getFinalPrefix(prefix, shouldLogTimestamp = false) {
   // Format the timestamp as HH-mm-ss:SSS
   const now = new Date();
   const pad = (n, z = 2) => String(n).padStart(z, '0');
-  const formattedTimestamp = `[${
-    pad(now.getHours()) + '-' +
-    pad(now.getMinutes()) + '-' +
-    pad(now.getSeconds()) + ':' +
-    pad(now.getMilliseconds(), 3)
-  }]`;
+  const formattedTimestamp =
+    `[${pad(now.getHours())}-${pad(now.getMinutes())}-${pad(now.getSeconds())}:${pad(now.getMilliseconds(), 3)}]`;
   return result ? `${formattedTimestamp} ${result}` : formattedTimestamp;
 }
 

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -60,7 +60,6 @@
     "lockfile": "1.0.4",
     "lodash": "4.17.23",
     "log-symbols": "7.0.1",
-    "moment": "2.30.1",
     "ncp": "2.0.0",
     "package-directory": "8.2.0",
     "plist": "3.1.0",


### PR DESCRIPTION
This PR replaces `moment.js` with a native `Date()`-based equivalent. There are several reasons for this:
* `moment.js` is in maintenance mode
* it is a fairly large package (4.3MB unpacked)
* this repo only uses `moment.js` in one location

The last point is also the reason why I am proposing to use the native API instead of another smaller package like `day.js`, even though it is a bit less readable due to no built-in formatter method.

More information:
* https://momentjs.com/docs/#/-project-status/
* https://e18e.dev/docs/replacements/moment.html