### PR TITLE
fix(appium): load @appium/docutils dynamically in docs build script

### DIFF
--- a/packages/appium/docs/scripts/build-docs.js
+++ b/packages/appium/docs/scripts/build-docs.js
@@ -10,7 +10,6 @@
 /* eslint-disable promise/prefer-await-to-callbacks */
 /* eslint-disable promise/prefer-await-to-then */
 
-const {deploy, buildSite} = require('@appium/docutils');
 const {
   log,
   LANGS,
@@ -35,6 +34,9 @@ const push = Boolean(process.env.APPIUM_DOCS_PUBLISH);
  * Builds and optionally deploys docs for each supported language.
  */
 async function main() {
+  // @appium/docutils is ESM-only; this file is CommonJS, so it must be loaded dynamically
+  const {deploy, buildSite} = await import('@appium/docutils');
+
   log.info(`Building Appium docs and committing to ${DOCS_BRANCH}`);
 
   const semVersion = semver.parse(version);


### PR DESCRIPTION
@appium/docutils will become ESM-only once it migrates to ESM, which breaks this file's top-level require('@appium/docutils'). Since this script itself stays CommonJS, load the dependency via a dynamic import() inside main() instead.
