### PR TITLE
feat(execute-driver-plugin)!: Migrate to ESM

### DIFF
--- a/packages/execute-driver-plugin/lib/execute-child.ts
+++ b/packages/execute-driver-plugin/lib/execute-child.ts
@@ -1,10 +1,11 @@
+import {fileURLToPath} from 'node:url';
 import {promisify} from 'node:util';
 import vm from 'node:vm';
 
 import {logger, util} from '@appium/support';
 
-import type {DriverScriptMessageEvent, RunScriptResult, ScriptResult} from './types';
-import {wrapHostBindingForVmContext} from './vm-host-binding';
+import type {DriverScriptMessageEvent, RunScriptResult, ScriptResult} from './types.js';
+import {wrapHostBindingForVmContext} from './vm-host-binding.js';
 
 const log = logger.getLogger('ExecuteDriver Child');
 let send: (res: ScriptResult) => Promise<void>;
@@ -159,7 +160,7 @@ async function main(eventParams: DriverScriptMessageEvent): Promise<void> {
 }
 
 // ensure we're running this script in IPC mode
-if (require.main === module && typeof process.send === 'function') {
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1] && typeof process.send === 'function') {
   send = promisify(process.send).bind(process) as (res: ScriptResult) => Promise<void>;
   log.info('Running driver execution in child process');
   process.on('message', main);

--- a/packages/execute-driver-plugin/lib/index.ts
+++ b/packages/execute-driver-plugin/lib/index.ts
@@ -1,3 +1,3 @@
-export {MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY} from './execute-child';
-export {ExecuteDriverPlugin} from './plugin';
-export type * from './types';
+export {MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY} from './execute-child.js';
+export {ExecuteDriverPlugin} from './plugin.js';
+export type * from './types.js';

--- a/packages/execute-driver-plugin/lib/plugin.ts
+++ b/packages/execute-driver-plugin/lib/plugin.ts
@@ -1,8 +1,9 @@
 import cp from 'node:child_process';
+import {fileURLToPath} from 'node:url';
 
 import {timing} from '@appium/support';
 import type {ExternalDriver, MethodMap, NextPluginCallback, PluginCommand} from '@appium/types';
-import {BasePlugin} from 'appium/plugin';
+import {BasePlugin} from 'appium/plugin.js';
 
 const FEAT_FLAG = 'execute_driver_script';
 const DEFAULT_SCRIPT_TIMEOUT_MS = 1000 * 60 * 60; // default to 1 hour timeout
@@ -80,7 +81,7 @@ export class ExecuteDriverPlugin extends BasePlugin {
       this.log.info(`Constructed webdriverio driver options; W3C mode is ${driverOpts.isW3C ? 'on' : 'off'}`);
 
       // fork the execution script as a child process
-      const childScript = require.resolve('./execute-child.js');
+      const childScript = fileURLToPath(new URL('./execute-child.js', import.meta.url));
       this.log.info(`Forking process to run webdriver script as child using ${childScript}`);
       const scriptProc = cp.fork(childScript);
 

--- a/packages/execute-driver-plugin/package.json
+++ b/packages/execute-driver-plugin/package.json
@@ -29,8 +29,16 @@
     "lib",
     "tsconfig.json"
   ],
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.ts
+++ b/packages/execute-driver-plugin/test/e2e/plugin.e2e.spec.ts
@@ -1,6 +1,7 @@
 import type {AddressInfo} from 'node:net';
 import path from 'node:path';
 import {after, before, describe, it} from 'node:test';
+import {fileURLToPath} from 'node:url';
 
 import {pluginE2EHarness} from '@appium/plugin-test-support';
 import {fs, node} from '@appium/support';
@@ -10,11 +11,11 @@ import {exec} from 'teen_process';
 import {remote as wdio} from 'webdriverio';
 import type {Browser} from 'webdriverio';
 
-import {MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY} from '../../lib/execute-child';
+import {MJSONWP_ELEMENT_KEY, W3C_ELEMENT_KEY} from '../../lib/execute-child.js';
 
 use(chaiAsPromised);
 
-const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/execute-driver-plugin', __filename)!;
+const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/execute-driver-plugin', fileURLToPath(import.meta.url))!;
 const APPIUM_HOME = path.join(THIS_PLUGIN_DIR, 'local_appium_home');
 const FAKE_DRIVER_DIR = path.join(THIS_PLUGIN_DIR, '..', 'fake-driver');
 const TEST_HOST = '127.0.0.1';

--- a/packages/execute-driver-plugin/test/unit/plugin.spec.ts
+++ b/packages/execute-driver-plugin/test/unit/plugin.spec.ts
@@ -3,7 +3,7 @@ import {describe, it} from 'node:test';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import {ExecuteDriverPlugin} from '../../lib/plugin';
+import {ExecuteDriverPlugin} from '../../lib/plugin.js';
 
 use(chaiAsPromised);
 

--- a/packages/execute-driver-plugin/test/unit/vm-host-binding.spec.ts
+++ b/packages/execute-driver-plugin/test/unit/vm-host-binding.spec.ts
@@ -4,7 +4,7 @@ import vm from 'node:vm';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import {wrapHostBindingForVmContext} from '../../lib/vm-host-binding';
+import {wrapHostBindingForVmContext} from '../../lib/vm-host-binding.js';
 
 use(chaiAsPromised);
 

--- a/packages/execute-driver-plugin/tsconfig.json
+++ b/packages/execute-driver-plugin/tsconfig.json
@@ -5,6 +5,12 @@
     "checkJs": true,
     "esModuleInterop": true,
     "strict": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "paths": {
+      "appium": ["../appium"],
+      "appium/plugin.js": ["../appium/plugin.d.ts"]
+    },
     "types": ["node"]
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",


### PR DESCRIPTION
## Summary
- Converts `@appium/execute-driver-plugin` from CommonJS to a native ESM package, following the same pattern already applied to `@appium/universal-xml-plugin` (#22557), `@appium/strongbox` (#22563), `@appium/relaxed-caps-plugin`, and `@appium/images-plugin`.
- Adds `.js` extensions to all relative imports and to the `appium/plugin` subpath import.
- Replaces `require.resolve('./execute-child.js')` in `lib/plugin.ts` (used to resolve the path for `cp.fork()`) with `fileURLToPath(new URL('./execute-child.js', import.meta.url))`.
- Replaces the `require.main === module` IPC-mode guard in `lib/execute-child.ts` with `fileURLToPath(import.meta.url) === process.argv[1]`. This file is both imported (for `MJSONWP_ELEMENT_KEY`/`W3C_ELEMENT_KEY`) and run standalone as the forked child process entry point, so this guard matters at runtime, not just for a smoke-test flag.
- Replaces `__filename` with `fileURLToPath(import.meta.url)` in `test/e2e/plugin.e2e.spec.ts`.
- Sets `"type": "module"` and adds an explicit `exports` map in `package.json`, restricting consumers to the package's public entry point (`.` and `./package.json`).
- Enables `module`/`moduleResolution: "NodeNext"` in `tsconfig.json`, with a local `paths` override so `appium/plugin.js` resolves to its `.d.ts` file during type-checking.

BREAKING CHANGE: `@appium/execute-driver-plugin` is now an ESM-only package. It can no longer be loaded via CommonJS `require()`; consumers must use `import` or dynamic `import()`. Appium's own extension loader already loads plugins via dynamic `import()`, so `appium plugin install/use execute-driver` is unaffected. Deep imports into the package's internals are no longer possible — only the public entry point is exposed via `exports`. The forked child process (`execute-child.js`) now runs as ESM as well, since it inherits `"type": "module"` from the package's `package.json`.