### PR TITLE
fix(support): Avoid exceptions in unwrapElement

### DIFF
--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -346,10 +346,11 @@ export function jsonStringify(
  * @returns The element ID string
  */
 export function unwrapElement(el: Element | string): string {
-  const elObj = el as unknown as Record<string, string>;
-  for (const propName of [W3C_WEB_ELEMENT_IDENTIFIER, 'ELEMENT']) {
-    if (Object.hasOwn(elObj, propName)) {
-      return elObj[propName];
+  if (isPlainObject(el)) {
+    for (const propName of [W3C_WEB_ELEMENT_IDENTIFIER, 'ELEMENT']) {
+      if (Object.hasOwn(el, propName)) {
+        return el[propName] as string;
+      }
     }
   }
   return el as string;

--- a/packages/support/test/unit/util.spec.ts
+++ b/packages/support/test/unit/util.spec.ts
@@ -299,6 +299,9 @@ describe('util', function () {
       const el = 4;
       expect(util.unwrapElement(el as any)).to.equal(el);
     });
+    it('should not throw for null element input', function () {
+      expect(util.unwrapElement(null as any)).to.equal(null);
+    });
     it('should pass through an element that is an object', function () {
       const el = {RANDOM: 4};
       expect(util.unwrapElement(el as any)).to.equal(el);


### PR DESCRIPTION
It turns out Object.hasOwn is more picky than lodash's _.has and throws an exception if the argument is not an object