### PR TITLE
chore: Linter warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,8 @@ on:
       - 'lerna.json'
       - '.npmrc'
       - '.github/workflows/build.yml' # this file
-      - '.eslintignore'
+      - 'oxlint.config.mjs'
+      - 'oxfmt.config.mjs'
       - '!**/sample-code/**'
       - '!packages/*/docs/**'
   pull_request:
@@ -34,7 +35,8 @@ on:
       - 'lerna.json'
       - '.npmrc'
       - '.github/workflows/build.yml' # this file
-      - '.eslintignore'
+      - 'oxlint.config.mjs'
+      - 'oxfmt.config.mjs'
       - '!**/sample-code/**'
       - '!packages/*/docs/**'
 
@@ -191,7 +193,7 @@ jobs:
           node-version: lts/*
           install-command: npm ci
           run-build: 'false'
-      - name: ESLint
+      - name: Lint
         run: npm run lint:ci
       - name: Prettier
         run: npm run format:check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -195,5 +195,5 @@ jobs:
           run-build: 'false'
       - name: Lint
         run: npm run lint:ci
-      - name: Prettier
+      - name: Format check
         run: npm run format:check

--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -59,7 +59,7 @@
     "postinstall": "node ./scripts/autoinstall-extensions.js",
     "publish:docs": "cross-env APPIUM_DOCS_PUBLISH=1 npm run build:docs",
     "test": "npm run test:unit",
-    "test:e2e": "node --test --enable-source-maps --test-force-exit --test-concurrency=1 --test-timeout=90000 \"./build/test/e2e/**/*.spec.js\"",
+    "test:e2e": "node --test --enable-source-maps --test-force-exit --test-concurrency=1 --test-timeout=200000 \"./build/test/e2e/**/*.spec.js\"",
     "test:smoke": "cross-env APPIUM_HOME=./local_appium_home node ./index.js driver install uiautomator2 && cross-env APPIUM_HOME=./local_appium_home node ./index.js driver list",
     "test:unit": "node --test --enable-source-maps --test-timeout=5000 \"./build/test/unit/**/*.spec.js\""
   },

--- a/packages/driver-test-support/lib/helpers.ts
+++ b/packages/driver-test-support/lib/helpers.ts
@@ -52,14 +52,14 @@ export function createAppiumURL(address: string, port: string | number, session:
 export function createAppiumURL(
   address: string,
   port: string | number,
-  session?: string,
-  pathname?: string,
+  session: string = '',
+  pathname: string = '',
 ): string | ((session: string, pathname: string) => string) {
   const urlFor = (sess: string, path: string) => buildAppiumURL(address, port, sess, path);
   if (arguments.length === 2) {
     return urlFor;
   }
-  return urlFor(session!, pathname!);
+  return urlFor(session, pathname);
 }
 function buildAppiumURL(address: string, port: string | number, session: string, pathname: string): string {
   let base = address;

--- a/packages/support/test/unit/system.spec.ts
+++ b/packages/support/test/unit/system.spec.ts
@@ -15,7 +15,7 @@ const libs = {os, system};
 
 describe('system', function () {
   let sandbox: ReturnType<typeof createSandbox>;
-  let osMock: ReturnType<typeof createSandbox>['mock'] extends (obj: infer O) => infer R ? R : never;
+  let osMock: ReturnType<typeof createSandbox>['mock'] extends (obj: infer _O) => infer R ? R : never;
   let mocks: Record<string | symbol, any>;
 
   beforeEach(function () {


### PR DESCRIPTION
## Summary

- Fix oxlint warnings: drop non-null assertions in `createAppiumURL` by giving `session`/`pathname` empty-string defaults, and prefix the unused inferred type param in `system.spec.ts` with `_`.
- Rename the CI step from `ESLint` to `Lint` and swap the stale `.eslintignore` path trigger in `build.yml` for `oxlint.config.mjs`/`oxfmt.config.mjs`, reflecting the earlier oxlint migration.
- Bump the `test:e2e` timeout from 90s to 200s in `packages/appium/package.json`.