### PR TITLE
feat(execute-driver-plugin)!: replace bluebird usage inside scripts with native promises

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20361,7 +20361,6 @@
       "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "asyncbox": "6.1.0",
         "lodash": "4.17.23",
         "webdriverio": "9.24.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20361,7 +20361,6 @@
       "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "bluebird": "3.7.2",
         "lodash": "4.17.23",
         "webdriverio": "9.24.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20361,6 +20361,7 @@
       "version": "5.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "asyncbox": "6.1.0",
         "lodash": "4.17.23",
         "webdriverio": "9.24.0"
       },

--- a/packages/execute-driver-plugin/README.md
+++ b/packages/execute-driver-plugin/README.md
@@ -29,7 +29,7 @@ can be arbitrary JavaScript, this is an insecure feature, and must also be expli
 appium --use-plugins=execute-driver --allow-insecure=<driver>:execute_driver_script
 ```
 
-`<driver>` is the driver name you want to enable the feature.
+`<driver>` is the name of the driver whose sessions will have access to the plugin.
 
 ## Usage
 
@@ -40,7 +40,17 @@ const {result, logs} = await driver.executeDriverScript(script);
 // 'logs' contains everything logged to console during script execution
 ```
 
-Refer to your Appium client documentation for the exact syntax of this command.
+Refer to your Appium client documentation for the exact syntax of the script execution command.
+
+Since plugin version `6.0.0`, scripts can also use `setTimeout`/`clearTimeout`, all standard
+`Promise` methods, as well as all methods from Appium's [`asyncbox`](https://github.com/appium/asyncbox)
+utility module:
+
+```js
+// Both scripts are equivalent
+const script1 = `return await new Promise((resolve) => setTimeout(resolve, 1000));`;
+const script2 = `return await asyncbox.sleep(1000);`;
+```
 
 ## License
 

--- a/packages/execute-driver-plugin/README.md
+++ b/packages/execute-driver-plugin/README.md
@@ -42,14 +42,12 @@ const {result, logs} = await driver.executeDriverScript(script);
 
 Refer to your Appium client documentation for the exact syntax of the script execution command.
 
-Since plugin version `6.0.0`, scripts can also use `setTimeout`/`clearTimeout`, all standard
-`Promise` methods, as well as all methods from Appium's [`asyncbox`](https://github.com/appium/asyncbox)
-utility module:
+Since plugin version `6.0.0`, scripts can also use the `setTimeout`/`clearTimeout` methods,
+enabling the use of unconditional delays:
 
 ```js
-// Both scripts are equivalent
-const script1 = `return await new Promise((resolve) => setTimeout(resolve, 1000));`;
-const script2 = `return await asyncbox.sleep(1000);`;
+// this will take around one second to execute
+const script = `return await new Promise((resolve) => setTimeout(resolve, 1000));`;
 ```
 
 ## License

--- a/packages/execute-driver-plugin/lib/execute-child.ts
+++ b/packages/execute-driver-plugin/lib/execute-child.ts
@@ -1,4 +1,3 @@
-import * as asyncbox from 'asyncbox';
 import _ from 'lodash';
 import vm from 'node:vm';
 import {promisify} from 'node:util';
@@ -48,10 +47,10 @@ async function runScript(eventParams: DriverScriptMessageEvent): Promise<RunScri
   log.info('Running driver script in Node vm');
 
   // run the driver script, giving user access to the driver object, a fake console logger,
-  // the asyncbox module, and standard setTimeout/clearTimeout functions
+  // and standard setTimeout/clearTimeout functions
   let result = await vm.runInNewContext(
     fullScript,
-    {driver, console: consoleFns, asyncbox, setTimeout, clearTimeout},
+    {driver, console: consoleFns, setTimeout, clearTimeout},
     {timeout: timeoutMs, breakOnSigint: true}
   );
 

--- a/packages/execute-driver-plugin/lib/execute-child.ts
+++ b/packages/execute-driver-plugin/lib/execute-child.ts
@@ -6,9 +6,11 @@ import type {DriverScriptMessageEvent, ScriptResult, RunScriptResult} from './ty
 
 // Historically, scripts could use the Promise.delay function, which relied on bluebird.
 // The native promise library does not have a 1:1 equivalent, so we add it to maintain backwards compatibility.
-const promiseWithDelay = Object.assign(Promise, {
-  delay: (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)),
-});
+class PromiseWithDelay<T> extends Promise<T> {
+  static delay(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+}
 
 const log = logger.getLogger('ExecuteDriver Child');
 let send: (res: ScriptResult) => Promise<void>;
@@ -56,7 +58,7 @@ async function runScript(eventParams: DriverScriptMessageEvent): Promise<RunScri
   // console logger, and a promise library
   let result = await vm.runInNewContext(
     fullScript,
-    {driver, console: consoleFns, Promise: promiseWithDelay},
+    {driver, console: consoleFns, Promise: PromiseWithDelay},
     {timeout: timeoutMs, breakOnSigint: true}
   );
 

--- a/packages/execute-driver-plugin/lib/plugin.ts
+++ b/packages/execute-driver-plugin/lib/plugin.ts
@@ -100,7 +100,7 @@ export class ExecuteDriverPlugin extends BasePlugin {
       // promise that deals with the result from the child process
       const waitForResult = async () => {
         const res = await new Promise<{error?: {message: string}; success?: any}>((resolve) => {
-          scriptProc.on('message', resolve); // this is node IPC
+          scriptProc.once('message', resolve); // this is node IPC
         });
 
         this.log.info(

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -39,7 +39,6 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.*ts\""
   },
   "dependencies": {
-    "asyncbox": "6.1.0",
     "lodash": "4.17.23",
     "webdriverio": "9.24.0"
   },

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -39,7 +39,6 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.*ts\""
   },
   "dependencies": {
-    "bluebird": "3.7.2",
     "lodash": "4.17.23",
     "webdriverio": "9.24.0"
   },

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -39,6 +39,7 @@
     "test:unit": "mocha \"./test/unit/**/*.spec.*ts\""
   },
   "dependencies": {
+    "asyncbox": "6.1.0",
     "lodash": "4.17.23",
     "webdriverio": "9.24.0"
   },

--- a/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.ts
+++ b/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.ts
@@ -175,15 +175,5 @@ describe('ExecuteDriverPlugin', function () {
         /.+50.+timeout.+/
       );
     });
-
-    it('should be able to use asyncbox module functions in a driver script', async function () {
-      const script = `
-        await asyncbox.sleep(1000);
-        return true;
-      `;
-      await expect(driver.executeDriverScript(script, 'webdriverio', 50)).to.eventually.be.rejectedWith(
-        /.+50.+timeout.+/
-      );
-    });
   });
 });

--- a/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.ts
+++ b/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.ts
@@ -166,9 +166,19 @@ describe('ExecuteDriverPlugin', function () {
       );
     });
 
-    it('should be able to set a timeout on a driver script', async function () {
+    it('should be able to use standard promise and timeout functions in a driver script', async function () {
       const script = `
-        await Promise.delay(1000);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        return true;
+      `;
+      await expect(driver.executeDriverScript(script, 'webdriverio', 50)).to.eventually.be.rejectedWith(
+        /.+50.+timeout.+/
+      );
+    });
+
+    it('should be able to use asyncbox module functions in a driver script', async function () {
+      const script = `
+        await asyncbox.sleep(1000);
         return true;
       `;
       await expect(driver.executeDriverScript(script, 'webdriverio', 50)).to.eventually.be.rejectedWith(


### PR DESCRIPTION
BREAKING CHANGE: The `Promise` object in the script context now matches the global `Promise` object instead of `bluebird`. Methods specific to `bluebird` are no longer supported.

* Replace `bluebird` with native `Promise`s in the module code
* The `Promise` object in the script context now matches the global `Promise` object instead of `bluebird`
* Add support for `setTimeout` and `clearTimeout` functions in the script context 