### PR TITLE
fix(logger): Make sure we always have single logger instance per process

### DIFF
--- a/packages/appium/lib/logsink.js
+++ b/packages/appium/lib/logsink.js
@@ -5,10 +5,6 @@ import _ from 'lodash';
 import { adler32 } from './utils';
 import { LRUCache } from 'lru-cache';
 
-// set up distributed logging before everything else
-global._global_npmlog = globalLog;
-// npmlog is used only for emitting, we use winston for output
-globalLog.level = 'info';
 const LEVELS_MAP = {
   debug: 4,
   info: 3,
@@ -42,6 +38,7 @@ const COLORS_CACHE = new LRUCache({
   updateAgeOnGet: true,
 });
 
+// npmlog is used only for emitting, we use winston for output (global is set by support)
 /** @type {import('winston').Logger?} */
 let log = null;
 
@@ -102,6 +99,8 @@ export async function init(args) {
       }
     }
   });
+  // Only Winston produces output; avoid duplicate lines from the logger's default stream
+  globalLog.stream = null;
 }
 
 /**

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -44,7 +44,7 @@ export class Log extends EventEmitter implements Logger {
   prefixStyle: StyleObject;
   headingStyle: StyleObject;
   heading: string;
-  stream: Writable; // Defaults to process.stderr
+  stream: Writable | null; // Defaults to process.stderr; set to null when using custom output (e.g. Winston)
 
   _asyncStorage: AsyncLocalStorage<Record<string, any>>;
   _colorEnabled?: boolean;

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -422,5 +422,18 @@ interface ArgumentFormatResult {
   stack: string | undefined,
 }
 
-export const GLOBAL_LOG = new Log();
+// Unique key for the process-wide logger on globalThis (avoids collisions with other globals).
+const GLOBAL_NPMLOG_KEY = 'appium-logger-global-8f4a1c2b-5e6d-4a9b-8c3f-7d2e1b0a9c6e';
+
+type GlobalWithLogger = typeof globalThis & { [K in typeof GLOBAL_NPMLOG_KEY]: Log | undefined };
+
+// Reuse process-wide logger so multiple loads of this module use the same Log instance.
+const g = globalThis as GlobalWithLogger;
+export const GLOBAL_LOG =
+  g[GLOBAL_NPMLOG_KEY] ??
+  (() => {
+    const log = new Log();
+    g[GLOBAL_NPMLOG_KEY] = log;
+    return log;
+  })();
 export default GLOBAL_LOG;

--- a/packages/logger/lib/types.ts
+++ b/packages/logger/lib/types.ts
@@ -1,5 +1,6 @@
 import type {EventEmitter} from 'node:events';
 import type {AsyncLocalStorage} from 'node:async_hooks';
+import type {Writable} from 'node:stream';
 
 export interface Logger extends EventEmitter {
   level: string;
@@ -8,7 +9,7 @@ export interface Logger extends EventEmitter {
   prefixStyle: StyleObject;
   headingStyle: StyleObject;
   heading: string;
-  stream: any; // Defaults to process.stderr
+  stream: Writable | null; // Defaults to process.stderr; set to null when using custom output (e.g. Winston)
 
   /**
    * Creates a log message

--- a/packages/support/lib/logging.ts
+++ b/packages/support/lib/logging.ts
@@ -133,7 +133,7 @@ function _getLogger(): {logger: Logger; defaultToVerbose: boolean} {
   const logger: Logger = testingMode && !forceLogMode
     ? MOCK_LOG
     : (globalWithNpmlog._global_npmlog ?? globalLog);
-  if (!testingMode && defaultToVerbose && logger === globalLog) {
+  if (!testingMode && !globalWithNpmlog._global_npmlog && logger === globalLog) {
     globalWithNpmlog._global_npmlog = globalLog;
     logger.maxRecordSize = MAX_LOG_RECORDS_COUNT;
   }

--- a/packages/support/lib/logging.ts
+++ b/packages/support/lib/logging.ts
@@ -135,8 +135,8 @@ function _getLogger(): {logger: Logger; defaultToVerbose: boolean} {
     : (globalWithNpmlog._global_npmlog ?? globalLog);
   if (!testingMode && defaultToVerbose && logger === globalLog) {
     globalWithNpmlog._global_npmlog = globalLog;
+    logger.maxRecordSize = MAX_LOG_RECORDS_COUNT;
   }
-  logger.maxRecordSize = MAX_LOG_RECORDS_COUNT;
   return {logger, defaultToVerbose};
 }
 

--- a/packages/support/lib/logging.ts
+++ b/packages/support/lib/logging.ts
@@ -50,7 +50,7 @@ export const log = getLogger();
  * @returns A wrapped Appium logger instance
  */
 export function getLogger(prefix: AppiumLoggerPrefix | null = null): AppiumLogger {
-  const [logger, usingGlobalLog] = _getLogger();
+  const {logger, defaultToVerbose} = _getLogger();
 
   const wrappedLogger = {
     unwrap: () => logger,
@@ -104,7 +104,9 @@ export function getLogger(prefix: AppiumLoggerPrefix | null = null): AppiumLogge
     };
   }
 
-  if (!usingGlobalLog) {
+  // Default to verbose when the global was not already set (first use, or standalone);
+  // main server will override later.
+  if (defaultToVerbose) {
     wrappedLogger.level = 'verbose';
   }
 
@@ -124,18 +126,18 @@ export function markSensitive<T>(logMessage: T): {[k: string]: T} {
   return _markSensitive(logMessage);
 }
 
-function _getLogger(): [Logger, boolean] {
+function _getLogger(): {logger: Logger; defaultToVerbose: boolean} {
   const testingMode = process.env._TESTING === '1';
   const forceLogMode = process.env._FORCE_LOGS === '1';
+  const defaultToVerbose = !globalWithNpmlog._global_npmlog;
   const logger: Logger = testingMode && !forceLogMode
     ? MOCK_LOG
     : (globalWithNpmlog._global_npmlog ?? globalLog);
-  // So that other code (e.g. main server) can resolve the same instance; only this module touches _global_npmlog.
-  if (!testingMode && !globalWithNpmlog._global_npmlog && logger === globalLog) {
+  if (!testingMode && defaultToVerbose && logger === globalLog) {
     globalWithNpmlog._global_npmlog = globalLog;
   }
   logger.maxRecordSize = MAX_LOG_RECORDS_COUNT;
-  return [logger, !!globalWithNpmlog._global_npmlog];
+  return {logger, defaultToVerbose};
 }
 
 function getFinalPrefix(


### PR DESCRIPTION
Addresses https://github.com/appium/appium/issues/21940

Root cause analysis:

- If the main Appium server sets `global._global_npmlog` **before** any driver/remotexpc code runs, then when **both** copies of support run `_getLogger()`, they both see the global and both use that **one** Log. In that case you still have **two** `Log` instances in memory (one from each logger module load), but only **one** is actually used → no duplicate from “two loggers”.
- If `global._global_npmlog` is **not** set when the second copy of support loads (e.g. plugin/driver loads before the server sets it), then that second support uses **its** `globalLog` (Log B). Then you can have **two** Logs in use (driver’s and remotexpc’s), and depending on who logs where, you can get duplicate lines.

So: **different instances are still created** because **each time `@appium/logger` is loaded as a separate module instance, it unconditionally creates a new `Log()`**. The global is only used inside **support** to choose which logger to use; it does not stop the logger package from creating another instance.