### PR TITLE
feat(storage-plugin): Add route aliases

### DIFF
--- a/packages/appium/docs/en/reference/api/plugins.md
+++ b/packages/appium/docs/en/reference/api/plugins.md
@@ -169,10 +169,17 @@ Modifies the [`createSession`](./webdriver.md#createsession) endpoint:
     All endpoints for this plugin can be invoked without creating a session, allowing you to prepare
     your test environment in advance.
 
+!!! info
+
+    Prior to plugin version 1.2.0, all endpoints below were mounted under the `/storage` prefix
+    (e.g. `/storage/add`) instead of `/appium/storage`. The `/storage`-prefixed routes are still
+    available for backward compatibility, but are deprecated and will be removed in a future
+    version of the plugin.
+
 ### addStorageItem
 
 ```
-POST /storage/add
+POST /appium/storage/add
 ```
 
 Adds a new file to the storage.
@@ -198,8 +205,8 @@ Example:
 ```json
 {
   "ws": {
-    "stream": "/storage/add/ccc963411b2621335657963322890305ebe96186/stream",
-    "events": "/storage/add/ccc963411b2621335657963322890305ebe96186/events"
+    "stream": "/appium/storage/add/ccc963411b2621335657963322890305ebe96186/stream",
+    "events": "/appium/storage/add/ccc963411b2621335657963322890305ebe96186/events"
   },
   "ttlMs": 300000
 }
@@ -208,7 +215,7 @@ Example:
 ### deleteStorageItem
 
 ```
-POST /storage/delete
+POST /appium/storage/delete
 ```
 
 Deletes a file in the storage.
@@ -227,7 +234,7 @@ the storage, or if the delete request is invalid.
 ### listStorageItems
 
 ```
-GET /storage/list
+GET /appium/storage/list
 ```
 
 List all files present in the storage.
@@ -245,7 +252,7 @@ List all files present in the storage.
 ### resetStorage
 
 ```
-POST /storage/reset
+POST /appium/storage/reset
 ```
 
 Deletes all uploaded files and stops any incomplete uploads.

--- a/packages/storage-plugin/README.md
+++ b/packages/storage-plugin/README.md
@@ -64,7 +64,7 @@ If a folder with the same name already exists in the storage, an error will be t
 [Refer to the Appium documentation](https://appium.io/docs/en/latest/reference/api/plugins/#storage-plugin).
 
 > [!NOTE]
-> Prior to plugin version 1.1.8, all endpoints were mounted under the `/storage` prefix (e.g. `/storage/add`)
+> Prior to plugin version 1.2.0, all endpoints were mounted under the `/storage` prefix (e.g. `/storage/add`)
 > instead of `/appium/storage`. These legacy routes are still available for backward compatibility,
 > but are deprecated and will be removed in a future version of the plugin.
 

--- a/packages/storage-plugin/README.md
+++ b/packages/storage-plugin/README.md
@@ -39,7 +39,7 @@ The procedure for storing a local file on the Appium server is as follows:
 
 - Calculate the [SHA1](https://en.wikipedia.org/wiki/SHA-1) hash of the source file
 - Decide the name of the destination file in the server storage (it can be the same as the original file name)
-- Send a `POST` request to the `/storage/add` endpoint, which will return the `events` and `stream` websocket paths
+- Send a `POST` request to the `/appium/storage/add` endpoint, which will return the `events` and `stream` websocket paths
 - Connect to both web sockets
 - Start listening for messages on the `events` web socket. Each message there is a JSON object wrapped
   to a string. The message must be either `{"value": {"success": true, "name":"app.ipa","sha1":"ccc963411b2621335657963322890305ebe96186"}}` to notify about a successful
@@ -62,6 +62,11 @@ If a folder with the same name already exists in the storage, an error will be t
 ## API
 
 [Refer to the Appium documentation](https://appium.io/docs/en/latest/reference/api/plugins/#storage-plugin).
+
+> [!NOTE]
+> Prior to plugin version 1.1.8, all endpoints were mounted under the `/storage` prefix (e.g. `/storage/add`)
+> instead of `/appium/storage`. These legacy routes are still available for backward compatibility,
+> but are deprecated and will be removed in a future version of the plugin.
 
 The plugin also supports [several environment variables](https://appium.io/docs/en/latest/reference/cli/env-vars/) for further customization.
 

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -14,9 +14,18 @@ import type {AddRequestResult, ItemOptions, StorageItem} from './types';
 const log = logger.getLogger('StoragePlugin');
 
 let SHARED_STORAGE: Storage | null = null;
-const STORAGE_PREFIX = '/storage';
+const STORAGE_PREFIX = '/appium/storage';
+/**
+ * @deprecated Use `STORAGE_PREFIX` (`/appium/storage`) instead. This alias only exists for
+ * backward compatibility and will be removed in a future version of Appium.
+ */
+const DEPRECATED_STORAGE_PREFIX = '/storage';
 const WS_TTL_MS = 5 * 60 * 1000;
-const STORAGE_HANDLERS: Record<string, (req: Request, httpServer?: AppiumServer) => Promise<any>> = {};
+const STORAGE_HANDLERS: Record<
+  string,
+  (req: Request, httpServer?: AppiumServer, basePath?: string) => Promise<any>
+> = {};
+const deprecatedRoutesLogged: Set<string> = new Set();
 const STORAGE_ADDITIONS_CACHE: LRUCache<string, () => any> = new LRUCache({
   max: 20,
   ttl: WS_TTL_MS,
@@ -25,40 +34,61 @@ const STORAGE_ADDITIONS_CACHE: LRUCache<string, () => any> = new LRUCache({
 
 export class StoragePlugin extends BasePlugin {
   static async updateServer(expressApp: Express, httpServer: AppiumServer): Promise<void> {
-    const buildHandler = (methodName: string) => async (req: Request, res: Response) => {
-      let status = 200;
-      let body: any;
-      try {
-        const value = await STORAGE_HANDLERS[methodName](req, httpServer);
-        body = {value: value ?? null};
-      } catch (e) {
-        [status, body] = getResponseForW3CError(e);
-      }
-      log.debug(
-        'Responding to %s with %s',
-        methodName,
-        logger.markSensitive(util.truncateString(JSON.stringify(body.value), {length: 200})),
-      );
-      res.set('content-type', 'application/json; charset=utf-8');
-      res.status(status).send(body);
-    };
+    const buildHandler = (methodName: string, basePath: string, isDeprecated: boolean) =>
+      async (req: Request, res: Response) => {
+        if (isDeprecated && !deprecatedRoutesLogged.has(req.path)) {
+          deprecatedRoutesLogged.add(req.path);
+          log.warn(
+            `The '${req.path}' endpoint has been deprecated and will be removed in a future version ` +
+              `of Appium. Please use '${req.path.replace(DEPRECATED_STORAGE_PREFIX, STORAGE_PREFIX)}' instead`,
+          );
+        }
 
-    expressApp.post(`${STORAGE_PREFIX}/add`, buildHandler(STORAGE_HANDLERS.addStorageItem.name));
-    expressApp.get(`${STORAGE_PREFIX}/list`, buildHandler(STORAGE_HANDLERS.listStorageItems.name));
-    expressApp.post(`${STORAGE_PREFIX}/reset`, buildHandler(STORAGE_HANDLERS.resetStorage.name));
-    expressApp.post(`${STORAGE_PREFIX}/delete`, buildHandler(STORAGE_HANDLERS.deleteStorageItem.name));
+        let status = 200;
+        let body: any;
+        try {
+          const value = await STORAGE_HANDLERS[methodName](req, httpServer, basePath);
+          body = {value: value ?? null};
+        } catch (e) {
+          [status, body] = getResponseForW3CError(e);
+        }
+        log.debug(
+          'Responding to %s with %s',
+          methodName,
+          logger.markSensitive(util.truncateString(JSON.stringify(body.value), {length: 200})),
+        );
+        res.set('content-type', 'application/json; charset=utf-8');
+        res.status(status).send(body);
+      };
+
+    for (const [basePath, isDeprecated] of [
+      [STORAGE_PREFIX, false],
+      [DEPRECATED_STORAGE_PREFIX, true],
+    ] as const) {
+      expressApp.post(`${basePath}/add`, buildHandler(STORAGE_HANDLERS.addStorageItem.name, basePath, isDeprecated));
+      expressApp.get(`${basePath}/list`, buildHandler(STORAGE_HANDLERS.listStorageItems.name, basePath, isDeprecated));
+      expressApp.post(
+        `${basePath}/reset`,
+        buildHandler(STORAGE_HANDLERS.resetStorage.name, basePath, isDeprecated),
+      );
+      expressApp.post(
+        `${basePath}/delete`,
+        buildHandler(STORAGE_HANDLERS.deleteStorageItem.name, basePath, isDeprecated),
+      );
+    }
   }
 }
 
 STORAGE_HANDLERS.addStorageItem = async function addStorageItem(
   req: Request,
   httpServer?: AppiumServer,
+  basePath: string = STORAGE_PREFIX,
 ): Promise<AddRequestResult> {
   if (!httpServer) {
     throw new Error('httpServer is required to add a storage item');
   }
   const itemOptions = requireValidItemOptions(parseRequestArgs(req, ['name', 'sha1']) as ItemOptions);
-  const [stream, events] = await prepareWebSockets(httpServer, itemOptions);
+  const [stream, events] = await prepareWebSockets(httpServer, itemOptions, basePath);
   return {
     ws: {
       stream,
@@ -107,8 +137,12 @@ function parseRequestArgs(req: Request, requiredKeys: string[]): Record<string, 
   return req.body;
 }
 
-async function prepareWebSockets(httpServer: AppiumServer, itemOptions: ItemOptions): Promise<[string, string]> {
-  const commonPathname = `${STORAGE_PREFIX}/add/${itemOptions.sha1}`;
+async function prepareWebSockets(
+  httpServer: AppiumServer,
+  itemOptions: ItemOptions,
+  basePath: string,
+): Promise<[string, string]> {
+  const commonPathname = `${basePath}/add/${itemOptions.sha1}`;
   const streamPathname = `${commonPathname}/stream`;
   const eventsPathname = `${commonPathname}/events`;
   if (!util.isEmpty(httpServer.getWebSocketHandlers(streamPathname))) {

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -17,7 +17,7 @@ let SHARED_STORAGE: Storage | null = null;
 const STORAGE_PREFIX = '/appium/storage';
 /**
  * @deprecated Use `STORAGE_PREFIX` (`/appium/storage`) instead. This alias only exists for
- * backward compatibility and will be removed in a future version of Appium.
+ * backward compatibility and will be removed in a future version of the storage plugin.
  */
 const DEPRECATED_STORAGE_PREFIX = '/storage';
 const WS_TTL_MS = 5 * 60 * 1000;
@@ -33,12 +33,14 @@ const STORAGE_ADDITIONS_CACHE: LRUCache<string, () => any> = new LRUCache({
 export class StoragePlugin extends BasePlugin {
   static async updateServer(expressApp: Express, httpServer: AppiumServer): Promise<void> {
     const buildHandler =
-      (methodName: string, basePath: string, isDeprecated: boolean) => async (req: Request, res: Response) => {
-        if (isDeprecated && !deprecatedRoutesLogged.has(req.path)) {
-          deprecatedRoutesLogged.add(req.path);
+      (methodName: string, basePath: string, routePath: string, isDeprecated: boolean) =>
+      async (req: Request, res: Response) => {
+        if (isDeprecated && !deprecatedRoutesLogged.has(routePath)) {
+          deprecatedRoutesLogged.add(routePath);
           log.warn(
-            `The '${req.path}' endpoint has been deprecated and will be removed in a future version ` +
-              `of Appium. Please use '${req.path.replace(DEPRECATED_STORAGE_PREFIX, STORAGE_PREFIX)}' instead`,
+            `The '${routePath}' endpoint has been deprecated and will be removed in a future version ` +
+              `of the storage plugin. Please use ` +
+              `'${routePath.replace(DEPRECATED_STORAGE_PREFIX, STORAGE_PREFIX)}' instead`,
           );
         }
 
@@ -63,12 +65,21 @@ export class StoragePlugin extends BasePlugin {
       [STORAGE_PREFIX, false],
       [DEPRECATED_STORAGE_PREFIX, true],
     ] as const) {
-      expressApp.post(`${basePath}/add`, buildHandler(STORAGE_HANDLERS.addStorageItem.name, basePath, isDeprecated));
-      expressApp.get(`${basePath}/list`, buildHandler(STORAGE_HANDLERS.listStorageItems.name, basePath, isDeprecated));
-      expressApp.post(`${basePath}/reset`, buildHandler(STORAGE_HANDLERS.resetStorage.name, basePath, isDeprecated));
+      expressApp.post(
+        `${basePath}/add`,
+        buildHandler(STORAGE_HANDLERS.addStorageItem.name, basePath, `${basePath}/add`, isDeprecated),
+      );
+      expressApp.get(
+        `${basePath}/list`,
+        buildHandler(STORAGE_HANDLERS.listStorageItems.name, basePath, `${basePath}/list`, isDeprecated),
+      );
+      expressApp.post(
+        `${basePath}/reset`,
+        buildHandler(STORAGE_HANDLERS.resetStorage.name, basePath, `${basePath}/reset`, isDeprecated),
+      );
       expressApp.post(
         `${basePath}/delete`,
-        buildHandler(STORAGE_HANDLERS.deleteStorageItem.name, basePath, isDeprecated),
+        buildHandler(STORAGE_HANDLERS.deleteStorageItem.name, basePath, `${basePath}/delete`, isDeprecated),
       );
     }
   }

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -21,10 +21,8 @@ const STORAGE_PREFIX = '/appium/storage';
  */
 const DEPRECATED_STORAGE_PREFIX = '/storage';
 const WS_TTL_MS = 5 * 60 * 1000;
-const STORAGE_HANDLERS: Record<
-  string,
-  (req: Request, httpServer?: AppiumServer, basePath?: string) => Promise<any>
-> = {};
+const STORAGE_HANDLERS: Record<string, (req: Request, httpServer?: AppiumServer, basePath?: string) => Promise<any>> =
+  {};
 const deprecatedRoutesLogged: Set<string> = new Set();
 const STORAGE_ADDITIONS_CACHE: LRUCache<string, () => any> = new LRUCache({
   max: 20,
@@ -34,8 +32,8 @@ const STORAGE_ADDITIONS_CACHE: LRUCache<string, () => any> = new LRUCache({
 
 export class StoragePlugin extends BasePlugin {
   static async updateServer(expressApp: Express, httpServer: AppiumServer): Promise<void> {
-    const buildHandler = (methodName: string, basePath: string, isDeprecated: boolean) =>
-      async (req: Request, res: Response) => {
+    const buildHandler =
+      (methodName: string, basePath: string, isDeprecated: boolean) => async (req: Request, res: Response) => {
         if (isDeprecated && !deprecatedRoutesLogged.has(req.path)) {
           deprecatedRoutesLogged.add(req.path);
           log.warn(
@@ -67,10 +65,7 @@ export class StoragePlugin extends BasePlugin {
     ] as const) {
       expressApp.post(`${basePath}/add`, buildHandler(STORAGE_HANDLERS.addStorageItem.name, basePath, isDeprecated));
       expressApp.get(`${basePath}/list`, buildHandler(STORAGE_HANDLERS.listStorageItems.name, basePath, isDeprecated));
-      expressApp.post(
-        `${basePath}/reset`,
-        buildHandler(STORAGE_HANDLERS.resetStorage.name, basePath, isDeprecated),
-      );
+      expressApp.post(`${basePath}/reset`, buildHandler(STORAGE_HANDLERS.resetStorage.name, basePath, isDeprecated));
       expressApp.post(
         `${basePath}/delete`,
         buildHandler(STORAGE_HANDLERS.deleteStorageItem.name, basePath, isDeprecated),

--- a/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
+++ b/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
@@ -57,7 +57,7 @@ describe('StoragePlugin', function () {
   beforeEach(async function () {
     storageRoot = await tempDir.openDir();
     driver = await wdio(WDIO_OPTS);
-    const baseUrl = `http://${TEST_HOST}:${WDIO_OPTS.port}/storage`;
+    const baseUrl = `http://${TEST_HOST}:${WDIO_OPTS.port}/appium/storage`;
     driver.addCommand(
       'addStorageItem',
       async (name: string, sha1: string) => (await axios.post(`${baseUrl}/add`, {name, sha1})).data.value,
@@ -99,6 +99,12 @@ describe('StoragePlugin', function () {
     await driver.resetStorageItems();
     items = await driver.listStorageItems();
     expect(items.length).to.eql(0);
+  });
+
+  it('should still serve the deprecated /storage endpoints', async function () {
+    const deprecatedBaseUrl = `http://${TEST_HOST}:${WDIO_OPTS.port}/storage`;
+    const {data} = await axios.get(`${deprecatedBaseUrl}/list`);
+    expect(data.value).to.be.empty;
   });
 
   async function addFileToStorage(sourcePath: string, name: string): Promise<void> {


### PR DESCRIPTION
## Summary
Addresses the storage-plugin item from #22051 ("Update storage plugin endpoints to follow W3C format: `/storage/*` -> `/appium/storage/*`").

- Adds new primary endpoints under `/appium/storage/*` (`add`, `list`, `reset`, `delete`), matching the `appium/`-namespaced convention used elsewhere in the W3C protocol.
- Keeps the existing `/storage/*` endpoints working as deprecated aliases for backward compatibility — each route is registered under both prefixes and dispatches to the same handlers.
- Logs a one-time warning per deprecated route path when a client hits `/storage/*`, pointing it to the `/appium/storage/*` replacement.
- The WebSocket `stream`/`events` paths returned by `add` now honor whichever prefix the client actually called through, so both old and new clients get correctly-prefixed WS URLs.
- Updates the plugin README (example + a note about the deprecated alias) and the e2e test (now exercises `/appium/storage/*` as the primary path, with an added case verifying `/storage/*` still works).
