### PR TITLE
feat(support): Add various helper utils

### DIFF
--- a/packages/support/lib/index.ts
+++ b/packages/support/lib/index.ts
@@ -73,7 +73,13 @@ export type {
 } from './net';
 export type {InstallPackageOpts, ExecOpts, NpmInstallReceipt} from './npm';
 export type {Affixes, OpenedAffixes} from './tempdir';
-export type {PluralizeOptions, EncodingOptions, LockFileOptions, NonEmptyString} from './util';
+export type {
+  PluralizeOptions,
+  EncodingOptions,
+  LockFileOptions,
+  TruncateStringOptions,
+  NonEmptyString,
+} from './util';
 export type {
   ExtractAllOptions,
   ZipEntry,

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -63,18 +63,7 @@ export function memoize<Fn extends (...args: any[]) => any, Key = unknown>(
   fn: Fn,
   resolver?: (...args: Parameters<Fn>) => Key
 ): Fn & {cache: Map<Key, ReturnType<Fn>>} {
-  const cache = new Map<Key, ReturnType<Fn>>();
-  const memoized = function (this: unknown, ...args: Parameters<Fn>): ReturnType<Fn> {
-    const key = (resolver ? resolver(...args) : (args[0] as unknown as Key)) as Key;
-    if (cache.has(key)) {
-      return cache.get(key) as ReturnType<Fn>;
-    }
-    const value = fn.apply(this, args);
-    cache.set(key, value);
-    return value;
-  } as Fn & {cache: Map<Key, ReturnType<Fn>>};
-  memoized.cache = cache;
-  return memoized;
+  return _.memoize(fn, resolver) as unknown as Fn & {cache: Map<Key, ReturnType<Fn>>};
 }
 
 /**
@@ -84,53 +73,7 @@ export function memoize<Fn extends (...args: any[]) => any, Key = unknown>(
  * @returns `true` if the value is a plain object
  */
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
-  const objectTag = '[object Object]';
-  const objectProto = Object.prototype;
-  const funcProto = Function.prototype;
-  const hasOwnProperty = objectProto.hasOwnProperty;
-  const funcToString = funcProto.toString;
-  const objectCtorString = funcToString.call(Object);
-
-  const objectToString = (val: unknown) => objectProto.toString.call(val);
-  const isObjectLike = (val: unknown): val is object => typeof val === 'object' && val !== null;
-
-  const getRawTag = (val: unknown): string => {
-    const typedValue = val as Record<PropertyKey, unknown>;
-    const symToStringTag = Symbol.toStringTag;
-    const isOwn = hasOwnProperty.call(typedValue, symToStringTag);
-    const tag = typedValue[symToStringTag];
-    try {
-      typedValue[symToStringTag] = undefined;
-      return objectToString(typedValue);
-    } finally {
-      if (isOwn) {
-        typedValue[symToStringTag] = tag;
-      } else {
-        delete typedValue[symToStringTag];
-      }
-    }
-  };
-
-  const baseGetTag = (val: unknown): string => {
-    if (val == null) {
-      return val === undefined ? '[object Undefined]' : '[object Null]';
-    }
-    return Symbol.toStringTag in Object(val) ? getRawTag(val) : objectToString(val);
-  };
-
-  if (!isObjectLike(value) || baseGetTag(value) !== objectTag) {
-    return false;
-  }
-  const proto = Object.getPrototypeOf(value);
-  if (proto === null) {
-    return true;
-  }
-  const Ctor = hasOwnProperty.call(proto, 'constructor') ? proto.constructor : undefined;
-  return (
-    typeof Ctor === 'function' &&
-    Ctor instanceof Ctor &&
-    Function.prototype.toString.call(Ctor) === objectCtorString
-  );
+  return _.isPlainObject(value);
 }
 
 /**
@@ -140,22 +83,7 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
  * @returns `true` if the value is empty
  */
 export function isEmpty(value: unknown): boolean {
-  if (value == null) {
-    return true;
-  }
-  if (typeof value === 'string' || Array.isArray(value)) {
-    return value.length === 0;
-  }
-  if (value instanceof Map || value instanceof Set) {
-    return value.size === 0;
-  }
-  if (ArrayBuffer.isView(value)) {
-    return value.byteLength === 0;
-  }
-  if (isPlainObject(value)) {
-    return Object.keys(value).length === 0;
-  }
-  return false;
+  return _.isEmpty(value);
 }
 
 /**
@@ -166,144 +94,8 @@ export function isEmpty(value: unknown): boolean {
  * @returns `true` when values are deeply equal
  */
 export function isEqual(left: unknown, right: unknown): boolean {
-  return areDeepEqual(left, right, new WeakMap());
+  return _.isEqual(left, right);
 }
-
-const areDeepEqual = (
-  left: unknown,
-  right: unknown,
-  seen: WeakMap<object, Set<object>>
-): boolean => {
-  if (Object.is(left, right)) {
-    return true;
-  }
-  if (typeof left !== typeof right) {
-    return false;
-  }
-  if (left == null || right == null) {
-    return false;
-  }
-  if (typeof left !== 'object' && typeof left !== 'function') {
-    return false;
-  }
-  if (typeof left === 'function' || typeof right === 'function') {
-    // Function values are only equal by strict identity (already handled by Object.is above).
-    return false;
-  }
-
-  const leftObj = left as object;
-  const rightObj = right as object;
-
-  const seenRight = seen.get(leftObj);
-  if (seenRight?.has(rightObj)) {
-    return true;
-  }
-  if (seenRight) {
-    seenRight.add(rightObj);
-  } else {
-    seen.set(leftObj, new Set([rightObj]));
-  }
-
-  if (left instanceof Date && right instanceof Date) {
-    return left.getTime() === right.getTime();
-  }
-  if (left instanceof Error && right instanceof Error) {
-    return left.name === right.name && left.message === right.message;
-  }
-  if (
-    Object.prototype.toString.call(left) === '[object Symbol]' &&
-    Object.prototype.toString.call(right) === '[object Symbol]'
-  ) {
-    return left.valueOf() === right.valueOf();
-  }
-  if (left instanceof RegExp && right instanceof RegExp) {
-    return left.source === right.source && left.flags === right.flags;
-  }
-  if (left instanceof Map && right instanceof Map) {
-    if (left.size !== right.size) {
-      return false;
-    }
-    const unmatchedRightEntries = Array.from(right.entries());
-    for (const [leftKey, leftValue] of left.entries()) {
-      const idx = unmatchedRightEntries.findIndex(
-        ([rightKey, rightValue]) =>
-          areDeepEqual(leftKey, rightKey, seen) && areDeepEqual(leftValue, rightValue, seen)
-      );
-      if (idx < 0) {
-        return false;
-      }
-      unmatchedRightEntries.splice(idx, 1);
-    }
-    return unmatchedRightEntries.length === 0;
-  }
-  if (left instanceof Set && right instanceof Set) {
-    if (left.size !== right.size) {
-      return false;
-    }
-    const unmatchedRightValues = Array.from(right.values());
-    for (const leftValue of left.values()) {
-      const idx = unmatchedRightValues.findIndex((rightValue) =>
-        areDeepEqual(leftValue, rightValue, seen)
-      );
-      if (idx < 0) {
-        return false;
-      }
-      unmatchedRightValues.splice(idx, 1);
-    }
-    return unmatchedRightValues.length === 0;
-  }
-  if (ArrayBuffer.isView(left) && ArrayBuffer.isView(right)) {
-    if (left.byteLength !== right.byteLength) {
-      return false;
-    }
-    const leftBytes = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
-    const rightBytes = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
-    for (let i = 0; i < leftBytes.length; i++) {
-      if (leftBytes[i] !== rightBytes[i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-  if (Array.isArray(left) && Array.isArray(right)) {
-    if (left.length !== right.length) {
-      return false;
-    }
-    for (let i = 0; i < left.length; i++) {
-      if (!areDeepEqual(left[i], right[i], seen)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  const leftTag = Object.prototype.toString.call(left);
-  const rightTag = Object.prototype.toString.call(right);
-  if (leftTag !== rightTag) {
-    return false;
-  }
-
-  const enumerableSymbols = (obj: object) =>
-    Object.getOwnPropertySymbols(obj).filter((s) =>
-      Object.prototype.propertyIsEnumerable.call(obj, s)
-    );
-  const leftKeys = [...Object.keys(leftObj), ...enumerableSymbols(leftObj)];
-  const rightKeys = [...Object.keys(rightObj), ...enumerableSymbols(rightObj)];
-  if (leftKeys.length !== rightKeys.length) {
-    return false;
-  }
-  for (const key of leftKeys) {
-    if (!rightKeys.includes(key)) {
-      return false;
-    }
-    const leftValue = (leftObj as Record<PropertyKey, unknown>)[key];
-    const rightValue = (rightObj as Record<PropertyKey, unknown>)[key];
-    if (!areDeepEqual(leftValue, rightValue, seen)) {
-      return false;
-    }
-  }
-  return true;
-};
 
 /**
  * Escapes RegExp special characters in a string.
@@ -312,7 +104,7 @@ const areDeepEqual = (
  * @returns Escaped string safe for RegExp source
  */
 export function escapeRegExp(value: string): string {
-  return value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+  return _.escapeRegExp(value);
 }
 
 /**
@@ -322,7 +114,7 @@ export function escapeRegExp(value: string): string {
  * @returns New array with unique values preserving input order
  */
 export function uniq<T>(values: readonly T[]): T[] {
-  return Array.from(new Set(values));
+  return _.uniq(values);
 }
 
 /**
@@ -336,18 +128,7 @@ export function defaults<T extends object, S extends object[]>(
   object: T,
   ...sources: S
 ): T & S[number] {
-  for (const source of sources) {
-    if (source == null) {
-      continue;
-    }
-    for (const key in source) {
-      const objectRecord = object as Record<string, unknown>;
-      if (objectRecord[key] === undefined) {
-        objectRecord[key] = (source as Record<string, unknown>)[key];
-      }
-    }
-  }
-  return object as T & S[number];
+  return _.defaults(object, ...sources) as T & S[number];
 }
 
 /**
@@ -357,51 +138,17 @@ export function defaults<T extends object, S extends object[]>(
  * @param options - Truncation options or max length
  * @returns Truncated string
  */
-export function truncateString(value: unknown, options: TruncateStringOptions | number = {}): string {
+export function truncateString(value: string, options: TruncateStringOptions | number = {}): string {
   const normalizedOptions = _.isNumber(options) ? {length: options} : options;
-  const {length = 30, omission = '…', separator} = normalizedOptions;
-  let stringValue: string;
-  if (value == null) {
-    stringValue = '';
-  } else if (typeof value === 'string') {
-    stringValue = value;
-  } else {
-    stringValue = `${value}`;
-    if (stringValue === '0' && typeof value === 'number' && 1 / value < 0) {
-      stringValue = '-0';
-    }
+  const {length, separator, omission = '…'} = normalizedOptions;
+  const truncateOpts: TruncateStringOptions = {omission};
+  if (!_.isUndefined(length)) {
+    truncateOpts.length = length;
   }
-  if (stringValue.length <= length) {
-    return stringValue;
+  if (!_.isUndefined(separator)) {
+    truncateOpts.separator = separator;
   }
-
-  const truncateLength = length - omission.length;
-  if (truncateLength <= 0) {
-    return omission;
-  }
-
-  let result = stringValue.slice(0, truncateLength);
-  if (separator) {
-    if (_.isString(separator)) {
-      const idx = result.lastIndexOf(separator);
-      if (idx >= 0) {
-        result = result.slice(0, idx);
-      }
-    } else {
-      const flags = separator.flags.includes('g') ? separator.flags : `${separator.flags}g`;
-      const separatorRegex = new RegExp(separator.source, flags);
-      let match: RegExpExecArray | null;
-      let lastMatch: RegExpExecArray | null = null;
-      // Find the last separator hit in the already-truncated result.
-      while ((match = separatorRegex.exec(result))) {
-        lastMatch = match;
-      }
-      if (lastMatch && _.isNumber(lastMatch.index)) {
-        result = result.slice(0, lastMatch.index);
-      }
-    }
-  }
-  return `${result}${omission}`;
+  return _.truncate(value as string, truncateOpts);
 }
 
 /**

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -52,6 +52,359 @@ export function hasValue<T>(val: T): val is NonNullable<T> {
 }
 
 /**
+ * Creates a memoized version of a function.
+ * By default, the first argument is used as the cache key.
+ *
+ * @param fn - Function to memoize
+ * @param resolver - Optional cache key resolver
+ * @returns Memoized function with exposed `cache` map
+ */
+export function memoize<Fn extends (...args: any[]) => any, Key = unknown>(
+  fn: Fn,
+  resolver?: (...args: Parameters<Fn>) => Key
+): Fn & {cache: Map<Key, ReturnType<Fn>>} {
+  const cache = new Map<Key, ReturnType<Fn>>();
+  const memoized = function (this: unknown, ...args: Parameters<Fn>): ReturnType<Fn> {
+    const key = (resolver ? resolver(...args) : (args[0] as unknown as Key)) as Key;
+    if (cache.has(key)) {
+      return cache.get(key) as ReturnType<Fn>;
+    }
+    const value = fn.apply(this, args);
+    cache.set(key, value);
+    return value;
+  } as Fn & {cache: Map<Key, ReturnType<Fn>>};
+  memoized.cache = cache;
+  return memoized;
+}
+
+/**
+ * Returns true if the value is a plain object (Object prototype or null prototype).
+ *
+ * @param value - Value to check
+ * @returns `true` if the value is a plain object
+ */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  const objectTag = '[object Object]';
+  const objectProto = Object.prototype;
+  const funcProto = Function.prototype;
+  const hasOwnProperty = objectProto.hasOwnProperty;
+  const funcToString = funcProto.toString;
+  const objectCtorString = funcToString.call(Object);
+
+  const objectToString = (val: unknown) => objectProto.toString.call(val);
+  const isObjectLike = (val: unknown): val is object => typeof val === 'object' && val !== null;
+
+  const getRawTag = (val: unknown): string => {
+    const typedValue = val as Record<PropertyKey, unknown>;
+    const symToStringTag = Symbol.toStringTag;
+    const isOwn = hasOwnProperty.call(typedValue, symToStringTag);
+    const tag = typedValue[symToStringTag];
+    try {
+      typedValue[symToStringTag] = undefined;
+      return objectToString(typedValue);
+    } finally {
+      if (isOwn) {
+        typedValue[symToStringTag] = tag;
+      } else {
+        delete typedValue[symToStringTag];
+      }
+    }
+  };
+
+  const baseGetTag = (val: unknown): string => {
+    if (val == null) {
+      return val === undefined ? '[object Undefined]' : '[object Null]';
+    }
+    return Symbol.toStringTag in Object(val) ? getRawTag(val) : objectToString(val);
+  };
+
+  if (!isObjectLike(value) || baseGetTag(value) !== objectTag) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  if (proto === null) {
+    return true;
+  }
+  const Ctor = hasOwnProperty.call(proto, 'constructor') ? proto.constructor : undefined;
+  return (
+    typeof Ctor === 'function' &&
+    Ctor instanceof Ctor &&
+    Function.prototype.toString.call(Ctor) === objectCtorString
+  );
+}
+
+/**
+ * Returns true when the value has no elements/properties.
+ *
+ * @param value - Value to check
+ * @returns `true` if the value is empty
+ */
+export function isEmpty(value: unknown): boolean {
+  if (value == null) {
+    return true;
+  }
+  if (typeof value === 'string' || Array.isArray(value)) {
+    return value.length === 0;
+  }
+  if (value instanceof Map || value instanceof Set) {
+    return value.size === 0;
+  }
+  if (ArrayBuffer.isView(value)) {
+    return value.byteLength === 0;
+  }
+  if (isPlainObject(value)) {
+    return Object.keys(value).length === 0;
+  }
+  return false;
+}
+
+/**
+ * Performs a deep equality check between two values.
+ *
+ * @param left - First value
+ * @param right - Second value
+ * @returns `true` when values are deeply equal
+ */
+export function isEqual(left: unknown, right: unknown): boolean {
+  return areDeepEqual(left, right, new WeakMap());
+}
+
+const areDeepEqual = (
+  left: unknown,
+  right: unknown,
+  seen: WeakMap<object, Set<object>>
+): boolean => {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (typeof left !== typeof right) {
+    return false;
+  }
+  if (left == null || right == null) {
+    return false;
+  }
+  if (typeof left !== 'object' && typeof left !== 'function') {
+    return false;
+  }
+  if (typeof left === 'function' || typeof right === 'function') {
+    // Function values are only equal by strict identity (already handled by Object.is above).
+    return false;
+  }
+
+  const leftObj = left as object;
+  const rightObj = right as object;
+
+  const seenRight = seen.get(leftObj);
+  if (seenRight?.has(rightObj)) {
+    return true;
+  }
+  if (seenRight) {
+    seenRight.add(rightObj);
+  } else {
+    seen.set(leftObj, new Set([rightObj]));
+  }
+
+  if (left instanceof Date && right instanceof Date) {
+    return left.getTime() === right.getTime();
+  }
+  if (left instanceof Error && right instanceof Error) {
+    return left.name === right.name && left.message === right.message;
+  }
+  if (
+    Object.prototype.toString.call(left) === '[object Symbol]' &&
+    Object.prototype.toString.call(right) === '[object Symbol]'
+  ) {
+    return left.valueOf() === right.valueOf();
+  }
+  if (left instanceof RegExp && right instanceof RegExp) {
+    return left.source === right.source && left.flags === right.flags;
+  }
+  if (left instanceof Map && right instanceof Map) {
+    if (left.size !== right.size) {
+      return false;
+    }
+    const unmatchedRightEntries = Array.from(right.entries());
+    for (const [leftKey, leftValue] of left.entries()) {
+      const idx = unmatchedRightEntries.findIndex(
+        ([rightKey, rightValue]) =>
+          areDeepEqual(leftKey, rightKey, seen) && areDeepEqual(leftValue, rightValue, seen)
+      );
+      if (idx < 0) {
+        return false;
+      }
+      unmatchedRightEntries.splice(idx, 1);
+    }
+    return unmatchedRightEntries.length === 0;
+  }
+  if (left instanceof Set && right instanceof Set) {
+    if (left.size !== right.size) {
+      return false;
+    }
+    const unmatchedRightValues = Array.from(right.values());
+    for (const leftValue of left.values()) {
+      const idx = unmatchedRightValues.findIndex((rightValue) =>
+        areDeepEqual(leftValue, rightValue, seen)
+      );
+      if (idx < 0) {
+        return false;
+      }
+      unmatchedRightValues.splice(idx, 1);
+    }
+    return unmatchedRightValues.length === 0;
+  }
+  if (ArrayBuffer.isView(left) && ArrayBuffer.isView(right)) {
+    if (left.byteLength !== right.byteLength) {
+      return false;
+    }
+    const leftBytes = new Uint8Array(left.buffer, left.byteOffset, left.byteLength);
+    const rightBytes = new Uint8Array(right.buffer, right.byteOffset, right.byteLength);
+    for (let i = 0; i < leftBytes.length; i++) {
+      if (leftBytes[i] !== rightBytes[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+  if (Array.isArray(left) && Array.isArray(right)) {
+    if (left.length !== right.length) {
+      return false;
+    }
+    for (let i = 0; i < left.length; i++) {
+      if (!areDeepEqual(left[i], right[i], seen)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  const leftTag = Object.prototype.toString.call(left);
+  const rightTag = Object.prototype.toString.call(right);
+  if (leftTag !== rightTag) {
+    return false;
+  }
+
+  const enumerableSymbols = (obj: object) =>
+    Object.getOwnPropertySymbols(obj).filter((s) =>
+      Object.prototype.propertyIsEnumerable.call(obj, s)
+    );
+  const leftKeys = [...Object.keys(leftObj), ...enumerableSymbols(leftObj)];
+  const rightKeys = [...Object.keys(rightObj), ...enumerableSymbols(rightObj)];
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+  for (const key of leftKeys) {
+    if (!rightKeys.includes(key)) {
+      return false;
+    }
+    const leftValue = (leftObj as Record<PropertyKey, unknown>)[key];
+    const rightValue = (rightObj as Record<PropertyKey, unknown>)[key];
+    if (!areDeepEqual(leftValue, rightValue, seen)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * Escapes RegExp special characters in a string.
+ *
+ * @param value - Input string
+ * @returns Escaped string safe for RegExp source
+ */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, '\\$&');
+}
+
+/**
+ * Returns a duplicate-free copy of the input array.
+ *
+ * @param values - Input array
+ * @returns New array with unique values preserving input order
+ */
+export function uniq<T>(values: readonly T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+/**
+ * Assigns default values for undefined properties on the target object.
+ *
+ * @param object - Destination object
+ * @param sources - Source objects providing defaults
+ * @returns The mutated destination object
+ */
+export function defaults<T extends object, S extends object[]>(
+  object: T,
+  ...sources: S
+): T & S[number] {
+  for (const source of sources) {
+    if (source == null) {
+      continue;
+    }
+    for (const key in source) {
+      const objectRecord = object as Record<string, unknown>;
+      if (objectRecord[key] === undefined) {
+        objectRecord[key] = (source as Record<string, unknown>)[key];
+      }
+    }
+  }
+  return object as T & S[number];
+}
+
+/**
+ * Truncates a string to a maximum length.
+ *
+ * @param value - Input string
+ * @param options - Truncation options or max length
+ * @returns Truncated string
+ */
+export function truncateString(value: unknown, options: TruncateStringOptions | number = {}): string {
+  const normalizedOptions = _.isNumber(options) ? {length: options} : options;
+  const {length = 30, omission = '…', separator} = normalizedOptions;
+  let stringValue: string;
+  if (value == null) {
+    stringValue = '';
+  } else if (typeof value === 'string') {
+    stringValue = value;
+  } else {
+    stringValue = `${value}`;
+    if (stringValue === '0' && typeof value === 'number' && 1 / value < 0) {
+      stringValue = '-0';
+    }
+  }
+  if (stringValue.length <= length) {
+    return stringValue;
+  }
+
+  const truncateLength = length - omission.length;
+  if (truncateLength <= 0) {
+    return omission;
+  }
+
+  let result = stringValue.slice(0, truncateLength);
+  if (separator) {
+    if (_.isString(separator)) {
+      const idx = result.lastIndexOf(separator);
+      if (idx >= 0) {
+        result = result.slice(0, idx);
+      }
+    } else {
+      const flags = separator.flags.includes('g') ? separator.flags : `${separator.flags}g`;
+      const separatorRegex = new RegExp(separator.source, flags);
+      let match: RegExpExecArray | null;
+      let lastMatch: RegExpExecArray | null = null;
+      // Find the last separator hit in the already-truncated result.
+      while ((match = separatorRegex.exec(result))) {
+        lastMatch = match;
+      }
+      if (lastMatch && _.isNumber(lastMatch.index)) {
+        result = result.slice(0, lastMatch.index);
+      }
+    }
+  }
+  return `${result}${omission}`;
+}
+
+/**
  * Escapes spaces in a string for use in command-line arguments (e.g. ` ` → `\ `).
  *
  * @param str - String that may contain spaces
@@ -372,6 +725,16 @@ export interface LockFileOptions {
   timeout?: number;
   /** If true, attempt to unlock and retry once if the first acquisition times out (e.g. stale lock). */
   tryRecovery?: boolean;
+}
+
+/** Options for truncateString(). */
+export interface TruncateStringOptions {
+  /** Maximum length of the resulting string. Default 30. */
+  length?: number;
+  /** Suffix appended to truncated strings. Default "...". */
+  omission?: string;
+  /** Optional separator to avoid splitting words/tokens. */
+  separator?: string | RegExp;
 }
 
 /** Guard function that runs the given behavior under the lock. */

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -731,7 +731,7 @@ export interface LockFileOptions {
 export interface TruncateStringOptions {
   /** Maximum length of the resulting string. Default 30. */
   length?: number;
-  /** Suffix appended to truncated strings. Default "...". */
+  /** Suffix appended to truncated strings. Default "…". */
   omission?: string;
   /** Optional separator to avoid splitting words/tokens. */
   separator?: string | RegExp;

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -114,20 +114,6 @@ export function uniq<T>(values: readonly T[]): T[] {
 }
 
 /**
- * Assigns default values for undefined properties on the target object.
- *
- * @param object - Destination object
- * @param sources - Source objects providing defaults
- * @returns The mutated destination object
- */
-export function defaults<T extends object, S extends object[]>(
-  object: T,
-  ...sources: S
-): T & S[number] {
-  return _.defaults(object, ...sources) as T & S[number];
-}
-
-/**
  * Truncates a string to a maximum length.
  *
  * @param value - Input string
@@ -136,13 +122,10 @@ export function defaults<T extends object, S extends object[]>(
  */
 export function truncateString(value: string, options: TruncateStringOptions | number = {}): string {
   const normalizedOptions = _.isNumber(options) ? {length: options} : options;
-  const {length, separator, omission = '…'} = normalizedOptions;
+  const {length, omission = '…'} = normalizedOptions;
   const truncateOpts: TruncateStringOptions = {omission};
   if (!_.isUndefined(length)) {
     truncateOpts.length = length;
-  }
-  if (!_.isUndefined(separator)) {
-    truncateOpts.separator = separator;
   }
   return _.truncate(value as string, truncateOpts);
 }
@@ -476,8 +459,6 @@ export interface TruncateStringOptions {
   length?: number;
   /** Suffix appended to truncated strings. Default "…". */
   omission?: string;
-  /** Optional separator to avoid splitting words/tokens. */
-  separator?: string | RegExp;
 }
 
 /** Guard function that runs the given behavior under the lock. */

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -53,17 +53,13 @@ export function hasValue<T>(val: T): val is NonNullable<T> {
 
 /**
  * Creates a memoized version of a function.
- * By default, the first argument is used as the cache key.
  *
  * @param fn - Function to memoize
  * @param resolver - Optional cache key resolver
- * @returns Memoized function with exposed `cache` map
+ * @returns Memoized function
  */
-export function memoize<Fn extends (...args: any[]) => any, Key = unknown>(
-  fn: Fn,
-  resolver?: (...args: Parameters<Fn>) => Key
-): Fn & {cache: Map<Key, ReturnType<Fn>>} {
-  return _.memoize(fn, resolver) as unknown as Fn & {cache: Map<Key, ReturnType<Fn>>};
+export function memoize<Fn extends (...args: any[]) => any>(fn: Fn): Fn {
+  return _.memoize(fn) as unknown as Fn;
 }
 
 /**

--- a/packages/support/test/unit/util.spec.ts
+++ b/packages/support/test/unit/util.spec.ts
@@ -663,13 +663,13 @@ describe('util', function () {
     });
 
     it('should handle non-string values safely', function () {
-      expect(() => util.truncateString(undefined)).not.to.throw();
-      expect(() => util.truncateString(null)).not.to.throw();
-      expect(util.truncateString(undefined)).to.equal('');
-      expect(util.truncateString(null)).to.equal('');
-      expect(util.truncateString(123456, 5)).to.equal('1234…');
-      expect(util.truncateString({a: 1}, 8)).to.equal('[object…');
-      expect(util.truncateString(-0)).to.equal('-0');
+      expect(() => util.truncateString(undefined as any)).not.to.throw();
+      expect(() => util.truncateString(null as any)).not.to.throw();
+      expect(util.truncateString(undefined as any)).to.equal('');
+      expect(util.truncateString(null as any)).to.equal('');
+      expect(util.truncateString(123456 as any, 5)).to.equal('1234…');
+      expect(util.truncateString({a: 1} as any, 8)).to.equal('[object…');
+      expect(util.truncateString(-0 as any)).to.equal('-0');
     });
 
     it('should return omission if max length is too small', function () {

--- a/packages/support/test/unit/util.spec.ts
+++ b/packages/support/test/unit/util.spec.ts
@@ -557,18 +557,11 @@ describe('util', function () {
     });
 
     it('should compare maps and sets', function () {
-      expect(
-        util.isEqual(
-          new Map([
-            ['a', 1],
-            ['b', {c: 2}],
-          ]),
-          new Map([
-            ['a', 1],
-            ['b', {c: 2}],
-          ])
-        )
-      ).to.be.true;
+      const entries: Array<[string, number | {c: number}]> = [
+        ['a', 1],
+        ['b', {c: 2}],
+      ];
+      expect(util.isEqual(new Map(entries), new Map(entries))).to.be.true;
       expect(util.isEqual(new Set([1, 2]), new Set([2, 1]))).to.be.true;
       expect(util.isEqual(new Set([1, 2]), new Set([2, 3]))).to.be.false;
     });

--- a/packages/support/test/unit/util.spec.ts
+++ b/packages/support/test/unit/util.spec.ts
@@ -475,4 +475,205 @@ describe('util', function () {
       expect(util.pluralize('word', 2, {inclusive: true})).to.eql('2 words');
     });
   });
+
+  describe('memoize', function () {
+    it('should memoize using first argument by default', function () {
+      let callCount = 0;
+      const fn = util.memoize((value: number) => {
+        callCount += 1;
+        return value * 2;
+      });
+      expect(fn(2)).to.equal(4);
+      expect(fn(2)).to.equal(4);
+      expect(callCount).to.equal(1);
+    });
+
+    it('should memoize using a custom resolver', function () {
+      let callCount = 0;
+      const fn = util.memoize(
+        (a: number, b: number) => {
+          callCount += 1;
+          return a + b;
+        },
+        (_a, b) => b
+      );
+      expect(fn(1, 2)).to.equal(3);
+      expect(fn(999, 2)).to.equal(3);
+      expect(callCount).to.equal(1);
+    });
+  });
+
+  describe('isPlainObject', function () {
+    it('should return true for plain objects', function () {
+      expect(util.isPlainObject({})).to.be.true;
+      expect(util.isPlainObject(Object.create(null))).to.be.true;
+    });
+
+    it('should return false for non-plain objects', function () {
+      expect(util.isPlainObject([])).to.be.false;
+      expect(util.isPlainObject(new Date())).to.be.false;
+      expect(util.isPlainObject(null)).to.be.false;
+    });
+
+    it('should match lodash behavior for edge cases', function () {
+      const spoofed = {a: 1, [Symbol.toStringTag]: 'Custom'};
+      expect(util.isPlainObject(spoofed)).to.be.true;
+
+      function CustomCtor(this: any) {
+        this.a = 1;
+      }
+      const withCustomCtorOnProto = Object.create({constructor: CustomCtor});
+      expect(util.isPlainObject(withCustomCtorOnProto)).to.be.false;
+    });
+  });
+
+  describe('isEmpty', function () {
+    it('should handle strings and arrays', function () {
+      expect(util.isEmpty('')).to.be.true;
+      expect(util.isEmpty('x')).to.be.false;
+      expect(util.isEmpty([])).to.be.true;
+      expect(util.isEmpty([1])).to.be.false;
+    });
+
+    it('should handle objects and collections', function () {
+      expect(util.isEmpty({})).to.be.true;
+      expect(util.isEmpty({a: 1})).to.be.false;
+      expect(util.isEmpty(new Map())).to.be.true;
+      expect(util.isEmpty(new Set([1]))).to.be.false;
+    });
+  });
+
+  describe('isEqual', function () {
+    it('should deeply compare nested objects', function () {
+      expect(util.isEqual({a: [1, {b: 'c'}]}, {a: [1, {b: 'c'}]})).to.be.true;
+      expect(util.isEqual({a: [1, {b: 'c'}]}, {a: [1, {b: 'd'}]})).to.be.false;
+    });
+
+    it('should compare special values and typed objects', function () {
+      expect(util.isEqual(NaN, NaN)).to.be.true;
+      expect(util.isEqual(new Date('2020-01-01'), new Date('2020-01-01'))).to.be.true;
+      expect(util.isEqual(/abc/gi, /abc/gi)).to.be.true;
+      expect(util.isEqual(Buffer.from('a'), Buffer.from('a'))).to.be.true;
+    });
+
+    it('should compare maps and sets', function () {
+      expect(
+        util.isEqual(
+          new Map([
+            ['a', 1],
+            ['b', {c: 2}],
+          ]),
+          new Map([
+            ['a', 1],
+            ['b', {c: 2}],
+          ])
+        )
+      ).to.be.true;
+      expect(util.isEqual(new Set([1, 2]), new Set([2, 1]))).to.be.true;
+      expect(util.isEqual(new Set([1, 2]), new Set([2, 3]))).to.be.false;
+    });
+
+    it('should compare functions by identity only', function () {
+      const fn1 = () => 1;
+      const fn2 = () => 1;
+      (fn1 as any).x = 1;
+      (fn2 as any).x = 1;
+      expect(util.isEqual(fn1, fn1)).to.be.true;
+      expect(util.isEqual(fn1, fn2)).to.be.false;
+    });
+
+    it('should ignore non-enumerable own properties', function () {
+      const left: Record<string, unknown> = {a: 1};
+      const right: Record<string, unknown> = {a: 1};
+      Object.defineProperty(left, 'hidden', {value: 1, enumerable: false});
+      Object.defineProperty(right, 'hidden', {value: 2, enumerable: false});
+      expect(util.isEqual(left, right)).to.be.true;
+    });
+
+    it('should compare errors and boxed symbols like lodash', function () {
+      expect(util.isEqual(new Error('boom'), new Error('boom'))).to.be.true;
+      expect(util.isEqual(new Error('boom'), new Error('kaboom'))).to.be.false;
+      expect(util.isEqual(Object(Symbol.for('x')), Object(Symbol.for('x')))).to.be.true;
+      expect(util.isEqual(Object(Symbol.for('x')), Object(Symbol.for('y')))).to.be.false;
+    });
+  });
+
+  describe('escapeRegExp', function () {
+    it('should escape regexp metacharacters', function () {
+      expect(util.escapeRegExp('a+b*c?.(x)[y]{z}|^$\\')).to.equal(
+        'a\\+b\\*c\\?\\.\\(x\\)\\[y\\]\\{z\\}\\|\\^\\$\\\\'
+      );
+    });
+  });
+
+  describe('uniq', function () {
+    it('should return a duplicate-free array preserving order', function () {
+      expect(util.uniq([1, 2, 1, 3, 2])).to.eql([1, 2, 3]);
+    });
+  });
+
+  describe('defaults', function () {
+    it('should only assign undefined properties', function () {
+      const actual = util.defaults({a: 1, b: undefined as number | undefined}, {a: 2, b: 2, c: 3});
+      expect(actual).to.eql({a: 1, b: 2, c: 3});
+    });
+
+    it('should keep null values and support multiple sources', function () {
+      const actual = util.defaults({a: null as number | null}, {a: 1}, {b: 2});
+      expect(actual).to.eql({a: null, b: 2});
+    });
+  });
+
+  describe('truncateString', function () {
+    it('should not change short strings', function () {
+      expect(util.truncateString('short')).to.equal('short');
+    });
+
+    it('should truncate with default options', function () {
+      const src = 'abcdefghijklmnopqrstuvwxyz0123456789';
+      expect(util.truncateString(src)).to.equal('abcdefghijklmnopqrstuvwxyz012…');
+    });
+
+    it('should support numeric length shorthand', function () {
+      expect(util.truncateString('abcdefghijklmnopqrstuvwxyz', 10)).to.equal('abcdefghi…');
+    });
+
+    it('should support custom omission', function () {
+      expect(util.truncateString('abcdefghijklmnopqrstuvwxyz', {length: 10, omission: '..'})).to.equal(
+        'abcdefgh..'
+      );
+    });
+
+    it('should support string separator', function () {
+      expect(
+        util.truncateString('hello world this is appium', {
+          length: 16,
+          separator: ' ',
+        })
+      ).to.equal('hello world…');
+    });
+
+    it('should support regexp separator', function () {
+      expect(
+        util.truncateString('hello world this is appium', {
+          length: 16,
+          separator: /\s+/,
+        })
+      ).to.equal('hello world…');
+    });
+
+    it('should handle non-string values safely', function () {
+      expect(() => util.truncateString(undefined)).not.to.throw();
+      expect(() => util.truncateString(null)).not.to.throw();
+      expect(util.truncateString(undefined)).to.equal('');
+      expect(util.truncateString(null)).to.equal('');
+      expect(util.truncateString(123456, 5)).to.equal('1234…');
+      expect(util.truncateString({a: 1}, 8)).to.equal('[object…');
+      expect(util.truncateString(-0)).to.equal('-0');
+    });
+
+    it('should return omission if max length is too small', function () {
+      expect(util.truncateString('hello world', 0)).to.equal('…');
+    });
+  });
 });

--- a/packages/support/test/unit/util.spec.ts
+++ b/packages/support/test/unit/util.spec.ts
@@ -602,18 +602,6 @@ describe('util', function () {
     });
   });
 
-  describe('defaults', function () {
-    it('should only assign undefined properties', function () {
-      const actual = util.defaults({a: 1, b: undefined as number | undefined}, {a: 2, b: 2, c: 3});
-      expect(actual).to.eql({a: 1, b: 2, c: 3});
-    });
-
-    it('should keep null values and support multiple sources', function () {
-      const actual = util.defaults({a: null as number | null}, {a: 1}, {b: 2});
-      expect(actual).to.eql({a: null, b: 2});
-    });
-  });
-
   describe('truncateString', function () {
     it('should not change short strings', function () {
       expect(util.truncateString('short')).to.equal('short');
@@ -632,24 +620,6 @@ describe('util', function () {
       expect(util.truncateString('abcdefghijklmnopqrstuvwxyz', {length: 10, omission: '..'})).to.equal(
         'abcdefgh..'
       );
-    });
-
-    it('should support string separator', function () {
-      expect(
-        util.truncateString('hello world this is appium', {
-          length: 16,
-          separator: ' ',
-        })
-      ).to.equal('hello world…');
-    });
-
-    it('should support regexp separator', function () {
-      expect(
-        util.truncateString('hello world this is appium', {
-          length: 16,
-          separator: /\s+/,
-        })
-      ).to.equal('hello world…');
     });
 
     it('should handle non-string values safely', function () {

--- a/packages/support/test/unit/util.spec.ts
+++ b/packages/support/test/unit/util.spec.ts
@@ -488,17 +488,14 @@ describe('util', function () {
       expect(callCount).to.equal(1);
     });
 
-    it('should memoize using a custom resolver', function () {
+    it('should memoize by first argument only', function () {
       let callCount = 0;
-      const fn = util.memoize(
-        (a: number, b: number) => {
-          callCount += 1;
-          return a + b;
-        },
-        (_a, b) => b
-      );
+      const fn = util.memoize((a: number, b: number) => {
+        callCount += 1;
+        return a + b;
+      });
       expect(fn(1, 2)).to.equal(3);
-      expect(fn(999, 2)).to.equal(3);
+      expect(fn(1, 999)).to.equal(3);
       expect(callCount).to.equal(1);
     });
   });


### PR DESCRIPTION
While removing lodash dependencies from repo modules I can observe that there are some particular lodash constructs that we use more often than others. So it makes sense to put them into shared utils