### PR TITLE
fix(support): accept Uint8Array/ArrayBuffer in plist parse path

### DIFF
--- a/packages/support/lib/plist.ts
+++ b/packages/support/lib/plist.ts
@@ -134,11 +134,11 @@ export function createPlist(object: object, binary = false): Buffer | string {
 /**
  * Parses a buffer or string into a JS object
  *
- * @param data - The plist as a string or Buffer
+ * @param data - The plist as a string, Buffer, Uint8Array, or ArrayBuffer
  * @returns Parsed plist as a JS object
  * @throws Will throw an error if the plist type is unknown
  */
-export function parsePlist(data: string | Buffer): object {
+export function parsePlist(data: string | Buffer | Uint8Array | ArrayBuffer): object {
   const textPlist = getXmlPlist(data);
   if (textPlist) {
     return plistParse(textPlist);
@@ -159,29 +159,44 @@ async function parseXmlPlistFile(plistFilename: string): Promise<object> {
   return plistParse(xmlContent);
 }
 
-function getXmlPlist(data: string | Buffer): string | null {
+function getXmlPlist(data: string | Buffer | Uint8Array | ArrayBuffer): string | null {
   if (typeof data === 'string' && data.startsWith(PLIST_IDENTIFIER.TEXT)) {
     return data;
   }
+  const binaryData = toBufferIfBinaryLike(data);
   if (
-    Buffer.isBuffer(data) &&
-    PLIST_IDENTIFIER.BUFFER.compare(data, 0, PLIST_IDENTIFIER.BUFFER.length) === 0
+    binaryData &&
+    PLIST_IDENTIFIER.BUFFER.compare(binaryData, 0, PLIST_IDENTIFIER.BUFFER.length) === 0
   ) {
-    return data.toString();
+    return binaryData.toString();
   }
   return null;
 }
 
-function getBinaryPlist(data: string | Buffer): Buffer | null {
+function getBinaryPlist(data: string | Buffer | Uint8Array | ArrayBuffer): Buffer | null {
   if (typeof data === 'string' && data.startsWith(BPLIST_IDENTIFIER.TEXT)) {
     return Buffer.from(data);
   }
 
+  const binaryData = toBufferIfBinaryLike(data);
   if (
-    Buffer.isBuffer(data) &&
-    BPLIST_IDENTIFIER.BUFFER.compare(data, 0, BPLIST_IDENTIFIER.BUFFER.length) === 0
+    binaryData &&
+    BPLIST_IDENTIFIER.BUFFER.compare(binaryData, 0, BPLIST_IDENTIFIER.BUFFER.length) === 0
   ) {
+    return binaryData;
+  }
+  return null;
+}
+
+function toBufferIfBinaryLike(data: unknown): Buffer | null {
+  if (Buffer.isBuffer(data)) {
     return data;
+  }
+  if (data instanceof Uint8Array) {
+    return Buffer.from(data.buffer, data.byteOffset, data.byteLength);
+  }
+  if (data instanceof ArrayBuffer) {
+    return Buffer.from(data);
   }
   return null;
 }

--- a/packages/support/test/unit/plist.spec.ts
+++ b/packages/support/test/unit/plist.spec.ts
@@ -53,4 +53,37 @@ describe('plist', function () {
       'com.apple.locationd.bundle-/System/Library/PrivateFrameworks/Parsec.framework'
     );
   });
+
+  it('should read text plist from Uint8Array', async function () {
+    const content = await fs.readFile(textPlistPath);
+    const object = plist.parsePlist(new Uint8Array(content));
+    expect(object).to.have.property(
+      'com.apple.locationd.bundle-/System/Library/PrivateFrameworks/Parsec.framework'
+    );
+  });
+
+  it('should read binary plist from Uint8Array', async function () {
+    const content = await fs.readFile(binaryPlistPath);
+    const object = plist.parsePlist(new Uint8Array(content));
+    expect(object).to.have.property(
+      'com.apple.locationd.bundle-/System/Library/PrivateFrameworks/Parsec.framework'
+    );
+  });
+
+  it('should read binary plist from ArrayBuffer', async function () {
+    const content = await fs.readFile(binaryPlistPath);
+    const object = plist.parsePlist(content.buffer.slice(content.byteOffset, content.byteOffset + content.byteLength));
+    expect(object).to.have.property(
+      'com.apple.locationd.bundle-/System/Library/PrivateFrameworks/Parsec.framework'
+    );
+  });
+
+  it('should parse nested data payload returned from plist parser', function () {
+    const innerPayload = plist.createBinaryPlist({answer: 42});
+    const outer = plist.createPlist({payload: innerPayload});
+    const outerParsed = plist.parsePlist(outer as string);
+    const nestedPayload = (outerParsed as {payload: Uint8Array | Buffer | ArrayBuffer}).payload;
+    const nestedParsed = plist.parsePlist(nestedPayload);
+    expect(nestedParsed).to.deep.equal({answer: 42});
+  });
 });


### PR DESCRIPTION
## Summary
- fix a backward-compatibility break in plist parsing when `<data>` values are represented as `Uint8Array`/`ArrayBuffer` instead of `Buffer`
- extend `@appium/support` plist helpers to normalize binary-like inputs before format detection/parsing
- keep existing `string`/`Buffer` behavior unchanged while adding additive support for modern binary types
- add regression coverage for usbmux-style nested parse flows (parse plist -> reparse embedded `PairRecordData`)

## Why
Recent dependency updates can return plist binary data as `Uint8Array`, while existing code paths in Appium ecosystem may pass these values back into `parsePlist()`.  
Without normalization, this causes `Unknown type of plist` / `Unexpected data` failures in downstream real-device flows (e.g. pair-record parsing via usbmux).
See https://github.com/appium/appium/issues/22254

## Changes
- update plist binary detection helpers to accept:
  - `Buffer`
  - `Uint8Array`
  - `ArrayBuffer`
- normalize non-Buffer binary input to `Buffer` before header checks
- update typings/docs to reflect expanded accepted input types
- add tests for:
  - XML parse from `Buffer` and `Uint8Array`
  - binary parse from `Buffer`, `Uint8Array`, and `ArrayBuffer`
  - nested `<data>` reparse regression scenario
  
## Compatibility
This is a backward-compatible, additive fix:
- no behavioral change for existing `string`/`Buffer` callers
- no output format changes intended
- only broadens accepted runtime input types