### PR TITLE
feat(docutils): add mermaid diagram support

### DIFF
--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -18,7 +18,11 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.mark
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:


### PR DESCRIPTION
This adds support for rendering Mermaid.js-based diagrams.

Reference: https://squidfunk.github.io/mkdocs-material/reference/diagrams/