### PR TITLE
feat(tsconfig): hoist typescript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24126,7 +24126,8 @@
       "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@tsconfig/node20": "20.1.9"
+        "@tsconfig/node20": "20.1.9",
+        "typescript": "6.0.3"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -35,7 +35,8 @@
     "test:smoke": "node tsconfig.json && node tsconfig.plugin.json"
   },
   "dependencies": {
-    "@tsconfig/node20": "20.1.9"
+    "@tsconfig/node20": "20.1.9",
+    "typescript": "6.0.3"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",


### PR DESCRIPTION
## Summary

Adds typescript as a direct dependency of @appium/tsconfig, pinned to 6.0.3 (matching the version used at the monorepo root), so that packages depending on @appium/tsconfig get a compatible typescript install hoisted for free instead of declaring it themselves. 

## Changes

- packages/tsconfig/package.json: add "typescript": "6.0.3" to dependencies.
- package-lock.json: updated to reflect the new dependency edge (no version changes/conflicts, since it resolves to the already-hoisted root typescript@6.0.3).

## Why

Consumers of @appium/tsconfig (internal packages and  the package's README) previously had to add typescript to their own devDependencies/dependencies separately to actually type-check with the shared config. Declaring it directly on @appium/tsconfig lets npm workspace hoisting provide it automatically.