### PR TITLE
fix: adjust Renovate config

### DIFF
--- a/renovate/default.json
+++ b/renovate/default.json
@@ -21,7 +21,7 @@
     },
     {
       "description": "Disable minimum release age checks for Appium organization packages",
-      "matchRepositories": ["appium/**"],
+      "matchSourceUrls": ["https://github.com/appium/**"],
       "minimumReleaseAge": null
     }
   ],


### PR DESCRIPTION
Follow-up to #22125.
I may have misunderstood the `matchRepositories` option - it seems that it checks against the name of the repo that is using Renovate, instead of the name of the repo of the dependency itself.
This PR changes the option to `matchSourceUrls` instead - this option is also used in Renovate's built-in monorepo presets, so it is likely to work the way we expect it to.