### PR TITLE
fix(logger): mask secure values surrounded by non-word characters

### DIFF
--- a/packages/logger/lib/secure-values-preprocessor.ts
+++ b/packages/logger/lib/secure-values-preprocessor.ts
@@ -34,7 +34,7 @@ export class SecureValuesPreprocessor {
       if (rule.length === 0) {
         throw new Error(`${JSON.stringify(rule)} -> The value must not be empty`);
       }
-      pattern = `\\b${escapeRegExp(rule)}\\b`;
+      pattern = toExactMatchPattern(rule);
     } else if (isPlainObject(rule)) {
       if (isLogFilterRegex(rule)) {
         if (typeof rule.pattern !== 'string' || rule.pattern.length === 0) {
@@ -45,7 +45,7 @@ export class SecureValuesPreprocessor {
         if (typeof rule.text !== 'string' || rule.text.length === 0) {
           throw new Error(`${JSON.stringify(rule)} -> The value of 'text' must be a valid non-empty string`);
         }
-        pattern = `\\b${escapeRegExp(rule.text)}\\b`;
+        pattern = toExactMatchPattern(rule.text);
       }
       if (!pattern) {
         throw new Error(`${JSON.stringify(rule)} -> Must either have a field named 'pattern' or 'text'`);
@@ -135,4 +135,21 @@ export class SecureValuesPreprocessor {
  */
 function isLogFilterRegex(value: object): value is LogFilterRegex {
   return 'pattern' in value;
+}
+
+/**
+ * Transforms the given text to a pattern, which does not match if the
+ * text is only a part of a longer word.
+ *
+ * `\b` only asserts a boundary next to a word character, so it is only added
+ * to the sides where the text itself begins or ends with one. Otherwise values
+ * like `P@ssw0rd!` would never match anything.
+ *
+ * @param {string} text The text to match
+ * @returns {string} The resulting regular expression source
+ */
+function toExactMatchPattern(text: string): string {
+  const prefix = /^\w/.test(text) ? '\\b' : '';
+  const suffix = /\w$/.test(text) ? '\\b' : '';
+  return `${prefix}${escapeRegExp(text)}${suffix}`;
 }

--- a/packages/logger/test/unit/preprocessor.spec.ts
+++ b/packages/logger/test/unit/preprocessor.spec.ts
@@ -59,6 +59,28 @@ describe('Log Internals', function () {
     expect(preprocessor.preprocess(':yolo" yo Yolo yyolo')).to.eql(`:${replacer}" yo ${replacer} yyolo`);
   });
 
+  it('should preprocess values starting or ending with non-word characters', async function () {
+    const issues = await preprocessor.loadRules(['P@ssw0rd!', '+15550100', '#hunter2']);
+    expect(issues.length).to.eql(0);
+    const replacer = preprocessor.rules[0].replacer;
+    expect(preprocessor.preprocess('P@ssw0rd! call +15550100 tag #hunter2')).to.eql(
+      `${replacer} call ${replacer} tag ${replacer}`,
+    );
+  });
+
+  it(`should preprocess a value with non-word characters given as 'text'`, async function () {
+    const issues = await preprocessor.loadRules([{text: '$ecret'}]);
+    expect(issues.length).to.eql(0);
+    const replacer = preprocessor.rules[0].replacer;
+    expect(preprocessor.preprocess('the token is $ecret')).to.eql(`the token is ${replacer}`);
+  });
+
+  it('should not preprocess a value which is a part of a longer word', async function () {
+    const issues = await preprocessor.loadRules(['yolo']);
+    expect(issues.length).to.eql(0);
+    expect(preprocessor.preprocess('yolos yyolo')).to.eql('yolos yyolo');
+  });
+
   it('should leave the string unchanged if all rules have issues', async function () {
     const replacer2 = '***';
     const issues = await preprocessor.loadRules([null, {flags: 'i'}, {pattern: '^:(', replacer: replacer2}] as any);


### PR DESCRIPTION
## Proposed changes

Log filtering rules built from a plain text value (a bare string, or the `text` property of a rule object) are wrapped into `\b` assertions. `\b` only asserts a boundary next to a word character, so if the value itself starts or ends with a non-word character the resulting pattern can never match, and the value is printed to the log unmasked. There is no warning, the rule looks like it was accepted.

Examples of values that are silently not redacted today:

| `--log-filters` entry | Log line | Current output |
| --- | --- | --- |
| `P@ssw0rd!` | `password: P@ssw0rd!` | unchanged |
| `+15550100` | `phone: +15550100` | unchanged |
| `#hunter2` | `token: #hunter2` | unchanged |
| `$ecret` | `key: $ecret` | unchanged |

Values consisting of word characters only (like `my.magic.app` from the docs) work fine, which is why this has gone unnoticed.

The boundary assertion is now added only to the side where the value actually begins or ends with a word character. Values made of word characters keep the exact behaviour they had before, so `yolo` still does not match `yyolo`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Three unit tests were added to `packages/logger/test/unit/preprocessor.spec.ts`: two cover values with leading/trailing non-word characters (as a bare string and via `text`), and one pins the existing behaviour of not matching a value that is part of a longer word, since that is what the assertions are there for.
Both new redaction tests fail on `master` and pass with this change.

No documentation update seemed necessary --> `docs/en/guides/log-filters.md` already describes `text` as "a simple non-empty exact text match to replace" which is what the code now does.