### PR TITLE
chore: Remove redundant chai type references

### DIFF
--- a/packages/appium/tsconfig.json
+++ b/packages/appium/tsconfig.json
@@ -15,7 +15,7 @@
       "appium": ["."]
     },
     "checkJs": true,
-    "types": ["node", "chai", "chai-as-promised"]
+    "types": ["node"]
   },
   "include": ["lib", "types", "test"],
   "references": [

--- a/packages/docutils/tsconfig.json
+++ b/packages/docutils/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": ".",
     "outDir": "build",
     "checkJs": true,
-    "types": ["node", "chai"],
+    "types": ["node"],
     "paths": {
       "@appium/support": ["../support"],
       "@appium/types": ["../types"]

--- a/packages/execute-driver-plugin/tsconfig.json
+++ b/packages/execute-driver-plugin/tsconfig.json
@@ -5,7 +5,7 @@
     "checkJs": true,
     "esModuleInterop": true,
     "strict": true,
-    "types": ["node", "chai", "chai-as-promised"]
+    "types": ["node"]
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib", "test"],

--- a/packages/fake-driver/tsconfig.json
+++ b/packages/fake-driver/tsconfig.json
@@ -11,7 +11,7 @@
     "outDir": "build",
     "checkJs": true,
     "strict": true,
-    "types": ["node", "chai", "chai-as-promised"],
+    "types": ["node"],
     "paths": {
       "@appium/types": ["../types"],
       "appium/support": ["../appium/support"],

--- a/packages/images-plugin/tsconfig.json
+++ b/packages/images-plugin/tsconfig.json
@@ -8,7 +8,7 @@
     "paths": {
       "@appium/opencv": ["../opencv"]
     },
-    "types": ["node", "chai", "sinon", "chai-as-promised"]
+    "types": ["node"]
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib", "test"],

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "strict": true,
     "outDir": "build",
-    "types": ["node", "chai"],
+    "types": ["node"],
     "checkJs": true
   },
   "include": ["lib", "test"]

--- a/packages/opencv/tsconfig.json
+++ b/packages/opencv/tsconfig.json
@@ -5,7 +5,7 @@
     "rootDir": ".",
     "outDir": "build",
     "checkJs": true,
-    "types": ["node", "chai", "chai-as-promised"]
+    "types": ["node"]
   },
   "include": ["lib", "test"]
 }

--- a/packages/relaxed-caps-plugin/tsconfig.json
+++ b/packages/relaxed-caps-plugin/tsconfig.json
@@ -3,7 +3,7 @@
     "strict": true,
     "rootDir": ".",
     "outDir": "build",
-    "types": ["node", "chai"]
+    "types": ["node"]
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib", "test"],

--- a/packages/storage-plugin/tsconfig.json
+++ b/packages/storage-plugin/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": ".",
     "outDir": "build",
     "checkJs": true,
-    "types": ["node", "chai", "chai-as-promised"]
+    "types": ["node"]
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib", "test"],

--- a/packages/strongbox/tsconfig.json
+++ b/packages/strongbox/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "build",
     "strict": true,
     "checkJs": true,
-    "types": ["node", "chai", "chai-as-promised"]
+    "types": ["node"]
   },
   "include": ["lib", "test/unit", "test/e2e"],
   "exclude": ["build"]

--- a/packages/support/tsconfig.json
+++ b/packages/support/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "build",
     "strict": true,
     "paths": {"@appium/types": ["../types"]},
-    "types": ["node", "chai", "chai-as-promised"]
+    "types": ["node"]
   },
   "include": ["lib", "test"],
   "references": [{"path": "../types"}, {"path": "../logger"}]


### PR DESCRIPTION
Since we use explicit imports (no implicit things like `should`) these type references are redundant now. We only should rely on native implicit types provided by node