### PR TITLE
docs: add AppiumConf 2026 archive & remove banner

### DIFF
--- a/packages/appium/docs/en/resources/index.md
+++ b/packages/appium/docs/en/resources/index.md
@@ -26,3 +26,4 @@ maintainers, Jonathan Lipps, with lots of useful guides
 - [AppiumConf 2021](https://www.youtube.com/playlist?list=PL9Z-JgiTsOYRCcJhDfmKAah9XmAp2b903)
 - [AppiumConf 2024](https://www.youtube.com/playlist?list=PL9Z-JgiTsOYQaU5i5LJtAWlh5WVZPi3If)
 - [SeleniumConf & AppiumConf 2025](https://www.youtube.com/playlist?list=PLRdSclUtJDYV2R92TLbmwxws6clruuTjH)
+- [SeleniumConf & AppiumConf 2026](https://www.youtube.com/playlist?list=PLRdSclUtJDYVgVqdKnSyBLBmFdA0KE_Dk)

--- a/packages/appium/docs/overrides/main.html
+++ b/packages/appium/docs/overrides/main.html
@@ -1,8 +1,0 @@
-{% extends "base.html" %}
-
-{% block announce %}
-    <center>
-    SeleniumConf & AppiumConf returns on May 6-8, 2026! Join us to learn and connect with the community!
-    <a href="https://seleniumconf.com/">Register Now</a>
-    </center>
-{% endblock %}


### PR DESCRIPTION
This PR removes the announcement banner for the now-finished SeleniumConf & AppiumConf 2026, and adds a link to an archive of the conference talks.