### PR TITLE
fix(images-plugin): avoid NaN coordinates when an action offset is unset

### DIFF
--- a/packages/images-plugin/lib/plugin.ts
+++ b/packages/images-plugin/lib/plugin.ts
@@ -94,9 +94,10 @@ export class ImageElementPlugin extends BasePlugin {
           throw new errors.NoSuchElementError();
         }
 
-        // Add the element's center coordinates to the offset value.
-        actionWithEl.x += imgEl.center.x;
-        actionWithEl.y += imgEl.center.y;
+        // Add the element's center to the offset. An unset offset must count as
+        // zero, otherwise the resulting coordinate is NaN.
+        actionWithEl.x = (actionWithEl.x ?? 0) + imgEl.center.x;
+        actionWithEl.y = (actionWithEl.y ?? 0) + imgEl.center.y;
         // Set the origin to the viewport so that the external driver can process it using coordinates.
         delete actionWithEl.origin;
       }

--- a/packages/images-plugin/test/unit/plugin.spec.ts
+++ b/packages/images-plugin/test/unit/plugin.spec.ts
@@ -221,6 +221,26 @@ describe('ImageElementPlugin#handle', function () {
         },
       ]);
     });
+    it('should treat omitted x and y as zero when origin is an image element', async function () {
+      const actionSequences: ActionSequence[] = [
+        {
+          type: 'pointer',
+          id: 'mouse',
+          parameters: {pointerType: 'touch'},
+          // The type requires x/y, but the incoming payload is not validated.
+          actions: [{type: 'pointerMove', duration: 0, origin: imageEl} as any],
+        },
+      ];
+      await p.performActions(next, driver as any, actionSequences);
+      expect(actionSequences).to.eql([
+        {
+          type: 'pointer',
+          id: 'mouse',
+          parameters: {pointerType: 'touch'},
+          actions: [{type: 'pointerMove', x: 24, y: 40, duration: 0}],
+        },
+      ]);
+    });
     it('should not be modified except pointerMove and scroll actions includes image element as origin', async function () {
       const actionSequences: ActionSequence[] = [
         {


### PR DESCRIPTION
## Proposed changes

When `performActions` rewrites a `pointerMove` / `scroll` that uses an image element as `origin`, it adds the image center to `x` and `y`.

The incoming action payload is not validated before it reaches the plugin, so if `x` or `y` is missing, `+=` turns the sum into `NaN`. The plugin then drops `origin` and forwards that coordinate to the driver, so the tap lands nowhere useful.

Missing offsets are now treated as 0 before adding the center.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Added a unit test that sends `pointerMove` with an image origin and no `x`/`y`. It fails on master and passes with this change.