### PR TITLE
chore: Ditch resolve-from and package-changed dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14515,23 +14515,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/package-changed": {
-      "version": "3.0.0",
-      "license": "ISC",
-      "dependencies": {
-        "commander": "^6.2.0"
-      },
-      "bin": {
-        "package-changed": "bin/package-changed.js"
-      }
-    },
-    "node_modules/package-changed/node_modules/commander": {
-      "version": "6.2.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/package-directory": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/package-directory/-/package-directory-8.2.0.tgz",
@@ -15913,6 +15896,7 @@
     },
     "node_modules/resolve-from": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18908,8 +18892,6 @@
         "lilconfig": "3.1.3",
         "lru-cache": "11.5.1",
         "ora": "5.4.1",
-        "package-changed": "3.0.0",
-        "resolve-from": "5.0.0",
         "semver": "7.8.1",
         "teen_process": "4.1.3",
         "type-fest": "5.7.0",
@@ -19598,7 +19580,6 @@
         "plist": "4.0.0",
         "pluralize": "8.0.0",
         "read-pkg": "10.1.0",
-        "resolve-from": "5.0.0",
         "sanitize-filename": "1.6.4",
         "semver": "7.8.1",
         "shell-quote": "1.8.4",

--- a/packages/appium/lib/cli/extension-command.ts
+++ b/packages/appium/lib/cli/extension-command.ts
@@ -21,12 +21,11 @@ import {
   INSTALL_TYPE_DEV,
 } from '../extension/extension-config';
 import {SubProcess} from 'teen_process';
-import {packageDidChange} from '../extension/package-changed';
 import {spawn} from 'node:child_process';
 import {inspect} from 'node:util';
 import {pathToFileURL} from 'node:url';
 import {Doctor, EXIT_CODE as DOCTOR_EXIT_CODE} from '../doctor/doctor';
-import {compact, npmPackage} from '../utils';
+import {compact, npmPackage, packageDidChange} from '../utils';
 import {getAppiumModuleRoot} from '../utils/module';
 import * as semver from 'semver';
 

--- a/packages/appium/lib/extension/extension-config.ts
+++ b/packages/appium/lib/extension/extension-config.ts
@@ -3,9 +3,8 @@ import type {ExtClass, ExtManifest, ExtName, ExtRecord, InstallType} from 'appiu
 import type {SchemaObject} from 'ajv';
 import {util, fs, system} from '@appium/support';
 import path from 'node:path';
-import {capitalize} from '../utils';
+import {capitalize, resolveFrom} from '../utils';
 import {pathToFileURL} from 'node:url';
-import resolveFrom from 'resolve-from';
 import {satisfies} from 'semver';
 import {commandClasses} from '../cli/extension';
 import type {
@@ -122,7 +121,7 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
     }
     let moduleObject: any;
     if (typeof argSchemaPath === 'string') {
-      const schemaPath = resolveFrom(appiumHome, path.join(pkgName, argSchemaPath));
+      const schemaPath = await resolveFrom(appiumHome, path.join(pkgName, argSchemaPath));
       moduleObject = require(schemaPath);
     } else {
       moduleObject = argSchemaPath;

--- a/packages/appium/lib/extension/manifest.ts
+++ b/packages/appium/lib/extension/manifest.ts
@@ -11,7 +11,7 @@ import type {
 } from 'appium/types';
 import {CURRENT_SCHEMA_REV, DRIVER_TYPE, PLUGIN_TYPE} from '../constants';
 import {INSTALL_TYPE_DEV, INSTALL_TYPE_NPM} from './extension-config';
-import {packageDidChange} from './package-changed';
+import {packageDidChange} from '../utils';
 import {migrate} from './manifest-migrations';
 
 const CONFIG_DATA_DRIVER_KEY = `${DRIVER_TYPE}s` as const;

--- a/packages/appium/lib/utils/index.ts
+++ b/packages/appium/lib/utils/index.ts
@@ -1,5 +1,9 @@
 export {adler32} from './hash';
+export {isPackageChanged} from './is-package-changed';
+export type {IsPackageChangedOptions, IsPackageChangedResult} from './is-package-changed';
 export {getAppiumModuleRoot, npmPackage} from './module';
+export {packageDidChange} from './package-changed';
+export {resolveFrom} from './resolve-from';
 export {
   bindAll,
   camelCase,

--- a/packages/appium/lib/utils/is-package-changed.ts
+++ b/packages/appium/lib/utils/is-package-changed.ts
@@ -1,0 +1,78 @@
+import {fs} from '@appium/support';
+import crypto from 'node:crypto';
+import path from 'node:path';
+
+export interface IsPackageChangedOptions {
+  cwd?: string;
+  hashFilename?: string;
+}
+
+export interface IsPackageChangedResult {
+  hash: string;
+  isChanged: boolean;
+  oldHash?: string;
+  writeHash: () => Promise<void>;
+}
+
+/**
+ * Detects whether `package.json` dependencies changed since the last hash write.
+ * Inlined from the `package-changed` package (lockfile support omitted; unused by Appium).
+ */
+export async function isPackageChanged(
+  options: IsPackageChangedOptions = {},
+): Promise<IsPackageChangedResult> {
+  const {hashFilename = '.packagehash', cwd = process.cwd()} = options;
+  const packagePath = await findPackageJson(cwd);
+  if (!packagePath) {
+    throw new Error('Cannot find package.json. Travelling up from current working directory.');
+  }
+
+  const packageHashPath = path.join(cwd, hashFilename);
+  const packageHashPathExists = await fs.exists(packageHashPath);
+  const recentDigest = await getPackageHash(packagePath);
+  const previousDigest = packageHashPathExists
+    ? await fs.readFile(packageHashPath, 'utf-8')
+    : undefined;
+  const isChanged = !packageHashPathExists || previousDigest !== recentDigest;
+
+  const writeHash = async () => {
+    await fs.writeFile(packageHashPath, recentDigest, 'utf-8');
+  };
+
+  return {
+    hash: recentDigest,
+    isChanged,
+    oldHash: previousDigest || undefined,
+    writeHash,
+  };
+}
+
+async function findPackageJson(cwd: string): Promise<string | undefined> {
+  let current = cwd;
+  while (true) {
+    const search = path.join(current, 'package.json');
+    if (await fs.exists(search)) {
+      return search;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      return;
+    }
+    current = parent;
+  }
+}
+
+async function getPackageHash(packagePath: string): Promise<string> {
+  const contents = await fs.readFile(packagePath, 'utf-8');
+  const packageBlob = JSON.parse(contents) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  const dependencies = {
+    dependencies: packageBlob.dependencies ?? {},
+    devDependencies: packageBlob.devDependencies ?? {},
+  };
+  const hashSum = crypto.createHash('md5');
+  hashSum.update(Buffer.from(JSON.stringify(dependencies)));
+  return hashSum.digest('hex');
+}

--- a/packages/appium/lib/utils/is-package-changed.ts
+++ b/packages/appium/lib/utils/is-package-changed.ts
@@ -24,7 +24,7 @@ export async function isPackageChanged(
   const {hashFilename = '.packagehash', cwd = process.cwd()} = options;
   const packagePath = await findPackageJson(cwd);
   if (!packagePath) {
-    throw new Error('Cannot find package.json. Travelling up from current working directory.');
+    throw new Error(`Cannot find package.json travelling up from "${cwd}".`);
   }
 
   const packageHashPath = path.join(cwd, hashFilename);

--- a/packages/appium/lib/utils/package-changed.ts
+++ b/packages/appium/lib/utils/package-changed.ts
@@ -1,15 +1,14 @@
 import {fs} from '@appium/support';
-import {isPackageChanged} from 'package-changed';
 import path from 'node:path';
 import {PKG_HASHFILE_RELATIVE_PATH} from '../constants';
 import {log} from '../logger';
+import {isPackageChanged} from './is-package-changed';
 
 /**
  * Determines if extensions have changed, and updates a hash the `package.json` in `appiumHome` if so.
  *
  * If they have, we need to sync them with the `extensions.yaml` manifest.
  *
- * _Warning: this makes a blocking call to `writeFileSync`._
  */
 export async function packageDidChange(appiumHome: string): Promise<boolean> {
   const hashFilename = path.join(appiumHome, PKG_HASHFILE_RELATIVE_PATH);
@@ -26,7 +25,7 @@ export async function packageDidChange(appiumHome: string): Promise<boolean> {
   }
 
   let isChanged: boolean;
-  let writeHash: () => void;
+  let writeHash: () => Promise<void>;
   let oldHash: string | undefined;
   let hash: string;
   try {
@@ -41,7 +40,7 @@ export async function packageDidChange(appiumHome: string): Promise<boolean> {
 
   if (isChanged) {
     try {
-      writeHash();
+      await writeHash();
       log.debug(
         `Updated hash of ${appiumHome}/package.json from: ${oldHash ?? '(none)'} to: ${hash}`,
       );

--- a/packages/appium/lib/utils/resolve-from.ts
+++ b/packages/appium/lib/utils/resolve-from.ts
@@ -3,11 +3,12 @@ import Module from 'node:module';
 import path from 'node:path';
 
 /**
- * Resolves an absolute path to `moduleId` using Node's module resolution from `fromDirectory`.
+ * Resolves `moduleId` using Node's module resolution from `fromDirectory`.
  *
  * @param fromDirectory - Directory to resolve from (typically a project or `APPIUM_HOME` root)
  * @param moduleId - Module id or path to resolve (e.g. `semver/package.json`)
- * @returns Absolute path to the resolved module
+ * @returns Resolved module id. Package paths are typically absolute filesystem paths; built-in
+ *   modules may resolve to non-absolute ids (e.g. `node:fs`, `fs`).
  * @throws `Error` if Node cannot resolve `moduleId` from `fromDirectory`
  */
 export async function resolveFrom(fromDirectory: string, moduleId: string): Promise<string> {

--- a/packages/appium/lib/utils/resolve-from.ts
+++ b/packages/appium/lib/utils/resolve-from.ts
@@ -8,17 +8,9 @@ import path from 'node:path';
  * @param fromDirectory - Directory to resolve from (typically a project or `APPIUM_HOME` root)
  * @param moduleId - Module id or path to resolve (e.g. `semver/package.json`)
  * @returns Absolute path to the resolved module
- * @throws `TypeError` if either argument is not a string
  * @throws `Error` if Node cannot resolve `moduleId` from `fromDirectory`
  */
 export async function resolveFrom(fromDirectory: string, moduleId: string): Promise<string> {
-  if (typeof fromDirectory !== 'string') {
-    throw new TypeError(`Expected \`fromDir\` to be of type \`string\`, got \`${typeof fromDirectory}\``);
-  }
-  if (typeof moduleId !== 'string') {
-    throw new TypeError(`Expected \`moduleId\` to be of type \`string\`, got \`${typeof moduleId}\``);
-  }
-
   let resolvedFromDirectory: string;
   try {
     resolvedFromDirectory = await realpath(fromDirectory);
@@ -33,7 +25,10 @@ export async function resolveFrom(fromDirectory: string, moduleId: string): Prom
 
   const fromFile = path.join(resolvedFromDirectory, 'noop.js');
   const nodeModule = Module as typeof Module & {
-    _resolveFilename: (id: string, parent: {id: string; filename: string; paths: string[]}) => string;
+    _resolveFilename: (
+      id: string,
+      parent: {id: string; filename: string; paths: string[]},
+    ) => string;
     _nodeModulePaths: (from: string) => string[];
   };
   return nodeModule._resolveFilename(moduleId, {

--- a/packages/appium/lib/utils/resolve-from.ts
+++ b/packages/appium/lib/utils/resolve-from.ts
@@ -1,0 +1,44 @@
+import {realpath} from 'node:fs/promises';
+import Module from 'node:module';
+import path from 'node:path';
+
+/**
+ * Resolves an absolute path to `moduleId` using Node's module resolution from `fromDirectory`.
+ *
+ * @param fromDirectory - Directory to resolve from (typically a project or `APPIUM_HOME` root)
+ * @param moduleId - Module id or path to resolve (e.g. `semver/package.json`)
+ * @returns Absolute path to the resolved module
+ * @throws `TypeError` if either argument is not a string
+ * @throws `Error` if Node cannot resolve `moduleId` from `fromDirectory`
+ */
+export async function resolveFrom(fromDirectory: string, moduleId: string): Promise<string> {
+  if (typeof fromDirectory !== 'string') {
+    throw new TypeError(`Expected \`fromDir\` to be of type \`string\`, got \`${typeof fromDirectory}\``);
+  }
+  if (typeof moduleId !== 'string') {
+    throw new TypeError(`Expected \`moduleId\` to be of type \`string\`, got \`${typeof moduleId}\``);
+  }
+
+  let resolvedFromDirectory: string;
+  try {
+    resolvedFromDirectory = await realpath(fromDirectory);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') {
+      resolvedFromDirectory = path.resolve(fromDirectory);
+    } else {
+      throw error;
+    }
+  }
+
+  const fromFile = path.join(resolvedFromDirectory, 'noop.js');
+  const nodeModule = Module as typeof Module & {
+    _resolveFilename: (id: string, parent: {id: string; filename: string; paths: string[]}) => string;
+    _nodeModulePaths: (from: string) => string[];
+  };
+  return nodeModule._resolveFilename(moduleId, {
+    id: fromFile,
+    filename: fromFile,
+    paths: nodeModule._nodeModulePaths(resolvedFromDirectory),
+  });
+}

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -76,8 +76,6 @@
     "lilconfig": "3.1.3",
     "lru-cache": "11.5.1",
     "ora": "5.4.1",
-    "package-changed": "3.0.0",
-    "resolve-from": "5.0.0",
     "semver": "7.8.1",
     "teen_process": "4.1.3",
     "type-fest": "5.7.0",

--- a/packages/appium/test/e2e/cli-driver.e2e.spec.ts
+++ b/packages/appium/test/e2e/cli-driver.e2e.spec.ts
@@ -1,8 +1,7 @@
-import {omitKeys} from '../../lib/utils';
+import {omitKeys, resolveFrom} from '../../lib/utils';
 import {exec} from 'teen_process';
 import {fs, system, tempDir, util} from '@appium/support';
 import path from 'node:path';
-import resolveFrom from 'resolve-from';
 import {
   DRIVER_TYPE,
   EXT_SUBCOMMAND_INSTALL as INSTALL,
@@ -184,8 +183,8 @@ describe('Driver CLI', function () {
       const list = await runList(['--installed']);
       expect(list.fake).to.exist;
       expect(list.test).to.exist;
-      expect(() => resolveFrom(appiumHome, '@appium/fake-driver/package.json')).not.to.throw();
-      expect(() => resolveFrom(appiumHome, '@appium/test-driver/package.json')).not.to.throw();
+      await resolveFrom(appiumHome, '@appium/fake-driver/package.json');
+      await resolveFrom(appiumHome, '@appium/test-driver/package.json');
     });
 
     it('should install _two_ drivers from npm', async function () {
@@ -194,10 +193,8 @@ describe('Driver CLI', function () {
       const list = await runList(['--installed']);
       expect(list.fake).to.exist;
       expect(list.uiautomator2).to.exist;
-      expect(() => resolveFrom(appiumHome, '@appium/fake-driver/package.json')).not.to.throw();
-      expect(() =>
-        resolveFrom(appiumHome, 'appium-uiautomator2-driver/package.json'),
-      ).not.to.throw();
+      await resolveFrom(appiumHome, '@appium/fake-driver/package.json');
+      await resolveFrom(appiumHome, 'appium-uiautomator2-driver/package.json');
     });
 
     it('should install a driver from npm with a specific version/tag', async function () {
@@ -333,7 +330,7 @@ describe('Driver CLI', function () {
       await resetAppiumHome();
       installResult = await installLocalExtension(appiumHome, DRIVER_TYPE, FAKE_DRIVER_DIR);
       listResult = await runList(['--installed']);
-      installPath = resolveFrom(appiumHome, '@appium/fake-driver');
+      installPath = await resolveFrom(appiumHome, '@appium/fake-driver');
     });
 
     it('should install a driver from a local npm module', function () {

--- a/packages/appium/test/e2e/local.e2e.spec.ts
+++ b/packages/appium/test/e2e/local.e2e.spec.ts
@@ -1,6 +1,6 @@
 import {env, fs, npm, tempDir} from '@appium/support';
 import path from 'node:path';
-import resolveFrom from 'resolve-from';
+import {resolveFrom} from '../../lib/utils';
 import * as YAML from 'yaml';
 import {
   DRIVER_TYPE,
@@ -85,8 +85,8 @@ describe('when Appium is a dependency of the current project', function () {
         expect(res).to.have.property('fake');
       });
 
-      it('should be resolvable from the local directory', function () {
-        expect(() => resolveFrom(appiumHome, '@appium/fake-driver/package.json')).not.to.throw();
+      it('should be resolvable from the local directory', async function () {
+        await resolveFrom(appiumHome, '@appium/fake-driver/package.json');
       });
     });
 
@@ -133,14 +133,10 @@ describe('when Appium is a dependency of the current project', function () {
             expect(manifestParsed).to.have.nested.property('drivers.fake');
           });
 
-          it('should actually install both drivers', function () {
+          it('should actually install both drivers', async function () {
             // Resolve package.json to assert the package is present (resolving the main entry can fail in CI)
-            expect(() =>
-              resolveFrom(appiumHome, '@appium/fake-driver/package.json'),
-            ).not.to.throw();
-            expect(() =>
-              resolveFrom(appiumHome, '@appium/test-driver/package.json'),
-            ).not.to.throw();
+            await resolveFrom(appiumHome, '@appium/fake-driver/package.json');
+            await resolveFrom(appiumHome, '@appium/test-driver/package.json');
           });
         });
       });

--- a/packages/appium/test/unit/extension/driver-config.spec.ts
+++ b/packages/appium/test/unit/extension/driver-config.spec.ts
@@ -231,7 +231,7 @@ describe('DriverConfig', function () {
 
           describe('when the property as a path is found', function () {
             beforeEach(function () {
-              MockResolveFrom.returns(resolveFixture('driver-schema.js'));
+              MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
             });
 
             it('should return an empty array', async function () {
@@ -268,7 +268,7 @@ describe('DriverConfig', function () {
           installType: 'npm',
           installPath: '/somewhere',
         };
-        MockResolveFrom.returns(resolveFixture('driver-schema.js'));
+        MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
         driverConfig = DriverConfig.create(manifest);
       });
 

--- a/packages/appium/test/unit/extension/mocks.ts
+++ b/packages/appium/test/unit/extension/mocks.ts
@@ -79,8 +79,8 @@ export interface MockGlob extends SinonStub {
 
 export interface Overrides {
   '@appium/support': MockAppiumSupport;
-  'resolve-from': MockResolveFrom;
-  'package-changed': MockPackageChanged;
+  '../../../lib/utils/resolve-from': {resolveFrom: MockResolveFrom};
+  '../../../lib/utils/is-package-changed': MockPackageChanged;
   glob: MockGlob;
 }
 
@@ -161,7 +161,7 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
 
   const MockResolveFrom = sandbox
     .stub()
-    .callsFake((cwd: string, id: string) => path.join(cwd, id)) as unknown as MockResolveFrom;
+    .callsFake(async (cwd: string, id: string) => path.join(cwd, id)) as unknown as MockResolveFrom;
 
   const MockGlob = sandbox
     .stub()
@@ -178,8 +178,8 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
 
   const overrides: Overrides = {
     '@appium/support': MockAppiumSupport,
-    'resolve-from': MockResolveFrom,
-    'package-changed': MockPackageChanged,
+    '../../../lib/utils/resolve-from': {resolveFrom: MockResolveFrom},
+    '../../../lib/utils/is-package-changed': MockPackageChanged,
     glob: MockGlob,
   };
 

--- a/packages/appium/test/unit/extension/mocks.ts
+++ b/packages/appium/test/unit/extension/mocks.ts
@@ -69,8 +69,8 @@ export interface MockPackageChanged {
   __writeHash: SinonStub;
 }
 
-export interface MockResolveFrom extends SinonStub {
-  (cwd: string, id: string): string;
+export interface MockResolveFrom extends SinonStub<[cwd: string, id: string], Promise<string>> {
+  (cwd: string, id: string): Promise<string>;
 }
 
 export interface MockGlob extends SinonStub {
@@ -159,9 +159,9 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
     __writeHash: sandbox.stub(),
   };
 
-  const MockResolveFrom = sandbox
-    .stub()
-    .callsFake(async (cwd: string, id: string) => path.join(cwd, id)) as unknown as MockResolveFrom;
+  const MockResolveFrom: MockResolveFrom = sandbox
+    .stub<[cwd: string, id: string], Promise<string>>()
+    .callsFake(async (cwd, id) => path.join(cwd, id));
 
   const MockGlob = sandbox
     .stub()

--- a/packages/appium/test/unit/extension/package-changed.spec.ts
+++ b/packages/appium/test/unit/extension/package-changed.spec.ts
@@ -20,13 +20,10 @@ describe('package-changed', function () {
 
   beforeEach(function () {
     ({MockPackageChanged, MockAppiumSupport, sandbox} = initMocks());
-    ({packageDidChange} = rewiremock.proxy(
-      () => require('../../../lib/utils/package-changed'),
-      {
-        '../../../lib/utils/is-package-changed': MockPackageChanged,
-        '@appium/support': MockAppiumSupport,
-      },
-    ));
+    ({packageDidChange} = rewiremock.proxy(() => require('../../../lib/utils/package-changed'), {
+      '../../../lib/utils/is-package-changed': MockPackageChanged,
+      '@appium/support': MockAppiumSupport,
+    }));
   });
 
   afterEach(function () {

--- a/packages/appium/test/unit/extension/package-changed.spec.ts
+++ b/packages/appium/test/unit/extension/package-changed.spec.ts
@@ -21,9 +21,9 @@ describe('package-changed', function () {
   beforeEach(function () {
     ({MockPackageChanged, MockAppiumSupport, sandbox} = initMocks());
     ({packageDidChange} = rewiremock.proxy(
-      () => require('../../../lib/extension/package-changed'),
+      () => require('../../../lib/utils/package-changed'),
       {
-        'package-changed': MockPackageChanged,
+        '../../../lib/utils/is-package-changed': MockPackageChanged,
         '@appium/support': MockAppiumSupport,
       },
     ));
@@ -51,7 +51,7 @@ describe('package-changed', function () {
       ).to.be.true;
     });
 
-    it('should call `package-changed` with a cwd and relative path to hash file', async function () {
+    it('should call `isPackageChanged` with a cwd and relative path to hash file', async function () {
       await packageDidChange('/some/path');
       expect(
         MockPackageChanged.isPackageChanged.calledWith({
@@ -71,7 +71,7 @@ describe('package-changed', function () {
       });
     });
 
-    describe('when the package has not changed per `package-changed`', function () {
+    describe('when the package has not changed per `isPackageChanged`', function () {
       beforeEach(function () {
         MockPackageChanged.isPackageChanged.resolves({
           isChanged: false,
@@ -91,7 +91,7 @@ describe('package-changed', function () {
       });
     });
 
-    describe('when the package has changed per `package-changed`', function () {
+    describe('when the package has changed per `isPackageChanged`', function () {
       it('should write the hash file', async function () {
         await packageDidChange('/some/where');
         expect(MockPackageChanged.__writeHash.calledOnce).to.be.true;

--- a/packages/appium/test/unit/extension/plugin-config.spec.ts
+++ b/packages/appium/test/unit/extension/plugin-config.spec.ts
@@ -200,7 +200,7 @@ describe('PluginConfig', function () {
 
           describe('when the property as a path is found', function () {
             beforeEach(function () {
-              MockResolveFrom.returns(resolveFixture('plugin-schema'));
+              MockResolveFrom.resolves(resolveFixture('plugin-schema'));
             });
 
             it('should return an empty array', async function () {
@@ -281,7 +281,7 @@ describe('PluginConfig', function () {
           installType: 'npm',
           installSpec: 'some-pkg',
         } as unknown as ExtManifestWithSchema<PluginType>;
-        MockResolveFrom.returns(resolveFixture('plugin-schema.js'));
+        MockResolveFrom.resolves(resolveFixture('plugin-schema.js'));
         pluginConfig = PluginConfig.create(manifest);
       });
 
@@ -306,7 +306,7 @@ describe('PluginConfig', function () {
         describe('when the schema differs (presumably a different extension)', function () {
           it('should throw', async function () {
             await pluginConfig.readExtensionSchema(extName, extData);
-            MockResolveFrom.returns(resolveFixture('driver-schema.js'));
+            MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
             await expect(pluginConfig.readExtensionSchema(extName, extData)).to.be.rejectedWith(
               /conflicts with an existing schema/i,
             );

--- a/packages/appium/test/unit/schema/schema.spec.ts
+++ b/packages/appium/test/unit/schema/schema.spec.ts
@@ -31,7 +31,6 @@ describe('schema', function () {
   beforeEach(function () {
     sandbox = createSandbox();
     mocks = {
-      'resolve-from': sandbox.stub(),
       '@sidvind/better-ajv-errors': sandbox.stub(),
     };
 

--- a/packages/support/lib/npm.ts
+++ b/packages/support/lib/npm.ts
@@ -292,17 +292,9 @@ export class NPM {
  * @param fromDirectory - Directory to resolve from (typically a project or `APPIUM_HOME` root)
  * @param moduleId - Module id or path to resolve (e.g. `semver/package.json`)
  * @returns Absolute path to the resolved module
- * @throws `TypeError` if either argument is not a string
  * @throws `Error` if Node cannot resolve `moduleId` from `fromDirectory`
  */
 export async function resolveFrom(fromDirectory: string, moduleId: string): Promise<string> {
-  if (typeof fromDirectory !== 'string') {
-    throw new TypeError(`Expected \`fromDir\` to be of type \`string\`, got \`${typeof fromDirectory}\``);
-  }
-  if (typeof moduleId !== 'string') {
-    throw new TypeError(`Expected \`moduleId\` to be of type \`string\`, got \`${typeof moduleId}\``);
-  }
-
   let resolvedFromDirectory: string;
   try {
     resolvedFromDirectory = await fs.realpath(fromDirectory);
@@ -317,7 +309,10 @@ export async function resolveFrom(fromDirectory: string, moduleId: string): Prom
 
   const fromFile = path.join(resolvedFromDirectory, 'noop.js');
   const nodeModule = Module as typeof Module & {
-    _resolveFilename: (id: string, parent: {id: string; filename: string; paths: string[]}) => string;
+    _resolveFilename: (
+      id: string,
+      parent: {id: string; filename: string; paths: string[]},
+    ) => string;
     _nodeModulePaths: (from: string) => string[];
   };
   return nodeModule._resolveFilename(moduleId, {

--- a/packages/support/lib/npm.ts
+++ b/packages/support/lib/npm.ts
@@ -1,3 +1,4 @@
+import Module from 'node:module';
 import path from 'node:path';
 import * as semver from 'semver';
 import type {PackageJson} from 'type-fest';
@@ -8,8 +9,6 @@ import type {ExecError, TeenProcessExecOptions} from 'teen_process';
 import {fs} from './fs';
 import * as util from './util';
 import * as system from './system';
-import resolveFrom from 'resolve-from';
-
 /**
  * Relative path to directory containing any Appium internal files
  * XXX: this is duplicated in `appium/lib/constants.js`.
@@ -238,7 +237,7 @@ export class NPM {
       throw new Error(String((res.json as {error: unknown}).error));
     }
 
-    const pkgJsonPath = resolveFrom(cwd, `${pkgName}/package.json`);
+    const pkgJsonPath = await resolveFrom(cwd, `${pkgName}/package.json`);
     try {
       const pkgJson = await fs.readFile(pkgJsonPath, 'utf8');
       const pkg = JSON.parse(pkgJson) as PackageJson;
@@ -285,6 +284,47 @@ export class NPM {
   private _getInstallLockfilePath(cwd: string): string {
     return path.join(cwd, INSTALL_LOCKFILE_RELATIVE_PATH);
   }
+}
+
+/**
+ * Resolves an absolute path to `moduleId` using Node's module resolution from `fromDirectory`.
+ *
+ * @param fromDirectory - Directory to resolve from (typically a project or `APPIUM_HOME` root)
+ * @param moduleId - Module id or path to resolve (e.g. `semver/package.json`)
+ * @returns Absolute path to the resolved module
+ * @throws `TypeError` if either argument is not a string
+ * @throws `Error` if Node cannot resolve `moduleId` from `fromDirectory`
+ */
+export async function resolveFrom(fromDirectory: string, moduleId: string): Promise<string> {
+  if (typeof fromDirectory !== 'string') {
+    throw new TypeError(`Expected \`fromDir\` to be of type \`string\`, got \`${typeof fromDirectory}\``);
+  }
+  if (typeof moduleId !== 'string') {
+    throw new TypeError(`Expected \`moduleId\` to be of type \`string\`, got \`${typeof moduleId}\``);
+  }
+
+  let resolvedFromDirectory: string;
+  try {
+    resolvedFromDirectory = await fs.realpath(fromDirectory);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') {
+      resolvedFromDirectory = path.resolve(fromDirectory);
+    } else {
+      throw error;
+    }
+  }
+
+  const fromFile = path.join(resolvedFromDirectory, 'noop.js');
+  const nodeModule = Module as typeof Module & {
+    _resolveFilename: (id: string, parent: {id: string; filename: string; paths: string[]}) => string;
+    _nodeModulePaths: (from: string) => string[];
+  };
+  return nodeModule._resolveFilename(moduleId, {
+    id: fromFile,
+    filename: fromFile,
+    paths: nodeModule._nodeModulePaths(resolvedFromDirectory),
+  });
 }
 
 export const npm = new NPM();

--- a/packages/support/lib/npm.ts
+++ b/packages/support/lib/npm.ts
@@ -287,11 +287,12 @@ export class NPM {
 }
 
 /**
- * Resolves an absolute path to `moduleId` using Node's module resolution from `fromDirectory`.
+ * Resolves `moduleId` using Node's module resolution from `fromDirectory`.
  *
  * @param fromDirectory - Directory to resolve from (typically a project or `APPIUM_HOME` root)
  * @param moduleId - Module id or path to resolve (e.g. `semver/package.json`)
- * @returns Absolute path to the resolved module
+ * @returns Resolved module id. Package paths are typically absolute filesystem paths; built-in
+ *   modules may resolve to non-absolute ids (e.g. `node:fs`, `fs`).
  * @throws `Error` if Node cannot resolve `moduleId` from `fromDirectory`
  */
 export async function resolveFrom(fromDirectory: string, moduleId: string): Promise<string> {

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -62,7 +62,6 @@
     "plist": "4.0.0",
     "pluralize": "8.0.0",
     "read-pkg": "10.1.0",
-    "resolve-from": "5.0.0",
     "sanitize-filename": "1.6.4",
     "semver": "7.8.1",
     "shell-quote": "1.8.4",

--- a/packages/support/test/mocks.ts
+++ b/packages/support/test/mocks.ts
@@ -2,13 +2,8 @@
  * A collection of mocks reused across unit tests.
  */
 
-import path from 'node:path';
 import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon';
 import type {NormalizedPackageJson} from 'read-pkg';
-
-export interface MockResolveFrom extends SinonStub {
-  (cwd: string, id: string): string;
-}
 
 export interface MockPkgDir extends SinonStub {
   (...args: any[]): Promise<string | undefined>;
@@ -31,7 +26,6 @@ export interface MockTeenProcess {
 }
 
 export interface Overrides {
-  'resolve-from': MockResolveFrom;
   'read-pkg': MockReadPkg;
   'package-directory': MockPkgDir;
   teen_process: MockTeenProcess;
@@ -39,7 +33,6 @@ export interface Overrides {
 }
 
 export interface InitMocksResult {
-  MockResolveFrom: MockResolveFrom;
   MockPkgDir: MockPkgDir;
   MockReadPkg: MockReadPkg;
   MockFs: MockFs;
@@ -49,10 +42,6 @@ export interface InitMocksResult {
 }
 
 export function initMocks(sandbox = createSandbox()): InitMocksResult {
-  const MockResolveFrom = sandbox
-    .stub()
-    .callsFake((cwd: string, id: string) => path.join(cwd, id)) as MockResolveFrom;
-
   const MockPkgDir = sandbox.stub().resolvesArg(0) as MockPkgDir;
 
   const MockReadPkg: MockReadPkg = {
@@ -81,7 +70,6 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
   };
 
   const overrides: Overrides = {
-    'resolve-from': MockResolveFrom,
     'read-pkg': MockReadPkg,
     'package-directory': MockPkgDir,
     teen_process: MockTeenProcess,
@@ -89,7 +77,6 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
   };
 
   return {
-    MockResolveFrom,
     MockPkgDir,
     MockReadPkg,
     MockFs,

--- a/packages/support/test/unit/npm.spec.ts
+++ b/packages/support/test/unit/npm.spec.ts
@@ -1,7 +1,40 @@
-import {expect} from 'chai';
-import {NPM} from '../../lib/npm';
+import path from 'node:path';
+import {expect, use} from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import {NPM, resolveFrom} from '../../lib/npm';
 
 describe('npm', function () {
+  before(function () {
+    use(chaiAsPromised);
+  });
+
+  describe('resolveFrom()', function () {
+    const supportRoot = path.join(__dirname, '..', '..');
+
+    it('should resolve a package path from a directory', async function () {
+      const resolved = await resolveFrom(supportRoot, 'semver/package.json');
+      expect(resolved).to.match(/semver[/\\]package\.json$/);
+    });
+
+    it('should reject invalid fromDirectory type', async function () {
+      await expect(resolveFrom(1 as unknown as string, 'semver/package.json')).to.eventually.be.rejectedWith(
+        TypeError,
+      );
+    });
+
+    it('should reject invalid moduleId type', async function () {
+      await expect(resolveFrom(supportRoot, 1 as unknown as string)).to.eventually.be.rejectedWith(
+        TypeError,
+      );
+    });
+
+    it('should reject when the module cannot be resolved', async function () {
+      await expect(
+        resolveFrom(supportRoot, 'nonexistent-appium-package-xyz/package.json'),
+      ).to.eventually.be.rejected;
+    });
+  });
+
   describe('getLatestSafeUpgradeFromVersions()', function () {
     const versions1 = [
       '0.1.0',

--- a/packages/support/test/unit/npm.spec.ts
+++ b/packages/support/test/unit/npm.spec.ts
@@ -16,22 +16,9 @@ describe('npm', function () {
       expect(resolved).to.match(/semver[/\\]package\.json$/);
     });
 
-    it('should reject invalid fromDirectory type', async function () {
-      await expect(resolveFrom(1 as unknown as string, 'semver/package.json')).to.eventually.be.rejectedWith(
-        TypeError,
-      );
-    });
-
-    it('should reject invalid moduleId type', async function () {
-      await expect(resolveFrom(supportRoot, 1 as unknown as string)).to.eventually.be.rejectedWith(
-        TypeError,
-      );
-    });
-
     it('should reject when the module cannot be resolved', async function () {
-      await expect(
-        resolveFrom(supportRoot, 'nonexistent-appium-package-xyz/package.json'),
-      ).to.eventually.be.rejected;
+      await expect(resolveFrom(supportRoot, 'nonexistent-appium-package-xyz/package.json')).to
+        .eventually.be.rejected;
     });
   });
 


### PR DESCRIPTION
## Summary

Continues the dependency slimming effort by removing `resolve-from` and `package-changed` from `@appium/appium` and `@appium/support`, replacing them with small local implementations.

- **`resolve-from`**: Inlined as an async helper using Node's `Module._resolveFilename` and `fs.realpath`. `@appium/support` keeps a private copy used by `NPM.getVersion()`; `@appium/appium` adds its own copy under `lib/utils/resolve-from.ts` for extension config and CLI. Both mirror the original sync API but return `Promise<string>`.
- **`package-changed`**: Inlined into `lib/utils/is-package-changed.ts` (`isPackageChanged`) and `lib/utils/package-changed.ts` (`packageDidChange`). Logic is unchanged: MD5 hash of `dependencies` + `devDependencies` only, compared against `.appium/packagehash`. Lockfile support from the original package is omitted (unused by Appium). All fs I/O is async via `@appium/support` `fs`.
- **Cleanup**: Removed both deps from `package.json` / lockfile; moved `package-changed` out of `lib/extension/` into `lib/utils/`; updated imports, unit mocks, and e2e tests for the async `resolveFrom` API.
