### PR TITLE
fix(docutils): do not silence errors when building without serve

### DIFF
--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -7,7 +7,6 @@
 import _ from 'lodash';
 import path from 'node:path';
 import type {TeenProcessExecOptions} from 'teen_process';
-import {exec} from 'teen_process';
 import {
   DEFAULT_DEPLOY_ALIAS_TYPE,
   DEFAULT_DEPLOY_BRANCH,
@@ -22,7 +21,7 @@ import {DocutilsError} from '../error';
 import {findMike, findMkDocsYml, isMkDocsInstalled, readPackageJson, requirePython} from '../fs';
 import {getLogger} from '../logger';
 import type {SpawnBackgroundProcessOpts} from '../util';
-import {argify, spawnBackgroundProcess, stopwatch} from '../util';
+import {argify, execWithErrorHandling, spawnBackgroundProcess, stopwatch} from '../util';
 
 const log = getLogger('builder:deploy');
 
@@ -51,7 +50,7 @@ async function doServe(
 async function doDeploy(mikePath: string, args: string[] = [], opts: TeenProcessExecOptions = {}) {
   const finalArgs = ['deploy', ...args];
   log.debug('Executing %s via: %s %O', NAME_MIKE, mikePath, finalArgs);
-  return await exec(mikePath, finalArgs, opts);
+  return await execWithErrorHandling(mikePath, finalArgs, opts);
 }
 
 /**

--- a/packages/docutils/lib/builder/site.ts
+++ b/packages/docutils/lib/builder/site.ts
@@ -7,13 +7,12 @@
 
 import path from 'node:path';
 import type {TeenProcessExecOptions} from 'teen_process';
-import {exec} from 'teen_process';
 import {DEFAULT_SITE_DIR, NAME_BIN, NAME_MKDOCS, NAME_MKDOCS_YML} from '../constants';
 import {DocutilsError} from '../error';
 import {findMkDocsYml, isMkDocsInstalled, readMkDocsYml, requirePython} from '../fs';
 import {getLogger} from '../logger';
 import type {SpawnBackgroundProcessOpts} from '../util';
-import {relative, spawnBackgroundProcess, stopwatch} from '../util';
+import {execWithErrorHandling, relative, spawnBackgroundProcess, stopwatch} from '../util';
 
 const log = getLogger('mkdocs');
 
@@ -43,7 +42,7 @@ async function doServe(
 async function doBuild(pythonPath: string, args: string[] = [], opts: TeenProcessExecOptions = {}) {
   const finalArgs = ['-m', NAME_MKDOCS, 'build', ...args];
   log.debug('Executing %s via: %s, %O', NAME_MKDOCS, pythonPath, finalArgs);
-  return await exec(pythonPath, finalArgs, opts);
+  return await execWithErrorHandling(pythonPath, finalArgs, opts);
 }
 
 /**

--- a/packages/docutils/lib/util.ts
+++ b/packages/docutils/lib/util.ts
@@ -111,7 +111,7 @@ export async function execWithErrorHandling(
     return await exec(cmd, args, opts);
   } catch (err) {
     const execErr = err as ExecError;
-    const execStderr = execErr.stderr ? `\nCommand error:\n${execErr.stderr}` : '';
-    throw new Error(`${execErr.message}${execStderr}`);
+    execErr.message = execErr.stderr ? `${execErr.message}\nCommand error:\n${execErr.stderr}` : execErr.message;
+    throw execErr;
   }
 }

--- a/packages/docutils/lib/util.ts
+++ b/packages/docutils/lib/util.ts
@@ -7,6 +7,8 @@ import _ from 'lodash';
 import type {SpawnOptions} from 'node:child_process';
 import {spawn} from 'node:child_process';
 import path from 'node:path';
+import type {ExecError, TeenProcessExecOptions} from 'teen_process';
+import {exec} from 'teen_process';
 
 /**
  * Computes a relative path, prepending `./`
@@ -96,3 +98,20 @@ export async function spawnBackgroundProcess(command: string, args: string[], op
 }
 
 export type SpawnBackgroundProcessOpts = Omit<SpawnOptions, 'stdio'>;
+
+/**
+ * Wraps {@linkcode exec} with error handling that appends stderr to the thrown error message.
+ */
+export async function execWithErrorHandling(
+  cmd: string,
+  args?: string[],
+  opts?: TeenProcessExecOptions,
+) {
+  try {
+    return await exec(cmd, args, opts);
+  } catch (err) {
+    const execErr = err as ExecError;
+    const execStderr = execErr.stderr ? `\nCommand error:\n${execErr.stderr}` : '';
+    throw new Error(`${execErr.message}${execStderr}`);
+  }
+}


### PR DESCRIPTION
The current behavior of `appium-docs build`, when running without the `--serve` option, silences the error messages from the original function (either `python -m mkdocs build` or `mike deploy`). This makes it impossible to identify the root cause if these functions return an error (for example in CI: https://github.com/appium/appium-xcuitest-driver/actions/runs/23710556037/job/69070407758).

This PR fixes the issue by reading the `err.stderr` field returned by `teen_process`, which is where the original error message is stored, and appending it to the full error message.

Here's a quick comparison when I changed `mkdocs build` to `mkdocs buil`:

Before:
```
Command '/usr/bin/python3 -m mkdocs buil -f /home/ee/Development/appium/packages/appium/docs/mkdocs-en.yml' exited with code 2
```

After:
```
Command '/usr/bin/python3 -m mkdocs buil -f /home/ee/Development/appium/packages/appium/docs/mkdocs-en.yml' exited with code 2
Command error:
Usage: python -m mkdocs [OPTIONS] COMMAND [ARGS]...
Try 'python -m mkdocs -h' for help.

Error: No such command 'buil'.
```