### PR TITLE
fix(appium): Exclude package.json from tsconfig

### DIFF
--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -32,16 +32,15 @@
   },
   "files": [
     "lib",
-    "build",
+    "build/lib",
+    "build/types",
     "index.js",
     "driver.*",
     "support.*",
     "plugin.*",
     "scripts/autoinstall-extensions.js",
     "types",
-    "tsconfig.json",
-    "!build/tsconfig.tsbuildinfo",
-    "!build/test"
+    "tsconfig.json"
   ],
   "scripts": {
     "build:docs": "node docs/scripts/build-docs.js",

--- a/packages/appium/test/unit/extension/extension-config.spec.ts
+++ b/packages/appium/test/unit/extension/extension-config.spec.ts
@@ -2,7 +2,7 @@ import {DRIVER_TYPE} from '../../../lib/constants';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import path from 'node:path';
-import {version as APPIUM_VER} from '../../../package.json';
+import {APPIUM_VER} from '../../../lib/config';
 import {FAKE_DRIVER_DIR, PROJECT_ROOT, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
 import {resolveEsmEntryPoint} from '../../../lib/extension/extension-config';

--- a/packages/appium/test/unit/extension/manifest.spec.ts
+++ b/packages/appium/test/unit/extension/manifest.spec.ts
@@ -7,7 +7,7 @@ import type {SinonSandbox} from 'sinon';
 import {DRIVER_TYPE, PLUGIN_TYPE} from '../../../lib/constants';
 import {resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import {version as APPIUM_VER} from '../../../package.json';
+import {APPIUM_VER} from '../../../lib/config';
 import EventEmitter from 'node:events';
 import type {MockAppiumSupport, MockGlob, MockPackageChanged} from './mocks';
 

--- a/packages/appium/tsconfig.json
+++ b/packages/appium/tsconfig.json
@@ -15,7 +15,7 @@
     "checkJs": true,
     "types": ["mocha", "chai", "chai-as-promised", "node"]
   },
-  "include": ["lib", "types", "test", "package.json"],
+  "include": ["lib", "types", "test"],
   "references": [
     {"path": "../schema"},
     {"path": "../types"},


### PR DESCRIPTION
Fixes potential driver load error:

```
[Appium] Could not load driver 'uiautomator2', so it will not be available. Error in loading the driver was: Cannot find module 'appium/driver'
Require stack:
- /home/ee/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-android-driver/build/lib/driver.js
- /home/ee/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-android-driver/build/lib/index.js
- /home/ee/.appium/node_modules/appium-uiautomator2-driver/build/lib/driver.js
- /home/ee/.appium/node_modules/appium-uiautomator2-driver/build/lib/index.js
[Appium] Error: Cannot find module 'appium/driver'
Require stack:
- /home/ee/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-android-driver/build/lib/driver.js
- /home/ee/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-android-driver/build/lib/index.js
- /home/ee/.appium/node_modules/appium-uiautomator2-driver/build/lib/driver.js
- /home/ee/.appium/node_modules/appium-uiautomator2-driver/build/lib/index.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1456:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1066:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1071:22)
    at Module._load (node:internal/modules/cjs/loader:1242:25)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.require (node:internal/modules/cjs/loader:1556:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/home/ee/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-android-driver/build/lib/driver.js:8:18)
    at Module._compile (node:internal/modules/cjs/loader:1812:14)
    at Object..js (node:internal/modules/cjs/loader:1943:10)
    at Module.load (node:internal/modules/cjs/loader:1533:32)
    at Module._load (node:internal/modules/cjs/loader:1335:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.require (node:internal/modules/cjs/loader:1556:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/home/ee/.appium/node_modules/appium-uiautomator2-driver/node_modules/appium-android-driver/build/lib/index.js:40:18)
    at Module._compile (node:internal/modules/cjs/loader:1812:14)
    at Object..js (node:internal/modules/cjs/loader:1943:10)
    at Module.load (node:internal/modules/cjs/loader:1533:32)
    at Module._load (node:internal/modules/cjs/loader:1335:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.require (node:internal/modules/cjs/loader:1556:12)
```