### PR TITLE
chore: update Renovate config

### DIFF
--- a/renovate/README.md
+++ b/renovate/README.md
@@ -37,6 +37,7 @@ Appium extension authors--or anyone else--may use this config as well.
 - `config:js-app` - everything gets pinned except peer deps (plus a bunch of other reasonable defaults)
 - `group:definitelyTyped` - Groups all `@types/*` packages into one PR
 - `security:minimumReleaseAgeNpm` - Delays updates for 3 days after they have been published to `npm`, protecting against supply chain attacks
+  - Packages under the Appium organization are excluded from this
 - `:automergeStableNonMajor` - Automatically merges "patch" and "minor" updates for semver stable (>=1.0.0) packages (assuming they pass CI)
 - `:automergeDigest` - Automatically merges "digest" updates (assuming they pass CI)
 - `:configMigration` - Automatically creates PRs for Renovate config file migration updates

--- a/renovate/README.md
+++ b/renovate/README.md
@@ -36,8 +36,10 @@ Appium extension authors--or anyone else--may use this config as well.
 
 - `config:js-app` - everything gets pinned except peer deps (plus a bunch of other reasonable defaults)
 - `group:definitelyTyped` - Groups all `@types/*` packages into one PR
+- `security:minimumReleaseAgeNpm` - Delays updates for 3 days after they have been published to `npm`, protecting against supply chain attacks
 - `:automergeStableNonMajor` - Automatically merges "patch" and "minor" updates for semver stable (>=1.0.0) packages (assuming they pass CI)
 - `:automergeDigest` - Automatically merges "digest" updates (assuming they pass CI)
+- `:configMigration` - Automatically creates PRs for Renovate config file migration updates
 - `:enableVulnerabilityAlerts` - For "security" purposes
 - `:rebaseStalePrs` - Renovate will automatically rebase its PRs
 - `:semanticCommits` - Renovate will use semantic commit messages

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -18,6 +18,11 @@
       "matchPackageNames": ["ora"],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Disable minimum release age checks for Appium organization packages",
+      "matchRepositories": ["appium/**"],
+      "minimumReleaseAge": null
     }
   ],
   "semanticCommitScope": "{{#if parentDir}}{{parentDir}}{{else}}deps{{/if}}"

--- a/renovate/default.json
+++ b/renovate/default.json
@@ -4,8 +4,10 @@
   "extends": [
     "config:js-app",
     "group:definitelyTyped",
+    "security:minimumReleaseAgeNpm",
     ":automergeStableNonMajor",
     ":automergeDigest",
+    ":configMigration",
     ":enableVulnerabilityAlerts",
     ":rebaseStalePrs",
     ":semanticCommits",


### PR DESCRIPTION
Add 2 new Renovate config options:
* `security:minimumReleaseAgeNpm` for better supply chain security
* `:configMigration` for easier maintenance of Renovate itself