### PR TITLE
feat(base-driver): map W3C 'no such shadow root' to NoSuchShadowRootError (#22209)

### DIFF
--- a/packages/base-driver/lib/protocol/errors.ts
+++ b/packages/base-driver/lib/protocol/errors.ts
@@ -140,6 +140,39 @@ export class NoSuchElementError extends ProtocolError {
 
 }
 
+/**
+ * W3C WebDriver "no such shadow root" error. Issued when a command
+ * targets an element's shadow root that does not exist (or has been
+ * detached). Previously this was mis-classified as UnknownError — see
+ * https://github.com/appium/appium/issues/22209.
+ */
+export class NoSuchShadowRootError extends ProtocolError {
+  constructor(message: string = '', cause?: Error) {
+    super(
+      message ||
+        'The element does not have a shadow root attached.',
+      NoSuchShadowRootError.code(),
+      NoSuchShadowRootError.w3cStatus(),
+      NoSuchShadowRootError.error(),
+      cause,
+    );
+  }
+
+  // W3C-only error. No historical JSONWP code is assigned to
+  // "no such shadow root"; keep a placeholder so the super call
+  // typechecks (other errors in this file follow the same shape).
+  static code() {
+    return 65;
+  }
+  static error() {
+    return 'no such shadow root';
+  }
+  static w3cStatus() {
+    return HTTPStatusCodes.NOT_FOUND;
+  }
+
+}
+
 export class NoSuchFrameError extends ProtocolError {
   constructor(message: string = '', cause?: Error) {
     super(
@@ -1047,6 +1080,7 @@ export const errors = {
   NoSuchContextError,
   InvalidContextError,
   NoSuchFrameError,
+  NoSuchShadowRootError,
   UnableToCaptureScreen,
   UnknownMethodError,
   UnsupportedOperationError,

--- a/packages/base-driver/test/unit/protocol/errors.spec.ts
+++ b/packages/base-driver/test/unit/protocol/errors.spec.ts
@@ -24,6 +24,7 @@ const errorsList: ErrorListItem[] = [
   {errorName: 'InvalidArgumentError', errorMsg: 'The arguments passed to the command are either invalid or malformed', error: 'invalid argument'},
   {errorName: 'NoSuchElementError', errorMsg: 'An element could not be located on the page using the given search parameters.', error: 'no such element', errorCode: 7},
   {errorName: 'NoSuchFrameError', errorMsg: 'A request to switch to a frame could not be satisfied because the frame could not be found.', error: 'no such frame', errorCode: 8},
+  {errorName: 'NoSuchShadowRootError', errorMsg: 'The element does not have a shadow root attached.', error: 'no such shadow root', errorCode: 65},
   {errorName: 'UnknownCommandError', errorMsg: 'The requested resource could not be found, or a request was received using an HTTP method that is not supported by the mapped resource.', error: 'unknown command', errorCode: 9},
   {errorName: 'StaleElementReferenceError', errorMsg: 'An element command failed because the referenced element is no longer attached to the DOM.', error: 'stale element reference', errorCode: 10},
   {errorName: 'ElementNotVisibleError', errorMsg: 'An element command could not be completed because the element is not visible on the page.', errorCode: 11},
@@ -120,6 +121,7 @@ describe('w3c Status Codes', function () {
     const non400Errors: [string, number][] = [
       ['NoSuchDriverError', 404],
       ['NoSuchFrameError', 404],
+      ['NoSuchShadowRootError', 404],
       ['NoAlertOpenError', 404],
       ['NoSuchWindowError', 404],
       ['StaleElementReferenceError', 404],


### PR DESCRIPTION
## Summary

Appium's base-driver had no dedicated \`ProtocolError\` subclass for the W3C WebDriver **no such shadow root** error. Every such response from the underlying browser (e.g. \`GetShadowRoot\` against an element whose shadow DOM is absent) fell through the \`w3cErrorCodeMap\` lookup to \`UnknownError\` — Selenium clients could not reach their dedicated \`NoSuchShadowRootException\` mapping because appium never surfaced the right \`error\` field.

## Fix

- Add \`NoSuchShadowRootError\` (w3c signature \`"no such shadow root"\`, HTTP 404, placeholder JSONWP code 65 for super-call compatibility with the existing \`ProtocolError\` shape).
- Register it in the \`errors\` map so \`errorFromW3CJsonCode\` returns the new class and \`getResponseForW3CError\` emits the correct W3C payload.
- Extend the table-driven \`errors.spec.ts\` + w3c-status case list so the mapping is locked.

Fixes #22209

## Test plan

- [x] \`npx tsc --noEmit -p packages/base-driver\`
- [x] \`cd packages/base-driver && npm run test:unit -- --grep 'errors'\` — 54 passing, including the new \`NoSuchShadowRootError\` row and the 404 status-code assertion