### PR TITLE
fix(eslint-config-appium-ts): set new ESLint 10 rules to 'warn'

### DIFF
--- a/packages/eslint-config-appium-ts/index.mjs
+++ b/packages/eslint-config-appium-ts/index.mjs
@@ -179,6 +179,15 @@ export default defineConfig([
        * `return await somePromise` have their own use-cases.
        */
       'require-await': 'off',
+
+      /**
+       * These rules are enabled by default since ESLint 10.
+       * They are set to 'warn' to prevent a breaking change.
+       */
+      'no-unassigned-vars': 'warn',
+      'no-useless-assignment': 'warn',
+      'preserve-caught-error': 'warn',
+
       'unicorn/prefer-node-protocol': 'warn',
 
       /**


### PR DESCRIPTION
Fixes a breaking change caused by these rules being enabled with the default error level.