### PR TITLE
chore(support): Deprecate sharp-related primitives

### DIFF
--- a/packages/support/lib/image-util.ts
+++ b/packages/support/lib/image-util.ts
@@ -4,6 +4,7 @@ let _sharp: typeof sharp | undefined;
 
 /**
  * @deprecated Sharp-backed image helpers are deprecated and will be removed in a future major version.
+ * Consumers are expected to implement this functionality on their side.
  * @returns The sharp module for image processing
  */
 export function requireSharp(): typeof sharp {
@@ -25,6 +26,7 @@ export function requireSharp(): typeof sharp {
 
 /**
  * @deprecated Sharp-backed image helpers are deprecated and will be removed in a future major version.
+ * Consumers are expected to implement this functionality on their side.
  * Crop the image by given rectangle (use base64 string as input and output)
  *
  * @param base64Image The string with base64 encoded image.

--- a/packages/support/lib/image-util.ts
+++ b/packages/support/lib/image-util.ts
@@ -3,6 +3,7 @@ import type sharp from 'sharp';
 let _sharp: typeof sharp | undefined;
 
 /**
+ * @deprecated Sharp-backed image helpers are deprecated and will be removed in a future major version.
  * @returns The sharp module for image processing
  */
 export function requireSharp(): typeof sharp {
@@ -23,6 +24,7 @@ export function requireSharp(): typeof sharp {
 }
 
 /**
+ * @deprecated Sharp-backed image helpers are deprecated and will be removed in a future major version.
  * Crop the image by given rectangle (use base64 string as input and output)
  *
  * @param base64Image The string with base64 encoded image.

--- a/packages/support/lib/index.ts
+++ b/packages/support/lib/index.ts
@@ -8,7 +8,6 @@ import {mkdirp} from './mkdirp';
 import * as logger from './logging';
 import * as process from './process';
 import * as zip from './zip';
-/** @deprecated Sharp-backed image helpers are deprecated and will be removed in a future major version. */
 import * as imageUtil from './image-util';
 import * as mjpeg from './mjpeg';
 import * as node from './node';

--- a/packages/support/lib/index.ts
+++ b/packages/support/lib/index.ts
@@ -8,6 +8,7 @@ import {mkdirp} from './mkdirp';
 import * as logger from './logging';
 import * as process from './process';
 import * as zip from './zip';
+/** @deprecated Sharp-backed image helpers are deprecated and will be removed in a future major version. */
 import * as imageUtil from './image-util';
 import * as mjpeg from './mjpeg';
 import * as node from './node';

--- a/packages/support/lib/mjpeg.ts
+++ b/packages/support/lib/mjpeg.ts
@@ -33,6 +33,7 @@ const noop = () => {};
 
 /**
  * @deprecated MJPEG stream helpers in @appium/support are deprecated and will be removed in a future major version.
+ * Consumers are expected to implement MJpegStream class on their side.
  * Class which stores the last bit of data streamed into it.
  */
 export class MJpegStream extends Writable {

--- a/packages/support/lib/mjpeg.ts
+++ b/packages/support/lib/mjpeg.ts
@@ -31,7 +31,10 @@ async function initMJpegConsumer(): Promise<MJpegConsumerConstructor> {
 const MJPEG_SERVER_TIMEOUT_MS = 10000;
 const noop = () => {};
 
-/** Class which stores the last bit of data streamed into it */
+/**
+ * @deprecated MJPEG stream helpers in @appium/support are deprecated and will be removed in a future major version.
+ * Class which stores the last bit of data streamed into it.
+ */
 export class MJpegStream extends Writable {
   readonly errorHandler: (err: Error) => void;
   readonly url: string;


### PR DESCRIPTION
sharp is heavy and there is no need to pull it into every module that depends on support.
The next step would be to move deprecated entities into corresponding drivers and to fetch sharp only where it is needed by the driver.