### PR TITLE
fix: typescript config

### DIFF
--- a/packages/appium/package.json
+++ b/packages/appium/package.json
@@ -42,6 +42,7 @@
     "types",
     "tsconfig.json"
   ],
+  "main": "./build/lib/main.js",
   "types": "./build/lib/main.d.ts",
   "publishConfig": {
     "access": "public"

--- a/packages/base-driver/tsconfig.json
+++ b/packages/base-driver/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@appium/tsconfig/tsconfig.json",
   "compilerOptions": {
     "strict": true,
+    "rootDir": ".",
     "outDir": "build",
     "paths": {
       "@appium/support": ["../support"],

--- a/packages/execute-driver-plugin/tsconfig.json
+++ b/packages/execute-driver-plugin/tsconfig.json
@@ -9,5 +9,11 @@
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib", "test"],
-  "references": [{"path": "../base-plugin"}, {"path": "../logger"}, {"path": "../support"}, {"path": "../types"}]
+  "references": [
+    {"path": "../base-plugin"},
+    {"path": "../logger"},
+    {"path": "../support"},
+    {"path": "../types"},
+    {"path": "../plugin-test-support"}
+  ]
 }

--- a/packages/images-plugin/tsconfig.json
+++ b/packages/images-plugin/tsconfig.json
@@ -17,6 +17,7 @@
     {"path": "../base-plugin"},
     {"path": "../logger"},
     {"path": "../support"},
-    {"path": "../types"}
+    {"path": "../types"},
+    {"path": "../plugin-test-support"}
   ]
 }

--- a/packages/plugin-test-support/tsconfig.json
+++ b/packages/plugin-test-support/tsconfig.json
@@ -12,5 +12,5 @@
     "types": ["node"]
   },
   "include": ["./lib"],
-  "references": [{"path": "../types"}, {"path": "../support"}]
+  "references": [{"path": "../types"}, {"path": "../support"}, {"path": "../appium"}]
 }

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "build",
-    "strict": true
+    "strict": true,
+    "types": ["node"]
   },
   "include": ["lib"]
 }

--- a/packages/storage-plugin/tsconfig.json
+++ b/packages/storage-plugin/tsconfig.json
@@ -8,5 +8,11 @@
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib", "test"],
-  "references": [{"path": "../base-plugin"}, {"path": "../logger"}, {"path": "../support"}, {"path": "../types"}]
+  "references": [
+    {"path": "../base-plugin"},
+    {"path": "../logger"},
+    {"path": "../support"},
+    {"path": "../types"},
+    {"path": "../plugin-test-support"}
+  ]
 }

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "extends": "@appium/tsconfig/tsconfig.json",
   "compilerOptions": {
+    "rootDir": ".",
     "outDir": "build",
     "checkJs": true,
     "strict": true,
+    "types": ["node"],
     "paths": {
       "@appium/schema": ["../schema"]
     }


### PR DESCRIPTION
## Summary

Prep work for an eventual TypeScript 7 (tsgo) migration. While benchmarking the native preview compiler against this monorepo's tsc -b build, it failed outright and surfaced four pre-existing project-reference bugs that classic tsc -b was silently tolerating through incidental build ordering — tsgo's more-parallel build scheduler has no such luck. Also hardened two packages against compiler-option defaults that change in TS 7.

- packages/appium/package.json: add "main": "./build/lib/main.js". The package only declared "types", so bare import ... from 'appium' (used by plugin-test-support) fell through to resolving the CLI shim index.js instead of the compiled library entry, which broke tsgo's emit-path mapping (TS5055: would overwrite input file). index.js already just re-exports the same module, so this is a no-op for consumers.
- plugin-test-support/tsconfig.json: add the missing {"path": "../appium"} project reference — it had a paths alias for "appium" with no corresponding reference, so nothing actually declared the build dependency.
- images-plugin, execute-driver-plugin, storage-plugin tsconfigs: same gap — each imports @appium/plugin-test-support in its e2e specs but never referenced it. Added the missing reference to all three.
- schema, types tsconfigs: add explicit "types": ["node"]. Both packages use process/Buffer globals but relied on the implicit types: ["*"] default (pulls in every installed @types/* package); TS 7 changes that default to [].
- base-driver, types tsconfigs: add explicit "rootDir": ".", matching every other package and TS 7's new explicit default, instead of relying on inference.

## Why now

Not switching the typescript devDependency yet — tsd and typescript-eslint don't support TS 7 (no stable compiler API until 7.1). This is groundwork so that whenever the ecosystem catches up, the actual version bump isn't tangled up with debugging unrelated build-graph bugs.