### PR TITLE
chore: Update pluginE2EHarness to drop implicit mocha deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18944,7 +18944,7 @@
     },
     "packages/plugin-test-support": {
       "name": "@appium/plugin-test-support",
-      "version": "1.2.4",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "async-lock": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18947,6 +18947,7 @@
       "version": "1.2.4",
       "license": "Apache-2.0",
       "dependencies": {
+        "async-lock": "1.4.1",
         "teen_process": "4.1.5"
       },
       "devDependencies": {
@@ -18957,8 +18958,7 @@
         "npm": ">=10"
       },
       "peerDependencies": {
-        "appium": "^3.0.0-beta.0",
-        "mocha": "*"
+        "appium": "^3.0.0-beta.0"
       }
     },
     "packages/relaxed-caps-plugin": {

--- a/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.ts
+++ b/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.ts
@@ -3,16 +3,18 @@ import path from 'node:path';
 import {pluginE2EHarness} from '@appium/plugin-test-support';
 import {remote as wdio} from 'webdriverio';
 import {W3C_ELEMENT_KEY, MJSONWP_ELEMENT_KEY} from '../../lib/execute-child';
-import {fs} from '@appium/support';
+import {fs, node} from '@appium/support';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import type {AddressInfo} from 'node:net';
+import type {Browser} from 'webdriverio';
 
 use(chaiAsPromised);
 
-const THIS_PLUGIN_DIR = path.join(__dirname, '..', '..');
+const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/execute-driver-plugin', __filename)!;
 const APPIUM_HOME = path.join(THIS_PLUGIN_DIR, 'local_appium_home');
 const FAKE_DRIVER_DIR = path.join(THIS_PLUGIN_DIR, '..', 'fake-driver');
-const TEST_HOST = 'localhost';
+const TEST_HOST = '127.0.0.1';
 const TEST_FAKE_APP = path.join(
   APPIUM_HOME,
   'node_modules',
@@ -29,19 +31,18 @@ const TEST_CAPS = {
   'appium:deviceName': 'Fake',
   'appium:app': TEST_FAKE_APP,
 };
-const WDIO_OPTS = {
+type WebdriverIOConfig = Parameters<typeof wdio>[0];
+const WDIO_OPTS: WebdriverIOConfig = {
   hostname: TEST_HOST,
   connectionRetryCount: 0,
   capabilities: TEST_CAPS,
 };
 
 describe('ExecuteDriverPlugin', function () {
-  let driver: any;
+  let driver: Browser;
 
   const basicScript = `return 'foo'`;
   const e2eSetupOpts = {
-    before,
-    after,
     host: TEST_HOST,
     driverName: 'fake',
     driverSource: 'local' as const,
@@ -57,13 +58,24 @@ describe('ExecuteDriverPlugin', function () {
   });
 
   describe('without --allow-insecure set', function () {
-    after(async function () {
-      driver && (await driver.deleteSession());
+    let port: number;
+    const {setup, teardown} = pluginE2EHarness({...e2eSetupOpts});
+
+    before(async function () {
+      const {server} = await setup();
+      const address = server.address();
+      port = (address as AddressInfo).port;
+      driver = await wdio({...WDIO_OPTS, port});
     });
-    pluginE2EHarness({...e2eSetupOpts});
+    after(async function () {
+      try {
+        await driver?.deleteSession();
+      } finally {
+        await teardown();
+      }
+    });
 
     it('should not work unless the allowInsecure feature flag is set', async function () {
-      driver = await wdio({...WDIO_OPTS, port: this.port});
       await expect(driver.executeDriverScript(basicScript)).to.eventually.be.rejectedWith(
         /allow-insecure.+execute_driver_script/i,
       );
@@ -71,15 +83,23 @@ describe('ExecuteDriverPlugin', function () {
   });
 
   describe('with --allow-insecure set', function () {
-    after(async function () {
-      driver && (await driver.deleteSession());
-    });
-    pluginE2EHarness({
+    let port: number;
+    const {setup, teardown} = pluginE2EHarness({
       ...e2eSetupOpts,
       serverArgs: {allowInsecure: ['*:execute_driver_script']},
     });
     before(async function () {
-      driver = await wdio({...WDIO_OPTS, port: this.port});
+      const {server} = await setup();
+      const address = server.address();
+      port = (address as AddressInfo).port;
+      driver = await wdio({...WDIO_OPTS, port});
+    });
+    after(async function () {
+      try {
+        await driver?.deleteSession();
+      } finally {
+        await teardown();
+      }
     });
 
     it('should execute a webdriverio script in the context of session', async function () {
@@ -90,9 +110,9 @@ describe('ExecuteDriverPlugin', function () {
       `;
       const expectedTimeouts = {command: 60000, implicit: 0};
       const {result, logs} = await driver.executeDriverScript(script);
-      expect(result[0]).to.eql(expectedTimeouts);
-      expect(result[1].build).to.exist;
-      expect(result[1].build.version).to.exist;
+      expect((result as any)[0]).to.eql(expectedTimeouts);
+      expect((result as any)[1].build).to.exist;
+      expect((result as any)[1].build.version).to.exist;
       expect(logs).to.eql({error: [], warn: [], log: []});
     });
 
@@ -152,11 +172,11 @@ describe('ExecuteDriverPlugin', function () {
         return await driver.$("~notfound");
       `;
       const {result} = await driver.executeDriverScript(script);
-      expect(result.error.error).to.equal('no such element');
-      expect(result.error.message).to.match(/element could not be located/);
-      expect(result.error.stacktrace).to.include('NoSuchElementError:');
-      expect(result.selector).to.equal('~notfound');
-      expect(result.sessionId).to.equal(driver.sessionId);
+      expect((result as any).error.error).to.equal('no such element');
+      expect((result as any).error.message).to.match(/element could not be located/);
+      expect((result as any).error.stacktrace).to.include('NoSuchElementError:');
+      expect((result as any).selector).to.equal('~notfound');
+      expect((result as any).sessionId).to.equal(driver.sessionId);
     });
 
     it('should correctly handle errors that happen when a script cannot be compiled', async function () {

--- a/packages/images-plugin/test/e2e/plugin.e2e.spec.ts
+++ b/packages/images-plugin/test/e2e/plugin.e2e.spec.ts
@@ -3,7 +3,7 @@ import {remote as wdio} from 'webdriverio';
 import {MATCH_FEATURES_MODE, GET_SIMILARITY_MODE} from '../../lib/constants';
 import {TEST_IMG_1_B64, TEST_IMG_2_B64, APPSTORE_IMG_PATH} from '../fixtures/index.cjs';
 import {pluginE2EHarness} from '@appium/plugin-test-support';
-import {tempDir, fs} from '@appium/support';
+import {tempDir, fs, node} from '@appium/support';
 import sharp from 'sharp';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -11,7 +11,7 @@ import type {AddressInfo} from 'node:net';
 
 use(chaiAsPromised);
 
-const THIS_PLUGIN_DIR = path.join(__dirname, '..', '..');
+const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/images-plugin', __filename)!;
 const APPIUM_HOME = path.join(THIS_PLUGIN_DIR, 'local_appium_home');
 const FAKE_DRIVER_DIR = path.join(THIS_PLUGIN_DIR, '..', 'fake-driver');
 const TEST_HOST = '127.0.0.1';

--- a/packages/images-plugin/test/e2e/plugin.e2e.spec.ts
+++ b/packages/images-plugin/test/e2e/plugin.e2e.spec.ts
@@ -7,6 +7,7 @@ import {tempDir, fs} from '@appium/support';
 import sharp from 'sharp';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
+import type {AddressInfo} from 'node:net';
 
 use(chaiAsPromised);
 
@@ -14,7 +15,6 @@ const THIS_PLUGIN_DIR = path.join(__dirname, '..', '..');
 const APPIUM_HOME = path.join(THIS_PLUGIN_DIR, 'local_appium_home');
 const FAKE_DRIVER_DIR = path.join(THIS_PLUGIN_DIR, '..', 'fake-driver');
 const TEST_HOST = '127.0.0.1';
-const TEST_PORT = 4723;
 const TEST_FAKE_APP = path.join(
   APPIUM_HOME,
   'node_modules',
@@ -30,18 +30,15 @@ const TEST_CAPS = {
   'appium:deviceName': 'Fake',
   'appium:app': TEST_FAKE_APP,
 };
-const WDIO_OPTS = {
+type WebdriverIOConfig = Parameters<typeof wdio>[0];
+const WDIO_OPTS: WebdriverIOConfig = {
   hostname: TEST_HOST,
-  port: TEST_PORT,
   connectionRetryCount: 0,
   capabilities: TEST_CAPS,
 };
 
 describe('ImageElementPlugin', function () {
-  pluginE2EHarness({
-    before,
-    after,
-    port: TEST_PORT,
+  const {setup, teardown} = pluginE2EHarness({
     host: TEST_HOST,
     appiumHome: APPIUM_HOME,
     driverName: 'fake',
@@ -51,8 +48,16 @@ describe('ImageElementPlugin', function () {
     pluginSource: 'local',
     pluginSpec: THIS_PLUGIN_DIR,
   });
-
   let driver: any;
+
+  before(async function () {
+    const {server} = await setup();
+    const address = server.address();
+    WDIO_OPTS.port = (address as AddressInfo).port;
+  });
+  after(async function () {
+    await teardown();
+  });
 
   beforeEach(async function () {
     driver = await wdio(WDIO_OPTS);

--- a/packages/plugin-test-support/CHANGELOG.md
+++ b/packages/plugin-test-support/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [2.0.0]
+
+### ⚠ BREAKING CHANGES
+
+* Update the interface `E2ESetupOpts`. It does not accept `before` and `after` arguments anymore,
+  as well as it does not do any assumptions about the used test framework anymore.
+* Update the returned result of `pluginE2EHarness`. Instead of implicitly adding `before` and `after`
+  mocha callbacks it returns `setup` and `teardown` callbacks, that could be explicitly invoked at appropriate
+  test/suite stages.
+* Remove dependencies on mocha.
+
+
+
+
+
 ## [1.2.4](https://github.com/appium/appium/compare/@appium/plugin-test-support@1.2.3...@appium/plugin-test-support@1.2.4) (2026-06-18)
 
 **Note:** Version bump only for package @appium/plugin-test-support

--- a/packages/plugin-test-support/README.md
+++ b/packages/plugin-test-support/README.md
@@ -4,24 +4,23 @@
 
 This package is for plugin authors to help test their plugins.
 
-[Mocha](https://mochajs.org) is the supported test framework (but can theoretically be used with others).
-
 ## Usage
 
 ### For E2E Tests
 
-The `pluginE2EHarness` method configures a server and driver for testing via "before all" and "after all"-style hooks.
+The `pluginE2EHarness` method configures a server and driver for testing via setup/teardown callbacks.
 
 This example uses [WebdriverIO](https://webdriver.io) to communicate with a test Appium server.
 
-```js
+```ts
 import {pluginE2EHarness} from '@appium/plugin-test-support';
 import {remote} from 'webdriverio';
 
 describe('MyPlugin', function() {
-  pluginE2EHarness({
-    before: global.before, // from mocha
-    after: global.after, // from mocha
+  let port: number;
+  let hostname: string;
+
+  const {setup, teardown} = pluginE2EHarness({
     serverArgs: SOME_EXTRA_SERVER_ARGS,
     port: 31337,
     host: '127.0.0.1',
@@ -29,17 +28,26 @@ describe('MyPlugin', function() {
     driverName: 'fake', // driver to test with
     driverSource: 'local', // use "local" unless you want appium to install from npm every time
     driverSpec: FAKE_DRIVER_DIR, // path to local driver working copy or installation
-    pluginName: 'MyPlugin', // your plugin 
+    pluginName: 'MyPlugin', // your plugin
     pluginSource: 'local', // use "local" for this
     pluginSpec: THIS_PLUGIN_DIR, // dir of this plugin's `package.json`
   });
 
+  before(async function () {
+    const {server} = await setup();
+    const address = server.address();
+    port = address.port;
+    hostname = address.address;
+  });
+  after(async function () {
+    await teardown();
+  });
+
+
   it('should use my plugin', async function() {
     // at this point, the Appium server will be running with the plugin/driver combination of your
     // choosing
-
-    // port/host should match what you provided to `pluginE2EHarness`
-    const browser = await remote({port: 31337, hostname: '127.0.0.1'});
+    const browser = await remote({port, hostname});
   })
 });
 ```

--- a/packages/plugin-test-support/lib/harness.ts
+++ b/packages/plugin-test-support/lib/harness.ts
@@ -6,25 +6,12 @@ import {fs} from 'appium/support';
 import {main as appiumServer} from 'appium';
 import type {AppiumServer} from '@appium/types';
 import type {E2ESetupOpts, AppiumEnv} from './types';
+import AsyncLock from 'async-lock';
 
 declare const __filename: string;
 const _require = createRequire(__filename);
 const APPIUM_BIN = _require.resolve('appium') as string;
-
-async function getPort(): Promise<number> {
-  const server = net.createServer();
-  return await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, () => {
-      const address = server.address();
-      if (!address || typeof address === 'string') {
-        server.close(() => reject(new Error('Could not resolve a free port')));
-        return;
-      }
-      server.close((err) => (err ? reject(err) : resolve(address.port)));
-    });
-  });
-}
+const lock = new AsyncLock();
 
 const logSymbols = {
   info: 'ℹ',
@@ -35,12 +22,22 @@ const logSymbols = {
 
 /**
  * Creates hooks to install a driver and a plugin and starts an Appium server w/ the given extensions.
+ *
+ * @param opts - Options for the plugin E2E harness
+ * @returns An object with `setup` and `teardown` callbacks
+ * @throws {Error} If a free port could not be found
+ * @throws {Error} If the Appium server could not be started
+ * @throws {Error} If the driver could not be installed
+ * @throws {Error} If the plugin could not be installed
  */
-export function pluginE2EHarness(opts: E2ESetupOpts): void {
+export function pluginE2EHarness(opts: E2ESetupOpts): {
+  setup: () => Promise<{
+    server: AppiumServer;
+  }>;
+  teardown: () => Promise<void>;
+} {
   const {
     appiumHome,
-    before,
-    after,
     serverArgs = {},
     driverSource,
     driverPackage,
@@ -56,12 +53,7 @@ export function pluginE2EHarness(opts: E2ESetupOpts): void {
 
   let server: AppiumServer | undefined;
 
-  before(async function (this: Mocha.Context) {
-    // Lazy-load chai so smoke test (node ./build/lib/index.js --smoke-test) does not require it
-    const chai = await import('chai');
-    const chaiAsPromised = (await import('chai-as-promised')).default;
-    chai.use(chaiAsPromised);
-
+  const setup = async function setup() {
     const setupAppiumHome = async (): Promise<AppiumEnv> => {
       const env: AppiumEnv = {...process.env};
 
@@ -122,7 +114,6 @@ export function pluginE2EHarness(opts: E2ESetupOpts): void {
     const startAppiumServer = async (): Promise<void> => {
       const resolvedPort = port ?? (await getPort());
       console.log(`${logSymbols.info} Will use port ${resolvedPort} for Appium server`);
-      (this as Mocha.Context & {port?: number}).port = resolvedPort;
 
       const args = {
         port: resolvedPort,
@@ -139,11 +130,39 @@ export function pluginE2EHarness(opts: E2ESetupOpts): void {
     await installDriver(env);
     await installPlugin(env);
     await startAppiumServer();
-  });
+    return {server: server as AppiumServer};
+  };
 
-  after(async function () {
-    if (server) {
-      await server.close();
-    }
+  const teardown = async function teardown() {
+    await server?.close();
+  };
+
+  return {
+    setup,
+    teardown,
+  };
+}
+
+/**
+ * Returns a first available free port number on the local machine.
+ * The function call is race-free and thread-safe.
+ *
+ * @returns Port number
+ * @throws {Error} If a free port could not be found
+ */
+export async function getPort(): Promise<number> {
+  return await lock.acquire('getPort', async () => {
+    const server = net.createServer();
+    return await new Promise<number>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, () => {
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+          server.close(() => reject(new Error('Could not resolve a free port')));
+          return;
+        }
+        server.close((err) => (err ? reject(err) : resolve(address.port)));
+      });
+    });
   });
 }

--- a/packages/plugin-test-support/lib/index.ts
+++ b/packages/plugin-test-support/lib/index.ts
@@ -1,4 +1,4 @@
-export {pluginE2EHarness} from './harness';
+export {pluginE2EHarness, getPort} from './harness';
 export type {E2ESetupOpts, AppiumEnv} from './types';
 
 // Handle smoke test flag

--- a/packages/plugin-test-support/lib/types.ts
+++ b/packages/plugin-test-support/lib/types.ts
@@ -11,10 +11,6 @@ export interface AppiumEnv extends NodeJS.ProcessEnv {
 export interface E2ESetupOpts {
   /** Path to Appium home directory */
   appiumHome?: string;
-  /** Mocha "before all" hook function */
-  before: (fn: (this: Mocha.Context) => Promise<void>) => void;
-  /** Mocha "after all" hook function */
-  after: (fn: (this: Mocha.Context) => Promise<void>) => void;
   /** Arguments to pass to Appium server */
   serverArgs?: Record<string, unknown>;
   /** Source of driver to install (e.g. 'local', 'npm') */

--- a/packages/plugin-test-support/package.json
+++ b/packages/plugin-test-support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appium/plugin-test-support",
-  "version": "1.2.4",
+  "version": "2.0.0",
   "description": "Testing utilities for Appium plugins",
   "keywords": [
     "automation",
@@ -39,14 +39,14 @@
     "test:unit": "exit 0"
   },
   "dependencies": {
+    "async-lock": "1.4.1",
     "teen_process": "4.1.5"
   },
   "devDependencies": {
     "@appium/types": "1.5.1"
   },
   "peerDependencies": {
-    "appium": "^3.0.0-beta.0",
-    "mocha": "*"
+    "appium": "^3.0.0-beta.0"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",

--- a/packages/plugin-test-support/tsconfig.json
+++ b/packages/plugin-test-support/tsconfig.json
@@ -9,7 +9,7 @@
       "appium/support": ["../support"],
       "appium": ["../appium"]
     },
-    "types": ["mocha", "chai", "sinon", "chai-as-promised", "node"]
+    "types": ["chai", "sinon", "chai-as-promised", "node"]
   },
   "include": ["./lib"],
   "references": [{"path": "../types"}, {"path": "../support"}]

--- a/packages/plugin-test-support/tsconfig.json
+++ b/packages/plugin-test-support/tsconfig.json
@@ -9,7 +9,7 @@
       "appium/support": ["../support"],
       "appium": ["../appium"]
     },
-    "types": ["chai", "sinon", "chai-as-promised", "node"]
+    "types": ["node"]
   },
   "include": ["./lib"],
   "references": [{"path": "../types"}, {"path": "../support"}]

--- a/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
+++ b/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
@@ -5,13 +5,13 @@ import {tempDir, fs} from '@appium/support';
 import axios from 'axios';
 import {WebSocket} from 'ws';
 import {expect} from 'chai';
+import type {AddressInfo} from 'node:net';
 
 const BUFFER_SIZE = 0xffff;
 const THIS_PLUGIN_DIR = path.join(__dirname, '..', '..');
 const APPIUM_HOME = path.join(THIS_PLUGIN_DIR, 'local_appium_home');
 const FAKE_DRIVER_DIR = path.join(THIS_PLUGIN_DIR, '..', 'fake-driver');
 const TEST_HOST = '127.0.0.1';
-const TEST_PORT = 4725;
 const TEST_FAKE_APP = path.join(
   APPIUM_HOME,
   'node_modules',
@@ -27,9 +27,9 @@ const TEST_CAPS = {
   'appium:deviceName': 'Fake',
   'appium:app': TEST_FAKE_APP,
 };
-const WDIO_OPTS = {
+type WebdriverIOConfig = Parameters<typeof wdio>[0];
+const WDIO_OPTS: WebdriverIOConfig = {
   hostname: TEST_HOST,
-  port: TEST_PORT,
   connectionRetryCount: 0,
   capabilities: TEST_CAPS,
 };
@@ -37,11 +37,29 @@ const WDIO_OPTS = {
 describe('StoragePlugin', function () {
   let driver: any;
   let storageRoot: string | undefined;
+  const {setup, teardown} = pluginE2EHarness({
+    host: TEST_HOST,
+    appiumHome: APPIUM_HOME,
+    driverName: 'fake',
+    driverSource: 'local',
+    driverSpec: FAKE_DRIVER_DIR,
+    pluginName: 'storage',
+    pluginSource: 'local',
+    pluginSpec: THIS_PLUGIN_DIR,
+  });
+  before(async function () {
+    const {server} = await setup();
+    const address = server.address();
+    WDIO_OPTS.port = (address as AddressInfo).port;
+  });
+  after(async function () {
+    await teardown();
+  });
 
   beforeEach(async function () {
     storageRoot = await tempDir.openDir();
     driver = await wdio(WDIO_OPTS);
-    const baseUrl = `http://${TEST_HOST}:${TEST_PORT}/storage`;
+    const baseUrl = `http://${TEST_HOST}:${WDIO_OPTS.port}/storage`;
     driver.addCommand(
       'addStorageItem',
       async (name: string, sha1: string) =>
@@ -72,20 +90,6 @@ describe('StoragePlugin', function () {
     }
   });
 
-  pluginE2EHarness({
-    before,
-    after,
-    port: TEST_PORT,
-    host: TEST_HOST,
-    appiumHome: APPIUM_HOME,
-    driverName: 'fake',
-    driverSource: 'local',
-    driverSpec: FAKE_DRIVER_DIR,
-    pluginName: 'storage',
-    pluginSource: 'local',
-    pluginSpec: THIS_PLUGIN_DIR,
-  });
-
   it('should manage storage files', async function () {
     let items = await driver.listStorageItems();
     expect(items).to.be.empty;
@@ -114,8 +118,8 @@ describe('StoragePlugin', function () {
     const {
       ws: {events, stream},
     } = await driver.addStorageItem(name, hash, sourcePath);
-    const streamWs = new WebSocket(`ws://${TEST_HOST}:${TEST_PORT}${stream}`);
-    const eventsWs = new WebSocket(`ws://${TEST_HOST}:${TEST_PORT}${events}`);
+    const streamWs = new WebSocket(`ws://${TEST_HOST}:${WDIO_OPTS.port}${stream}`);
+    const eventsWs = new WebSocket(`ws://${TEST_HOST}:${WDIO_OPTS.port}${events}`);
     try {
       await new Promise<void>((resolve, reject) => {
         streamWs.once('error', reject);

--- a/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
+++ b/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
@@ -1,14 +1,14 @@
 import path from 'node:path';
 import {remote as wdio} from 'webdriverio';
 import {pluginE2EHarness} from '@appium/plugin-test-support';
-import {tempDir, fs} from '@appium/support';
+import {tempDir, fs, node} from '@appium/support';
 import axios from 'axios';
 import {WebSocket} from 'ws';
 import {expect} from 'chai';
 import type {AddressInfo} from 'node:net';
 
 const BUFFER_SIZE = 0xffff;
-const THIS_PLUGIN_DIR = path.join(__dirname, '..', '..');
+const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/storage-plugin', __filename)!;
 const APPIUM_HOME = path.join(THIS_PLUGIN_DIR, 'local_appium_home');
 const FAKE_DRIVER_DIR = path.join(THIS_PLUGIN_DIR, '..', 'fake-driver');
 const TEST_HOST = '127.0.0.1';


### PR DESCRIPTION
This does breaking changes to `plugin-test-support`, although changing it breaks building of other plugins, so I had to bump the major version manually and  also added the corresponding changelog entry, but the CI still passes.

Split of https://github.com/appium/appium/pull/22415 (one of many)