### PR TITLE
docs: adjust plugin READMEs for consistency

### DIFF
--- a/packages/execute-driver-plugin/README.md
+++ b/packages/execute-driver-plugin/README.md
@@ -5,7 +5,7 @@
 [![NPM version](http://img.shields.io/npm/v/@appium/execute-driver-plugin.svg)](https://npmjs.org/package/@appium/execute-driver-plugin)
 [![Downloads](http://img.shields.io/npm/dm/@appium/execute-driver-plugin.svg)](https://npmjs.org/package/@appium/execute-driver-plugin)
 
-This plugin adds a new driver command that allows executing scripts in a child process. Currently,
+This plugin adds a new server endpoint that allows executing scripts in a child process. Currently,
 the only supported driver type is `webdriverio`, therefore the script must also be written in JS.
 
 ## Motivation
@@ -14,7 +14,7 @@ Running a driver script in a child process adds a degree of parallelisation, whi
 faster test execution.
 
 > [!WARNING]
-> This plugin enables execution of arbitrary JavaScript code. We recommend only using this plugin in a controlled environment. Scripts run in a Node.js `vm` context with a hardened view of the WebdriverIO driver (host-realm prototype metadata is not exposed), but `vm` is still not a full security boundary for untrusted code; treat `--allow-insecure=…:execute_driver_script` as highly privileged.
+> This plugin enables execution of arbitrary JavaScript code. We recommend only using this plugin in a controlled environment. Scripts run in a Node.js `vm` context with a hardened view of the WebdriverIO driver (host-realm prototype metadata is not exposed), but `vm` is still not a full security boundary for untrusted code; treat this plugin as highly privileged.
 
 ## Installation
 
@@ -22,18 +22,20 @@ faster test execution.
 appium plugin install execute-driver
 ```
 
-The plugin must be explicitly activated when launching the Appium server. Since the input script
-can be arbitrary JavaScript, this is an insecure feature, and must also be explicitly enabled:
+## Usage
+
+Like all plugins, this plugin must be explicitly activated when launching the Appium server. Since
+the input script can be arbitrary JavaScript, this is [an insecure feature](https://appium.io/docs/en/latest/guides/security/),
+and must also be explicitly enabled:
 
 ```
 appium --use-plugins=execute-driver --allow-insecure=<driver>:execute_driver_script
 ```
 
-`<driver>` is the name of the driver whose sessions will have access to the plugin.
-
-## Usage
+Once the plugin is running, you can call the new command:
 
 ```js
+// JavaScript (WebdriverIO)
 const script = `return await driver.getTimeouts();`;
 const {result, logs} = await driver.executeDriverScript(script);
 // 'result' contains the data returned by the script (in this case, the response to 'getTimeouts')
@@ -49,6 +51,10 @@ enabling the use of unconditional delays:
 // this will take around one second to execute
 const script = `return await new Promise((resolve) => setTimeout(resolve, 1000));`;
 ```
+
+## API
+
+[Refer to the Appium documentation](https://appium.io/docs/en/latest/reference/api/plugins/#execute-driver-plugin).
 
 ## License
 

--- a/packages/images-plugin/README.md
+++ b/packages/images-plugin/README.md
@@ -5,10 +5,10 @@
 [![NPM version](http://img.shields.io/npm/v/@appium/images-plugin.svg)](https://npmjs.org/package/@appium/images-plugin)
 [![Downloads](http://img.shields.io/npm/dm/@appium/images-plugin.svg)](https://npmjs.org/package/@appium/images-plugin)
 
-## Features
+This plugin provides two features for image-based testing:
 
-1. **Image Comparison** ([docs](./docs/image-comparison.md)) - A new Appium command and route that allows sending in two different images and comparing them in various ways.
-2. **Finding Elements by Image** ([docs](./docs/find-by-image.md)) - Using a template image, find a matching screen region of an app and interact with it via standard Appium element semantics.
+1. [**Image Comparison**](./docs/image-comparison.md) - A new Appium endpoint that allows accepts two images and allows comparing them in various ways
+2. [**Finding Elements by Image**](./docs/find-by-image.md) - Using a template image, find a matching screen region of an app, and interact with it using standard Appium element commands
 
 ## Installation
 
@@ -16,11 +16,20 @@
 appium plugin install images
 ```
 
-The plugin must be explicitly activated when launching the Appium server:
+## Usage
+
+Like all plugins, this plugin must be explicitly activated when launching the Appium server:
 
 ```
 appium --use-plugins=images
 ```
+
+Once the plugin is running, you can use its new and modified endpoints as described in the
+aforementioned guides.
+
+## API
+
+[Refer to the Appium documentation](https://appium.io/docs/en/latest/reference/api/plugins/#images-plugin).
 
 ## License
 

--- a/packages/relaxed-caps-plugin/README.md
+++ b/packages/relaxed-caps-plugin/README.md
@@ -24,11 +24,20 @@ capability requirements since Appium 2.
 appium plugin install relaxed-caps
 ```
 
-The plugin must be explicitly activated when launching the Appium server:
+## Usage
+
+Like all plugins, this plugin must be explicitly activated when launching the Appium server:
 
 ```
 appium --use-plugins=relaxed-caps
 ```
+
+Once the plugin is running, all unprefixed non-standard capabilities provided in any new session
+will automatically be prefixed with `appium:`.
+
+## API
+
+[Refer to the Appium documentation](https://appium.io/docs/en/latest/reference/api/plugins/#relaxed-caps-plugin).
 
 ## License
 

--- a/packages/storage-plugin/README.md
+++ b/packages/storage-plugin/README.md
@@ -2,6 +2,9 @@
 
 > Appium plugin for server-side file storage
 
+[![NPM version](http://img.shields.io/npm/v/@appium/storage-plugin.svg)](https://npmjs.org/package/@appium/storage-plugin)
+[![Downloads](http://img.shields.io/npm/dm/@appium/storage-plugin.svg)](https://npmjs.org/package/@appium/storage-plugin)
+
 This plugin adds the ability to create a dedicated storage space on the server side,
 which can be managed from the client side. This can be useful for files like application packages.
 Only one storage may exist per server process, shared by all testing sessions.
@@ -13,21 +16,22 @@ Only one storage may exist per server process, shared by all testing sessions.
 
 ## Installation
 
-```bash
+```
 appium plugin install storage
 ```
 
 ## Usage
 
-Add the plugin name to the list of plugins to use upon server startup:
+Like all plugins, this plugin must be explicitly activated when launching the Appium server:
 
-```bash
+```
 appium --use-plugins=storage
 ```
 
-By default, the plugin creates a new temporary folder where it manages uploaded files.
+Once the plugin is running, you can call its endpoints (see API section) to manage the storage
+space. These endpoints can be invoked even without an active Appium session.
 
-[Refer to the Appium documentation for the endpoints supported by this plugin.](https://appium.io/docs/en/latest/reference/api/storage-plugin/)
+By default, the plugin creates a new temporary folder where it manages uploaded files.
 
 ### Storing a File
 
@@ -55,23 +59,11 @@ Only flat files hierarchies are supported in the storage, no subfolders are allo
 If a file with the same name already exists in the storage, it will be overridden with the new one.
 If a folder with the same name already exists in the storage, an error will be thrown.
 
-### Environment Variables
+## API
 
-#### APPIUM_STORAGE_ROOT
+[Refer to the Appium documentation](https://appium.io/docs/en/latest/reference/api/plugins/#storage-plugin).
 
-It is also possible to customize the repository root folder path by assigning a custom path to the
-`APPIUM_STORAGE_ROOT` environment variable upon server startup. The plugin automatically deletes the
-root folder recursively upon server process termination, unless the server is
-killed forcefully. If `APPIUM_STORAGE_ROOT` points to an existing folder,
-then all files there are going to be preserved by default unless a different behavior is
-requested by [APPIUM_STORAGE_KEEP_ALL](#appium_storage_keep_all) environment variable value.
-
-#### APPIUM_STORAGE_KEEP_ALL
-
-If this environment variable is set to `true`, `1` or `yes` then the plugin will always keep
-storage files after the server process is terminated. All other
-values of this variable enforce the plugin to always delete all files
-from the storage folder.
+The plugin also supports [several environment variables](https://appium.io/docs/en/latest/reference/cli/env-vars/) for further customization.
 
 ## Examples
 

--- a/packages/universal-xml-plugin/README.md
+++ b/packages/universal-xml-plugin/README.md
@@ -6,8 +6,7 @@
 [![Downloads](http://img.shields.io/npm/dm/@appium/universal-xml-plugin.svg)](https://npmjs.org/package/@appium/universal-xml-plugin)
 
 This plugin takes the XML page source retrieved using an iOS or Android driver, and changes various
-node and attribute names to use common terminology that can apply to both platforms. This is
-achieved by altering the behavior of the `getPageSource` and `findElement` methods.
+node and attribute names to use common terminology that can apply to both platforms.
 
 ## Motivation
 
@@ -19,11 +18,20 @@ Having compatibility between iOS and Android XML sources can simplify creation o
 appium plugin install universal-xml
 ```
 
-The plugin must be explicitly activated when launching the Appium server:
+## Usage
+
+Like all plugins, this plugin must be explicitly activated when launching the Appium server:
 
 ```
 appium --use-plugins=universal-xml
 ```
+
+Once the plugin is running, it will intercept and transform the app source retrieved by the Get Page
+Source command, as well as element node/attribute names provided in Find Element-related commands.
+
+## API
+
+[Refer to the Appium documentation](https://appium.io/docs/en/latest/reference/api/plugins/#universal-xml-plugin).
 
 ## Examples
 


### PR DESCRIPTION
This is a docs update for the READMEs of all 5 plugins, improving consistency and linking their API docs.
For the storage plugin in particular, I've also added badges (that already existed for the other 4 plugins), and removed the environment variables section, instead redirecting users to the Appium docs, which already describe them.