### PR TITLE
chore: Reorganize dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11323,7 +11323,6 @@
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
-      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-to-typescript": {
@@ -19626,7 +19625,7 @@
       "name": "@appium/schema",
       "version": "1.2.0",
       "license": "Apache-2.0",
-      "devDependencies": {
+      "dependencies": {
         "json-schema": "0.4.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11323,6 +11323,7 @@
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
+      "dev": true,
       "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-to-typescript": {
@@ -19625,7 +19626,7 @@
       "name": "@appium/schema",
       "version": "1.2.0",
       "license": "Apache-2.0",
-      "dependencies": {
+      "devDependencies": {
         "json-schema": "0.4.0"
       },
       "engines": {
@@ -19695,7 +19696,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/logger": "2.0.8",
-        "@appium/tsconfig": "1.1.2",
         "@appium/types": "1.5.0",
         "@colors/colors": "1.6.0",
         "archiver": "8.0.0",
@@ -19727,6 +19727,9 @@
         "uuid": "14.0.0",
         "which": "6.0.1",
         "yauzl": "3.3.2"
+      },
+      "devDependencies": {
+        "@appium/tsconfig": "1.1.2"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -20122,14 +20125,19 @@
       "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/logger": "2.0.8",
         "@appium/schema": "1.2.0",
-        "@appium/tsconfig": "1.1.2",
         "type-fest": "5.7.0"
+      },
+      "devDependencies": {
+        "@appium/logger": "2.0.8",
+        "@appium/tsconfig": "1.1.2"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
+      },
+      "peerDependencies": {
+        "@appium/logger": "^2.0.0"
       }
     },
     "packages/types/node_modules/type-fest": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -38,7 +38,7 @@
     "test:smoke": "node ./build/lib/index.js --smoke-test",
     "test": "exit 0"
   },
-  "dependencies": {
+  "devDependencies": {
     "json-schema": "0.4.0"
   },
   "engines": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -38,7 +38,7 @@
     "test:smoke": "node ./build/lib/index.js --smoke-test",
     "test": "exit 0"
   },
-  "devDependencies": {
+  "dependencies": {
     "json-schema": "0.4.0"
   },
   "engines": {

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -39,9 +39,11 @@
     "test:smoke": "node ./build/lib/index.js",
     "test:unit": "mocha \"./test/unit/**/*.spec.ts\""
   },
+  "devDependencies": {
+    "@appium/tsconfig": "1.1.2"
+  },
   "dependencies": {
     "@appium/logger": "2.0.8",
-    "@appium/tsconfig": "1.1.2",
     "@appium/types": "1.5.0",
     "@colors/colors": "1.6.0",
     "archiver": "8.0.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -37,10 +37,15 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@appium/logger": "2.0.8",
     "@appium/schema": "1.2.0",
-    "@appium/tsconfig": "1.1.2",
     "type-fest": "5.7.0"
+  },
+  "devDependencies": {
+    "@appium/logger": "2.0.8",
+    "@appium/tsconfig": "1.1.2"
+  },
+  "peerDependencies": {
+    "@appium/logger": "^2.0.0"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",


### PR DESCRIPTION
## Summary

Phase 1 of the monorepo dependency reduction: reclassify build- and type-only packages so they are no longer listed as production dependencies. No runtime behavior changes.

- Move `@appium/tsconfig` to `devDependencies` in `@appium/support` and `@appium/types` (only referenced via `tsconfig.json` `extends`)
- Move `@appium/logger` out of `@appium/types` production deps: declare as `peerDependency` (`^2.0.0`) with a matching `devDependency` for monorepo builds (only `import type {Logger}` in source)

This trims misleading production dependency declarations without removing any packages that are actually needed at runtime.

## Rationale

Several workspace packages listed dependencies as production deps even though they are only needed at build or type-check time. That inflates the published dependency graph and makes it harder to see what each package truly needs at runtime.

`@appium/types` referencing `@appium/logger` is a type-only relationship. Every Appium consumer already installs `@appium/logger`, so a peer dependency is the correct contract.

## Changes by package

| Package | Before | After |
|---------|--------|-------|
| `@appium/support` | `@appium/tsconfig` in `dependencies` | `devDependencies` |
| `@appium/types` | `@appium/logger`, `@appium/tsconfig` in `dependencies` | `@appium/tsconfig` + `@appium/logger` in `devDependencies`; `@appium/logger` as `peerDependency` |
