### PR TITLE
feat(base-driver): Ditch bluebird

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19405,7 +19405,6 @@
         "async-lock": "1.4.1",
         "asyncbox": "6.3.0",
         "axios": "1.16.1",
-        "bluebird": "3.7.2",
         "body-parser": "2.2.2",
         "express": "5.2.1",
         "fastest-levenshtein": "1.0.16",

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -17,7 +17,6 @@ import {
   type SingularSessionData,
   type SessionCapabilities,
 } from '@appium/types';
-import B from 'bluebird';
 import _ from 'lodash';
 import {fixCaps, isW3cCaps} from '../helpers/capabilities';
 import {getLevenshteinSuggestion} from '../helpers/levenshtein-match';
@@ -113,11 +112,11 @@ export class BaseDriver<
         unexpectedShutdownRejecter?.(e);
       };
       try {
-        return await B.race([
+        return await Promise.race([
           this[cmd](...args),
           // This promise is needed to monitor if the session has been
           // shut down unexpectedly while the command was running
-          new B((resolve, reject) => {
+          new Promise((resolve, reject) => {
             unexpectedShutdownResolver = resolve;
             unexpectedShutdownRejecter = reject;
             this.eventEmitter.once(ON_UNEXPECTED_SHUTDOWN_EVENT, onUnexpectedShutdown);

--- a/packages/base-driver/lib/basedriver/helpers.ts
+++ b/packages/base-driver/lib/basedriver/helpers.ts
@@ -5,7 +5,6 @@ import {tempDir, fs, util, timing, node} from '@appium/support';
 import {LRUCache} from 'lru-cache';
 import AsyncLock from 'async-lock';
 import axios from 'axios';
-import B from 'bluebird';
 import type {
   ConfigureAppOptions,
   CachedAppInfo,
@@ -466,7 +465,7 @@ async function fetchApp(srcStream: Readable, dstPath: string): Promise<string> {
     const writer = fs.createWriteStream(dstPath);
     srcStream.pipe(writer);
 
-    await new B<void>((resolve, reject) => {
+    await new Promise<void>((resolve, reject) => {
       srcStream.once('error', reject);
       writer.once('finish', () => resolve());
       writer.once('error', (e: Error) => {

--- a/packages/base-driver/lib/express/server.ts
+++ b/packages/base-driver/lib/express/server.ts
@@ -34,7 +34,6 @@ import {
   removeAllWebSocketHandlers,
   getWebSocketHandlers,
 } from './websocket';
-import B from 'bluebird';
 import {DEFAULT_BASE_PATH} from '../constants';
 import {fs, timing} from '@appium/support';
 import type {
@@ -123,51 +122,51 @@ export async function server(opts: ServerOpts): Promise<AppiumServer> {
   const app = express();
   const httpServer = await createServer(app, cliArgs);
 
-  return await new B<AppiumServer>(async (resolve, reject) => {
-    // we put an async function as the promise constructor because we want some things to happen in
-    // serial (application of plugin updates, for example). But we still need to use a promise here
-    // because some elements of server start failure only happen in httpServer listeners. So the
-    // way we resolve it is to use an async function here but to wrap all the inner logic in
-    // try/catch so any errors can be passed to reject.
-    try {
-      const appiumServer = configureHttp({
-        httpServer,
-        reject,
-        keepAliveTimeout,
-        gracefulShutdownTimeout: cliArgs.shutdownTimeout,
-      });
-      const useLegacyUpgradeHandler = !hasShouldUpgradeCallback(httpServer);
-      configureServer({
-        app,
-        addRoutes: routeConfiguringFunction,
-        allowCors,
-        basePath,
-        extraMethodMap,
-        webSocketsMapping: appiumServer.webSocketsMapping,
-        useLegacyUpgradeHandler,
-      });
-      // allow extensions to update the app and http server objects
-      for (const updater of serverUpdaters) {
-        await updater(app, appiumServer, cliArgs);
+  return await new Promise<AppiumServer>((resolve, reject) => {
+    // we use a promise here because some elements of server start failure only happen in
+    // httpServer listeners. The async IIFE runs setup serially (e.g. plugin updates) while
+    // configureHttp can still reject via the listener registered below.
+    void (async () => {
+      try {
+        const appiumServer = configureHttp({
+          httpServer,
+          reject,
+          keepAliveTimeout,
+          gracefulShutdownTimeout: cliArgs.shutdownTimeout,
+        });
+        const useLegacyUpgradeHandler = !hasShouldUpgradeCallback(httpServer);
+        configureServer({
+          app,
+          addRoutes: routeConfiguringFunction,
+          allowCors,
+          basePath,
+          extraMethodMap,
+          webSocketsMapping: appiumServer.webSocketsMapping,
+          useLegacyUpgradeHandler,
+        });
+        // allow extensions to update the app and http server objects
+        for (const updater of serverUpdaters) {
+          await updater(app, appiumServer, cliArgs);
+        }
+
+        // once all configurations and updaters have been applied, make sure to set up a catchall
+        // handler so that anything unknown 404s. But do this after everything else since we don't
+        // want to block extensions' ability to add routes if they want.
+        app.all('/*all', catch404Handler);
+
+        await startServer({
+          httpServer,
+          hostname,
+          port,
+          keepAliveTimeout,
+          requestTimeout,
+        });
+
+        resolve(appiumServer);
+      } catch (err) {
+        reject(err);
       }
-
-      // once all configurations and updaters have been applied, make sure to set up a catchall
-      // handler so that anything unknown 404s. But do this after everything else since we don't
-      // want to block extensions' ability to add routes if they want.
-      app.all('/*all', catch404Handler);
-
-      await startServer({
-        httpServer,
-        hostname,
-        port,
-        keepAliveTimeout,
-        requestTimeout,
-      });
-
-      resolve(appiumServer);
-    } catch (err) {
-      reject(err);
-    }
+    })();
   });
 }
 
@@ -269,7 +268,7 @@ async function createServer(
 
   const certKey = [sslCertificatePath, sslKeyPath];
   const zipped = _.zip(
-    await B.all(certKey.map((p) => fs.exists(p))),
+    await Promise.all(certKey.map((p) => fs.exists(p))),
     ['certificate', 'key'],
     certKey
   ) as [boolean, string, string][];
@@ -280,7 +279,7 @@ async function createServer(
       );
     }
   }
-  const [cert, key] = await B.all(
+  const [cert, key] = await Promise.all(
     certKey.map((p) => fs.readFile(p, 'utf8'))
   ) as [string, string];
   log.debug('Enabling TLS/SPDY on the server using the provided certificate');
@@ -345,7 +344,7 @@ function configureHttp({
   // all connections are closed and the `close` event is emitted
   const originalClose = appiumServer.close.bind(appiumServer);
   appiumServer.close = async () =>
-    await new B<void>((_resolve, _reject) => {
+    await new Promise<void>((_resolve, _reject) => {
       log.info('Closing Appium HTTP server');
       const timer = new timing.Timer().start();
       const onTimeout = setTimeout(() => {
@@ -405,10 +404,19 @@ async function startServer({
   requestTimeout,
 }: StartServerOpts): Promise<void> {
   // If the hostname is omitted, the server will accept connections on any IP address
-  const start = B.promisify(httpServer.listen, {
-    context: httpServer,
-  }) as (port: number, hostname?: string) => B<HttpServer>;
-  const startPromise = start(port, hostname);
+  const startPromise = new Promise<void>((resolve, reject) => {
+    const onError = (err: Error) => {
+      httpServer.removeListener('listening', onListening);
+      reject(err);
+    };
+    const onListening = () => {
+      httpServer.removeListener('error', onError);
+      resolve();
+    };
+    httpServer.once('error', onError);
+    httpServer.once('listening', onListening);
+    httpServer.listen(port, hostname);
+  });
   httpServer.keepAliveTimeout = keepAliveTimeout;
   if (_.isInteger(requestTimeout)) {
     httpServer.requestTimeout = Number(requestTimeout);

--- a/packages/base-driver/lib/express/static.ts
+++ b/packages/base-driver/lib/express/static.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import {log} from './logger';
 import _ from 'lodash';
 import {fs} from '@appium/support';
-import B from 'bluebird';
+import {sleep} from 'asyncbox';
 import type {Request, Response} from 'express';
 
 export const STATIC_DIR = _.isNull(path.resolve(__dirname).match(/build[/\\]lib[/\\]express$/))
@@ -56,7 +56,7 @@ async function guineaPigTemplate(
   log.debug(`Sending guinea pig response with params: ${JSON.stringify(params)}`);
   if (delay) {
     log.debug(`Waiting ${delay}ms before responding`);
-    await B.delay(delay);
+    await sleep(delay);
   }
   res.set('content-type', 'text/html');
   res.cookie('guineacookie1', 'i am a cookie value', {path: '/'});

--- a/packages/base-driver/lib/express/websocket.ts
+++ b/packages/base-driver/lib/express/websocket.ts
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import B from 'bluebird';
 import type {AppiumServer, WSServer} from '@appium/types';
 
 export const DEFAULT_WS_PATHNAME_PREFIX = '/ws';
@@ -72,7 +71,7 @@ export async function removeAllWebSocketHandlers(this: AppiumServer): Promise<bo
   }
 
   return _.some(
-    await B.all(
+    await Promise.all(
       _.keys(this.webSocketsMapping).map((pathname) =>
         this.removeWebSocketHandler(pathname)
       )

--- a/packages/base-driver/lib/index.js
+++ b/packages/base-driver/lib/index.js
@@ -1,14 +1,3 @@
-import B from 'bluebird';
-
-try {
-  B.config({
-    cancellation: true,
-  });
-} catch {
-  // sometimes during testing this somehow gets required twice and results in an error about
-  // cancellation not being able to be enabled after promise has been configured
-}
-
 // BaseDriver exports
 export {ExtensionCore} from './basedriver/extension-core';
 import {BaseDriver} from './basedriver/driver';

--- a/packages/base-driver/lib/jsonwp-proxy/proxy-request.ts
+++ b/packages/base-driver/lib/jsonwp-proxy/proxy-request.ts
@@ -1,19 +1,16 @@
 import axios from 'axios';
-import { CancellationError } from 'bluebird';
-import EventEmitter from 'node:events';
-
-const CANCEL_EVENT = 'cancel';
-const FINISH_EVENT = 'finish';
 
 export class ProxyRequest {
   private readonly _requestConfig: axios.RawAxiosRequestConfig;
-  private readonly _ee: EventEmitter;
-  private _resultPromise: Promise<any> | null;
+  private _resultPromise: Promise<axios.AxiosResponse> | null;
+  private _abortController: AbortController | null;
+  private _cancelled: boolean;
 
   constructor(requestConfig: axios.RawAxiosRequestConfig<any>) {
     this._requestConfig = requestConfig;
-    this._ee = new EventEmitter();
     this._resultPromise = null;
+    this._abortController = null;
+    this._cancelled = false;
   }
 
   async execute(): Promise<axios.AxiosResponse> {
@@ -21,32 +18,35 @@ export class ProxyRequest {
       return await this._resultPromise;
     }
 
+    const abortController = new AbortController();
+    this._abortController = abortController;
+    this._cancelled = false;
+
     try {
-      this._resultPromise = Promise.race([
-        this._makeRacingTimer(),
-        this._makeRequest(),
-      ]);
+      this._resultPromise = this._makeRequest(abortController.signal);
       return await this._resultPromise;
     } finally {
-      this._ee.emit(FINISH_EVENT);
-      this._ee.removeAllListeners();
+      this._abortController = null;
     }
   }
 
   cancel(): void {
-    this._ee.emit(CANCEL_EVENT);
+    this._cancelled = true;
+    this._abortController?.abort();
   }
 
-  private async _makeRequest(): Promise<axios.AxiosResponse> {
-    return await axios(this._requestConfig);
-  }
-
-  private async _makeRacingTimer(): Promise<void> {
-    return await new Promise((resolve, reject) => {
-      this._ee.once(FINISH_EVENT, resolve);
-      this._ee.once(CANCEL_EVENT, () => reject(new CancellationError(
-        'The request has been cancelled'
-      )));
-    });
+  private async _makeRequest(signal: AbortSignal): Promise<axios.AxiosResponse> {
+    try {
+      return await axios({
+        ...this._requestConfig,
+        signal,
+      });
+    } catch (err) {
+      if (this._cancelled && axios.isCancel(err)) {
+        // The request was cancelled; do not propagate the error to callers.
+        return await new Promise<axios.AxiosResponse>(() => {});
+      }
+      throw err;
+    }
   }
 }

--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -10,7 +10,6 @@ import {
   BadParametersError,
 } from './errors';
 import {METHOD_MAP, NO_SESSION_ID_COMMANDS} from './routes';
-import B from 'bluebird';
 import {formatResponseValue, ensureW3cResponse} from './helpers';
 import {MAX_LOG_BODY_LENGTH, PROTOCOLS, DEFAULT_BASE_PATH} from '../constants';
 import {isW3cCaps} from '../helpers/capabilities';
@@ -600,7 +599,7 @@ function buildHandler(
   };
   // add the method to the app
   app[method.toLowerCase()](path, (req, res) => {
-    B.resolve(asyncHandler(req, res)).done();
+    void asyncHandler(req, res);
   });
 }
 

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -51,7 +51,6 @@
     "async-lock": "1.4.1",
     "asyncbox": "6.3.0",
     "axios": "1.16.1",
-    "bluebird": "3.7.2",
     "body-parser": "2.2.2",
     "express": "5.2.1",
     "fastest-levenshtein": "1.0.16",


### PR DESCRIPTION
## Summary

Removes the `bluebird` dependency from `@appium/base-driver` and replaces it with native `Promise` APIs and existing `asyncbox` helpers. No public API changes.

- **Dependency**: drop `bluebird` from `package.json`; remove global `B.config({ cancellation: true })` from `index.js`
- **Native promises**: `Promise.all` / `Promise.race` / `new Promise()` in `driver.ts`, `helpers.ts`, `server.ts`, `websocket.ts`; `void asyncHandler(...)` in `protocol.ts`
- **asyncbox**: `B.delay` → `sleep()` in `static.ts`
- **HTTP server startup**: replace `B.promisify(httpServer.listen)` with a `listening` / `error` promise; refactor `server()` startup to satisfy `no-async-promise-executor` (async IIFE inside a sync executor)
- **`ProxyRequest` cancellation**: replace Bluebird `CancellationError` + `Promise.race` + `EventEmitter` with `AbortController` — `cancel()` aborts the in-flight axios request without propagating a cancellation error to callers (preserves the intent of `cancelActiveRequests()`)
