### PR TITLE
ci: Remove the redundant `recursion` API param

### DIFF
--- a/scripts/crowdin-update-docs-resources.mjs
+++ b/scripts/crowdin-update-docs-resources.mjs
@@ -101,7 +101,6 @@ async function deleteFile(fileId) {
 
 /**
  * @param {number} [parentDirectoryId]
- * @param {number} [recursion]
  * @return {Promise<Record<string, any>[]>}
  */
 async function listDirectories(parentDirectoryId) {
@@ -110,7 +109,6 @@ async function listDirectories(parentDirectoryId) {
     params: {
       limit: MAX_ITEMS_PER_PAGE,
       directoryId: parentDirectoryId,
-      recursion: parentDirectoryId ? 10 : undefined,
     },
   });
   return directoriesData.map(({data}) => data);


### PR DESCRIPTION
## Summary

Fixes the **Update Crowdin English Docs** workflow, which has been failing since mid-July with a Crowdin API 400 error.

The Crowdin sync script was sending an invalid `recursion=10` query parameter when listing subdirectories. The [Crowdin List Directories API](https://developer.crowdin.com/api/v2/#operation/api.projects.directories.getMany) expects `recursion` to be a boolean (`true`/`false`), not a numeric depth. Crowdin now rejects the invalid value with **400 Bad Request**, causing the job to crash.

The failure occurred while resolving nested doc paths like `/blog/posts`:

```
GET /api/v2/projects/742245/directories?limit=300&directoryId=4&recursion=10
→ AxiosError: Request failed with status code 400
```

The `recursion` parameter is also unnecessary here: `ensureDirectoryStructure()` walks the directory tree one level at a time and only needs direct children of each parent directory on each API call.
