### PR TITLE
fix(base-driver): keep the find error when the page source cannot be read

### DIFF
--- a/packages/base-driver/lib/basedriver/commands/find.ts
+++ b/packages/base-driver/lib/basedriver/commands/find.ts
@@ -60,11 +60,21 @@ async function findElOrElsWithProcessing<C extends Constraints>(
     return await this.findElOrEls(strategy, selector, mult, context);
   } catch (err) {
     if (this.opts.printPageSourceOnFindFailure) {
-      const src = await this.getPageSource();
       const message = err instanceof Error ? err.message : String(err);
       this.log.debug(`Error finding element${mult ? 's' : ''}: ${message}`);
-      this.log.debug(`Page source requested through 'printPageSourceOnFindFailure':`);
-      this.log.debug(src);
+      // Fetching the page source is only a diagnostic aid here. If it fails then
+      // the error above is still the one the client must receive.
+      try {
+        const src = await this.getPageSource();
+        this.log.debug(`Page source requested through 'printPageSourceOnFindFailure':`);
+        this.log.debug(src);
+      } catch (pageSourceErr) {
+        const pageSourceMessage = pageSourceErr instanceof Error ? pageSourceErr.message : String(pageSourceErr);
+        this.log.warn(
+          `Could not retrieve the page source requested through ` +
+            `'printPageSourceOnFindFailure': ${pageSourceMessage}`,
+        );
+      }
     }
     // still want the error to occur
     throw err;

--- a/packages/base-driver/test/unit/basedriver/commands/find.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/commands/find.spec.ts
@@ -1,0 +1,42 @@
+import {beforeEach, describe, it} from 'node:test';
+
+import type {InitialOpts} from '@appium/types';
+import chai, {expect} from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import {BaseDriver, errors} from '../../../../lib';
+
+chai.use(chaiAsPromised);
+
+const PAGE_SOURCE = '<hierarchy />';
+
+describe('find commands -', function () {
+  let driver: BaseDriver<any, any, any, any, any, any>;
+
+  beforeEach(function () {
+    driver = new BaseDriver({} as InitialOpts);
+    driver.locatorStrategies = ['xpath'];
+    (driver as any)._log = {
+      debug: () => {},
+      warn: () => {},
+    } as any;
+    (driver as any).findElOrEls = async () => {
+      throw new errors.NoSuchElementError();
+    };
+  });
+
+  describe('printPageSourceOnFindFailure', function () {
+    it('should throw the find error when the page source has been retrieved', async function () {
+      driver.opts.printPageSourceOnFindFailure = true;
+      (driver as any).getPageSource = async () => PAGE_SOURCE;
+      await expect(driver.findElement('xpath', '//Foo')).to.be.rejectedWith(errors.NoSuchElementError);
+    });
+    it('should throw the find error when the page source cannot be retrieved', async function () {
+      driver.opts.printPageSourceOnFindFailure = true;
+      (driver as any).getPageSource = async () => {
+        throw new errors.NotImplementedError('Not implemented yet for find.');
+      };
+      await expect(driver.findElements('xpath', '//Foo')).to.be.rejectedWith(errors.NoSuchElementError);
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

`printPageSourceOnFindFailure` fetches the page source from inside the `catch` block that handles a failed find:

    } catch (err) {
      if (this.opts.printPageSourceOnFindFailure) {
        const src = await this.getPageSource();
        ...
      }
      // still want the error to occur
      throw err;
    }

That `await` is unguarded, so when `getPageSource` rejects, its error replaces the find error and the `throw err` below never runs. The capability exists to help diagnose a failed find, and in this case it hides what actually failed.

This is not a rare path. `BaseDriver`'s own `getPageSource` throws `NotImplementedError`, so on any driver that does not override it, enabling the capability turns every find failure into `NotImplementedError: Not implemented yet for find.` instead of
`NoSuchElementError`. Client-side waits and `NoSuchElementError` handling break as a result. Drivers that do implement it are affected too, since page source retrieval tends to fail in the same situations that make finds fail: a dead session, a crashed app, a stale WebView context.

The page source fetch is now wrapped in its own `try`/`catch`. A failure to read it is logged as a warning and the original find error is still thrown. The find error is also logged before the fetch, so it appears in the log either way.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Added `test/unit/basedriver/commands/find.spec.ts` covering both a working and a failing `getPageSource`. On master the second case fails with:

    expected promise to be rejected with 'NoSuchElementError' but it was rejected with 'NotImplementedError: Not implemented yet for find.'