### PR TITLE
chore: Ditch `@colors/colors` and `supports-color`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19572,7 +19572,6 @@
         "sanitize-filename": "1.6.4",
         "semver": "7.8.1",
         "shell-quote": "1.8.4",
-        "supports-color": "10.2.2",
         "teen_process": "4.1.3",
         "type-fest": "5.7.0",
         "uuid": "14.0.0",
@@ -19841,18 +19840,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/yqnn"
-      }
-    },
-    "packages/support/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "packages/support/node_modules/tar-stream": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@colors/colors": "1.6.0",
         "@eslint/js": "10.0.1",
         "@stylistic/eslint-plugin": "5.10.0",
         "@tsconfig/node20": "20.1.9",
@@ -18942,7 +18941,6 @@
       "dependencies": {
         "@appium/support": "7.2.3",
         "@appium/types": "1.5.0",
-        "@colors/colors": "1.6.0",
         "async-lock": "1.4.1",
         "asyncbox": "6.3.0",
         "axios": "1.17.0",
@@ -19555,7 +19553,6 @@
       "dependencies": {
         "@appium/logger": "2.0.8",
         "@appium/types": "1.5.0",
-        "@colors/colors": "1.6.0",
         "archiver": "8.0.0",
         "asyncbox": "6.3.0",
         "axios": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "singleQuote": true
   },
   "devDependencies": {
-    "@colors/colors": "1.6.0",
     "@eslint/js": "10.0.1",
     "@stylistic/eslint-plugin": "5.10.0",
     "@tsconfig/node20": "20.1.9",

--- a/packages/appium/lib/bootstrap/main-helpers.ts
+++ b/packages/appium/lib/bootstrap/main-helpers.ts
@@ -6,7 +6,7 @@ import {
   server as baseServer,
   type ServerOpts,
 } from '@appium/base-driver';
-import {util} from '@appium/support';
+import {console as supportConsole, util} from '@appium/support';
 import type {AppiumServer, Driver, MethodMap, UpdateServerCallback} from '@appium/types';
 import {WebSocketServer} from 'ws';
 import type {NetworkInterfaceInfo} from 'node:os';
@@ -109,7 +109,7 @@ export async function preflightChecks(
     }
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
-    logger.error((message as string & {red: string}).red);
+    logger.error(supportConsole.styleText('red', message));
     if (throwInsteadOfExit) {
       throw err;
     }

--- a/packages/appium/lib/cli/driver-command.ts
+++ b/packages/appium/lib/cli/driver-command.ts
@@ -1,4 +1,4 @@
-import {util} from '@appium/support';
+import {console, util} from '@appium/support';
 import type {ExtMetadata, ExtRecord, InstallType} from 'appium/types';
 import ExtensionCliCommand from './extension-command';
 import type {
@@ -9,8 +9,6 @@ import type {
   RunOutput,
 } from './extension-command';
 import {KNOWN_DRIVERS} from '../constants';
-import '@colors/colors';
-
 const REQ_DRIVER_FIELDS = ['driverName', 'automationName', 'platformNames', 'mainClass'];
 type DriverInstallOpts = {driver: string; installType: InstallType; packageName?: string};
 type DriverUninstallOpts = {driver: string};
@@ -95,9 +93,9 @@ export default class DriverCliCommand extends ExtensionCliCommand<'driver'> {
    */
   override getPostInstallText({extName, extData}: ExtensionArgs<'driver'>): PostInstallText {
     return (
-      `Driver ${extName}@${extData.version} successfully installed\n`.green +
-      `- automationName: ${extData.automationName.green}\n` +
-      `- platformNames: ${JSON.stringify(extData.platformNames).green}`
+      `${console.styleText('green', `Driver ${extName}@${extData.version} successfully installed`)}\n` +
+      `${console.styleText('green', `- automationName: ${extData.automationName}`)}\n` +
+      console.styleText('green', `- platformNames: ${JSON.stringify(extData.platformNames)}`)
     );
   }
 

--- a/packages/appium/lib/cli/driver-command.ts
+++ b/packages/appium/lib/cli/driver-command.ts
@@ -94,8 +94,8 @@ export default class DriverCliCommand extends ExtensionCliCommand<'driver'> {
   override getPostInstallText({extName, extData}: ExtensionArgs<'driver'>): PostInstallText {
     return (
       `${console.styleText('green', `Driver ${extName}@${extData.version} successfully installed`)}\n` +
-      `${console.styleText('green', `- automationName: ${extData.automationName}`)}\n` +
-      console.styleText('green', `- platformNames: ${JSON.stringify(extData.platformNames)}`)
+      `- automationName: ${console.styleText('green', extData.automationName)}\n` +
+      `- platformNames: ${console.styleText('green', JSON.stringify(extData.platformNames))}`
     );
   }
 

--- a/packages/appium/lib/cli/extension-command.ts
+++ b/packages/appium/lib/cli/extension-command.ts
@@ -1,6 +1,6 @@
 import {asyncfilter, asyncmap} from 'asyncbox';
 import path from 'node:path';
-import {util, npm, env, console, fs, system} from '@appium/support';
+import {console, env, fs, npm, system, util} from '@appium/support';
 import type {AppiumLogger, ExtensionType, IDoctorCheck} from '@appium/types';
 import type {
   ExtInstallReceipt as AppiumExtInstallReceipt,
@@ -452,7 +452,9 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
       await npm.uninstallPackage(this.config.appiumHome, pkgName);
     });
     await this.config.removeExtension(installSpec);
-    this.log.ok(`Successfully uninstalled ${this.type} '${installSpec}'`.green);
+    this.log.ok(
+      console.styleText('green', `Successfully uninstalled ${this.type} '${installSpec}'`),
+    );
     return this.config.installedExtensions;
   }
 
@@ -522,7 +524,7 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
             `A newer major version ${update.unsafeUpdate} ` +
             `is available for ${this.type} '${e}', which could include breaking changes. ` +
             `If you want to apply this update, re-run with --unsafe`;
-          this.log.info(newMajorUpdateMsg.yellow);
+          this.log.info(console.styleText('yellow', newMajorUpdateMsg));
         }
         updates[e] = {from: update.current, to: updateVer};
       } catch (err) {
@@ -533,19 +535,24 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
     this.log.info('Update report:');
 
     for (const [e, update] of Object.entries(updates)) {
-      this.log.ok(`  - ${this.type} ${e} updated: ${update.from} => ${update.to}`.green);
+      this.log.ok(
+        console.styleText('green', `  - ${this.type} ${e} updated: ${update.from} => ${update.to}`),
+      );
     }
 
     for (const [e, err] of Object.entries(errors)) {
       if (err instanceof NotUpdatableError) {
         this.log.warn(
-          `  - '${e}' was not installed via npm, so we could not check ` + `for updates`.yellow,
+          console.styleText(
+            'yellow',
+            `  - '${e}' was not installed via npm, so we could not check for updates`,
+          ),
         );
       } else if (err instanceof NoUpdatesAvailableError) {
-        this.log.info(`  - '${e}' had no updates available`.yellow);
+        this.log.info(console.styleText('yellow', `  - '${e}' had no updates available`));
       } else {
         // otherwise, make it pop with red!
-        this.log.error(`  - '${e}' failed to update: ${err}`.red);
+        this.log.error(console.styleText('red', `  - '${e}' failed to update: ${err}`));
       }
     }
     return {updates, errors};
@@ -725,7 +732,7 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
         );
         existingScripts.forEach(([name]) => this.log.info(`  - ${name}`));
       }
-      this.log.ok(`Successfully retrieved the list of scripts`.green);
+      this.log.ok(console.styleText('green', 'Successfully retrieved the list of scripts'));
       return {};
     }
 
@@ -760,7 +767,7 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
 
       try {
         await runner.join();
-        this.log.ok(`${scriptName} successfully ran`.green);
+        this.log.ok(console.styleText('green', `${scriptName} successfully ran`));
         return {output: output.getBuff()};
       } catch (err) {
         const errMessage = err instanceof Error ? err.message : String(err);
@@ -786,7 +793,7 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
             }
           });
       });
-      this.log.ok(`${scriptName} successfully ran`.green);
+      this.log.ok(console.styleText('green', `${scriptName} successfully ran`));
       return {};
     } catch (err) {
       const errMessage = err instanceof Error ? err.message : String(err);
@@ -1055,10 +1062,10 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
     if (data.installed) {
       const installTxt = this._formatInstallText(data);
       const updateTxt = showUpdates ? this._formatUpdateText(data) : '';
-      return `- ${name.yellow}${installTxt}${updateTxt}`;
+      return `- ${console.styleText('yellow', name)}${installTxt}${updateTxt}`;
     }
-    const installTxt = ' [not installed]'.grey;
-    return `- ${name.yellow}${installTxt}`;
+    const installTxt = console.styleText('grey', ' [not installed]');
+    return `- ${console.styleText('yellow', name)}${installTxt}`;
   }
 
   /**
@@ -1071,10 +1078,10 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
     switch (installType) {
       case INSTALL_TYPE_GIT:
       case INSTALL_TYPE_GITHUB:
-        typeTxt = `(cloned from ${installSpec})`.yellow;
+        typeTxt = console.styleText('yellow', `(cloned from ${installSpec})`);
         break;
       case INSTALL_TYPE_LOCAL:
-        typeTxt = `(linked from ${installSpec})`.magenta;
+        typeTxt = console.styleText('magenta', `(linked from ${installSpec})`);
         break;
       case INSTALL_TYPE_DEV:
         typeTxt = '(dev mode)';
@@ -1082,7 +1089,7 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
       default:
         typeTxt = '(npm)';
     }
-    return `@${String(version).yellow} ${('[installed ' + typeTxt + ']').green}`;
+    return `${console.styleText('yellow', `@${String(version)}`)} ${console.styleText('green', `[installed ${typeTxt}]`)}`;
   }
 
   /**
@@ -1092,17 +1099,17 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
   private _formatUpdateText(data: ExtensionListData): string {
     const {updateVersion, unsafeUpdateVersion, upToDate, updateError} = data;
     if (updateError) {
-      return ` [Cannot check for updates: ${updateError}]`.red;
+      return console.styleText('red', ` [Cannot check for updates: ${updateError}]`);
     }
     let txt = '';
     if (updateVersion) {
-      txt += ` [${updateVersion} available]`.magenta;
+      txt += console.styleText('magenta', ` [${updateVersion} available]`);
     }
     if (upToDate) {
-      txt += ` [Up to date]`.green;
+      txt += console.styleText('green', ' [Up to date]');
     }
     if (unsafeUpdateVersion) {
-      txt += ` [${unsafeUpdateVersion} available (potentially unsafe)]`.cyan;
+      txt += console.styleText('cyan', ` [${unsafeUpdateVersion} available (potentially unsafe)]`);
     }
     return txt;
   }

--- a/packages/appium/lib/cli/extension-command.ts
+++ b/packages/appium/lib/cli/extension-command.ts
@@ -1075,13 +1075,16 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
   private _formatInstallText(data: ExtensionListData): string {
     const {installType, installSpec, version} = data;
     let typeTxt;
+    let isTypeTextStyled = false;
     switch (installType) {
       case INSTALL_TYPE_GIT:
       case INSTALL_TYPE_GITHUB:
         typeTxt = console.styleText('yellow', `(cloned from ${installSpec})`);
+        isTypeTextStyled = true;
         break;
       case INSTALL_TYPE_LOCAL:
         typeTxt = console.styleText('magenta', `(linked from ${installSpec})`);
+        isTypeTextStyled = true;
         break;
       case INSTALL_TYPE_DEV:
         typeTxt = '(dev mode)';
@@ -1089,7 +1092,10 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
       default:
         typeTxt = '(npm)';
     }
-    return `${console.styleText('yellow', `@${String(version)}`)} ${console.styleText('green', `[installed ${typeTxt}]`)}`;
+    const installLabelStart = console.styleText('green', '[installed ');
+    const installLabelEnd = console.styleText('green', ']');
+    const installTypeText = isTypeTextStyled ? typeTxt : console.styleText('green', typeTxt);
+    return `${console.styleText('yellow', `@${String(version)}`)} ${installLabelStart}${installTypeText}${installLabelEnd}`;
   }
 
   /**

--- a/packages/appium/lib/cli/extension-command.ts
+++ b/packages/appium/lib/cli/extension-command.ts
@@ -1074,7 +1074,7 @@ abstract class ExtensionCliCommand<ExtType extends ExtensionType = ExtensionType
    */
   private _formatInstallText(data: ExtensionListData): string {
     const {installType, installSpec, version} = data;
-    let typeTxt;
+    let typeTxt: string;
     let isTypeTextStyled = false;
     switch (installType) {
       case INSTALL_TYPE_GIT:

--- a/packages/appium/lib/cli/plugin-command.ts
+++ b/packages/appium/lib/cli/plugin-command.ts
@@ -1,4 +1,4 @@
-import {util} from '@appium/support';
+import {console, util} from '@appium/support';
 import type {ExtMetadata, ExtRecord, InstallType} from 'appium/types';
 import ExtensionCliCommand from './extension-command';
 import type {
@@ -93,7 +93,10 @@ export default class PluginCliCommand extends ExtensionCliCommand<'plugin'> {
    * @returns formatted success text
    */
   override getPostInstallText({extName, extData}: ExtensionArgs<'plugin'>): PostInstallText {
-    return `Plugin ${extName}@${extData.version} successfully installed`.green;
+    return console.styleText(
+      'green',
+      `Plugin ${extName}@${extData.version} successfully installed`,
+    );
   }
 
   /**

--- a/packages/appium/lib/cli/utils.ts
+++ b/packages/appium/lib/cli/utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 
+import {console as supportConsole} from '@appium/support';
 import ora from 'ora';
 
 export const JSON_SPACES = 4;
@@ -49,9 +50,9 @@ export function errAndQuit(json: boolean, msg: unknown): never {
   if (json) {
     console.log(JSON.stringify({error: String(msg)}, null, JSON_SPACES));
   } else {
-    console.error((String(msg) as any).red);
+    console.error(supportConsole.styleText('red', String(msg)));
     if ((msg as ErrorLike)?.stderr) {
-      console.error((String((msg as ErrorLike).stderr) as any).red);
+      console.error(supportConsole.styleText('red', String((msg as ErrorLike).stderr)));
     }
   }
   process.exit(1);

--- a/packages/appium/lib/doctor/doctor.ts
+++ b/packages/appium/lib/doctor/doctor.ts
@@ -1,5 +1,4 @@
-import '@colors/colors';
-import {util, doctor, logger} from '@appium/support';
+import {console, doctor, logger, util} from '@appium/support';
 import type {AppiumLogger, DoctorCheckResult, IDoctorCheck} from '@appium/types';
 
 /**
@@ -159,10 +158,10 @@ export class Doctor {
     const res = await f.check.diagnose();
     if (res.ok) {
       f.fixed = true;
-      this.log.info(` ${'\u2714'.green} ${res.message}`);
+      this.log.info(` ${console.styleText('green', '\u2714')} ${res.message}`);
       this.log.info(`### Fix was successfully applied ###`);
     } else {
-      this.log.info(` ${'\u2716'.red} ${res.message}`);
+      this.log.info(` ${console.styleText('red', '\u2716')} ${res.message}`);
       this.log.info(`### Fix was applied but issue remains ###`);
     }
   }
@@ -187,13 +186,13 @@ export class Doctor {
 
   private toIssue(result: DoctorCheckResult, check: IDoctorCheck): DoctorIssue | null {
     if (result.ok) {
-      this.log.info(` ${'\u2714'.green} ${result.message}`);
+      this.log.info(` ${console.styleText('green', '\u2714')} ${result.message}`);
       return null;
     }
 
     const errorMessage = result.optional
-      ? ` ${'\u2716'.yellow} ${result.message}`
-      : ` ${'\u2716'.red} ${result.message}`;
+      ? ` ${console.styleText('yellow', '\u2716')} ${result.message}`
+      : ` ${console.styleText('red', '\u2716')} ${result.message}`;
     this.log.warn(errorMessage);
     return {
       error: errorMessage,

--- a/packages/appium/test/e2e/e2e-helpers.ts
+++ b/packages/appium/test/e2e/e2e-helpers.ts
@@ -2,7 +2,6 @@
  * Helper functions for E2E tests to spawn an `appium` subprocess.
  */
 import {console as supportConsole, fs} from '@appium/support';
-import '@colors/colors';
 import path from 'node:path';
 import {exec} from 'teen_process';
 import type {ExecError} from 'teen_process';
@@ -91,8 +90,7 @@ async function run(
       log.debug(`Running: ${process.execPath} ${fullArgs.join(' ')}`);
     }
     const retval = await exec(process.execPath, fullArgs, {...opts, cwd, env});
-    const strip = (s: string) =>
-      opts.env?.FORCE_COLOR ? s : ((s as unknown as {stripColors: string}).stripColors ?? s);
+    const strip = (s: string) => (opts.env?.FORCE_COLOR ? s : supportConsole.stripColors(s));
     return {
       stdout: strip(retval.stdout),
       stderr: strip(retval.stderr),

--- a/packages/appium/test/unit/bootstrap/main-helpers.spec.ts
+++ b/packages/appium/test/unit/bootstrap/main-helpers.spec.ts
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import type {SinonSandbox, SinonSpy} from 'sinon';
 import {createSandbox} from 'sinon';
-import {stripColors} from '@colors/colors';
+import {console as supportConsole} from '@appium/support';
 import {getBuildInfo} from '../../../lib/helpers/build';
 import {inspect, showBuildInfo} from '../../../lib/bootstrap/main-helpers';
 import {log as logger} from '../../../lib/logger';
@@ -40,7 +40,9 @@ describe('bootstrap/main-helpers', function () {
     it('should log the result of inspecting a value', function () {
       const infoLog = sandbox.spy(logger, 'info');
       inspect({foo: 'bar'});
-      expect(stripColors(infoLog.firstCall.firstArg)).to.match(/\{\s*\n*foo:\s'bar'\s*\n*\}/);
+      expect(supportConsole.stripColors(infoLog.firstCall.firstArg)).to.match(
+        /\{\s*\n*foo:\s'bar'\s*\n*\}/,
+      );
     });
   });
 });

--- a/packages/base-driver/lib/express/express-logging.ts
+++ b/packages/base-driver/lib/express/express-logging.ts
@@ -1,5 +1,4 @@
-import {util, logger} from '@appium/support';
-import '@colors/colors';
+import {console, logger, util} from '@appium/support';
 import morgan from 'morgan';
 import type {Request, RequestHandler, Response} from 'express';
 import {log} from './logger';
@@ -40,7 +39,10 @@ function startLogFormatterHandler(tokens: unknown, req: Request, res: Response):
       // ignore
     }
   }
-  log.info(requestStartLoggingFormat(tokens, req, res), logger.markSensitive(reqBody.grey));
+  log.info(
+    requestStartLoggingFormat(tokens, req, res),
+    logger.markSensitive(console.styleText('grey', reqBody)),
+  );
   return undefined;
 }
 
@@ -58,19 +60,21 @@ function requestEndLoggingFormat(tokens: MorganTokens, req: Request, res: Respon
   const status = res.statusCode;
   let statusStr = ':status';
   if (status >= 500) {
-    statusStr = statusStr.red;
+    statusStr = console.styleText('red', statusStr);
   } else if (status >= 400) {
-    statusStr = statusStr.yellow;
+    statusStr = console.styleText('yellow', statusStr);
   } else if (status >= 300) {
-    statusStr = statusStr.cyan;
+    statusStr = console.styleText('cyan', statusStr);
   } else {
-    statusStr = statusStr.green;
+    statusStr = console.styleText('green', statusStr);
   }
   const fn = compile(
-    `${'<-- :method :url '.white}${statusStr} ${':response-time ms - :res[content-length]'.grey}`,
+    `${console.styleText('white', '<-- :method :url ')}${statusStr} ${console.styleText('grey', ':response-time ms - :res[content-length]')}`,
   );
   return fn(tokens, req, res);
 }
 
-const requestStartLoggingFormat = compile(`${'-->'.white} ${':method'.white} ${':url'.white}`);
+const requestStartLoggingFormat = compile(
+  `${console.styleText('white', '-->')} ${console.styleText('white', ':method')} ${console.styleText('white', ':url')}`,
+);
 // #endregion

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@appium/support": "7.2.3",
     "@appium/types": "1.5.0",
-    "@colors/colors": "1.6.0",
     "async-lock": "1.4.1",
     "asyncbox": "6.3.0",
     "axios": "1.17.0",

--- a/packages/support/lib/console.ts
+++ b/packages/support/lib/console.ts
@@ -43,8 +43,11 @@ export type TextStyle =
   | 'cyanBright'
   | 'whiteBright';
 
-const ANSI_RE = // eslint-disable-next-line no-control-regex
-  /\x1b\[[0-9;]*m/g;
+// CSI (Control Sequence Introducer) and OSC (Operating System Command) per ECMA-48.
+const ANSI_CSI_RE = // eslint-disable-next-line no-control-regex
+  /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const ANSI_OSC_RE = // eslint-disable-next-line no-control-regex
+  /\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
 
 /** Applies terminal styling via Node's `util.styleText`. */
 export function styleText(style: TextStyle, text: string): string {
@@ -52,9 +55,9 @@ export function styleText(style: TextStyle, text: string): string {
   return nodeStyleText(format, text);
 }
 
-/** Removes ANSI color/style sequences from a string. */
+/** Removes ANSI escape sequences (CSI and OSC) from a string. */
 export function stripColors(text: string): string {
-  return text.replace(ANSI_RE, '');
+  return text.replace(ANSI_OSC_RE, '').replace(ANSI_CSI_RE, '');
 }
 
 function isUnicodeSupported(): boolean {
@@ -82,7 +85,8 @@ function stderrSupportsColor(stream: {isTTY?: boolean} = process.stderr): boolea
   }
   const {FORCE_COLOR: forceColor} = env;
   if (forceColor !== undefined) {
-    return forceColor !== '0' && forceColor !== 'false';
+    const normalized = forceColor.toLowerCase();
+    return normalized !== '0' && normalized !== 'false';
   }
   if (env.TERM === 'dumb') {
     return false;

--- a/packages/support/lib/console.ts
+++ b/packages/support/lib/console.ts
@@ -1,10 +1,62 @@
 import {createSupportsColor} from 'supports-color';
 import {Console as NodeConsole} from 'node:console';
-import type {Color} from '@colors/colors';
-import '@colors/colors';
 import {Writable} from 'node:stream';
-import type {InspectOptions} from 'node:util';
+import {styleText as nodeStyleText, type InspectOptions} from 'node:util';
 import type {JsonValue} from 'type-fest';
+
+/** ANSI styles supported by Node's `util.styleText`. `grey` is accepted as an alias for `gray`. */
+export type TextStyle =
+  | 'reset'
+  | 'bold'
+  | 'dim'
+  | 'italic'
+  | 'underline'
+  | 'blink'
+  | 'inverse'
+  | 'hidden'
+  | 'strikethrough'
+  | 'doubleunderline'
+  | 'black'
+  | 'red'
+  | 'green'
+  | 'yellow'
+  | 'blue'
+  | 'magenta'
+  | 'cyan'
+  | 'white'
+  | 'gray'
+  | 'grey'
+  | 'bgBlack'
+  | 'bgRed'
+  | 'bgGreen'
+  | 'bgYellow'
+  | 'bgBlue'
+  | 'bgMagenta'
+  | 'bgCyan'
+  | 'bgWhite'
+  | 'framed'
+  | 'overlined'
+  | 'redBright'
+  | 'greenBright'
+  | 'yellowBright'
+  | 'blueBright'
+  | 'magentaBright'
+  | 'cyanBright'
+  | 'whiteBright';
+
+const ANSI_RE = // eslint-disable-next-line no-control-regex
+  /\x1b\[[0-9;]*m/g;
+
+/** Applies terminal styling via Node's `util.styleText`. */
+export function styleText(style: TextStyle, text: string): string {
+  const format = style === 'grey' ? 'gray' : style;
+  return nodeStyleText(format, text);
+}
+
+/** Removes ANSI color/style sequences from a string. */
+export function stripColors(text: string): string {
+  return text.replace(ANSI_RE, '');
+}
 
 function isUnicodeSupported(): boolean {
   if (process.env.TERM === 'dumb') {
@@ -72,7 +124,7 @@ class NullWritable extends Writable {
  * DO NOT extend this to do anything other than what it already does. Download a library or something.
  */
 export class CliConsole {
-  static readonly symbolToColor: Record<SymbolKey, keyof Color> = {
+  static readonly symbolToColor: Record<SymbolKey, TextStyle> = {
     success: 'green',
     info: 'cyan',
     warning: 'yellow',
@@ -102,9 +154,7 @@ export class CliConsole {
 
     let newMsg = `${logSymbols[symbol]} ${msg}`;
     if (this.#useColor) {
-      const color = CliConsole.symbolToColor[symbol];
-      // @colors/colors extends String with color getters (e.g. .green, .red)
-      newMsg = (newMsg as unknown as Record<string, string>)[color] ?? newMsg;
+      newMsg = styleText(CliConsole.symbolToColor[symbol], newMsg);
     }
     return newMsg;
   }

--- a/packages/support/lib/console.ts
+++ b/packages/support/lib/console.ts
@@ -1,4 +1,3 @@
-import {createSupportsColor} from 'supports-color';
 import {Console as NodeConsole} from 'node:console';
 import {Writable} from 'node:stream';
 import {styleText as nodeStyleText, type InspectOptions} from 'node:util';
@@ -75,6 +74,25 @@ function isUnicodeSupported(): boolean {
 
 const UNICODE = isUnicodeSupported();
 
+/** Returns whether stderr should use ANSI color by default. */
+function stderrSupportsColor(stream: {isTTY?: boolean} = process.stderr): boolean {
+  const {env} = process;
+  if (env.NO_COLOR !== undefined || env.NODE_DISABLE_COLORS !== undefined) {
+    return false;
+  }
+  const {FORCE_COLOR: forceColor} = env;
+  if (forceColor !== undefined) {
+    return forceColor !== '0' && forceColor !== 'false';
+  }
+  if (env.TERM === 'dumb') {
+    return false;
+  }
+  if (!stream.isTTY) {
+    return false;
+  }
+  return true;
+}
+
 const logSymbols = {
   info: UNICODE ? 'ℹ' : 'i',
   success: UNICODE ? '✔' : '√',
@@ -82,17 +100,13 @@ const logSymbols = {
   error: UNICODE ? '✖' : '×',
 } as const;
 
-/**
- * Options for {@linkcode CliConsole}.
- *
- * @see https://npm.im/supports-color
- */
+/** Options for {@linkcode CliConsole}. */
 export interface ConsoleOpts {
   /** If _truthy_, suppress all output except JSON (use {@linkcode CliConsole#json}), which writes to `STDOUT`. */
   jsonMode?: boolean;
   /** If _falsy_, do not use fancy symbols. */
   useSymbols?: boolean;
-  /** If _falsy_, do not use color output. If _truthy_, forces color output. By default, checks terminal/TTY for support via pkg `supports-color`. Ignored if `useSymbols` is `false`. */
+  /** If _falsy_, do not use color output. If _truthy_, forces color output. By default, checks `NO_COLOR`, `FORCE_COLOR`, `TERM`, and stderr TTY. Ignored if `useSymbols` is `false`. */
   useColor?: boolean;
 }
 
@@ -139,7 +153,7 @@ export class CliConsole {
     const {jsonMode = false, useSymbols = true, useColor} = opts;
     this.#console = new NodeConsole(process.stdout, jsonMode ? new NullWritable() : process.stderr);
     this.#useSymbols = Boolean(useSymbols);
-    this.#useColor = Boolean(useColor ?? createSupportsColor(process.stderr));
+    this.#useColor = Boolean(useColor ?? stderrSupportsColor(process.stderr));
   }
 
   /**

--- a/packages/support/lib/index.ts
+++ b/packages/support/lib/index.ts
@@ -62,6 +62,7 @@ export default {
 };
 
 export type {ConsoleOpts} from './console';
+export type {TextStyle} from './console';
 export type {CopyFileOptions, ReadFn, WalkDirCallback} from './fs';
 export type {
   NetOptions,

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -64,7 +64,6 @@
     "sanitize-filename": "1.6.4",
     "semver": "7.8.1",
     "shell-quote": "1.8.4",
-    "supports-color": "10.2.2",
     "teen_process": "4.1.3",
     "type-fest": "5.7.0",
     "uuid": "14.0.0",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -45,7 +45,6 @@
   "dependencies": {
     "@appium/logger": "2.0.8",
     "@appium/types": "1.5.0",
-    "@colors/colors": "1.6.0",
     "archiver": "8.0.0",
     "asyncbox": "6.3.0",
     "axios": "1.17.0",

--- a/packages/support/test/unit/console.spec.ts
+++ b/packages/support/test/unit/console.spec.ts
@@ -1,0 +1,60 @@
+import {expect} from 'chai';
+import * as consoleModule from '../../lib/console';
+
+const {CliConsole, stripColors, styleText} = consoleModule;
+
+describe('console', function () {
+  it('should expose styleText and stripColors on the module namespace', function () {
+    expect(consoleModule.styleText).to.equal(styleText);
+    expect(consoleModule.stripColors).to.equal(stripColors);
+  });
+
+  describe('styleText()', function () {
+    it('should accept grey as an alias for gray', function () {
+      expect(stripColors(styleText('grey', 'muted'))).to.equal('muted');
+    });
+
+    it('should strip ANSI sequences from styled text', function () {
+      expect(stripColors(styleText('red', 'error'))).to.equal('error');
+    });
+
+    it('should leave plain text unchanged when stripping', function () {
+      expect(stripColors('plain')).to.equal('plain');
+    });
+  });
+
+  describe('CliConsole', function () {
+    describe('decorate()', function () {
+      it('should return undefined for undefined input', function () {
+        const cli = new CliConsole();
+        expect(cli.decorate(undefined, 'info')).to.be.undefined;
+      });
+
+      it('should return the message unchanged when symbols are disabled', function () {
+        const cli = new CliConsole({useSymbols: false});
+        expect(cli.decorate('hello', 'success')).to.equal('hello');
+      });
+
+      it('should prefix the message with a symbol', function () {
+        const cli = new CliConsole({useColor: false});
+        const decorated = cli.decorate('done', 'success');
+        expect(decorated).to.match(/^.\s+done$/);
+      });
+
+      it('should colorize when useColor is enabled', function () {
+        const cli = new CliConsole({useColor: true});
+        const decorated = cli.decorate('done', 'success')!;
+        expect(stripColors(decorated)).to.match(/^.\s+done$/);
+      });
+    });
+
+    it('should map symbols to the expected colors', function () {
+      expect(CliConsole.symbolToColor).to.eql({
+        success: 'green',
+        info: 'cyan',
+        warning: 'yellow',
+        error: 'red',
+      });
+    });
+  });
+});

--- a/packages/support/test/unit/console.spec.ts
+++ b/packages/support/test/unit/console.spec.ts
@@ -46,6 +46,30 @@ describe('console', function () {
         const decorated = cli.decorate('done', 'success')!;
         expect(stripColors(decorated)).to.match(/^.\s+done$/);
       });
+
+      describe('when useColor is defaulted from the environment', function () {
+        const originalEnv = {...process.env};
+
+        afterEach(function () {
+          process.env = {...originalEnv};
+        });
+
+        it('should not colorize when NO_COLOR is set', function () {
+          process.env.NO_COLOR = '1';
+          delete process.env.FORCE_COLOR;
+          const cli = new CliConsole();
+          const decorated = cli.decorate('done', 'success')!;
+          expect(decorated).to.equal(stripColors(decorated));
+        });
+
+        it('should colorize when FORCE_COLOR is set', function () {
+          delete process.env.NO_COLOR;
+          process.env.FORCE_COLOR = '1';
+          const cli = new CliConsole({useColor: undefined});
+          const decorated = cli.decorate('done', 'success')!;
+          expect(stripColors(decorated)).to.match(/^.\s+done$/);
+        });
+      });
     });
 
     it('should map symbols to the expected colors', function () {

--- a/packages/support/test/unit/console.spec.ts
+++ b/packages/support/test/unit/console.spec.ts
@@ -21,6 +21,11 @@ describe('console', function () {
     it('should leave plain text unchanged when stripping', function () {
       expect(stripColors('plain')).to.equal('plain');
     });
+
+    it('should strip non-SGR CSI sequences', function () {
+      expect(stripColors('hello\x1b[2Kworld')).to.equal('helloworld');
+      expect(stripColors('before\x1b[1Gafter')).to.equal('beforeafter');
+    });
   });
 
   describe('CliConsole', function () {
@@ -57,6 +62,14 @@ describe('console', function () {
         it('should not colorize when NO_COLOR is set', function () {
           process.env.NO_COLOR = '1';
           delete process.env.FORCE_COLOR;
+          const cli = new CliConsole();
+          const decorated = cli.decorate('done', 'success')!;
+          expect(decorated).to.equal(stripColors(decorated));
+        });
+
+        it('should not colorize when FORCE_COLOR is false regardless of case', function () {
+          delete process.env.NO_COLOR;
+          process.env.FORCE_COLOR = 'FALSE';
           const cli = new CliConsole();
           const decorated = cli.decorate('done', 'success')!;
           expect(decorated).to.equal(stripColors(decorated));


### PR DESCRIPTION
## Summary

Replaces terminal coloring dependencies with Node-native APIs and local helpers in `@appium/support`, continuing the dependency slimming effort.

- **`@colors/colors`**: Removed from root devDependencies, `@appium/support`, and `@appium/base-driver`. Migrated all string-prototype color usage (`.green`, `.red`, etc.) to `console.styleText()` from `@appium/support`.
- **`supports-color`**: Removed from `@appium/support`. `CliConsole` now uses a local `stderrSupportsColor()` helper that checks `NO_COLOR`, `NODE_DISABLE_COLORS`, `FORCE_COLOR`, `TERM`, and stderr TTY.
- **`console` module**: `styleText`, `stripColors`, and `TextStyle` live in [`packages/support/lib/console.ts`](packages/support/lib/console.ts) and are exposed via the `console` namespace (`import {console} from '@appium/support'` → `console.styleText(...)`).
- **Call sites updated**: CLI commands, doctor, bootstrap helpers, HTTP logging (`express-logging.ts`), and e2e/unit tests.
