### PR TITLE
chore(opencv): drop bluebird

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20277,7 +20277,6 @@
       "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bluebird": "3.7.2",
         "lodash": "4.17.23",
         "opencv-bindings": "4.5.5",
         "sharp": "0.34.5"

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -42,7 +42,6 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.*ts\""
   },
   "dependencies": {
-    "bluebird": "3.7.2",
     "lodash": "4.17.23",
     "opencv-bindings": "4.5.5",
     "sharp": "0.34.5"


### PR DESCRIPTION
The `setTimeout` call could in theory be replaced with `sleep` from `asyncbox`, but I don't think it's worth adding the package just for one usage.