### PR TITLE
fix: use module sync in appium/support

### DIFF
--- a/packages/base-driver/lib/test-pages/static-dir.ts
+++ b/packages/base-driver/lib/test-pages/static-dir.ts
@@ -1,3 +1,4 @@
+import {node} from '@appium/support';
 import path from 'node:path';
 
 /**
@@ -9,11 +10,9 @@ import path from 'node:path';
 export const TEST_FIXTURES_DIR = resolveTestFixturesDir();
 
 function resolveTestFixturesDir(): string {
-  const fromDir = __dirname;
-  const parts = path.resolve(fromDir).split(path.sep);
-  const baseDriverIndex = parts.indexOf('base-driver');
-  if (baseDriverIndex < 0) {
-    throw new Error(`Could not find the module root folder in the path: ${fromDir}`);
+  const packageRoot = node.getModuleRootSync('@appium/base-driver', __filename);
+  if (!packageRoot) {
+    throw new Error(`Could not find the module root folder for @appium/base-driver`);
   }
-  return path.join(parts.slice(0, baseDriverIndex + 1).join(path.sep), 'test-fixtures', 'static');
+  return path.join(packageRoot, 'test-fixtures', 'static');
 }

--- a/packages/base-driver/lib/test-pages/static-dir.ts
+++ b/packages/base-driver/lib/test-pages/static-dir.ts
@@ -1,5 +1,6 @@
-import {node} from '@appium/support';
 import path from 'node:path';
+
+import {node} from '@appium/support';
 
 /**
  * Absolute path to bundled legacy test fixture static files.

--- a/packages/base-driver/lib/test-pages/static-dir.ts
+++ b/packages/base-driver/lib/test-pages/static-dir.ts
@@ -12,7 +12,7 @@ export const TEST_FIXTURES_DIR = resolveTestFixturesDir();
 function resolveTestFixturesDir(): string {
   const packageRoot = node.getModuleRootSync('@appium/base-driver', __filename);
   if (!packageRoot) {
-    throw new Error(`Could not find the module root folder for @appium/base-driver`);
+    throw new Error(`Could not find the module root folder for @appium/base-driver from ${__filename}`);
   }
   return path.join(packageRoot, 'test-fixtures', 'static');
 }

--- a/packages/base-driver/test/unit/test-pages/static-dir.spec.ts
+++ b/packages/base-driver/test/unit/test-pages/static-dir.spec.ts
@@ -1,16 +1,16 @@
-import {existsSync} from 'node:fs';
+import assert from 'node:assert/strict';
 import path from 'node:path';
 import {describe, it} from 'node:test';
 
-import {expect} from 'chai';
+import {fs, node} from '@appium/support';
 
 import {TEST_FIXTURES_DIR} from '../../../lib/test-pages/static-dir';
 
 describe('test page static directory', function () {
-  it('should resolve the bundled test fixtures', function () {
-    expect(TEST_FIXTURES_DIR).to.equal(
-      path.resolve(__dirname, '..', '..', '..', '..', 'test-fixtures', 'static'),
-    );
-    expect(existsSync(TEST_FIXTURES_DIR)).to.be.true;
+  it('should resolve the bundled test fixtures', async function () {
+    const pkgRoot = node.getModuleRootSync('@appium/base-driver', __filename);
+    assert.notEqual(pkgRoot, null);
+    assert.equal(TEST_FIXTURES_DIR, path.join(pkgRoot!, 'test-fixtures', 'static'));
+    assert.ok((await fs.stat(TEST_FIXTURES_DIR)).isDirectory());
   });
 });

--- a/packages/base-driver/test/unit/test-pages/static-dir.spec.ts
+++ b/packages/base-driver/test/unit/test-pages/static-dir.spec.ts
@@ -1,0 +1,16 @@
+import {existsSync} from 'node:fs';
+import path from 'node:path';
+import {describe, it} from 'node:test';
+
+import {expect} from 'chai';
+
+import {TEST_FIXTURES_DIR} from '../../../lib/test-pages/static-dir';
+
+describe('test page static directory', function () {
+  it('should resolve the bundled test fixtures', function () {
+    expect(TEST_FIXTURES_DIR).to.equal(
+      path.resolve(__dirname, '..', '..', '..', '..', 'test-fixtures', 'static'),
+    );
+    expect(existsSync(TEST_FIXTURES_DIR)).to.be.true;
+  });
+});


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/appium/appium/issues/22510

I assume using existing `getModuleRootSync` will help to resolve the path.

(Note that `TEST_FIXTURES_DIR` is deprecated, and it will be removed in the next major version)

## Types of changes

What types of changes does your code introduce to Appium?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
