### PR TITLE
chore(storage-plugin): drop bluebird

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20345,7 +20345,7 @@
       "dependencies": {
         "@appium/support": "^7.0.5",
         "async-lock": "1.4.1",
-        "bluebird": "3.7.2",
+        "asyncbox": "6.1.0",
         "lodash": "4.17.23",
         "lru-cache": "11.2.6",
         "ws": "8.19.0"

--- a/packages/storage-plugin/package.json
+++ b/packages/storage-plugin/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@appium/support": "^7.0.5",
     "async-lock": "1.4.1",
-    "bluebird": "3.7.2",
+    "asyncbox": "6.1.0",
     "lodash": "4.17.23",
     "lru-cache": "11.2.6",
     "ws": "8.19.0"


### PR DESCRIPTION
The `concurrency` option added in `asyncbox` `v6.1.0` is quite useful here.