### PR TITLE
feat(images-plugin)!: Migrate to ESM

### DIFF
--- a/packages/images-plugin/lib/compare.ts
+++ b/packages/images-plugin/lib/compare.ts
@@ -9,10 +9,10 @@ import {
   type SimilarityOptions,
   type SimilarityResult,
 } from '@appium/opencv';
-import {errors} from 'appium/driver';
+import {errors} from 'appium/driver.js';
 
-import {GET_SIMILARITY_MODE, MATCH_FEATURES_MODE, MATCH_TEMPLATE_MODE} from './constants';
-import type {ComparisonResult} from './types';
+import {GET_SIMILARITY_MODE, MATCH_FEATURES_MODE, MATCH_TEMPLATE_MODE} from './constants.js';
+import type {ComparisonResult} from './types.js';
 
 /**
  * Performs images comparison using OpenCV framework features.

--- a/packages/images-plugin/lib/constants.ts
+++ b/packages/images-plugin/lib/constants.ts
@@ -1,6 +1,6 @@
-import {node} from 'appium/support';
+import {node} from 'appium/support.js';
 
-import type {ImageSettings} from './types';
+import type {ImageSettings} from './types.js';
 
 export const IMAGE_STRATEGY = '-image';
 

--- a/packages/images-plugin/lib/finder.ts
+++ b/packages/images-plugin/lib/finder.ts
@@ -1,17 +1,17 @@
 import type {Element, ExternalDriver, Rect, Size} from '@appium/types';
-import {errors} from 'appium/driver';
+import {errors} from 'appium/driver.js';
 import {LRUCache} from 'lru-cache';
 import sharp from 'sharp';
 
-import {compareImages} from './compare';
+import {compareImages} from './compare.js';
 import {
   DEFAULT_FIX_IMAGE_TEMPLATE_SCALE,
   DEFAULT_SETTINGS,
   DEFAULT_TEMPLATE_IMAGE_SCALE,
   MATCH_TEMPLATE_MODE,
-} from './constants';
-import {ImageElement} from './image-element';
-import {log} from './logger';
+} from './constants.js';
+import {ImageElement} from './image-element.js';
+import {log} from './logger.js';
 import type {
   FindByImageOptions,
   ImageSettings,
@@ -19,7 +19,7 @@ import type {
   OccurrenceResultWithVisualization,
   Screenshot,
   ScreenshotScale,
-} from './types';
+} from './types.js';
 
 // Used to compare ratio and screen width
 // Pixel is basically under 1080 for example. 100K is probably enough fo a while.

--- a/packages/images-plugin/lib/image-element.ts
+++ b/packages/images-plugin/lib/image-element.ts
@@ -1,6 +1,6 @@
 import {util} from '@appium/support';
 import type {ActionSequence, Element, ExternalDriver, Rect} from '@appium/types';
-import {errors} from 'appium/driver';
+import {errors} from 'appium/driver.js';
 
 import {
   DEFAULT_SETTINGS,
@@ -8,10 +8,10 @@ import {
   IMAGE_ELEMENT_PREFIX,
   IMAGE_STRATEGY,
   IMAGE_TAP_STRATEGIES,
-} from './constants';
-import type {ImageElementFinder} from './finder';
-import {log} from './logger';
-import type {Dimension, ImageElementOpts, ImageSettings, Position} from './types';
+} from './constants.js';
+import type {ImageElementFinder} from './finder.js';
+import {log} from './logger.js';
+import type {Dimension, ImageElementOpts, ImageSettings, Position} from './types.js';
 
 const TAP_DURATION_MS = 125;
 

--- a/packages/images-plugin/lib/index.ts
+++ b/packages/images-plugin/lib/index.ts
@@ -1,7 +1,7 @@
-export {compareImages} from './compare';
-export {IMAGE_STRATEGY} from './constants';
-export * from './constants';
-export {ImageElementFinder} from './finder';
-export {ImageElement} from './image-element';
-export {getImgElFromArgs, ImageElementPlugin} from './plugin';
-export type * from './types';
+export {compareImages} from './compare.js';
+export {IMAGE_STRATEGY} from './constants.js';
+export * from './constants.js';
+export {ImageElementFinder} from './finder.js';
+export {ImageElement} from './image-element.js';
+export {getImgElFromArgs, ImageElementPlugin} from './plugin.js';
+export type * from './types.js';

--- a/packages/images-plugin/lib/logger.ts
+++ b/packages/images-plugin/lib/logger.ts
@@ -1,3 +1,3 @@
-import {logger} from 'appium/support';
+import {logger} from 'appium/support.js';
 
 export const log = logger.getLogger('ImageElementPlugin');

--- a/packages/images-plugin/lib/plugin.ts
+++ b/packages/images-plugin/lib/plugin.ts
@@ -1,13 +1,13 @@
 import type {MatchingOptions, OccurrenceOptions, SimilarityOptions} from '@appium/opencv';
 import {util} from '@appium/support';
 import type {ActionSequence, Element, ExternalDriver, MethodMap} from '@appium/types';
-import {errors} from 'appium/driver';
-import {BasePlugin} from 'appium/plugin';
+import {errors} from 'appium/driver.js';
+import {BasePlugin} from 'appium/plugin.js';
 
-import {compareImages} from './compare';
-import {IMAGE_ELEMENT_PREFIX, IMAGE_STRATEGY} from './constants';
-import {ImageElementFinder} from './finder';
-import {ImageElement} from './image-element';
+import {compareImages} from './compare.js';
+import {IMAGE_ELEMENT_PREFIX, IMAGE_STRATEGY} from './constants.js';
+import {ImageElementFinder} from './finder.js';
+import {ImageElement} from './image-element.js';
 
 export class ImageElementPlugin extends BasePlugin {
   // this plugin supports a non-standard 'compare images' command

--- a/packages/images-plugin/lib/types.ts
+++ b/packages/images-plugin/lib/types.ts
@@ -1,8 +1,8 @@
 import type {MatchingResult, OccurrenceResult, SimilarityResult} from '@appium/opencv';
 import type {Rect} from '@appium/types';
 
-import type {IMAGE_EL_TAP_STRATEGY_MJSONWP, IMAGE_EL_TAP_STRATEGY_W3C} from './constants';
-import type {ImageElementFinder} from './finder';
+import type {IMAGE_EL_TAP_STRATEGY_MJSONWP, IMAGE_EL_TAP_STRATEGY_W3C} from './constants.js';
+import type {ImageElementFinder} from './finder.js';
 
 /**
  * Image settings interface for device settings

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -30,15 +30,23 @@
     "lib",
     "tsconfig.json"
   ],
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "test": "npm run test:unit",
     "test:smoke": "node ./build/lib/index.js",
-    "test:unit": "node --test --enable-source-maps --test-timeout=5000 \"./build/test/unit/**/*.spec.js\"",
+    "test:unit": "node --test --experimental-test-module-mocks --enable-source-maps --test-timeout=5000 \"./build/test/unit/**/*.spec.js\"",
     "test:e2e": "node --test --enable-source-maps --test-force-exit --test-concurrency=1 --test-timeout=20000 \"./build/test/e2e/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/images-plugin/test/e2e/plugin.e2e.spec.ts
+++ b/packages/images-plugin/test/e2e/plugin.e2e.spec.ts
@@ -1,6 +1,7 @@
 import type {AddressInfo} from 'node:net';
 import path from 'node:path';
 import {after, afterEach, before, beforeEach, describe, it} from 'node:test';
+import {fileURLToPath} from 'node:url';
 
 import {pluginE2EHarness} from '@appium/plugin-test-support';
 import {fs, node, tempDir} from '@appium/support';
@@ -10,11 +11,11 @@ import sharp from 'sharp';
 import {exec} from 'teen_process';
 import {remote as wdio} from 'webdriverio';
 
-import {GET_SIMILARITY_MODE, MATCH_FEATURES_MODE} from '../../lib/constants';
+import {GET_SIMILARITY_MODE, MATCH_FEATURES_MODE} from '../../lib/constants.js';
 
 use(chaiAsPromised);
 
-const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/images-plugin', __filename)!;
+const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/images-plugin', fileURLToPath(import.meta.url))!;
 const APPIUM_HOME = path.join(THIS_PLUGIN_DIR, 'local_appium_home');
 const FAKE_DRIVER_DIR = path.join(THIS_PLUGIN_DIR, '..', 'fake-driver');
 const FIXTURES_DIR = path.join(THIS_PLUGIN_DIR, 'test', 'fixtures');

--- a/packages/images-plugin/test/unit/finder.spec.ts
+++ b/packages/images-plugin/test/unit/finder.spec.ts
@@ -1,20 +1,26 @@
-import {afterEach, beforeEach, describe, it} from 'node:test';
+import {afterEach, beforeEach, describe, it, mock} from 'node:test';
 
 import type {Constraints} from '@appium/types';
-import {BaseDriver} from 'appium/driver';
-import {util} from 'appium/support';
+import {BaseDriver} from 'appium/driver.js';
+import {util} from 'appium/support.js';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sharp from 'sharp';
 import {createSandbox, type SinonSandbox} from 'sinon';
 
-import * as compareModule from '../../lib/compare';
-import {IMAGE_STRATEGY} from '../../lib/constants';
-import {ImageElementFinder} from '../../lib/finder';
-import {ImageElement} from '../../lib/image-element';
-import {ImageElementPlugin} from '../../lib/plugin';
+import {IMAGE_STRATEGY} from '../../lib/constants.js';
+import type {ImageElementFinder as TImageElementFinder} from '../../lib/finder.js';
+import {ImageElement} from '../../lib/image-element.js';
 
 use(chaiAsPromised);
+
+// finder.js and plugin.js both statically import compareImages from compare.js;
+// the mock must be registered before they are loaded, since ESM bindings are
+// resolved at module-evaluation time and cannot be re-stubbed afterwards.
+const compareStub: sinon.SinonStub = createSandbox().stub();
+mock.module('../../lib/compare.js', {namedExports: {compareImages: compareStub}});
+const {ImageElementFinder} = await import('../../lib/finder.js');
+const {ImageElementPlugin} = await import('../../lib/plugin.js');
 
 const plugin = new ImageElementPlugin('test');
 const TINY_PNG =
@@ -82,10 +88,9 @@ describe('finding elements by image', function () {
     const screenshot = Buffer.from('iVBORfoo', 'base64');
     const template = Buffer.from('iVBORbar', 'base64');
     let d: PluginDriver;
-    let f: ImageElementFinder;
-    let compareStub: sinon.SinonStub;
+    let f: TImageElementFinder;
 
-    function basicStub(driver: PluginDriver, finder: ImageElementFinder) {
+    function basicStub(driver: PluginDriver, finder: TImageElementFinder) {
       const rectStub = sandbox.stub(driver, 'getWindowRect').returns({
         x: 0,
         y: 0,
@@ -95,7 +100,7 @@ describe('finding elements by image', function () {
       return {rectStub, screenStub};
     }
 
-    function basicImgElVerify(imgElProto: any, finder: ImageElementFinder) {
+    function basicImgElVerify(imgElProto: any, finder: TImageElementFinder) {
       const imgElId = util.unwrapElement(imgElProto);
       const imgEl = finder.getImageElement(imgElId);
       expect(imgEl).to.be.instanceOf(ImageElement);
@@ -107,7 +112,7 @@ describe('finding elements by image', function () {
     beforeEach(function () {
       d = new PluginDriver();
       f = new ImageElementFinder();
-      compareStub = sandbox.stub(compareModule, 'compareImages');
+      compareStub.reset();
       compareStub.resolves({rect, score});
       basicStub(d, f);
     });
@@ -194,7 +199,7 @@ describe('finding elements by image', function () {
   });
 
   describe('fixImageTemplateScale', function () {
-    let f: ImageElementFinder;
+    let f: TImageElementFinder;
     const basicTemplate = 'iVBORbaz';
     const basicTemplateBuf = Buffer.from(basicTemplate, 'base64');
 
@@ -309,7 +314,7 @@ describe('finding elements by image', function () {
 
   describe('getScreenshotForImageFind', function () {
     let d: PluginDriver;
-    let f: ImageElementFinder;
+    let f: TImageElementFinder;
 
     beforeEach(function () {
       d = new PluginDriver();

--- a/packages/images-plugin/test/unit/image-element.spec.ts
+++ b/packages/images-plugin/test/unit/image-element.spec.ts
@@ -1,16 +1,16 @@
 import {afterEach, before, beforeEach, describe, it} from 'node:test';
 
 import type {Constraints} from '@appium/types';
-import {BaseDriver} from 'appium/driver';
-import {util} from 'appium/support';
+import {BaseDriver} from 'appium/driver.js';
+import {util} from 'appium/support.js';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {createSandbox, type SinonSandbox} from 'sinon';
 
-import {IMAGE_ELEMENT_PREFIX} from '../../lib/constants';
-import {ImageElementFinder} from '../../lib/finder';
-import {ImageElement} from '../../lib/image-element';
-import {getImgElFromArgs} from '../../lib/plugin';
+import {IMAGE_ELEMENT_PREFIX} from '../../lib/constants.js';
+import {ImageElementFinder} from '../../lib/finder.js';
+import {ImageElement} from '../../lib/image-element.js';
+import {getImgElFromArgs} from '../../lib/plugin.js';
 
 use(chaiAsPromised);
 

--- a/packages/images-plugin/test/unit/plugin.spec.ts
+++ b/packages/images-plugin/test/unit/plugin.spec.ts
@@ -1,18 +1,19 @@
 import path from 'node:path';
 import {before, describe, it} from 'node:test';
+import {fileURLToPath} from 'node:url';
 
 import type {ActionSequence, Constraints} from '@appium/types';
-import {BaseDriver} from 'appium/driver';
-import {fs, node, util} from 'appium/support';
+import {BaseDriver} from 'appium/driver.js';
+import {fs, node, util} from 'appium/support.js';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import {GET_SIMILARITY_MODE, IMAGE_STRATEGY, MATCH_FEATURES_MODE, MATCH_TEMPLATE_MODE} from '../../lib/constants';
-import {ImageElementPlugin} from '../../lib/plugin';
+import {GET_SIMILARITY_MODE, IMAGE_STRATEGY, MATCH_FEATURES_MODE, MATCH_TEMPLATE_MODE} from '../../lib/constants.js';
+import {ImageElementPlugin} from '../../lib/plugin.js';
 
 use(chaiAsPromised);
 
-const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/images-plugin', __filename)!;
+const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/images-plugin', fileURLToPath(import.meta.url))!;
 const FIXTURES_DIR = path.join(THIS_PLUGIN_DIR, 'test', 'fixtures');
 const TEST_IMG_1_PATH = path.join(FIXTURES_DIR, 'img1.png');
 const TEST_IMG_2_PATH = path.join(FIXTURES_DIR, 'img2.png');

--- a/packages/images-plugin/tsconfig.json
+++ b/packages/images-plugin/tsconfig.json
@@ -5,8 +5,14 @@
     "checkJs": true,
     "esModuleInterop": true,
     "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "paths": {
-      "@appium/opencv": ["../opencv"]
+      "@appium/opencv": ["../opencv"],
+      "appium": ["../appium"],
+      "appium/driver.js": ["../appium/driver.d.ts"],
+      "appium/plugin.js": ["../appium/plugin.d.ts"],
+      "appium/support.js": ["../appium/support.d.ts"]
     },
     "types": ["node"]
   },


### PR DESCRIPTION
## Summary
- Converts `@appium/images-plugin` from CommonJS to a native ESM package, following the same pattern already applied to `@appium/universal-xml-plugin` (#22557), `@appium/strongbox` (#22563), and `@appium/relaxed-caps-plugin`.
- Adds `.js` extensions to all relative imports and to the `appium/driver`, `appium/plugin`, and `appium/support` subpath imports throughout `lib/` and `test/`.
- Replaces `__filename` with `fileURLToPath(import.meta.url)` in `test/unit/plugin.spec.ts` and `test/e2e/plugin.e2e.spec.ts`, which use it to locate the plugin's fixtures directory via `node.getModuleRootSync`.
- Sets `"type": "module"` and adds an explicit `exports` map in `package.json`, restricting consumers to the package's public entry point (`.` and `./package.json`).
- Enables `module`/`moduleResolution: "NodeNext"` in `tsconfig.json`, with local `paths` overrides so `appium/driver.js`, `appium/plugin.js`, and `appium/support.js` resolve to their `.d.ts` files during type-checking (this is the first migrated package to import the `appium/support` subpath, so that override is new).
- Reworks `test/unit/finder.spec.ts`, which stubbed `compareImages` via `sandbox.stub(compareModule, 'compareImages')` — this throws `TypeError: ES Modules cannot be stubbed` once `compare.ts` is a real ES module, since namespace exports are frozen. Replaced with `node:test`'s `mock.module()`, registering the mock before dynamically (top-level-await) importing `ImageElementFinder`/`ImageElementPlugin`, since both statically import `compareImages` and ESM bindings resolve at module-evaluation time.
- Adds `--experimental-test-module-mocks` to the `test:unit` script, required for `mock.module()`.

BREAKING CHANGE: `@appium/images-plugin` is now an ESM-only package. It can no longer be loaded via CommonJS `require()`; consumers must use `import` or dynamic `import()`. Deep imports into the package's internals are no longer possible — only the public entry point is exposed via `exports`.
