### PR TITLE
chore: fix new linting errors in ESLint 10 

### DIFF
--- a/packages/appium/lib/bidi-commands.ts
+++ b/packages/appium/lib/bidi-commands.ts
@@ -256,10 +256,11 @@ function initBidiSocket(this: AppiumDriver, ws: WebSocket, req: IncomingMessage)
     if (bidiProxyUrl) {
       try {
         new URL(bidiProxyUrl);
-      } catch {
+      } catch (e) {
         throw new Error(
           `Got request for ${driverName} to proxy bidi connections to upstream socket with ` +
             `url ${bidiProxyUrl}, but this was not a valid url`,
+          {cause: e}
         );
       }
       this.log.info(`Bidi connection for ${driverName} will be proxied to ${bidiProxyUrl}. ` +

--- a/packages/appium/lib/bootstrap/config-file.ts
+++ b/packages/appium/lib/bootstrap/config-file.ts
@@ -129,7 +129,8 @@ function yamlLoader(filepath: string, content: string): unknown {
     return yaml.parse(content);
   } catch (e) {
     throw new Error(
-      `The YAML config at '${filepath}' cannot be loaded. Original error: ${(e as Error).message}`
+      `The YAML config at '${filepath}' cannot be loaded. Original error: ${(e as Error).message}`,
+      {cause: e}
     );
   }
 }
@@ -145,7 +146,8 @@ function jsonLoader(filepath: string, content: string): unknown {
   } catch (e) {
     rawConfig.delete(filepath);
     throw new Error(
-      `The JSON config at '${filepath}' cannot be loaded. Original error: ${(e as Error).message}`
+      `The JSON config at '${filepath}' cannot be loaded. Original error: ${(e as Error).message}`,
+      {cause: e}
     );
   }
 }

--- a/packages/appium/lib/bootstrap/node-helpers.ts
+++ b/packages/appium/lib/bootstrap/node-helpers.ts
@@ -147,7 +147,10 @@ export async function requireDir(
         return;
       } catch {}
     }
-    throw new Error(`The ${displayName} '${root}' must exist and be a valid directory`);
+    throw new Error(
+      `The ${displayName} '${root}' must exist and be a valid directory`,
+      {cause: e}
+    );
   }
   if (stat && !stat.isDirectory()) {
     throw new Error(`The ${displayName} '${root}' must be a valid directory`);
@@ -155,9 +158,10 @@ export async function requireDir(
   if (requireWriteable) {
     try {
       await fs.access(root, fs.constants.W_OK);
-    } catch {
+    } catch (e) {
       throw new Error(
-        `The ${displayName} '${root}' must be writeable for the current user account '${os.userInfo().username}'`
+        `The ${displayName} '${root}' must be writeable for the current user account '${os.userInfo().username}'`,
+        {cause: e}
       );
     }
   }

--- a/packages/appium/lib/extension/driver-config.ts
+++ b/packages/appium/lib/extension/driver-config.ts
@@ -83,7 +83,7 @@ export class DriverConfig extends ExtensionConfig<DriverType> {
         `Have you installed a driver that supports those ` +
         `capabilities? Run 'appium driver list --installed' to see. ` +
         `(Lower-level error: ${err.message})`;
-      throw new Error(msg);
+      throw new Error(msg, {cause: err});
     }
   }
 

--- a/packages/appium/lib/extension/extension-config.ts
+++ b/packages/appium/lib/extension/extension-config.ts
@@ -591,7 +591,8 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
       extensionManifest = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
     } catch (e: any) {
       throw new ReferenceError(
-        `Could not read the ${this.extensionType} manifest at ${packageJsonPath}: ${e.message}`
+        `Could not read the ${this.extensionType} manifest at ${packageJsonPath}: ${e.message}`,
+        {cause: e}
       );
     }
     let entryPointRelativePath: string | undefined;
@@ -602,7 +603,8 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
       entryPointRelativePath = entryPointRelativePath ?? extensionManifest.main ?? DEFAULT_ENTRY_POINT;
     } catch (e: any) {
       throw new ReferenceError(
-        `Could not find the ${this.extensionType} installed at ${moduleRoot}: ${e.message}`
+        `Could not find the ${this.extensionType} installed at ${moduleRoot}: ${e.message}`,
+        {cause: e}
       );
     }
     const entryPointFullPath = path.resolve(moduleRoot, entryPointRelativePath as string);

--- a/packages/appium/lib/extension/manifest.ts
+++ b/packages/appium/lib/extension/manifest.ts
@@ -118,7 +118,8 @@ export class Manifest {
             `Appium had trouble loading the extension installation ` +
               `cache file (${manifestPathResolved}). It may be invalid YAML. Specific error: ${
                 err.message
-              }`
+              }`,
+            {cause: err}
           );
         }
       }
@@ -166,7 +167,8 @@ export class Manifest {
         throw new Error(
           `Appium could not create the directory for the manifest file: ${path.dirname(
             manifestPathResolved
-          )}. Original error: ${err.message}`
+          )}. Original error: ${err.message}`,
+          {cause: err}
         );
       }
       try {
@@ -176,7 +178,8 @@ export class Manifest {
         throw new Error(
           `Appium could not write to manifest at ${manifestPathResolved} using APPIUM_HOME ${
             this.#appiumHome
-          }. Please ensure it is writable. Original error: ${err.message}`
+          }. Please ensure it is writable. Original error: ${err.message}`,
+          {cause: err}
         );
       }
     })();

--- a/packages/appium/lib/extension/package-changed.ts
+++ b/packages/appium/lib/extension/package-changed.ts
@@ -20,7 +20,8 @@ export async function packageDidChange(appiumHome: string): Promise<boolean> {
     await fs.mkdirp(hashFilenameDir);
   } catch (err: any) {
     throw new Error(
-      `Appium could not create the directory for hash file: ${hashFilenameDir}. Original error: ${err.message}`
+      `Appium could not create the directory for hash file: ${hashFilenameDir}. Original error: ${err.message}`,
+      {cause: err}
     );
   }
 
@@ -46,7 +47,8 @@ export async function packageDidChange(appiumHome: string): Promise<boolean> {
       );
     } catch (err: any) {
       throw new Error(
-        `Appium could not write hash file: ${hashFilenameDir}. Original error: ${err.message}`
+        `Appium could not write hash file: ${hashFilenameDir}. Original error: ${err.message}`,
+        {cause: err}
       );
     }
   }

--- a/packages/appium/lib/schema/cli-transformers.ts
+++ b/packages/appium/lib/schema/cli-transformers.ts
@@ -41,7 +41,7 @@ export const transformers = {
       const msg = loadedFromFile
         ? `The provided value of '${csvOrPath}' must be a valid CSV`
         : `Must be a comma-delimited string, e.g., "foo,bar,baz"`;
-      throw new TypeError(`${msg}. Original error: ${(err as Error).message}`);
+      throw new TypeError(`${msg}. Original error: ${(err as Error).message}`, {cause: err});
     }
   },
 
@@ -66,7 +66,7 @@ export const transformers = {
       const msg = loadedFromFile
         ? `'${jsonOrPath}' must be a valid JSON`
         : `The provided value must be a valid JSON`;
-      throw new TypeError(`${msg}. Original error: ${(e as Error).message}`);
+      throw new TypeError(`${msg}. Original error: ${(e as Error).message}`, {cause: e});
     }
   },
 } as const;

--- a/packages/appium/lib/utils.ts
+++ b/packages/appium/lib/utils.ts
@@ -22,9 +22,9 @@ export const getAppiumModuleRoot = _.memoize(function getAppiumModuleRoot(): str
 export function adler32(str: string, seed: number | null = null): number {
   let a = 1,
     b = 0,
-    M = 0,
-    c = 0,
-    d = 0;
+    M: number,
+    c: number,
+    d: number;
   const L = str.length;
   if (typeof seed === 'number') {
     a = seed & 0xffff;

--- a/packages/appium/lib/utils.ts
+++ b/packages/appium/lib/utils.ts
@@ -21,10 +21,8 @@ export const getAppiumModuleRoot = _.memoize(function getAppiumModuleRoot(): str
  */
 export function adler32(str: string, seed: number | null = null): number {
   let a = 1,
-    b = 0,
-    M: number,
-    c: number,
-    d: number;
+    b = 0;
+  let M: number, c: number, d: number;
   const L = str.length;
   if (typeof seed === 'number') {
     a = seed & 0xffff;

--- a/packages/appium/lib/utils.ts
+++ b/packages/appium/lib/utils.ts
@@ -22,16 +22,15 @@ export const getAppiumModuleRoot = _.memoize(function getAppiumModuleRoot(): str
 export function adler32(str: string, seed: number | null = null): number {
   let a = 1,
     b = 0;
-  let M: number, c: number, d: number;
   const L = str.length;
   if (typeof seed === 'number') {
     a = seed & 0xffff;
     b = seed >>> 16;
   }
   for (let i = 0; i < L;) {
-    M = Math.min(L - i, 2918);
+    let M = Math.min(L - i, 2918);
     while (M > 0) {
-      c = str.charCodeAt(i++);
+      let c = str.charCodeAt(i++);
       if (c < 0x80) {
         a += c;
       } else if (c < 0x800) {
@@ -41,7 +40,7 @@ export function adler32(str: string, seed: number | null = null): number {
         a += 128 | (c & 63);
       } else if (c >= 0xd800 && c < 0xe000) {
         c = (c & 1023) + 64;
-        d = str.charCodeAt(i++) & 1023;
+        const d = str.charCodeAt(i++) & 1023;
         a += 240 | ((c >> 8) & 7);
         b += a;
         --M;

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -130,7 +130,6 @@ export class BaseDriver<
           unexpectedShutdownRejecter = null;
           // @ts-ignore typescript cannot understand this
           unexpectedShutdownResolver?.();
-          unexpectedShutdownResolver = null;
         }
 
         // if we have set a new command timeout (which is the default), start a

--- a/packages/base-driver/lib/basedriver/helpers.ts
+++ b/packages/base-driver/lib/basedriver/helpers.ts
@@ -354,7 +354,7 @@ export function parseCapsArray(capValue: string | string[]): string[] {
   } catch (e) {
     const message = `Failed to parse capability as JSON array: ${(e as Error).message}`;
     if (_.isString(capValue) && _.startsWith(_.trimStart(capValue), '[')) {
-      throw new TypeError(message);
+      throw new TypeError(message, {cause: e});
     }
     logger.warn(message);
   }
@@ -453,7 +453,10 @@ async function queryAppLink(appLink: string, reqHeaders: RawAxiosRequestHeaders)
     const {data: stream, headers, status} = await axios(requestOpts);
     return {stream, headers, status};
   } catch (err) {
-    throw new Error(`Cannot download the app from ${axiosUrl}: ${(err as Error).message}`);
+    throw new Error(
+      `Cannot download the app from ${axiosUrl}: ${(err as Error).message}`,
+      {cause: err}
+    );
   }
 }
 
@@ -472,7 +475,7 @@ async function fetchApp(srcStream: Readable, dstPath: string): Promise<string> {
       });
     });
   } catch (err) {
-    throw new Error(`Cannot fetch the application: ${(err as Error).message}`);
+    throw new Error(`Cannot fetch the application: ${(err as Error).message}`, {cause: err});
   }
 
   const secondsElapsed = timer.getDuration().asSeconds;

--- a/packages/base-driver/lib/jsonwp-proxy/proxy.ts
+++ b/packages/base-driver/lib/jsonwp-proxy/proxy.ts
@@ -209,7 +209,8 @@ export class JWProxy {
             logger.markSensitive(truncateBody(body))
           );
           throw new Error(
-            'Cannot interpret the request body as valid JSON. Check the server log for more details.'
+            'Cannot interpret the request body as valid JSON. Check the server log for more details.',
+            {cause: error}
           );
         }
       } else {

--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -620,7 +620,7 @@ async function doJwpProxy(driver: BaseDriver<any>, req: Request, res: Response):
     if (isErrorType(err, errors.ProxyRequestError)) {
       throw err;
     } else {
-      throw new Error(`Could not proxy. Proxy error: ${err.message}`);
+      throw new Error(`Could not proxy. Proxy error: ${err.message}`, {cause: err});
     }
   }
 }

--- a/packages/base-driver/lib/protocol/routes.ts
+++ b/packages/base-driver/lib/protocol/routes.ts
@@ -594,7 +594,7 @@ export function routeToCommandName(
     normalizedPathname = new URL(`https://appium.io${normalizedEndpoint}`).pathname;
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
-    throw new Error(`'${endpoint}' cannot be translated to a command name: ${msg}`);
+    throw new Error(`'${endpoint}' cannot be translated to a command name: ${msg}`, {cause: err});
   }
 
   const normalizedMethod = _.toUpper(method ?? '');

--- a/packages/docutils/lib/validate.ts
+++ b/packages/docutils/lib/validate.ts
@@ -220,8 +220,11 @@ export class DocutilsValidator extends EventEmitter {
         requiredPackages.push({name, version});
       }
       log.debug('Parsed %s: %O', NAME_REQUIREMENTS_TXT, requiredPackages);
-    } catch {
-      throw new DocutilsError(`Could not find ${REQUIREMENTS_TXT_PATH}. This is a bug`);
+    } catch (e) {
+      throw new DocutilsError(
+        `Could not find ${REQUIREMENTS_TXT_PATH}. This is a bug`,
+        {cause: e}
+      );
     }
 
     return (this.requirementsTxt = requiredPackages);

--- a/packages/driver-test-support/lib/unit-suite.ts
+++ b/packages/driver-test-support/lib/unit-suite.ts
@@ -264,12 +264,12 @@ export function driverUnitTestSuite<C extends Constraints>(
         for (let i = 0; i < numCmds; i++) {
           cmds.push(d.executeCommand('getStatus'));
         }
-        let results = await Promise.all(cmds) as number[];
+        await Promise.all(cmds) as number[];
         cmds = [];
         for (let i = 0; i < numCmds; i++) {
           cmds.push(d.executeCommand('getStatus'));
         }
-        results = await Promise.all(cmds) as number[];
+        const results = await Promise.all(cmds) as number[];
         for (let i = 1; i < numCmds; i++) {
           if (results[i] <= results[i - 1]) {
             throw new Error('Got result out of order');

--- a/packages/execute-driver-plugin/lib/plugin.ts
+++ b/packages/execute-driver-plugin/lib/plugin.ts
@@ -140,7 +140,7 @@ export class ExecuteDriverPlugin extends BasePlugin {
       // and set up a race between the response from the child and the timeout
       return await Promise.race([waitForResult(), waitForTimeout()]);
     } catch (err: any) {
-      throw new Error(`Could not execute driver script. Original error was: ${err}`);
+      throw new Error(`Could not execute driver script. Original error was: ${err}`, {cause: err});
     } finally {
       // ensure we always cancel the timeout so that the timeout promise stops
       // spinning and allows this process to die gracefully

--- a/packages/opencv/lib/index.ts
+++ b/packages/opencv/lib/index.ts
@@ -429,7 +429,8 @@ export async function getImageOccurrence(
       // Below error message, `Cannot find any occurrences` is referenced in find by image
       throw new Error(
         `Cannot find any occurrences of the partial image in the full image. ` +
-          `Original error: ${e?.message || String(e)}`
+          `Original error: ${e?.message || String(e)}`,
+        {cause: e}
       );
     }
 

--- a/packages/schema/scripts/generate-schema-json.mjs
+++ b/packages/schema/scripts/generate-schema-json.mjs
@@ -49,9 +49,10 @@ async function write() {
     // Use createRequire to require CommonJS module from ESM
     const require = createRequire(import.meta.url);
     ({AppiumConfigJsonSchema: schema} = require(SCHEMA_SRC));
-  } catch {
+  } catch (e) {
     throw new Error(
-      `${error} Failed to read ${SCHEMA_SRC}; did you execute \`npm run build\` first?`
+      `${error} Failed to read ${SCHEMA_SRC}; did you execute \`npm run build\` first?`,
+      {cause: e}
     );
   }
 
@@ -62,7 +63,10 @@ async function write() {
     await writeFile(OUTPUT_PATH, json);
     console.log(`${info} Wrote JSON schema to ${OUTPUT_PATH}`);
   } catch (err) {
-    throw new Error(`${error} Failed to write JSON schema to ${OUTPUT_PATH}: ${err.message}`);
+    throw new Error(
+      `${error} Failed to write JSON schema to ${OUTPUT_PATH}: ${err.message}`,
+      {cause: err}
+    );
   }
 }
 

--- a/packages/support/lib/fs.ts
+++ b/packages/support/lib/fs.ts
@@ -212,7 +212,10 @@ export const fs = {
       fromStat = await fsPromises.stat(from);
     } catch (err) {
       if (isErrnoException(err) && err.code === 'ENOENT') {
-        throw new Error(`The source path '${from}' does not exist or is not accessible`);
+        throw new Error(
+          `The source path '${from}' does not exist or is not accessible`,
+          {cause: err}
+        );
       }
       throw err;
     }

--- a/packages/support/lib/image-util.ts
+++ b/packages/support/lib/image-util.ts
@@ -14,7 +14,8 @@ export function requireSharp(): typeof sharp {
       throw new Error(
         `Cannot load the 'sharp' module needed for images processing. ` +
           `Consider visiting https://sharp.pixelplumbing.com/install ` +
-          `for troubleshooting. Original error: ${message}`
+          `for troubleshooting. Original error: ${message}`,
+        {cause: err}
       );
     }
   }

--- a/packages/support/lib/mjpeg.ts
+++ b/packages/support/lib/mjpeg.ts
@@ -17,10 +17,11 @@ async function initMJpegConsumer(): Promise<MJpegConsumerConstructor> {
   if (!MJpegConsumer) {
     try {
       MJpegConsumer = (await requirePackage('mjpeg-consumer')) as MJpegConsumerConstructor;
-    } catch {
+    } catch (e) {
       throw new Error(
         'mjpeg-consumer module is required to use MJPEG-over-HTTP features. ' +
-          'Please install it first (npm i -g mjpeg-consumer) and restart Appium.'
+          'Please install it first (npm i -g mjpeg-consumer) and restart Appium.',
+        {cause: e}
       );
     }
   }
@@ -118,7 +119,8 @@ export class MJpegStream extends Writable {
         message = String(e);
       }
       throw new Error(
-        `Cannot connect to the MJPEG stream at ${url}. Original error: ${message}`
+        `Cannot connect to the MJPEG stream at ${url}. Original error: ${message}`,
+        {cause: e}
       );
     }
 

--- a/packages/support/lib/net.ts
+++ b/packages/support/lib/net.ts
@@ -153,7 +153,7 @@ export async function downloadFile(
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Cannot download the file from ${remoteUrl}: ${message}`);
+    throw new Error(`Cannot download the file from ${remoteUrl}: ${message}`, {cause: err});
   }
 
   const {size} = await fs.stat(dstPath);

--- a/packages/support/lib/node.ts
+++ b/packages/support/lib/node.ts
@@ -155,7 +155,7 @@ async function linkGlobalPackage(packageName: string): Promise<void> {
     if (e.stderr) {
       log.debug(e.stderr);
     }
-    throw new Error(msg);
+    throw new Error(msg, {cause: err});
   }
 }
 

--- a/packages/support/lib/npm.ts
+++ b/packages/support/lib/npm.ts
@@ -104,7 +104,8 @@ export class NPM {
     } catch (e) {
       const {stdout = '', stderr = '', code = null} = e as ExecError;
       throw new Error(
-        `npm command '${argsCopy.join(' ')}' failed with code ${code}.\n\nSTDOUT:\n${stdout.trim()}\n\nSTDERR:\n${stderr.trim()}`
+        `npm command '${argsCopy.join(' ')}' failed with code ${code}.\n\nSTDOUT:\n${stdout.trim()}\n\nSTDERR:\n${stderr.trim()}`,
+        {cause: e}
       );
     }
     return ret;
@@ -245,11 +246,12 @@ export class NPM {
       const pkgJson = await fs.readFile(pkgJsonPath, 'utf8');
       const pkg = JSON.parse(pkgJson) as PackageJson;
       return {installPath: path.dirname(pkgJsonPath), pkg};
-    } catch {
+    } catch (e) {
       throw new Error(
         'The package was not downloaded correctly; its package.json ' +
           'did not exist or was unreadable. We looked for it at ' +
-          pkgJsonPath
+          pkgJsonPath,
+        {cause: e}
       );
     }
   }

--- a/packages/support/lib/plist.ts
+++ b/packages/support/lib/plist.ts
@@ -37,7 +37,7 @@ export async function parsePlistFile(
     return {};
   }
 
-  let obj: object = {};
+  let obj: object;
   let type = 'binary';
   try {
     const parsed = await parseFile(plist);

--- a/packages/support/lib/process.ts
+++ b/packages/support/lib/process.ts
@@ -28,7 +28,10 @@ export async function getProcessIds(appName: string): Promise<number[]> {
   } catch (err) {
     const code = (err as ExecError).code;
     if (code !== 1) {
-      throw new Error(`Error getting process ids for app '${appName}': ${(err as Error).message}`);
+      throw new Error(
+        `Error getting process ids for app '${appName}': ${(err as Error).message}`,
+        {cause: err}
+      );
     }
     pids = [];
   }
@@ -56,7 +59,10 @@ export async function killProcess(appName: string, force = false): Promise<void>
   } catch (err) {
     const code = (err as ExecError).code;
     if (code !== 1) {
-      throw new Error(`Error killing app '${appName}' with pkill: ${(err as Error).message}`);
+      throw new Error(
+        `Error killing app '${appName}' with pkill: ${(err as Error).message}`,
+        {cause: err}
+      );
     }
   }
 }

--- a/packages/support/lib/system.ts
+++ b/packages/support/lib/system.ts
@@ -42,7 +42,7 @@ export async function macOsxVersion(): Promise<string> {
   try {
     stdout = (await exec('sw_vers', ['-productVersion'])).stdout.trim();
   } catch (err) {
-    throw new Error(`Could not detect Mac OS X Version: ${err}`);
+    throw new Error(`Could not detect Mac OS X Version: ${err}`, {cause: err});
   }
 
   const versionMatch = VERSION_PATTERN.exec(stdout);

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -695,7 +695,8 @@ export function getLockFileGuard<T>(
           } else {
             throw new Error(
               `Could not acquire lock on '${lockFile}' after ${timeout}s. ` +
-                `Original error: ${err.message}`
+                `Original error: ${err.message}`,
+              {cause: e}
             );
           }
         }

--- a/packages/support/lib/zip.ts
+++ b/packages/support/lib/zip.ts
@@ -553,8 +553,8 @@ async function extractWithSystemUnzip(zipFilePath: string, destDir: string): Pro
   let executablePath: string;
   try {
     executablePath = await getExecutablePath(isWindowsHost ? 'powershell.exe' : 'unzip');
-  } catch {
-    throw new Error('Could not find system unzip');
+  } catch (e) {
+    throw new Error('Could not find system unzip', {cause: e});
   }
 
   if (isWindowsHost) {

--- a/packages/support/test/unit/util.spec.ts
+++ b/packages/support/test/unit/util.spec.ts
@@ -129,7 +129,7 @@ describe('util', function () {
 
   describe('localIp', function () {
     it('should find a local ip address', function () {
-      let ifConfigOut: any = {
+      const ifConfigOut: any = {
         lo0: [
           {
             address: '::1',
@@ -185,7 +185,6 @@ describe('util', function () {
       };
       const osMock = sandbox.mock(os);
       osMock.expects('networkInterfaces').returns(ifConfigOut);
-      ifConfigOut = '';
       const ip = util.localIp();
       expect(ip).to.eql('123.123.123.123');
       osMock.verify();

--- a/packages/types/scripts/generate-schema-types.mjs
+++ b/packages/types/scripts/generate-schema-types.mjs
@@ -47,13 +47,17 @@ async function main() {
       ts = await compileFromFile(JSON_SCHEMA_PATH);
     } catch (err) {
       throw new Error(
-        `${error} Could not convert Appium schema JSON to TypeScript: ${err.message}. Does it exist?`
+        `${error} Could not convert Appium schema JSON to TypeScript: ${err.message}. Does it exist?`,
+        {cause: err}
       );
     }
     try {
       await fs.writeFile(OUTPUT_PATH, ts);
     } catch (err) {
-      throw new Error(`${error} Could not write Appium schema declaration file: ${err.message}`);
+      throw new Error(
+        `${error} Could not write Appium schema declaration file: ${err.message}`,
+        {cause: err}
+      );
     }
     console.log(`${info} Wrote %s`, OUTPUT_PATH);
     console.log(`${success} Done.`);


### PR DESCRIPTION
The ESLint 10 upgrade is finally unblocked after #22222 - however, the new version [adds three new rules in the recommended preset](https://eslint.org/docs/latest/use/migrate-to-10.0.0#eslint-recommended). This PR addresses errors caused by these new rules, separating these changes from the actual ESLint 10 upgrade PR.