### PR TITLE
feat(relaxed-caps-plugin)!: Migrate to ESM

### DIFF
--- a/packages/relaxed-caps-plugin/lib/index.ts
+++ b/packages/relaxed-caps-plugin/lib/index.ts
@@ -1,6 +1,8 @@
-export {RelaxedCapsPlugin} from './plugin';
+import {fileURLToPath} from 'node:url';
+
+export {RelaxedCapsPlugin} from './plugin.js';
 
 // Handle smoke test flag
-if (require.main === module && process.argv[2] === '--smoke-test') {
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1] && process.argv[2] === '--smoke-test') {
   process.exit(0);
 }

--- a/packages/relaxed-caps-plugin/lib/plugin.ts
+++ b/packages/relaxed-caps-plugin/lib/plugin.ts
@@ -1,7 +1,7 @@
-import {isStandardCap} from 'appium/driver';
-import {BasePlugin} from 'appium/plugin';
+import {isStandardCap} from 'appium/driver.js';
+import {BasePlugin} from 'appium/plugin.js';
 
-import type {CapsRecord, W3CCapsLike} from './types';
+import type {CapsRecord, W3CCapsLike} from './types.js';
 
 const VENDOR_PREFIX = 'appium';
 const HAS_VENDOR_PREFIX_RE = /^.+:/;

--- a/packages/relaxed-caps-plugin/package.json
+++ b/packages/relaxed-caps-plugin/package.json
@@ -32,8 +32,16 @@
     "lib",
     "tsconfig.json"
   ],
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/relaxed-caps-plugin/test/unit/plugin.spec.ts
+++ b/packages/relaxed-caps-plugin/test/unit/plugin.spec.ts
@@ -3,7 +3,7 @@ import {describe, it, beforeEach, afterEach} from 'node:test';
 import {expect} from 'chai';
 import sinon from 'sinon';
 
-import {RelaxedCapsPlugin} from '../../lib/plugin';
+import {RelaxedCapsPlugin} from '../../lib/plugin.js';
 
 const STD_CAPS = {
   browserName: 'chrome',

--- a/packages/relaxed-caps-plugin/tsconfig.json
+++ b/packages/relaxed-caps-plugin/tsconfig.json
@@ -3,7 +3,14 @@
     "strict": true,
     "rootDir": ".",
     "outDir": "build",
-    "types": ["node"]
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "paths": {
+      "appium": ["../appium"],
+      "appium/driver.js": ["../appium/driver.d.ts"],
+      "appium/plugin.js": ["../appium/plugin.d.ts"]
+    }
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib", "test"],


### PR DESCRIPTION
## Summary
- Converts `@appium/relaxed-caps-plugin` from CommonJS to a native ESM package, matching the migration already done for `@appium/universal-xml-plugin` (#22557) and `@appium/strongbox` (#22563).
- Adds `.js` extensions to all relative/subpath imports (`./plugin.js`, `./types.js`, `appium/driver.js`, `appium/plugin.js`) as required by `NodeNext` module resolution.
- Replaces the CJS `require.main === module` entry check in `lib/index.ts` with the `import.meta.url` / `fileURLToPath` equivalent for the `--smoke-test` flag.
- Sets `"type": "module"` and adds an explicit `exports` map in `package.json`, restricting consumers to the package's public entry point (`.` and `./package.json`).
- Enables `module`/`moduleResolution: "NodeNext"` in `tsconfig.json`, with local `paths` overrides so `appium/driver.js` and `appium/plugin.js` resolve to their `.d.ts` files during type-checking.

BREAKING CHANGE: `@appium/relaxed-caps-plugin` is now an ESM-only package. It can no longer be loaded via CommonJS `require()`; consumers must use `import` or dynamic `import()`. Deep imports into the package's internals are no longer possible — only the public entry point is exposed via `exports`.
