### PR TITLE
chore(fake-driver): drop bluebird

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20379,7 +20379,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "0.9.8",
-        "bluebird": "3.7.2",
+        "asyncbox": "6.1.0",
         "lodash": "4.17.23",
         "xpath": "0.0.34"
       },

--- a/packages/fake-driver/lib/driver.ts
+++ b/packages/fake-driver/lib/driver.ts
@@ -1,4 +1,4 @@
-import B from 'bluebird';
+import {sleep} from 'asyncbox';
 import type {Express, Request, Response} from 'express';
 import type {Server as HttpServer} from 'node:http';
 import {BaseDriver, errors} from 'appium/driver';
@@ -195,45 +195,45 @@ export class FakeDriver<Thing = unknown> extends BaseDriver<FakeDriverConstraint
   }
 
   async getFakeThing(): Promise<Thing | null> {
-    await B.delay(1);
+    await sleep(1);
     return this.fakeThing;
   }
 
   async setFakeThing(thing: Thing): Promise<null> {
-    await B.delay(1);
+    await sleep(1);
     this.fakeThing = thing;
     return null;
   }
 
   async getFakeDriverArgs(): Promise<typeof this.cliArgs> {
-    await B.delay(1);
+    await sleep(1);
     return this.cliArgs;
   }
 
   /** TODO: track deprecated commands when called and return their names. */
   async getDeprecatedCommandsCalled(): Promise<string[]> {
-    await B.delay(1);
+    await sleep(1);
     return [];
   }
 
   async callDeprecatedCommand(): Promise<void> {
-    await B.delay(1);
+    await sleep(1);
   }
 
   async doSomeMath(num1: number, num2: number): Promise<number> {
-    await B.delay(1);
+    await sleep(1);
     return num1 + num2;
   }
 
   async doSomeMath2(num1: number, num2: number): Promise<number> {
-    await B.delay(1);
+    await sleep(1);
     return num1 + num2;
   }
 
   private async startClock(): Promise<void> {
     this._clockRunning = true;
     while (this._clockRunning) {
-      await B.delay(500);
+      await sleep(500);
       this.eventEmitter.emit('bidiEvent', {
         method: 'appium:clock.currentTime',
         params: {time: Date.now()},

--- a/packages/fake-driver/package.json
+++ b/packages/fake-driver/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@xmldom/xmldom": "0.9.8",
-    "bluebird": "3.7.2",
+    "asyncbox": "6.1.0",
     "lodash": "4.17.23",
     "xpath": "0.0.34"
   },


### PR DESCRIPTION
This module only used `B.delay`, so it's a great usecase for `asyncbox`'s `sleep`.