### PR TITLE
fix(base-driver): fix session id handling more

### DIFF
--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -35,12 +35,12 @@ export function determineProtocol(createSessionArgs: any[]): keyof typeof PROTOC
 }
 
 /**
- * Extract and validate sessionId from Express route parameter.
+ * Extract and validate the sessionId from the Express route parameter.
  * Express may return route params as string | string[] | undefined.
  * Appium uses standard routes (e.g., /session/:sessionId) which should always be strings.
  * Only `*` such as `/session/*sessionId` can return `string[]`.
  * Then, this method will return the first element as the session id.
- * It may break existing appium routing hanlding also, thus this method will log
+ * It may break existing appium routing handling also, thus this method will log
  * received parameters as well to help debugging.
  * @param driver Running driver
  * @param req The request in Express
@@ -50,10 +50,10 @@ export function getSessionId(driver: Core<any>, req: Request): string | undefine
   if (Array.isArray(req.params.sessionId)) {
     const sessionId = req.params.sessionId[0];
     getLogger(driver, sessionId).warn(
-      `Received malformed sessionId as array from route: ${req.originalUrl}. ` +
-      `This indicates a route definition issue. The route should start with '/session/:sessionId' (named parameter) ` +
+      `Received malformed sessionId as array from the route: ${req.originalUrl}. ` +
+      `This indicates the route definition issue. The route should start with '/session/:sessionId' (named parameter) ` +
       `instead of '/session/*sessionId' (wildcard). ` +
-      `Using first element as session id: ${sessionId}. ` +
+      `Using the first element as session id: ${sessionId}. ` +
       `Please fix the route definition to prevent this error.`
     );
     // This is to not log the message multiple times.

--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -56,7 +56,7 @@ export function getSessionId(driver: Core<any>, req: Request): string | undefine
       `Using first element as session id: ${sessionId}. ` +
       `Please fix the route definition to prevent this error.`
     );
-    // This is to not log the message twice.
+    // This is to not log the message multiple times.
     req.params.sessionId = sessionId;
     return sessionId;
   }


### PR DESCRIPTION
## Proposed changes

An error I observed https://github.com/appium/appium/pull/21942#discussion_r2791740734 was by remaining `req.params.sessionId`. So, the fix is to use `getSessionId` everywhere. But this case occurs only when users use `/session/*sessionId/something` syntax, so usually it is a wrong one - the driver/plugin author should fix.

So, this PR prevents repeating the log in a request, but prints a message to provide a hint to fix the wrong routing definition for authors.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
