### PR TITLE
feat(docutils): add option to only use major version when deploying

### DIFF
--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -74,9 +74,16 @@ export interface DeployOpts {
    */
   message?: string;
   /**
-   * Version (dir) to deploy build to
+   * Version (dir) to deploy build to. If omitted, the version number is extracted from the
+   * `package.json` file.
    */
   deployVersion?: string;
+  /**
+   * If `true`, when extracting the deployment version from `package.json`, always use a
+   * v-prefixed major version number (e.g. `6.3.2` -> `v6`).
+   * Ignored if `deployVersion` is specified.
+   */
+  usePrefixedMajorDeployVersion?: boolean;
   /**
    * Alias for the build (e.g., `latest`); triggers alias update
    */
@@ -115,6 +122,7 @@ export async function deploy({
   mkdocsYml: mkDocsYmlPath,
   packageJson: packageJsonPath,
   deployVersion: version,
+  usePrefixedMajorDeployVersion: usePrefixedMajorVersion,
   cwd = process.cwd(),
   serve = false,
   push = false,
@@ -144,7 +152,7 @@ export async function deploy({
       `Could not find ${NAME_MKDOCS_YML} from ${cwd}; please run "${NAME_BIN} init"`,
     );
   }
-  version = version ?? (await findDeployVersion(packageJsonPath, cwd));
+  version = version ?? (await findDeployVersion(packageJsonPath, usePrefixedMajorVersion, cwd));
 
   // substitute %s in message with version
   message = message?.replace('%s', version);
@@ -234,9 +242,14 @@ async function doDeploy(mikePath: string, args: string[] = [], opts: TeenProcess
 /**
  * Derives a deployment version from `package.json`
  * @param packageJsonPath Path to `package.json` if known
+ * @param usePrefixedMajorVersion Whether to extract a v-prefixed major version
  * @param cwd Current working directory
  */
-async function findDeployVersion(packageJsonPath?: string, cwd = process.cwd()): Promise<string> {
+async function findDeployVersion(
+  packageJsonPath?: string,
+  usePrefixedMajorVersion?: boolean,
+  cwd = process.cwd(),
+): Promise<string> {
   const {pkg} = await readPackageJson(packageJsonPath ? path.dirname(packageJsonPath) : cwd, true);
   const version = pkg.version;
   if (!version) {
@@ -245,11 +258,11 @@ async function findDeployVersion(packageJsonPath?: string, cwd = process.cwd()):
     );
   }
 
-  // return MAJOR.MINOR as the version by default, if that is a thing we can extract, otherwise
-  // just return the version as is
+  // If a minor version can be extracted, use MAJOR.MINOR as the deploy version, otherwise use MAJOR.
+  // If usePrefixedMajorVersion is true, always use vMAJOR
   const versionParts = version.split('.');
   if (versionParts.length === 1) {
-    return version;
+    return usePrefixedMajorVersion ? `v${version}` : version;
   }
-  return `${versionParts[0]}.${versionParts[1]}`;
+  return usePrefixedMajorVersion ? `v${versionParts[0]}` : `${versionParts[0]}.${versionParts[1]}`;
 }

--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -245,7 +245,7 @@ async function doDeploy(mikePath: string, args: string[] = [], opts: TeenProcess
  * @param usePrefixedMajorVersion Whether to extract a v-prefixed major version
  * @param cwd Current working directory
  */
-async function findDeployVersion(
+export async function findDeployVersion(
   packageJsonPath?: string,
   usePrefixedMajorVersion?: boolean,
   cwd = process.cwd(),

--- a/packages/docutils/lib/cli/command/build.ts
+++ b/packages/docutils/lib/cli/command/build.ts
@@ -117,6 +117,12 @@ const opts = {
     requiresArg: true,
     defaultDescription: '(derived from package.json)',
   },
+  'use-prefixed-major-deploy-version': {
+    describe: 'Deploy using a v-prefixed major version',
+    implies: 'deploy',
+    group: BuildCommandGroup.Deploy,
+    type: 'boolean',
+  },
   alias: {
     describe: 'Alias for the build (e.g., "latest"); triggers alias update',
     implies: 'deploy',

--- a/packages/docutils/test/unit/builder.spec.ts
+++ b/packages/docutils/test/unit/builder.spec.ts
@@ -1,0 +1,52 @@
+import path from 'node:path';
+import {fs, tempDir} from '@appium/support';
+import {findDeployVersion} from '../../lib/builder/deploy';
+import {NAME_PACKAGE_JSON} from '../../lib/constants';
+import * as chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+chai.use(chaiAsPromised);
+const {expect} = chai;
+
+/**
+ * Helper function to create a project directory with package.json
+ */
+async function createPackageJson(
+  testDir: string,
+  packageJson: Record<string, any>,
+): Promise<string> {
+  await fs.mkdirp(testDir);
+  const packageJsonPath = path.join(testDir, NAME_PACKAGE_JSON);
+  await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8');
+  return packageJsonPath;
+}
+
+describe('findDeployVersion', function () {
+  let testDir: string;
+  let packageJsonPath: string;
+
+  before(async function () {
+    testDir = await tempDir.openDir();
+    packageJsonPath = await createPackageJson(testDir, {
+      version: '2.3.8',
+    });
+  });
+
+  after(async function () {
+    if (testDir) {
+      await fs.rimraf(testDir);
+    }
+  });
+
+  it('should use MAJOR.MINOR version by default', async function () {
+    expect(await findDeployVersion(packageJsonPath)).to.equal('2.3');
+  });
+
+  it('should use prefixed MAJOR version if usePrefixedMajorVersion is used', async function () {
+    expect(await findDeployVersion(packageJsonPath, true)).to.equal('v2');
+  });
+
+  it('should support custom working directory', async function () {
+    expect(await findDeployVersion(undefined, false, testDir)).to.equal('2.3');
+  });
+});


### PR DESCRIPTION
This PR adds the optional `use-prefixed-major-deploy-version` flag to the `appium-docs build` command, which causes the docs to be built for the current major version (plus the `v` prefix), instead of the major+minor version. This results in simpler documentation maintenance for projects that commonly receive minor versions (such as drivers).