### PR TITLE
chore(base-driver): Enable strict TS mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/lodash": "4.17.24",
         "@types/method-override": "3.0.0",
         "@types/mocha": "10.0.10",
+        "@types/morgan": "1.9.10",
         "@types/mv": "2.1.4",
         "@types/ncp": "2.0.8",
         "@types/node": "24.12.4",
@@ -3558,6 +3559,16 @@
       "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/morgan": {
+      "version": "1.9.10",
+      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
+      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mv": {
       "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@types/lodash": "4.17.24",
     "@types/method-override": "3.0.0",
     "@types/mocha": "10.0.10",
+    "@types/morgan": "1.9.10",
     "@types/mv": "2.1.4",
     "@types/ncp": "2.0.8",
     "@types/node": "24.12.4",

--- a/packages/base-driver/lib/basedriver/commands/execute.ts
+++ b/packages/base-driver/lib/basedriver/commands/execute.ts
@@ -17,7 +17,7 @@ declare module '../driver' {
   interface BaseDriver<C extends Constraints> extends IExecuteCommands {}
 }
 
-const ExecuteCommands: IExecuteCommands = {
+const ExecuteCommands = {
   async executeMethod<C extends Constraints>(
     this: BaseDriver<C>,
     script: string,
@@ -49,6 +49,6 @@ const ExecuteCommands: IExecuteCommands = {
     const command = this[commandName] as DriverCommand;
     return await command.call(this, ...args);
   },
-};
+} as IExecuteCommands;
 
 mixin(ExecuteCommands);

--- a/packages/base-driver/lib/basedriver/commands/find.ts
+++ b/packages/base-driver/lib/basedriver/commands/find.ts
@@ -61,7 +61,8 @@ async function findElOrElsWithProcessing<C extends Constraints>(
   } catch (err) {
     if (this.opts.printPageSourceOnFindFailure) {
       const src = await this.getPageSource();
-      this.log.debug(`Error finding element${mult ? 's' : ''}: ${err.message}`);
+      const message = err instanceof Error ? err.message : String(err);
+      this.log.debug(`Error finding element${mult ? 's' : ''}: ${message}`);
       this.log.debug(`Page source requested through 'printPageSourceOnFindFailure':`);
       this.log.debug(src);
     }
@@ -71,11 +72,11 @@ async function findElOrElsWithProcessing<C extends Constraints>(
 }
 
 const FindCommands: IFindCommands = {
-  async findElement<C extends Constraints>(this: BaseDriver<C>, strategy, selector) {
+  async findElement<C extends Constraints>(this: BaseDriver<C>, strategy: string, selector: string) {
     return await this.findElOrElsWithProcessing(strategy, selector, false);
   },
 
-  async findElements<C extends Constraints>(this: BaseDriver<C>, strategy, selector) {
+  async findElements<C extends Constraints>(this: BaseDriver<C>, strategy: string, selector: string) {
     return await this.findElOrElsWithProcessing(strategy, selector, true);
   },
 

--- a/packages/base-driver/lib/basedriver/commands/timeout.ts
+++ b/packages/base-driver/lib/basedriver/commands/timeout.ts
@@ -13,19 +13,26 @@ declare module '../driver' {
 const MIN_TIMEOUT = 0;
 
 const TimeoutCommands: ITimeoutCommands = {
-  async timeouts<C extends Constraints>(this: BaseDriver<C>, type, ms, script, pageLoad, implicit) {
+  async timeouts<C extends Constraints>(
+    this: BaseDriver<C>,
+    type?: string,
+    ms?: number | string,
+    script?: number,
+    pageLoad?: number,
+    implicit?: number
+  ) {
     if (type && typeof type === 'string' && util.hasValue(ms)) {
       // legacy stuff with some Appium-specific additions
       this.log.debug(`Timeout arguments: ${JSON.stringify({type, ms})}}`);
       switch (type) {
         case 'command':
-          return void (await this.newCommandTimeout(ms));
+          return void (await this.newCommandTimeout(this.parseTimeoutArgument(ms)));
         case 'implicit':
-          return void (await this.implicitWaitW3C(ms));
+          return void (await this.implicitWaitW3C(this.parseTimeoutArgument(ms)));
         case 'page load':
-          return void (await this.pageLoadTimeoutW3C(ms));
+          return void (await this.pageLoadTimeoutW3C(this.parseTimeoutArgument(ms)));
         case 'script':
-          return void (await this.scriptTimeoutW3C(ms));
+          return void (await this.scriptTimeoutW3C(this.parseTimeoutArgument(ms)));
         default:
           throw new Error(`'${type}' type is not supported for the timeout API`);
       }
@@ -46,7 +53,7 @@ const TimeoutCommands: ITimeoutCommands = {
     }
   },
 
-  async getTimeouts() {
+  async getTimeouts<C extends Constraints>(this: BaseDriver<C>) {
     return {
       command: this.newCommandTimeoutMs,
       implicit: this.implicitWaitMs,

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -41,7 +41,7 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
 
   sessionId: string | null;
 
-  sessionCreationTimestampMs: number;
+  sessionCreationTimestampMs!: number;
 
   opts: DriverOpts<C>;
 
@@ -284,8 +284,10 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
       ];
     };
     const parseFullNames = (fullNames: string[]) => fullNames.map(parseFullName);
-    const matches = ([automationName, featureName]: [string, string]) =>
-      [currentAutomationName, ALL_DRIVERS_MATCH].includes(automationName) && featureName === name;
+    const matches = (pair: string[]) => {
+      const [automationName, featureName] = pair;
+      return [currentAutomationName, ALL_DRIVERS_MATCH].includes(automationName) && featureName === name;
+    };
 
     // if we have explicitly denied this feature, return false immediately
     if (!util.isEmpty(this.denyInsecure) && parseFullNames(this.denyInsecure).some(matches)) {

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -1,3 +1,4 @@
+import type AsyncLock from 'async-lock';
 import {util} from '@appium/support';
 import {
   BASE_DESIRED_CAP_CONSTRAINTS,
@@ -24,8 +25,11 @@ import {DELETE_SESSION_COMMAND, determineProtocol, errors} from '../protocol';
 import {processCapabilities, validateCaps} from './capabilities';
 import {DriverCore} from './core';
 import * as helpers from './helpers';
-import {resolveExecuteExtensionName} from '../helpers/extension-command-name';
 import {mergePlainObjects} from '../utils';
+import {resolveExecuteExtensionName} from '../helpers/extension-command-name';
+
+type CommandInvoker<C extends Constraints> = BaseDriver<C> &
+  Record<string, ((...args: any[]) => any) | undefined>;
 
 const EVENT_SESSION_INIT = 'newSessionRequested';
 const EVENT_SESSION_START = 'newSessionStarted';
@@ -46,8 +50,8 @@ export class BaseDriver<
 {
   cliArgs: CArgs & ServerArgs;
   caps: DriverCaps<C>;
-  originalCaps: W3CDriverCaps<C>;
-  desiredCapConstraints: C;
+  originalCaps!: W3CDriverCaps<C>;
+  desiredCapConstraints!: C;
   server?: AppiumServer;
   serverHost?: string;
   serverPort?: number;
@@ -99,8 +103,10 @@ export class BaseDriver<
       throw new errors.NoSuchDriverError('The driver was unexpectedly shut down!');
     }
 
+    const invoker = this as unknown as CommandInvoker<C>;
+    const command = invoker[cmd];
     // If we don't have this command, it must not be implemented
-    if (!this[cmd]) {
+    if (!command) {
       await this.startNewCommandTimeout();
       throw new errors.NotYetImplementedError();
     }
@@ -115,7 +121,7 @@ export class BaseDriver<
       };
       try {
         return await Promise.race([
-          this[cmd](...args),
+          command.call(this, ...args),
           // This promise is needed to monitor if the session has been
           // shut down unexpectedly while the command was running
           new Promise((resolve, reject) => {
@@ -147,8 +153,10 @@ export class BaseDriver<
     };
 
     const synchronizationKey = BaseDriver.name;
-    // eslint-disable-next-line dot-notation
-    const commandsQueueLen: number = this.commandsQueueGuard['queues']?.[synchronizationKey]?.length ?? 0;
+    const commandsQueueGuard = this.commandsQueueGuard as AsyncLock & {
+      queues?: Record<string, unknown[]>;
+    };
+    const commandsQueueLen: number = commandsQueueGuard.queues?.[synchronizationKey]?.length ?? 0;
     if (this.isCommandsQueueEnabled && commandsQueueLen > 0) {
       this.log.debug(
         `Scheduling the '${cmd}' command to the ${this.constructor.name} commands queue. ` +
@@ -182,7 +190,7 @@ export class BaseDriver<
     if (cmd === 'execute') {
       const firstArg = args?.[0];
       if (typeof firstArg === 'string' && firstArg.trim().length > 0) {
-        return resolveExecuteExtensionName.call(this, firstArg);
+        return resolveExecuteExtensionName.call(this as BaseDriver<Constraints>, firstArg);
       }
     }
 
@@ -240,15 +248,12 @@ export class BaseDriver<
     this.log.debug('Running generic full reset');
 
     // preserving state
-    const currentConfig = {};
-    for (const property of [
-      'implicitWaitMs',
-      'newCommandTimeoutMs',
-      'sessionId',
-      'resetOnUnexpectedShutdown',
-    ]) {
-      currentConfig[property] = this[property];
-    }
+    const currentConfig = {
+      implicitWaitMs: this.implicitWaitMs,
+      newCommandTimeoutMs: this.newCommandTimeoutMs,
+      sessionId: this.sessionId,
+      shutdownUnexpectedly: this.shutdownUnexpectedly,
+    };
 
     try {
       if (this.sessionId !== null) {
@@ -258,9 +263,7 @@ export class BaseDriver<
       await this.createSession(this.originalCaps);
     } finally {
       // always restore state.
-      for (const [key, value] of Object.entries(currentConfig)) {
-        this[key] = value;
-      }
+      Object.assign(this, currentConfig);
     }
     await this.clearNewCommandTimeout();
   }
@@ -313,7 +316,8 @@ export class BaseDriver<
       ) as DriverCaps<C>;
       caps = fixCaps(caps, this._desiredCapConstraints, this.log) as DriverCaps<C>;
     } catch (e) {
-      throw new errors.SessionNotCreatedError(e.message);
+      const message = e instanceof Error ? e.message : String(e);
+      throw new errors.SessionNotCreatedError(message);
     }
 
     this.validateDesiredCaps(caps);
@@ -421,10 +425,12 @@ export class BaseDriver<
     try {
       validateCaps(caps, this._desiredCapConstraints);
     } catch (e) {
+      const capError = e instanceof Error ? e : new Error(String(e));
       throw this.log.errorWithException(
         new errors.SessionNotCreatedError(
           `Session capabilities were not valid for the ` +
-          `following reason(s): ${e.message}`, e
+          `following reason(s): ${capError.message}`,
+          capError
         )
       );
     }

--- a/packages/base-driver/lib/basedriver/extension-core.ts
+++ b/packages/base-driver/lib/basedriver/extension-core.ts
@@ -22,7 +22,7 @@ export class ExtensionCore {
   _logPrefix?: string;
   // used to handle driver events
   readonly eventEmitter: NodeJS.EventEmitter;
-  protected _log: AppiumLogger;
+  protected _log!: AppiumLogger;
   private ipc?: IAppiumIpc;
 
 
@@ -85,7 +85,8 @@ export class ExtensionCore {
     }
 
     // If the driver doesn't have this command, it must not be implemented
-    if (!this[command]) {
+    const handler = (this as ExtensionCore & Record<string, unknown>)[command];
+    if (typeof handler !== 'function') {
       throw new errors.NotYetImplementedError();
     }
   }
@@ -120,8 +121,12 @@ export class ExtensionCore {
         `method '${command}'`,
     );
     // call the handler with the signature appropriate to extension type (plugin or driver)
-    const response = (next && driver) ? await this[command](next, driver, ...args) : await this[command](...args);
-    const finalResponse = response === undefined ? {} : response;
+    const commandHandler = (this as unknown as Record<string, (...handlerArgs: any[]) => Promise<unknown>>)[
+      command
+    ];
+    const response =
+      next && driver ? await commandHandler(next, driver, ...args) : await commandHandler(...args);
+    const finalResponse: BiDiResultData = response === undefined || response === null ? {} : response;
     this.log.debug(
       `Responding to bidi command '${bidiCmd}' with ` +
       `${util.truncateString(JSON.stringify(finalResponse), {length: MAX_LOG_BODY_LENGTH})}`

--- a/packages/base-driver/lib/basedriver/extension-core.ts
+++ b/packages/base-driver/lib/basedriver/extension-core.ts
@@ -125,8 +125,11 @@ export class ExtensionCore {
       command
     ];
     const response =
-      next && driver ? await commandHandler(next, driver, ...args) : await commandHandler(...args);
-    const finalResponse: BiDiResultData = response === undefined || response === null ? {} : response;
+      next && driver
+        ? await commandHandler.call(this, next, driver, ...args)
+        : await commandHandler.call(this, ...args);
+    const finalResponse: BiDiResultData =
+      response === undefined ? {} : (response as BiDiResultData);
     this.log.debug(
       `Responding to bidi command '${bidiCmd}' with ` +
       `${util.truncateString(JSON.stringify(finalResponse), {length: MAX_LOG_BODY_LENGTH})}`

--- a/packages/base-driver/lib/basedriver/helpers.ts
+++ b/packages/base-driver/lib/basedriver/helpers.ts
@@ -20,7 +20,7 @@ export const {version: BASEDRIVER_VER} = fs.readPackageJsonFrom(__dirname);
 const CACHED_APPS_MAX_AGE_MS = 1000 * 60 * toNaturalNumber(60 * 24, 'APPIUM_APPS_CACHE_MAX_AGE');
 const MAX_CACHED_APPS = toNaturalNumber(1024, 'APPIUM_APPS_CACHE_MAX_ITEMS');
 const HTTP_STATUS_NOT_MODIFIED = 304;
-const DEFAULT_REQ_HEADERS = Object.freeze({
+const DEFAULT_REQ_HEADERS: RawAxiosRequestHeaders = Object.freeze({
   'user-agent': `Appium (BaseDriver v${BASEDRIVER_VER})`,
 });
 const AVG_DOWNLOAD_SPEED_MEASUREMENT_THRESHOLD_SEC = 2;

--- a/packages/base-driver/lib/express/express-logging.ts
+++ b/packages/base-driver/lib/express/express-logging.ts
@@ -23,11 +23,12 @@ export const startLogFormatter: RequestHandler = morgan(startLogFormatterHandler
 type MorganTokens = unknown;
 type FormatFn = (tokens: MorganTokens, req: Request, res: Response) => string;
 
-function endLogFormatterHandler(tokens: MorganTokens, req: Request, res: Response): void {
+function endLogFormatterHandler(tokens: MorganTokens, req: Request, res: Response): undefined {
   log.info(requestEndLoggingFormat(tokens, req, res));
+  return undefined;
 }
 
-function startLogFormatterHandler(tokens: unknown, req: Request, res: Response): void {
+function startLogFormatterHandler(tokens: unknown, req: Request, res: Response): undefined {
   let reqBody = '';
   if (req.body) {
     try {
@@ -43,6 +44,7 @@ function startLogFormatterHandler(tokens: unknown, req: Request, res: Response):
     requestStartLoggingFormat(tokens, req, res),
     logger.markSensitive(reqBody.grey)
   );
+  return undefined;
 }
 
 // Copied the morgan compile function over so that cooler formats may be configured

--- a/packages/base-driver/lib/express/idempotency.ts
+++ b/packages/base-driver/lib/express/idempotency.ts
@@ -122,7 +122,7 @@ function cacheResponse(key: string, req: Request, res: Response): void {
       return originalSocketWriter(
         chunk as string | Buffer | Uint8Array,
         encoding as BufferEncoding,
-        next as (err?: Error) => void
+        next as (err?: Error | null) => void
       );
     }
 
@@ -139,7 +139,7 @@ function cacheResponse(key: string, req: Request, res: Response): void {
     return originalSocketWriter(
       chunk as string | Buffer | Uint8Array,
       encoding as BufferEncoding,
-      next as (err?: Error) => void
+      next as (err?: Error | null) => void
     );
   };
   socket.write = patchedWriter as typeof socket.write;

--- a/packages/base-driver/lib/express/server.ts
+++ b/packages/base-driver/lib/express/server.ts
@@ -340,7 +340,9 @@ function configureHttp({
 
   // http.Server.close() only stops new connections, but we need to wait until
   // all connections are closed and the `close` event is emitted
-  const originalClose = appiumServer.close.bind(appiumServer);
+  const originalClose = appiumServer.close.bind(appiumServer) as (
+    callback?: (err?: Error | null) => void
+  ) => void;
   appiumServer.close = async () =>
     await new Promise<void>((_resolve, _reject) => {
       log.info('Closing Appium HTTP server');
@@ -364,7 +366,7 @@ function configureHttp({
         _resolve();
       };
       httpServer.once('close', onClose);
-      originalClose((err?: Error) => {
+      originalClose((err?: Error | null) => {
         if (err) {
           clearTimeout(onTimeout);
           httpServer.removeListener('close', onClose);

--- a/packages/base-driver/lib/helpers/levenshtein-match.ts
+++ b/packages/base-driver/lib/helpers/levenshtein-match.ts
@@ -37,7 +37,7 @@ export function rankLevenshteinCandidates(
         acc[key] = [name];
       }
       return acc;
-    }, {});
+    }, {} as StringRecord<string[]>);
   const sortedDistanceKeys = Object.keys(matchesMap).sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
   const sorted = sortedDistanceKeys.flatMap((k) => (matchesMap[k] ?? []).sort());
 

--- a/packages/base-driver/lib/jsonwp-proxy/proxy.ts
+++ b/packages/base-driver/lib/jsonwp-proxy/proxy.ts
@@ -92,7 +92,14 @@ export class JWProxy {
       timeout: number;
     };
     options.scheme = options.scheme.toLowerCase();
-    Object.assign(this, options);
+    this.scheme = options.scheme;
+    this.server = options.server;
+    this.port = options.port;
+    this.base = options.base;
+    this.reqBasePath = options.reqBasePath;
+    this.sessionId = options.sessionId;
+    this.timeout = options.timeout;
+    this.headers = options.headers;
 
     this._activeRequests = [];
     this._downstreamProtocol = null;

--- a/packages/base-driver/lib/protocol/protocol.ts
+++ b/packages/base-driver/lib/protocol/protocol.ts
@@ -162,7 +162,11 @@ export function checkParams(
  * @param jsonObj - Parsed JSON request body
  * @param payloadParams - Route payload definition (required/optional/makeArgs)
  */
-export function makeArgs(requestParams: PayloadParams, jsonObj: any, payloadParams: PayloadParams): any[] {
+export function makeArgs(
+  requestParams: Record<string, string | string[] | undefined>,
+  jsonObj: any,
+  payloadParams: PayloadParams
+): any[] {
   // We want to pass the "url" parameters to the commands in reverse order
   // since the command will sometimes want to ignore, say, the sessionId.
   // This has the effect of putting sessionId last, which means in JS we can
@@ -337,7 +341,7 @@ function getLogger(driver: Core<any>, sessionId: string | null = null): AppiumLo
   return logger.getLogger(logPrefix);
 }
 
-function wrapParams<T>(paramSets, jsonObj: T): T | Record<string, T> {
+function wrapParams<T>(paramSets: PayloadParams, jsonObj: T): T | Record<string, T> {
   /* There are commands like performTouch which take a single parameter (primitive type or array).
    * Some drivers choose to pass this parameter as a value (eg. [action1, action2...]) while others to
    * wrap it within an object(eg' {gesture:  [action1, action2...]}), which makes it hard to validate.
@@ -353,9 +357,11 @@ function unwrapParams<T>(paramSets: PayloadParams, jsonObj: T): T | Record<strin
   /* There are commands like setNetworkConnection which send parameters wrapped inside a key such as
    * "parameters". This function unwraps them (eg. {"parameters": {"type": 1}} becomes {"type": 1}).
    */
-  return typeof jsonObj === 'object' && jsonObj !== null && paramSets.unwrap && jsonObj[paramSets.unwrap]
-    ? jsonObj[paramSets.unwrap]
-    : jsonObj;
+  const unwrapped =
+    typeof jsonObj === 'object' && jsonObj !== null && paramSets.unwrap
+      ? (jsonObj as Record<string, T>)[paramSets.unwrap]
+      : undefined;
+  return unwrapped !== undefined ? unwrapped : jsonObj;
 }
 
 
@@ -465,8 +471,11 @@ function buildHandler(
       const args = makeArgs(req.params, jsonObj, spec.payloadParams || {});
       let driverRes: any;
       // validate command args according to MJSONWP
-      if (validators[spec.command]) {
-        validators[spec.command](...args);
+      const validator = (validators as Record<string, ((...validatorArgs: any[]) => void) | undefined>)[
+        spec.command
+      ];
+      if (validator) {
+        validator(...args);
       }
 
       // run the driver command wrapped inside the argument validators
@@ -553,9 +562,16 @@ function buildHandler(
     } catch (err) {
       // if anything goes wrong, figure out what our response should be
       // based on the type of error that we encountered
-      let actualErr;
-      if (err instanceof Error || (Object.hasOwn(err, 'stack') && Object.hasOwn(err, 'message'))) {
+      let actualErr: Error;
+      if (err instanceof Error) {
         actualErr = err;
+      } else if (
+        typeof err === 'object' &&
+        err !== null &&
+        Object.hasOwn(err, 'stack') &&
+        Object.hasOwn(err, 'message')
+      ) {
+        actualErr = err as Error;
       } else {
         getLogger(driver, sessionId || newSessionId).warn(
           'The thrown error object does not seem to be a valid instance of the Error class. This ' +
@@ -567,11 +583,12 @@ function buildHandler(
       currentProtocol =
         currentProtocol || extractProtocol(driver, sessionId || newSessionId);
 
-      let errMsg = err.stacktrace || err.stack;
-      if (!errMsg.includes(err.message)) {
+      const stacktrace = (err as {stacktrace?: string}).stacktrace;
+      let errMsg = stacktrace || actualErr.stack || '';
+      if (!errMsg.includes(actualErr.message)) {
         // if the message has more information, add it. but often the message
         // is the first part of the stack trace
-        errMsg = `${err.message}${errMsg ? '\n' + errMsg : ''}`;
+        errMsg = `${actualErr.message}${errMsg ? '\n' + errMsg : ''}`;
       }
       if (isErrorType(err, errors.ProxyRequestError)) {
         actualErr = err.getActualError();
@@ -597,7 +614,10 @@ function buildHandler(
     }
   };
   // add the method to the app
-  app[method.toLowerCase()](path, (req, res) => {
+  const registerRoute = (
+    app as Application & Record<string, (routePath: string, ...handlers: any[]) => void>
+  )[method.toLowerCase()].bind(app);
+  registerRoute(path, (req: Request, res: Response) => {
     void asyncHandler(req, res);
   });
 }
@@ -617,8 +637,10 @@ async function doJwpProxy(driver: BaseDriver<any>, req: Request, res: Response):
   } catch (err) {
     if (isErrorType(err, errors.ProxyRequestError)) {
       throw err;
-    } else {
+    }
+    if (err instanceof Error) {
       throw new Error(`Could not proxy. Proxy error: ${err.message}`, {cause: err});
     }
+    throw new Error(`Could not proxy. Proxy error: ${String(err)}`, {cause: err});
   }
 }

--- a/packages/base-driver/tsconfig.json
+++ b/packages/base-driver/tsconfig.json
@@ -7,6 +7,7 @@
     }
   },
   "compilerOptions": {
+    "strict": true,
     "outDir": "build",
     "paths": {
       "@appium/support": ["../support"],

--- a/packages/driver-test-support/lib/unit-suite.ts
+++ b/packages/driver-test-support/lib/unit-suite.ts
@@ -113,7 +113,7 @@ export function driverUnitTestSuite<C extends Constraints>(
     it('should not allow commands in middle of unexpected shutdown', async function () {
       sandbox.stub(d, 'deleteSession').callsFake(async function (this: InstanceType<typeof DriverClass>) {
         await sleep(100);
-        DriverClass.prototype.deleteSession.call(this);
+        await DriverClass.prototype.deleteSession.call(this);
       });
       await d.createSession(w3cCaps);
       const p = new Promise<void>((resolve, reject) => {
@@ -136,7 +136,7 @@ export function driverUnitTestSuite<C extends Constraints>(
     it('should allow new commands after done shutting down', async function () {
       sandbox.stub(d, 'deleteSession').callsFake(async function (this: InstanceType<typeof DriverClass>) {
         await sleep(100);
-        DriverClass.prototype.deleteSession.call(this);
+        await DriverClass.prototype.deleteSession.call(this);
       });
 
       await d.createSession(structuredClone(w3cCaps));


### PR DESCRIPTION
## Summary

Enables TypeScript **`strict`** mode for `@appium/base-driver` and fixes all resulting type errors without relaxing compiler options.

## Changes

### TypeScript config
- Set `"strict": true` in `packages/base-driver/tsconfig.json`.

### Typing and strict-mode fixes
- **Commands** — `executeMethod` typed via `IExecuteCommands`; explicit parameter types for find/timeout helpers; legacy timeout values routed through `parseTimeoutArgument`.
- **Driver** — Definite assignment for session/cap fields; dynamic command dispatch via `command.call(this, …)` (preserves `this`); typed async-lock queue access; safer `unknown` handling in `catch` blocks; `reset()` now preserves `shutdownUnexpectedly` (replacing the invalid `resetOnUnexpectedShutdown` key).
- **Extension core / protocol / proxy** — Safer dynamic property access; explicit `JWProxy` constructor assignments (including `headers`, previously set only via `Object.assign`); Express route registration with `.bind(app)`; stricter protocol/validator indexing and error handling.
- **Express** — `idempotency` and `server.close` callbacks accept `Error | null`; download helper headers typed as `RawAxiosRequestHeaders`.

### Morgan types
- Added **`@types/morgan`** at the repo root (replacing the local `declare module 'morgan'` stub).
- Custom Morgan format handlers in `express-logging.ts` return `undefined` to satisfy `FormatFn`.

### Test support
- `driver-test-support` unit suite: `await` on stubbed `deleteSession` calls (floating-promise lint + correct async behavior).

## Test plan

- [x] `npx tsc -b packages/base-driver`
- [x] `npm run build:compile`
- [x] `npm run lint:ci`
- [x] `npm run test:unit -w @appium/base-driver` (433 passing)