### PR TITLE
fix(storage-plugin): add fs.sanitizeName for the delete request as well

### DIFF
--- a/packages/appium/docs/en/reference/api/plugins.md
+++ b/packages/appium/docs/en/reference/api/plugins.md
@@ -222,7 +222,7 @@ Deletes a file in the storage.
 #### Response
 
 `boolean` - `true` upon successful file deletion, or `false` if the file does not exist in
-the storage 
+the storage or if the `name` parameter is invalid.
 
 ### listStorageItems
 

--- a/packages/appium/docs/en/reference/api/plugins.md
+++ b/packages/appium/docs/en/reference/api/plugins.md
@@ -222,7 +222,7 @@ Deletes a file in the storage.
 #### Response
 
 `boolean` - `true` upon successful file deletion, or `false` if the file does not exist in
-the storage or if the `name` parameter is invalid.
+the storage, or if the delete request is invalid.
 
 ### listStorageItems
 

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -1,5 +1,10 @@
 import {BasePlugin} from 'appium/plugin';
-import {requireValidItemOptions, Storage, StorageArgumentError, validateStorageItemName} from './storage';
+import {
+  requireValidItemOptions,
+  Storage,
+  StorageArgumentError,
+  validateStorageItemName,
+} from './storage';
 import {tempDir, fs, logger, util} from '@appium/support';
 import type {AddRequestResult, ItemOptions, StorageItem} from './types';
 import type {Express, Request, Response} from 'express';
@@ -79,9 +84,7 @@ STORAGE_HANDLERS.deleteStorageItem = async function deleteStorageItem(
 ): Promise<boolean> {
   const {name} = parseRequestArgs(req, ['name']);
   validateStorageItemName(name);
-  return await executeStorageMethod(
-    async (storage: Storage) => await storage.delete(name),
-  );
+  return await executeStorageMethod(async (storage: Storage) => await storage.delete(name));
 };
 
 STORAGE_HANDLERS.resetStorage = async function resetStorage(): Promise<void> {

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -87,7 +87,7 @@ STORAGE_HANDLERS.deleteStorageItem = async function deleteStorageItem(
     name = parseRequestArgs(req, ['name']).name;
     validateStorageItemName(name);
   } catch (e) {
-    log.error(e);
+    log.error(`Failed to parse the request body for deleting a storage item: ${(e as Error).message}`);
     return false;
   }
   return await executeStorageMethod(async (storage: Storage) => await storage.delete(name));

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -87,7 +87,9 @@ STORAGE_HANDLERS.deleteStorageItem = async function deleteStorageItem(
     name = parseRequestArgs(req, ['name']).name;
     validateStorageItemName(name);
   } catch (e) {
-    log.error(`Failed to parse the request body for deleting a storage item: ${(e as Error).message}`);
+    log.error(
+      `Failed to parse the request body for deleting a storage item: ${(e as Error).message}`,
+    );
     return false;
   }
   return await executeStorageMethod(async (storage: Storage) => await storage.delete(name));

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -1,5 +1,5 @@
 import {BasePlugin} from 'appium/plugin';
-import {requireValidItemOptions, Storage, StorageArgumentError} from './storage';
+import {requireValidItemOptions, Storage, StorageArgumentError, validateStorageItemName} from './storage';
 import {tempDir, fs, logger, util} from '@appium/support';
 import type {AddRequestResult, ItemOptions, StorageItem} from './types';
 import type {Express, Request, Response} from 'express';
@@ -77,8 +77,10 @@ STORAGE_HANDLERS.listStorageItems = async function listStorageItems(): Promise<S
 STORAGE_HANDLERS.deleteStorageItem = async function deleteStorageItem(
   req: Request,
 ): Promise<boolean> {
+  const {name} = parseRequestArgs(req, ['name']);
+  validateStorageItemName(name);
   return await executeStorageMethod(
-    async (storage: Storage) => await storage.delete(parseRequestArgs(req, ['name']).name),
+    async (storage: Storage) => await storage.delete(name),
   );
 };
 

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -82,8 +82,14 @@ STORAGE_HANDLERS.listStorageItems = async function listStorageItems(): Promise<S
 STORAGE_HANDLERS.deleteStorageItem = async function deleteStorageItem(
   req: Request,
 ): Promise<boolean> {
-  const {name} = parseRequestArgs(req, ['name']);
-  validateStorageItemName(name);
+  let name: string;
+  try {
+    name = parseRequestArgs(req, ['name']).name;
+    validateStorageItemName(name);
+  } catch (e) {
+    log.error(e);
+    return false;
+  }
   return await executeStorageMethod(async (storage: Storage) => await storage.delete(name));
 };
 

--- a/packages/storage-plugin/lib/storage.ts
+++ b/packages/storage-plugin/lib/storage.ts
@@ -237,15 +237,7 @@ export function requireValidItemOptions(opts: ItemOptions): ItemOptions {
   if (util.isEmpty(opts.name)) {
     throw new StorageArgumentError(`The provided file name '${opts.name}' must not be empty`);
   }
-  const sanitizedName = fs.sanitizeName(opts.name, {
-    replacement: '_',
-  });
-  if (opts.name !== sanitizedName) {
-    throw new StorageArgumentError(
-      `The provided name value '${opts.name}' must be a valid file name. ` +
-        `Did you mean '${sanitizedName}'?`,
-    );
-  }
+  validateStorageItemName(opts.name);
   if (opts.sha1?.length !== SHA1_HASH_LEN) {
     throw new StorageArgumentError(
       `The provided hash value '${opts.sha1}' must be a valid SHA1 string, for ` +
@@ -253,6 +245,22 @@ export function requireValidItemOptions(opts: ItemOptions): ItemOptions {
     );
   }
   return opts;
+}
+
+/**
+ * Validate storage item name and throw if it is invalid.
+ * @param name The name to validate.
+ */
+export function validateStorageItemName(name: string): void {
+  const sanitizedName = fs.sanitizeName(name, {
+    replacement: '_',
+  });
+  if (name !== sanitizedName) {
+    throw new StorageArgumentError(
+      `The provided name value '${name}' must be a valid file name. ` +
+        `Did you mean '${sanitizedName}'?`,
+    );
+  }
 }
 
 function toTempName(origName: string): string {

--- a/packages/storage-plugin/lib/storage.ts
+++ b/packages/storage-plugin/lib/storage.ts
@@ -234,9 +234,6 @@ export class StorageArgumentError extends Error {}
  * @param opts Candidate item options.
  */
 export function requireValidItemOptions(opts: ItemOptions): ItemOptions {
-  if (util.isEmpty(opts.name)) {
-    throw new StorageArgumentError(`The provided file name '${opts.name}' must not be empty`);
-  }
   validateStorageItemName(opts.name);
   if (opts.sha1?.length !== SHA1_HASH_LEN) {
     throw new StorageArgumentError(
@@ -252,6 +249,10 @@ export function requireValidItemOptions(opts: ItemOptions): ItemOptions {
  * @param name The name to validate.
  */
 export function validateStorageItemName(name: string): void {
+  if (util.isEmpty(name)) {
+    throw new StorageArgumentError(`The provided file name '${name}' must not be empty`);
+  }
+
   const sanitizedName = fs.sanitizeName(name, {
     replacement: '_',
   });

--- a/packages/storage-plugin/test/unit/storage.spec.ts
+++ b/packages/storage-plugin/test/unit/storage.spec.ts
@@ -1,4 +1,4 @@
-import {Storage} from '../../lib/storage';
+import {Storage, StorageArgumentError, validateStorageItemName} from '../../lib/storage';
 import {tempDir, fs, logger} from '@appium/support';
 import path from 'node:path';
 import {expect, use} from 'chai';
@@ -107,6 +107,20 @@ describe('storage', function () {
     const files = await storage.list();
     expect(files).not.to.be.empty;
     expect(await fs.exists(storageRoot!)).to.be.true;
+  });
+
+  describe('validateStorageItemName', function () {
+    it('should accept valid file names', function () {
+      expect(() => validateStorageItemName('foo.bar')).not.to.throw();
+      expect(() => validateStorageItemName('foo-bar_baz')).not.to.throw();
+    });
+
+    it('should reject names that must be sanitized', function () {
+      expect(() => validateStorageItemName('foo/bar')).to.throw(
+        StorageArgumentError,
+        "The provided name value 'foo/bar' must be a valid file name. Did you mean 'foo_bar'?",
+      );
+    });
   });
 
   async function addFileToStorage(name: string, size: number): Promise<string> {

--- a/packages/storage-plugin/test/unit/storage.spec.ts
+++ b/packages/storage-plugin/test/unit/storage.spec.ts
@@ -121,6 +121,13 @@ describe('storage', function () {
         "The provided name value 'foo/bar' must be a valid file name. Did you mean 'foo_bar'?",
       );
     });
+
+    it('should reject empty file names', function () {
+      expect(() => validateStorageItemName('')).to.throw(
+        StorageArgumentError,
+        "The provided file name '' must not be empty",
+      );
+    });
   });
 
   async function addFileToStorage(name: string, size: number): Promise<string> {


### PR DESCRIPTION
## Proposed changes

`fs.sanitizeName` is applied to the file creation, but not for the deletion in the storage plugin.
It makes sense to apply the same check for the file deletion.

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
