### PR TITLE
chore(deps-dev): remove unused yaml-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,8 +80,7 @@
         "typescript": "5.9.3",
         "typescript-eslint": "8.56.0",
         "webdriverio": "9.24.0",
-        "ws": "8.19.0",
-        "yaml-js": "0.3.1"
+        "ws": "8.19.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -19666,14 +19665,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
-    },
-    "node_modules/yaml-js": {
-      "version": "0.3.1",
-      "dev": true,
-      "license": "WTFPL",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -152,8 +152,7 @@
     "typescript": "5.9.3",
     "typescript-eslint": "8.56.0",
     "webdriverio": "9.24.0",
-    "ws": "8.19.0",
-    "yaml-js": "0.3.1"
+    "ws": "8.19.0"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",


### PR DESCRIPTION
This module is not imported anywhere. If we do need a parser, we're already importing the `yaml` module elsewhere.