### PR TITLE
fix(base-driver): redact proxied response body in proxy logs

### DIFF
--- a/packages/base-driver/lib/jsonwp-proxy/proxy.ts
+++ b/packages/base-driver/lib/jsonwp-proxy/proxy.ts
@@ -241,7 +241,7 @@ export class JWProxy {
         // If it cannot be coerced to an object then the response is wrong
         throwProxyError(data);
       }
-      this.log.debug(`Got response with status ${status}: ${truncateBody(data)}`);
+      this.log.debug(`Got response with status ${status}: %s`, logger.markSensitive(truncateBody(data)));
       isResponseLogged = true;
       const isSessionCreationRequest = url.endsWith('/session') && method === 'POST';
       if (isSessionCreationRequest) {
@@ -269,11 +269,12 @@ export class JWProxy {
       let proxyErrorMsg = err.message;
       if (util.hasValue(err.response)) {
         if (!isResponseLogged) {
-          const error = truncateBody(err.response.data);
+          const error = logger.markSensitive(truncateBody(err.response.data));
           this.log.info(
             util.hasValue(err.response.status)
-              ? `Got response with status ${err.response.status}: ${error}`
-              : `Got response with unknown status: ${error}`,
+              ? `Got response with status ${err.response.status}: %s`
+              : `Got response with unknown status: %s`,
+            error,
           );
         }
       } else {


### PR DESCRIPTION
### Problem

`JWProxy` already redacts the **request** body in its logs via `logger.markSensitive(...)` — see the `Proxying [...]` debug line and the `Invalid body payload` warning. But the **response** body is logged unmasked in two places:

- success path — `` this.log.debug(`Got response with status ${status}: ${truncateBody(data)}`) ``
- error path — `` this.log.info(`Got response with status ...: ${error}`) `` where `error = truncateBody(err.response.data)`

Response payloads can carry the same sensitive material as requests (tokens, credentials, session data), so secret redaction under `--log-filters` is applied inconsistently: requests are protected, responses are not.

### Fix

Pass both proxied response-body log lines through `logger.markSensitive(...)`, matching the request-side pattern already used in this file. No behavioural change beyond making the response body eligible for the same secure-values redaction as the request body.

### How tested

The change mirrors the existing `logger.markSensitive(truncateBody(...))` usage already present in `proxy.ts` for request logging — no new API surface. Relies on the existing CI (lint / build / base-driver unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)