### PR TITLE
test(appium): use dynamic import instead of require in extension-config test

### DIFF
--- a/packages/appium/test/unit/extension/extension-config.spec.ts
+++ b/packages/appium/test/unit/extension/extension-config.spec.ts
@@ -334,8 +334,12 @@ describe('ExtensionConfig', function () {
         });
 
         it('should return the class by loading from the manifest main entry point', async function () {
+          // `packages/appium` has no dependency on `@appium/relaxed-caps-plugin`, so a literal
+          // specifier here would make tsc try (and fail) to resolve its type declarations; a
+          // non-literal specifier keeps this dynamic import untyped, like `require()` used to be.
+          const relaxedCapsPluginSpecifier = '@appium/relaxed-caps-plugin';
           expect(await config.requireAsync('relaxed-caps')).to.equal(
-            (await import('@appium/relaxed-caps-plugin')).RelaxedCapsPlugin,
+            (await import(relaxedCapsPluginSpecifier)).RelaxedCapsPlugin,
           );
         });
       });

--- a/packages/appium/test/unit/extension/extension-config.spec.ts
+++ b/packages/appium/test/unit/extension/extension-config.spec.ts
@@ -335,7 +335,7 @@ describe('ExtensionConfig', function () {
 
         it('should return the class by loading from the manifest main entry point', async function () {
           expect(await config.requireAsync('relaxed-caps')).to.equal(
-            require('@appium/relaxed-caps-plugin').RelaxedCapsPlugin,
+            (await import('@appium/relaxed-caps-plugin')).RelaxedCapsPlugin,
           );
         });
       });


### PR DESCRIPTION
require() cannot load ESM-only packages, so this forward-compatible switch to dynamic import keeps the test working for both CJS and ESM extensions (e.g. once @appium/relaxed-caps-plugin migrates to ESM) without depending on that unrelated package's release.
