### PR TITLE
feat(opencv)!: Migrate to ESM

### DIFF
--- a/packages/opencv/lib/index.ts
+++ b/packages/opencv/lib/index.ts
@@ -2,7 +2,7 @@ import {Buffer} from 'node:buffer';
 
 import sharp from 'sharp';
 
-import {OpenCvAutoreleasePool} from './autorelease-pool';
+import {OpenCvAutoreleasePool} from './autorelease-pool.js';
 import type {
   Match,
   MatchComputationResult,
@@ -16,7 +16,7 @@ import type {
   SimilarityOptions,
   SimilarityResult,
   TemplateMatchingMethod,
-} from './types';
+} from './types.js';
 
 let cv: OpenCVBindings | undefined;
 
@@ -69,7 +69,9 @@ const DEFAULT_MATCHING_METHOD: TemplateMatchingMethod = 'TM_CCOEFF_NORMED';
  * ```
  */
 export async function initOpenCv(): Promise<void> {
-  cv = require('opencv-bindings') as OpenCVBindings;
+  // @ts-expect-error opencv-bindings ships no type declarations; remove this once it does
+  const {default: cvBindings} = await import('opencv-bindings');
+  cv = cvBindings as OpenCVBindings;
   while (!cv.getBuildInformation) {
     await new Promise((resolve) => setTimeout(resolve, 500));
   }

--- a/packages/opencv/package.json
+++ b/packages/opencv/package.json
@@ -32,8 +32,16 @@
     "build/lib",
     "tsconfig.json"
   ],
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/opencv/test/e2e/opencv.e2e.spec.ts
+++ b/packages/opencv/test/e2e/opencv.e2e.spec.ts
@@ -1,15 +1,21 @@
 import path from 'node:path';
 import {describe, it, before} from 'node:test';
+import {fileURLToPath} from 'node:url';
 
 import {fs, node} from '@appium/support';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import {getImageOccurrence, getImagesMatches, getImagesSimilarity} from '../../lib';
+import {getImageOccurrence, getImagesMatches, getImagesSimilarity} from '../../lib/index.js';
 
 use(chaiAsPromised);
 
-const FIXTURES_ROOT = path.resolve(node.getModuleRootSync('@appium/opencv', __filename)!, 'test', 'e2e', 'images');
+const FIXTURES_ROOT = path.resolve(
+  node.getModuleRootSync('@appium/opencv', fileURLToPath(import.meta.url))!,
+  'test',
+  'e2e',
+  'images',
+);
 
 describe('OpenCV helpers', {timeout: 120000}, () => {
   let imgFixture: Buffer;

--- a/packages/opencv/test/unit/opencv.spec.ts
+++ b/packages/opencv/test/unit/opencv.spec.ts
@@ -2,12 +2,14 @@ import {describe, it} from 'node:test';
 
 import {expect} from 'chai';
 
-import {initOpenCv} from '../../lib';
+import {initOpenCv} from '../../lib/index.js';
 
 describe('OpenCV', function () {
   it('should initialize opencv library', {timeout: 10000}, async () => {
     await initOpenCv();
-    const buildInfo = require('opencv-bindings').getBuildInformation();
+    // @ts-expect-error opencv-bindings ships no type declarations; remove this once it does
+    const {default: cv} = await import('opencv-bindings');
+    const buildInfo = cv.getBuildInformation();
     expect(buildInfo).to.include('OpenCV');
   });
 });

--- a/packages/opencv/tsconfig.json
+++ b/packages/opencv/tsconfig.json
@@ -5,6 +5,8 @@
     "rootDir": ".",
     "outDir": "build",
     "checkJs": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "types": ["node"]
   },
   "include": ["lib", "test"]


### PR DESCRIPTION
## Summary
- Converts `@appium/opencv` from CommonJS to a native ESM package, following the same pattern already applied to `@appium/universal-xml-plugin`, `@appium/strongbox`, `@appium/relaxed-caps-plugin`, `@appium/images-plugin`, and `@appium/execute-driver-plugin`.
- Adds `.js` extensions to relative imports in `lib/index.ts` (`./autorelease-pool.js`, `./types.js`) and to the `../../lib/index.js` import in `test/unit/opencv.spec.ts` and `test/e2e/opencv.e2e.spec.ts`.
- Replaces `__filename` with `fileURLToPath(import.meta.url)` in `test/e2e/opencv.e2e.spec.ts`, which uses it to locate the fixtures directory via `node.getModuleRootSync`.
- Replaces the lazy `require('opencv-bindings')` call in `initOpenCv()` with a dynamic `import('opencv-bindings')`, since it's already invoked from an async function. Applies the same change to the equivalent call in `test/unit/opencv.spec.ts`.
- `opencv-bindings` ships no type declarations and none exist on `@types`, so a `// @ts-expect-error` annotation (with a note to remove it once upstream types land) is added at each of the two new dynamic-import call sites instead of a blanket ambient `declare module` — this way `tsc` starts failing loudly, rather than silently staying stale, the moment real types become available.
- Sets `"type": "module"` and adds an explicit `exports` map in `package.json`, restricting consumers to the package's public entry point (`.` and `./package.json`).
- Enables `module`/`moduleResolution: "NodeNext"` in `tsconfig.json`.

BREAKING CHANGE: `@appium/opencv` is now an ESM-only package. It can no longer be loaded via CommonJS `require()`; consumers must use `import` or dynamic `import()`. Deep imports into the package's internals are no longer possible — only the public entry point is exposed via `exports`.
