### PR TITLE
feat(strongbox)!: Migrate package to ESM

### DIFF
--- a/packages/strongbox/lib/base-item.ts
+++ b/packages/strongbox/lib/base-item.ts
@@ -1,8 +1,8 @@
 import {mkdir, readFile, unlink, writeFile} from 'node:fs/promises';
 import path from 'node:path';
 
-import type {Item, ItemEncoding, Strongbox, Value} from '.';
-import {slugify} from './util';
+import type {Item, ItemEncoding, Strongbox, Value} from './index.js';
+import {slugify} from './util.js';
 
 /**
  * Base item implementation

--- a/packages/strongbox/lib/index.ts
+++ b/packages/strongbox/lib/index.ts
@@ -3,8 +3,8 @@ import path from 'node:path';
 
 import envPaths from 'env-paths';
 
-import {BaseItem} from './base-item';
-import {slugify} from './util';
+import {BaseItem} from './base-item.js';
+import {slugify} from './util.js';
 
 /**
  * Valid file encodings.

--- a/packages/strongbox/package.json
+++ b/packages/strongbox/package.json
@@ -56,11 +56,11 @@
     "env-paths": "4.0.0"
   },
   "tsd": {
-    "directory": "test/types",
     "compilerOptions": {
       "composite": false,
       "declarationMap": false
-    }
+    },
+    "directory": "test/types"
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",

--- a/packages/strongbox/package.json
+++ b/packages/strongbox/package.json
@@ -32,15 +32,23 @@
     "lib",
     "tsconfig.json"
   ],
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "test": "run-p test:unit test:types",
     "test:smoke": "node .",
-    "test:unit": "node --test --enable-source-maps --test-timeout=5000 \"./build/test/unit/**/*.spec.js\"",
+    "test:unit": "node --test --experimental-test-module-mocks --enable-source-maps --test-timeout=5000 \"./build/test/unit/**/*.spec.js\"",
     "test:types": "tsd",
     "test:e2e": "node --test --enable-source-maps --test-force-exit --test-concurrency=1 --test-timeout=20000 \"./build/test/e2e/**/*.e2e.spec.js\""
   },
@@ -48,7 +56,11 @@
     "env-paths": "4.0.0"
   },
   "tsd": {
-    "directory": "test/types"
+    "directory": "test/types",
+    "compilerOptions": {
+      "composite": false,
+      "declarationMap": false
+    }
   },
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",

--- a/packages/strongbox/test/e2e/strongbox.e2e.spec.ts
+++ b/packages/strongbox/test/e2e/strongbox.e2e.spec.ts
@@ -4,8 +4,8 @@ import {afterEach, beforeEach, describe, it} from 'node:test';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import type {Item, Strongbox} from '../../lib';
-import {strongbox} from '../../lib';
+import type {Item, Strongbox} from '../../lib/index.js';
+import {strongbox} from '../../lib/index.js';
 
 use(chaiAsPromised);
 

--- a/packages/strongbox/test/types/strongbox.test-d.ts
+++ b/packages/strongbox/test/types/strongbox.test-d.ts
@@ -1,6 +1,6 @@
 import {expectAssignable, expectNotAssignable} from 'tsd';
 
-import {BaseItem, Item, strongbox, Value} from '../..';
+import {BaseItem, Item, strongbox, Value} from '@appium/strongbox';
 
 expectAssignable<Item<string>>(new BaseItem('foo', strongbox('foo')));
 expectAssignable<AsyncIterable<Item<any>>>(strongbox('foo'));

--- a/packages/strongbox/test/types/strongbox.test-d.ts
+++ b/packages/strongbox/test/types/strongbox.test-d.ts
@@ -1,6 +1,5 @@
-import {expectAssignable, expectNotAssignable} from 'tsd';
-
 import {BaseItem, Item, strongbox, Value} from '@appium/strongbox';
+import {expectAssignable, expectNotAssignable} from 'tsd';
 
 expectAssignable<Item<string>>(new BaseItem('foo', strongbox('foo')));
 expectAssignable<AsyncIterable<Item<any>>>(strongbox('foo'));

--- a/packages/strongbox/test/unit/base-item.spec.ts
+++ b/packages/strongbox/test/unit/base-item.spec.ts
@@ -7,8 +7,8 @@ import chaiAsPromised from 'chai-as-promised';
 import type {SinonSandbox, SinonStubbedMember} from 'sinon';
 import {createSandbox} from 'sinon';
 
-import type {Item, Strongbox} from '../../lib/index.js';
 import type {BaseItem as TBaseItem} from '../../lib/base-item.js';
+import type {Item, Strongbox} from '../../lib/index.js';
 
 use(chaiAsPromised);
 

--- a/packages/strongbox/test/unit/base-item.spec.ts
+++ b/packages/strongbox/test/unit/base-item.spec.ts
@@ -1,44 +1,47 @@
 import type fs from 'node:fs/promises';
 import path from 'node:path';
-import {beforeEach, describe, it} from 'node:test';
+import {before, beforeEach, describe, it, mock} from 'node:test';
 
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import rewiremock from 'rewiremock/node';
 import type {SinonSandbox, SinonStubbedMember} from 'sinon';
 import {createSandbox} from 'sinon';
 
-import type {Item, Strongbox} from '../../lib';
-import type {BaseItem as TBaseItem} from '../../lib/base-item';
+import type {Item, Strongbox} from '../../lib/index.js';
+import type {BaseItem as TBaseItem} from '../../lib/base-item.js';
 
 use(chaiAsPromised);
 
-type MockFs = {
-  [K in keyof typeof fs]: SinonStubbedMember<(typeof fs)[K]>;
-};
+type MockFs = Pick<
+  {[K in keyof typeof fs]: SinonStubbedMember<(typeof fs)[K]>},
+  'mkdir' | 'readFile' | 'unlink' | 'writeFile'
+>;
 
 describe('Strongbox', function () {
   let sandbox: SinonSandbox;
-  let MockFs: MockFs = {} as any;
+  let MockFs: MockFs;
   const DATA_DIR = path.resolve(path.sep, 'some', 'dir');
-  // note to self: looks like this is safe to do before the rewiremock.proxy call
   let BaseItem: typeof TBaseItem;
 
-  beforeEach(function () {
+  before(async function () {
     sandbox = createSandbox();
-    ({BaseItem} = rewiremock.proxy(
-      () => require('../../lib'),
-      (r) => ({
-        // all of these props are async functions
-        'node:fs/promises': r
-          .mockThrough((prop) => {
-            MockFs = {...MockFs, [prop]: sandbox.stub().resolves()};
-            return MockFs[prop as keyof typeof fs];
-          })
-          .dynamic(), // this allows us to change the mock behavior on-the-fly
-        'env-paths': sandbox.stub().returns({data: DATA_DIR}),
-      }),
-    ));
+    MockFs = {
+      mkdir: sandbox.stub(),
+      readFile: sandbox.stub(),
+      unlink: sandbox.stub(),
+      writeFile: sandbox.stub(),
+    };
+    // mocks the module for the lifetime of this file; individual stub
+    // behavior is reset (not the module itself) between tests below
+    mock.module('node:fs/promises', {namedExports: MockFs});
+    ({BaseItem} = await import('../../lib/base-item.js'));
+  });
+
+  beforeEach(function () {
+    sandbox.reset();
+    for (const stub of Object.values(MockFs)) {
+      stub.resolves();
+    }
   });
 
   describe('BaseItem', function () {

--- a/packages/strongbox/test/unit/strongbox.spec.ts
+++ b/packages/strongbox/test/unit/strongbox.spec.ts
@@ -1,45 +1,57 @@
 import type fs from 'node:fs/promises';
 import path from 'node:path';
-import {afterEach, beforeEach, describe, it} from 'node:test';
+import {before, beforeEach, describe, it, mock} from 'node:test';
 
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import rewiremock from 'rewiremock/node';
 import type {SinonSandbox, SinonStub, SinonStubbedMember} from 'sinon';
 import {createSandbox} from 'sinon';
 
-import type {Item, Strongbox as TStrongbox, StrongboxOpts, Value} from '../../lib';
+import type * as StrongboxLib from '../../lib/index.js';
+import type {Item, Strongbox as TStrongbox, StrongboxOpts, Value} from '../../lib/index.js';
 
 use(chaiAsPromised);
 
-type MockFs = {
-  [K in keyof typeof fs]: SinonStubbedMember<(typeof fs)[K]>;
-};
+type MockFs = Pick<
+  {[K in keyof typeof fs]: SinonStubbedMember<(typeof fs)[K]>},
+  'opendir' | 'rm' | 'mkdir' | 'readFile' | 'unlink' | 'writeFile'
+>;
 
 describe('Strongbox', function () {
   let strongbox: (name: string, opts?: Partial<StrongboxOpts>) => TStrongbox;
-  let Strongbox: new (name: string, opts?: StrongboxOpts) => TStrongbox;
+  let Strongbox: typeof StrongboxLib.Strongbox;
   let sandbox: SinonSandbox;
   let DEFAULT_SUFFIX: string;
-  let MockFs: MockFs = {} as any;
+  let MockFs: MockFs;
+  let envPathsStub: SinonStub;
 
   const DATA_DIR = path.resolve('some', 'dir', 'strongbox');
 
-  beforeEach(function () {
+  before(async function () {
     sandbox = createSandbox();
-    ({strongbox, DEFAULT_SUFFIX, Strongbox} = rewiremock.proxy(
-      () => require('../../lib'),
-      (r) => ({
-        // all of these props are async functions
-        'node:fs/promises': r
-          .mockThrough((prop) => {
-            MockFs = {...MockFs, [prop]: sandbox.stub().resolves()};
-            return MockFs[prop as keyof typeof fs];
-          })
-          .dynamic(), // this allows us to change the mock behavior on-the-fly
-        'env-paths': sandbox.stub().returns({data: DATA_DIR}),
-      }),
-    ));
+    MockFs = {
+      opendir: sandbox.stub(),
+      rm: sandbox.stub(),
+      mkdir: sandbox.stub(),
+      readFile: sandbox.stub(),
+      unlink: sandbox.stub(),
+      writeFile: sandbox.stub(),
+    };
+    envPathsStub = sandbox.stub();
+    // mocks the modules for the lifetime of this file; individual stub
+    // behavior is reset (not the modules themselves) between tests below
+    mock.module('node:fs/promises', {namedExports: MockFs});
+    mock.module('env-paths', {defaultExport: envPathsStub});
+    ({strongbox, DEFAULT_SUFFIX, Strongbox} = await import('../../lib/index.js'));
+  });
+
+  beforeEach(function () {
+    sandbox.resetHistory();
+    sandbox.resetBehavior();
+    for (const stub of Object.values(MockFs)) {
+      stub.resolves();
+    }
+    envPathsStub.returns({data: DATA_DIR});
   });
 
   describe('static method', function () {
@@ -314,9 +326,5 @@ describe('Strongbox', function () {
         await expect(gen.next()).to.be.rejectedWith('EACCES');
       });
     });
-  });
-
-  afterEach(function () {
-    sandbox.restore();
   });
 });

--- a/packages/strongbox/tsconfig.json
+++ b/packages/strongbox/tsconfig.json
@@ -5,6 +5,8 @@
     "outDir": "build",
     "strict": true,
     "checkJs": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "types": ["node"]
   },
   "include": ["lib", "test/unit", "test/e2e"],


### PR DESCRIPTION
## Summary

- Migrates @appium/strongbox to a pure ESM package ("type": "module"), matching the pattern established in #22557 for @appium/universal-xml-plugin.
- Adds an exports map so the package now only exposes its public entry point (. and ./package.json); deep imports into internals are no longer possible.
- Updates tsconfig.json to NodeNext module/resolution and adds explicit .js extensions to internal relative imports (lib/index.ts, lib/base-item.ts).
- Rewrites the node:fs/promises-mocking unit tests (base-item.spec.ts, strongbox.spec.ts) off rewiremock — which only intercepts CommonJS require() and can't work against static ESM imports — onto Node's native node:test mock.module() API (--experimental-test-module-mocks). Modules are mocked once per file in a before() hook and stub behavior is reset per test in beforeEach, since ESM module identity is cached per specifier (unlike rewiremock's per-call isolated registry).
- Adds a tsd.compilerOptions override (composite/declarationMap disabled) to work around a TypeScript quirk where tsd's ad-hoc type-checking program otherwise pulls in the package's own .ts sources instead of its compiled .d.ts output.

BREAKING CHANGE: @appium/strongbox is now an ESM-only package. It can no longer be loaded via CommonJS require(); consumers must use import or dynamic import(). No other package in this monorepo currently depends on @appium/strongbox, so this only affects external consumers.
