### PR TITLE
chore(test-support): Remove unused bluebird dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20440,7 +20440,6 @@
       "dependencies": {
         "@appium/support": "7.2.2",
         "@colors/colors": "1.6.0",
-        "bluebird": "3.7.2",
         "lodash": "4.18.1",
         "loud-rejection": "2.2.0",
         "sinon": "22.0.0"

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@appium/support": "7.2.2",
     "@colors/colors": "1.6.0",
-    "bluebird": "3.7.2",
     "lodash": "4.18.1",
     "loud-rejection": "2.2.0",
     "sinon": "22.0.0"


### PR DESCRIPTION
Even though bluebird is listed in dependencies it's not used anywhere