### PR TITLE
feat(appium): add --allow-unknown-args to tolerate unrecognized server CLI arguments

### DIFF
--- a/packages/appium/docs/en/reference/cli/server.md
+++ b/packages/appium/docs/en/reference/cli/server.md
@@ -29,6 +29,7 @@ appium
 |`--address`, `-a`|IPv4/IPv6 address to listen on|string|`0.0.0.0`|
 |`--allow-cors`|Allow web browser connections from any host|boolean|`false`|
 |`--allow-insecure`|List of [insecure features](../../guides/security.md) that should be allowed in this server's sessions. Individual features can be overridden by `--deny-insecure`. Has no effect in combination with `--relaxed-security`.|array<string>|`[]`|
+|`--allow-unknown-args`|Do not exit if unrecognized command-line arguments are passed to the server; ignore them instead. Useful when the Appium CLI is wrapped by external tooling that appends extra flags.|boolean|`false`|
 |`--base-path`, `-pa`|Base path to use as the prefix for all webdriver routes running on the server|string|`""`|
 |`--callback-address`, `-ca`|Callback IP address|string|`0.0.0.0`|
 |`--callback-port`, `-cp`|Callback port|integer|`4723`|

--- a/packages/appium/lib/cli/parser.ts
+++ b/packages/appium/lib/cli/parser.ts
@@ -323,6 +323,13 @@ export class ArgParser {
       if (unknownArgs?.length && (knownArgs.driverCommand === 'run' || knownArgs.pluginCommand === 'run')) {
         return ArgParser._transformParsedArgs(knownArgs, unknownArgs);
       } else if (unknownArgs?.length) {
+        if (knownArgs.allowUnknownArgs) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `[WARN] Ignoring unrecognized arguments because '--allow-unknown-args' is set: ${unknownArgs.join(' ')}`,
+          );
+          return ArgParser._transformParsedArgs(knownArgs);
+        }
         throw new Error(`[ERROR] Unrecognized arguments: ${unknownArgs.join(' ')}`);
       }
       return ArgParser._transformParsedArgs(knownArgs);

--- a/packages/appium/test/e2e/args.e2e.spec.ts
+++ b/packages/appium/test/e2e/args.e2e.spec.ts
@@ -108,13 +108,7 @@ describe('argument parsing', function () {
       await expect(
         exec(
           process.execPath,
-          [
-            EXECUTABLE,
-            '--pigs=sheep',
-            '--allow-unknown-args',
-            '--port',
-            String(await getTestPort()),
-          ],
+          [EXECUTABLE, '--pigs=sheep', '--allow-unknown-args', '--port', String(await getTestPort())],
           {
             env: {APPIUM_HOME: appiumHome, PATH: process.env.PATH},
             cwd: APPIUM_ROOT,

--- a/packages/appium/test/e2e/args.e2e.spec.ts
+++ b/packages/appium/test/e2e/args.e2e.spec.ts
@@ -98,4 +98,30 @@ describe('argument parsing', function () {
       expect(formatAppiumArgErrorOutput(actual)).to.equal(expected);
     });
   });
+
+  describe('when the user provides an unknown argument with --allow-unknown-args', function () {
+    it('should tolerate the unknown argument and start the server', {timeout: 10000}, async function () {
+      // Unlike the unknown-argument case above, `--allow-unknown-args` must not abort parsing:
+      // the unrecognized flag is ignored and the server starts. We assert the run reaches
+      // server startup (and thus hits the exec timeout) instead of exiting early with an
+      // argument-parsing error.
+      await expect(
+        exec(
+          process.execPath,
+          [
+            EXECUTABLE,
+            '--pigs=sheep',
+            '--allow-unknown-args',
+            '--port',
+            String(await getTestPort()),
+          ],
+          {
+            env: {APPIUM_HOME: appiumHome, PATH: process.env.PATH},
+            cwd: APPIUM_ROOT,
+            timeout: 5000,
+          },
+        ),
+      ).to.be.rejectedWith(Error, /timed out/);
+    });
+  });
 });

--- a/packages/appium/test/fixtures/default-args.ts
+++ b/packages/appium/test/fixtures/default-args.ts
@@ -2,6 +2,7 @@ export default {
   address: '0.0.0.0',
   allowCors: false,
   allowInsecure: [] as string[],
+  allowUnknownArgs: false,
   basePath: '',
   callbackPort: 4723,
   debugLogSpacing: false,

--- a/packages/schema/lib/appium-config-schema.ts
+++ b/packages/schema/lib/appium-config-schema.ts
@@ -56,6 +56,13 @@ export const AppiumConfigJsonSchema = {
           type: 'array',
           uniqueItems: true,
         },
+        'allow-unknown-args': {
+          description:
+            'Do not exit if unrecognized command-line arguments are passed to the server; ignore them instead. This can be useful when the Appium CLI is wrapped by external tooling that appends extra flags. Disabled by default, so unknown arguments are still treated as errors.',
+          title: 'allow-unknown-args config',
+          type: 'boolean',
+          default: false,
+        },
         'base-path': {
           appiumCliAliases: ['pa'],
           default: '',

--- a/packages/schema/lib/appium-config.schema.json
+++ b/packages/schema/lib/appium-config.schema.json
@@ -49,6 +49,12 @@
           "type": "array",
           "uniqueItems": true
         },
+        "allow-unknown-args": {
+          "description": "Do not exit if unrecognized command-line arguments are passed to the server; ignore them instead. This can be useful when the Appium CLI is wrapped by external tooling that appends extra flags. Disabled by default, so unknown arguments are still treated as errors.",
+          "title": "allow-unknown-args config",
+          "type": "boolean",
+          "default": false
+        },
         "base-path": {
           "appiumCliAliases": [
             "pa"

--- a/packages/types/lib/appium-config.ts
+++ b/packages/types/lib/appium-config.ts
@@ -18,6 +18,10 @@ export type AllowCorsConfig = boolean;
  */
 export type AllowInsecureConfig = string[];
 /**
+ * Do not exit if unrecognized command-line arguments are passed to the server; ignore them instead. This can be useful when the Appium CLI is wrapped by external tooling that appends extra flags. Disabled by default, so unknown arguments are still treated as errors.
+ */
+export type AllowUnknownArgsConfig = boolean;
+/**
  * Base path to use as the prefix for all webdriver routes running on the server
  */
 export type BasePathConfig = string;
@@ -197,6 +201,7 @@ export interface ServerConfig {
   address?: AddressConfig;
   "allow-cors"?: AllowCorsConfig;
   "allow-insecure"?: AllowInsecureConfig;
+  "allow-unknown-args"?: AllowUnknownArgsConfig;
   "base-path"?: BasePathConfig;
   "callback-address"?: CallbackAddressConfig;
   "callback-port"?: CallbackPortConfig;


### PR DESCRIPTION
### Problem
`ArgParser#parseArgs` already parses with argparse's `parse_known_args`, and only throws when
unrecognized arguments remain (the `run` subcommand is the exception — it forwards them as
`extraArgs`):

```ts
} else if (unknownArgs?.length) {
  throw new Error(`[ERROR] Unrecognized arguments: ${unknownArgs.join(' ')}`);
}
```

When the Appium CLI is wrapped by external tooling (device farms, CI harnesses, launchers) that
appends extra flags the server doesn't recognize, this hard-exit is difficult to work around
without patching Appium. Today the only options are to strip those args before invocation or to
patch the parser/argparse.

### Fix
Add an opt-in boolean server argument **`--allow-unknown-args`** (default `false`). When set,
unrecognized server arguments are logged (stderr) and ignored instead of exiting. Default behavior
is unchanged — unknown args are still an error.

### Changes
- `packages/schema/lib/appium-config-schema.ts`: add the `allow-unknown-args` boolean server property.
- `packages/schema/lib/appium-config.schema.json`: mirror the generated entry (hand-added to match
  the source; can be regenerated via the schema build if preferred).
- `packages/appium/lib/cli/parser.ts`: when `allowUnknownArgs` is set, log + ignore leftover args
  instead of throwing.

### Notes
- Opt-in and default-off, so it can't mask typos for existing users.
- I hand-mirrored the generated `appium-config.schema.json` entry to keep source/artifact in sync;
  happy to regenerate it via the repo's schema generator and to add unit tests + docs if the
  direction looks good to maintainers.
