### PR TITLE
chore(deps): update argparse to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@eslint/js": "10.0.1",
         "@stylistic/eslint-plugin": "5.10.0",
         "@tsconfig/node20": "20.1.9",
-        "@types/argparse": "2.0.17",
         "@types/async-lock": "1.4.2",
         "@types/bluebird": "3.5.42",
         "@types/chai": "5.2.3",
@@ -3706,13 +3705,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/argparse": {
-      "version": "2.0.17",
-      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.17.tgz",
-      "integrity": "sha512-fueJssTf+4dW4HODshEGkIZbkLKHzgu1FvCI4cTc/MKum/534Euo3SrN+ilq8xgyHnOjtmg33/hee8iXLRg1XA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/async-lock": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
@@ -5349,6 +5341,7 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -18117,7 +18110,7 @@
         "@sidvind/better-ajv-errors": "5.0.0",
         "ajv": "8.20.0",
         "ajv-formats": "3.0.1",
-        "argparse": "2.0.1",
+        "argparse": "3.0.0",
         "asyncbox": "6.3.5",
         "axios": "1.18.1",
         "lilconfig": "3.1.3",
@@ -18137,6 +18130,22 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
       }
+    },
+    "packages/appium/node_modules/argparse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "Python-2.0"
     },
     "packages/appium/node_modules/lilconfig": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@eslint/js": "10.0.1",
     "@stylistic/eslint-plugin": "5.10.0",
     "@tsconfig/node20": "20.1.9",
-    "@types/argparse": "2.0.17",
     "@types/async-lock": "1.4.2",
     "@types/bluebird": "3.5.42",
     "@types/chai": "5.2.3",

--- a/packages/appium/lib/cli/parser.ts
+++ b/packages/appium/lib/cli/parser.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type {DriverType, PluginType} from '@appium/types';
 import type {CliExtensionSubcommand} from 'appium/types';
 import {ArgumentParser} from 'argparse';
-import type {SubArgumentParserOptions, SubParser} from 'argparse';
+import type {SubArgumentParserOptions, SubparsersAction} from 'argparse';
 
 import {
   DRIVER_TYPE,
@@ -158,7 +158,7 @@ export class ArgParser {
   /**
    * Adds the `server` subcommand parser and returns its argument definitions.
    */
-  private static _addServerToParser(subParser: SubParser): ArgumentDefinitions {
+  private static _addServerToParser(subParser: SubparsersAction): ArgumentDefinitions {
     const serverParser = subParser.add_parser('server', {
       add_help: true,
       help: 'Start an Appium server',
@@ -179,7 +179,7 @@ export class ArgParser {
   /**
    * Adds extension sub-sub-commands to `driver`/`plugin` subcommands
    */
-  private static _addExtensionCommandsToParser(subParser: SubParser): void {
+  private static _addExtensionCommandsToParser(subParser: SubparsersAction): void {
     for (const type of [DRIVER_TYPE, PLUGIN_TYPE] as [DriverType, PluginType]) {
       const extParser = subParser.add_parser(type, {
         add_help: true,
@@ -252,7 +252,7 @@ export class ArgParser {
   /**
    * Add subcommand and sub-sub commands for 'setup' subcommand.
    */
-  private static _addSetupToParser(subParser: SubParser): void {
+  private static _addSetupToParser(subParser: SubparsersAction): void {
     const setupParser = subParser.add_parser('setup', {
       add_help: true,
       help: 'Batch install or uninstall Appium drivers and plugins',

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -74,7 +74,7 @@
     "@sidvind/better-ajv-errors": "5.0.0",
     "ajv": "8.20.0",
     "ajv-formats": "3.0.1",
-    "argparse": "2.0.1",
+    "argparse": "3.0.0",
     "asyncbox": "6.3.5",
     "axios": "1.18.1",
     "lilconfig": "3.1.3",


### PR DESCRIPTION
Replaces #22506.

Worth noting that as per the argparse changelog, help output is now colored by default. I don't really expect this to cause issues.