### PR TITLE
feat(docutils)!: Migrate to ESM

### DIFF
--- a/packages/docutils/bin/appium-docs.js
+++ b/packages/docutils/bin/appium-docs.js
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 // @ts-check
 
-'use strict';
-
-const {main} = require('../build/lib/cli');
-const {getLogger} = require('../build/lib/logger');
+import {main} from '../build/lib/cli/index.js';
+import {getLogger} from '../build/lib/logger.js';
 
 const log = getLogger('cli');
 

--- a/packages/docutils/lib/builder/deploy.ts
+++ b/packages/docutils/lib/builder/deploy.ts
@@ -17,12 +17,12 @@ import {
   NAME_BIN,
   NAME_MIKE,
   NAME_MKDOCS_YML,
-} from '../constants';
-import {DocutilsError} from '../error';
-import {findMike, findMkDocsYml, isMkDocsInstalled, readPackageJson, requirePython} from '../fs';
-import {getLogger} from '../logger';
-import type {SpawnBackgroundProcessOpts} from '../utils';
-import {argify, execWithErrorHandling, spawnBackgroundProcess, stopwatch} from '../utils';
+} from '../constants.js';
+import {DocutilsError} from '../error.js';
+import {findMike, findMkDocsYml, isMkDocsInstalled, readPackageJson, requirePython} from '../fs.js';
+import {getLogger} from '../logger.js';
+import type {SpawnBackgroundProcessOpts} from '../utils/index.js';
+import {argify, execWithErrorHandling, spawnBackgroundProcess, stopwatch} from '../utils/index.js';
 
 const log = getLogger('builder:deploy');
 

--- a/packages/docutils/lib/builder/index.ts
+++ b/packages/docutils/lib/builder/index.ts
@@ -3,5 +3,5 @@
  * @module
  */
 
-export * from './deploy';
-export * from './site';
+export * from './deploy.js';
+export * from './site.js';

--- a/packages/docutils/lib/builder/site.ts
+++ b/packages/docutils/lib/builder/site.ts
@@ -9,12 +9,12 @@ import path from 'node:path';
 
 import type {TeenProcessExecOptions} from 'teen_process';
 
-import {DEFAULT_SITE_DIR, NAME_BIN, NAME_MKDOCS, NAME_MKDOCS_YML} from '../constants';
-import {DocutilsError} from '../error';
-import {findMkDocsYml, isMkDocsInstalled, readMkDocsYml, requirePython} from '../fs';
-import {getLogger} from '../logger';
-import type {SpawnBackgroundProcessOpts} from '../utils';
-import {execWithErrorHandling, relative, spawnBackgroundProcess, stopwatch} from '../utils';
+import {DEFAULT_SITE_DIR, NAME_BIN, NAME_MKDOCS, NAME_MKDOCS_YML} from '../constants.js';
+import {DocutilsError} from '../error.js';
+import {findMkDocsYml, isMkDocsInstalled, readMkDocsYml, requirePython} from '../fs.js';
+import {getLogger} from '../logger.js';
+import type {SpawnBackgroundProcessOpts} from '../utils/index.js';
+import {execWithErrorHandling, relative, spawnBackgroundProcess, stopwatch} from '../utils/index.js';
 
 const log = getLogger('mkdocs');
 

--- a/packages/docutils/lib/cli/check.ts
+++ b/packages/docutils/lib/cli/check.ts
@@ -6,8 +6,8 @@
 import {fs, util} from '@appium/support';
 import type {Options} from 'yargs';
 
-import {getLogger} from '../logger';
-import {kebabCase} from '../utils';
+import {getLogger} from '../logger.js';
+import {kebabCase} from '../utils/index.js';
 
 const log = getLogger('check');
 

--- a/packages/docutils/lib/cli/command/build.ts
+++ b/packages/docutils/lib/cli/command/build.ts
@@ -7,11 +7,11 @@ import path from 'node:path';
 
 import type {CommandModule, InferredOptionTypes, Options} from 'yargs';
 
-import {buildSite, deploy} from '../../builder';
-import {NAME_BIN} from '../../constants';
-import {getLogger} from '../../logger';
-import {stopwatch} from '../../utils';
-import {checkMissingPaths} from '../check';
+import {buildSite, deploy} from '../../builder/index.js';
+import {NAME_BIN} from '../../constants.js';
+import {getLogger} from '../../logger.js';
+import {stopwatch} from '../../utils/index.js';
+import {checkMissingPaths} from '../check.js';
 
 const log = getLogger('build');
 

--- a/packages/docutils/lib/cli/command/index.ts
+++ b/packages/docutils/lib/cli/command/index.ts
@@ -3,6 +3,6 @@
  * @module
  */
 
-export {default as build} from './build';
-export {default as init} from './init';
-export {default as validate} from './validate';
+export {default as build} from './build.js';
+export {default as init} from './init.js';
+export {default as validate} from './validate.js';

--- a/packages/docutils/lib/cli/command/init.ts
+++ b/packages/docutils/lib/cli/command/init.ts
@@ -5,10 +5,10 @@
 
 import type {CommandModule, InferredOptionTypes, Options} from 'yargs';
 
-import {init} from '../../init';
-import {getLogger} from '../../logger';
-import {stopwatch} from '../../utils';
-import {checkMissingPaths} from '../check';
+import {init} from '../../init.js';
+import {getLogger} from '../../logger.js';
+import {stopwatch} from '../../utils/index.js';
+import {checkMissingPaths} from '../check.js';
 
 const log = getLogger('init');
 

--- a/packages/docutils/lib/cli/command/validate.ts
+++ b/packages/docutils/lib/cli/command/validate.ts
@@ -6,11 +6,11 @@
 import {util} from '@appium/support';
 import type {CommandModule, InferredOptionTypes, Options} from 'yargs';
 
-import {DocutilsError} from '../../error';
-import {getLogger} from '../../logger';
-import type {ValidationKind} from '../../validate';
-import {DocutilsValidator} from '../../validate';
-import {checkMissingPaths} from '../check';
+import {DocutilsError} from '../../error.js';
+import {getLogger} from '../../logger.js';
+import type {ValidationKind} from '../../validate.js';
+import {DocutilsValidator} from '../../validate.js';
+import {checkMissingPaths} from '../check.js';
 
 const log = getLogger('validate');
 

--- a/packages/docutils/lib/cli/config.ts
+++ b/packages/docutils/lib/cli/config.ts
@@ -11,10 +11,10 @@ import * as YAML from 'yaml';
 import parser from 'yargs-parser';
 import {hideBin} from 'yargs/helpers';
 
-import type {LogLevelMap} from '../constants';
-import {DEFAULT_LOG_LEVEL, NAME_BIN} from '../constants';
-import {getLogger, initLogger, isLogLevelString} from '../logger';
-import {relative} from '../utils';
+import type {LogLevelMap} from '../constants.js';
+import {DEFAULT_LOG_LEVEL, NAME_BIN} from '../constants.js';
+import {getLogger, initLogger, isLogLevelString} from '../logger.js';
+import {relative} from '../utils/index.js';
 
 const log = getLogger('config');
 

--- a/packages/docutils/lib/cli/index.ts
+++ b/packages/docutils/lib/cli/index.ts
@@ -5,16 +5,18 @@
  * @module
  */
 
+import {fileURLToPath} from 'node:url';
+
 import {hideBin} from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 
-import type {LogLevelMap} from '../constants';
-import {DEFAULT_LOG_LEVEL, NAME_BIN, PKG_ROOT_DIR} from '../constants';
-import {DocutilsError} from '../error';
-import {getLogger} from '../logger';
-import {readPackage} from '../utils';
-import {build, init, validate} from './command';
-import {findConfig} from './config';
+import type {LogLevelMap} from '../constants.js';
+import {DEFAULT_LOG_LEVEL, NAME_BIN, PKG_ROOT_DIR} from '../constants.js';
+import {DocutilsError} from '../error.js';
+import {getLogger} from '../logger.js';
+import {readPackage} from '../utils/index.js';
+import {build, init, validate} from './command/index.js';
+import {findConfig} from './config.js';
 
 const log = getLogger('cli');
 const IMPLICATIONS_FAILED_REGEX = /implications\s+failed:\n\s*(.+)\s->\s(.+)$/i;
@@ -110,7 +112,7 @@ export async function main(argv = hideBin(process.argv)) {
     .parseAsync();
 }
 
-if (require.main === module) {
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
   // eslint-disable-next-line promise/prefer-await-to-then, promise/prefer-await-to-callbacks
   main().catch((err) => {
     log.error('Caught otherwise-unhandled rejection (this is probably a bug):', err);

--- a/packages/docutils/lib/constants.ts
+++ b/packages/docutils/lib/constants.ts
@@ -3,10 +3,12 @@
  * @module
  */
 
-const {LogLevels} = require('consola');
 import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
-import {findPackageRootSync} from './utils';
+import {LogLevels} from 'consola';
+
+import {findPackageRootSync} from './utils/index.js';
 
 /**
  * CLI executable name
@@ -70,7 +72,7 @@ export const DEFAULT_LOG_LEVEL = 'info';
 /**
  * Blocking I/O
  */
-export const PKG_ROOT_DIR = findPackageRootSync(__dirname);
+export const PKG_ROOT_DIR = findPackageRootSync(path.dirname(fileURLToPath(import.meta.url)));
 
 /**
  * Path to the `requirements.txt` file (in this package)

--- a/packages/docutils/lib/fs.ts
+++ b/packages/docutils/lib/fs.ts
@@ -17,11 +17,17 @@ import {
   NAME_MKDOCS_YML,
   NAME_PACKAGE_JSON,
   NAME_PYTHON,
-} from './constants';
-import {DocutilsError} from './error';
-import {getLogger} from './logger';
-import type {MkDocsYml} from './model';
-import {findPackageRoot, type NormalizedPackageJson, type PackageJson, mergeDefaultsDeep, readPackage} from './utils';
+} from './constants.js';
+import {DocutilsError} from './error.js';
+import {getLogger} from './logger.js';
+import type {MkDocsYml} from './model.js';
+import {
+  findPackageRoot,
+  type NormalizedPackageJson,
+  type PackageJson,
+  mergeDefaultsDeep,
+  readPackage,
+} from './utils/index.js';
 
 const log = getLogger('fs');
 

--- a/packages/docutils/lib/index.ts
+++ b/packages/docutils/lib/index.ts
@@ -3,8 +3,8 @@
  * @module
  */
 
-export * from './builder';
-export * from './constants';
-export * from './logger';
-export * from './scaffold';
-export * from './validate';
+export * from './builder/index.js';
+export * from './constants.js';
+export * from './logger.js';
+export * from './scaffold.js';
+export * from './validate.js';

--- a/packages/docutils/lib/init.ts
+++ b/packages/docutils/lib/init.ts
@@ -8,13 +8,13 @@ import {exec} from 'teen_process';
 import type {Simplify} from 'type-fest';
 import * as YAML from 'yaml';
 
-import {NAME_MKDOCS_YML, PIP_ENV_VARS, REQUIREMENTS_TXT_PATH} from './constants';
-import {DocutilsError} from './error';
-import {requirePython, stringifyYaml} from './fs';
-import {getLogger} from './logger';
-import type {MkDocsYml} from './model';
-import {createScaffoldTask} from './scaffold';
-import type {ScaffoldTask, ScaffoldTaskOptions} from './scaffold';
+import {NAME_MKDOCS_YML, PIP_ENV_VARS, REQUIREMENTS_TXT_PATH} from './constants.js';
+import {DocutilsError} from './error.js';
+import {requirePython, stringifyYaml} from './fs.js';
+import {getLogger} from './logger.js';
+import type {MkDocsYml} from './model.js';
+import {createScaffoldTask} from './scaffold.js';
+import type {ScaffoldTask, ScaffoldTaskOptions} from './scaffold.js';
 
 /**
  * Data for the base `mkdocs.yml` file

--- a/packages/docutils/lib/logger.ts
+++ b/packages/docutils/lib/logger.ts
@@ -6,16 +6,17 @@
  * @module
  */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const {ConsolaInstance, createConsola, LogLevel} = require('consola');
-import {DEFAULT_LOG_LEVEL, LogLevelMap} from './constants';
+import {createConsola} from 'consola';
+import type {ConsolaInstance, LogLevel} from 'consola';
+
+import {DEFAULT_LOG_LEVEL, LogLevelMap} from './constants.js';
 
 /**
  * The global log level
  *
  * "Global" inasmuch as any logger created from the root logger will use this level.
  */
-let globalLevel: typeof LogLevel = LogLevelMap[DEFAULT_LOG_LEVEL];
+let globalLevel: LogLevel = LogLevelMap[DEFAULT_LOG_LEVEL];
 
 /**
  * Type guard to see if a string is a recognized log level
@@ -43,7 +44,7 @@ rootLogger.pauseLogs();
 /**
  * A map of tags to loggers
  */
-const loggers: Map<string, WeakRef<typeof ConsolaInstance>> = new Map();
+const loggers: Map<string, WeakRef<ConsolaInstance>> = new Map();
 
 /**
  * Returns a tagged logger, creating and caching one if needed.
@@ -71,7 +72,7 @@ export function getLogger(tag: string, parent = rootLogger) {
  * @remarks Child loggers seem to inherit the "paused" state of the parent, so when this is called, we must resume all of them.
  */
 let hasInitializedLogger = false;
-export const initLogger = (level: keyof typeof LogLevelMap | typeof LogLevel) => {
+export const initLogger = (level: keyof typeof LogLevelMap | LogLevel) => {
   if (hasInitializedLogger) {
     return;
   }

--- a/packages/docutils/lib/scaffold.ts
+++ b/packages/docutils/lib/scaffold.ts
@@ -9,12 +9,12 @@ import {fs, util} from '@appium/support';
 import {createPatch} from 'diff';
 import type {JsonObject, JsonValue} from 'type-fest';
 
-import {NAME_ERR_ENOENT} from './constants';
-import {DocutilsError} from './error';
-import {readPackageJson, stringifyJson, writeFileString} from './fs';
-import {getLogger} from './logger';
-import type {NormalizedPackageJson} from './utils';
-import {mergeDefaultsDeep, relative} from './utils';
+import {NAME_ERR_ENOENT} from './constants.js';
+import {DocutilsError} from './error.js';
+import {readPackageJson, stringifyJson, writeFileString} from './fs.js';
+import {getLogger} from './logger.js';
+import type {NormalizedPackageJson} from './utils/index.js';
+import {mergeDefaultsDeep, relative} from './utils/index.js';
 
 const log = getLogger('init');
 const dryRunLog = getLogger('dry-run', log);

--- a/packages/docutils/lib/utils/index.ts
+++ b/packages/docutils/lib/utils/index.ts
@@ -1,9 +1,9 @@
-export {argify, kebabCase} from './cli';
-export {isStringArray, mergeDefaultsDeep} from './object';
-export type {TupleToObject} from './object';
-export {findPackageRoot, findPackageRootSync, readPackage} from './package-json';
-export type {NormalizedPackageJson, NormalizeOptions, PackageJson, ReadPackageOptions} from './package-json';
-export {relative} from './path';
-export {execWithErrorHandling, spawnBackgroundProcess} from './process';
-export type {SpawnBackgroundProcessOpts} from './process';
-export {stopwatch} from './timing';
+export {argify, kebabCase} from './cli.js';
+export {isStringArray, mergeDefaultsDeep} from './object.js';
+export type {TupleToObject} from './object.js';
+export {findPackageRoot, findPackageRootSync, readPackage} from './package-json.js';
+export type {NormalizedPackageJson, NormalizeOptions, PackageJson, ReadPackageOptions} from './package-json.js';
+export {relative} from './path.js';
+export {execWithErrorHandling, spawnBackgroundProcess} from './process.js';
+export type {SpawnBackgroundProcessOpts} from './process.js';
+export {stopwatch} from './timing.js';

--- a/packages/docutils/lib/validate.ts
+++ b/packages/docutils/lib/validate.ts
@@ -19,11 +19,11 @@ import {
   NAME_PYTHON,
   NAME_REQUIREMENTS_TXT,
   REQUIREMENTS_TXT_PATH,
-} from './constants';
-import {DocutilsError} from './error';
-import {findMkDocsYml, findPython, isMkDocsInstalled, readMkDocsYml} from './fs';
-import {getLogger} from './logger';
-import type {MkDocsYml, PipPackage} from './model';
+} from './constants.js';
+import {DocutilsError} from './error.js';
+import {findMkDocsYml, findPython, isMkDocsInstalled, readMkDocsYml} from './fs.js';
+import {getLogger} from './logger.js';
+import type {MkDocsYml, PipPackage} from './model.js';
 
 /**
  * Matches the Python version string from `python --version`

--- a/packages/docutils/package.json
+++ b/packages/docutils/package.json
@@ -37,8 +37,16 @@
     "tsconfig.json",
     "requirements.txt"
   ],
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/docutils/test/e2e/build.e2e.spec.ts
+++ b/packages/docutils/test/e2e/build.e2e.spec.ts
@@ -11,12 +11,12 @@ import {expect} from 'chai';
 import * as YAML from 'yaml';
 import yargs from 'yargs/yargs';
 
-import {buildSite} from '../../lib/builder';
-import {build as buildCommand, init as initCommand, validate as validateCommand} from '../../lib/cli/command';
-import {DEFAULT_SITE_DIR, NAME_BIN, NAME_MKDOCS_YML, NAME_PACKAGE_JSON} from '../../lib/constants';
-import {stringifyYaml} from '../../lib/fs';
-import {init, initPython} from '../../lib/init';
-import type {MkDocsYml} from '../../lib/model';
+import {buildSite} from '../../lib/builder/index.js';
+import {build as buildCommand, init as initCommand, validate as validateCommand} from '../../lib/cli/command/index.js';
+import {DEFAULT_SITE_DIR, NAME_BIN, NAME_MKDOCS_YML, NAME_PACKAGE_JSON} from '../../lib/constants.js';
+import {stringifyYaml} from '../../lib/fs.js';
+import {init, initPython} from '../../lib/init.js';
+import type {MkDocsYml} from '../../lib/model.js';
 
 /**
  * Helper function to create a project directory with package.json

--- a/packages/docutils/test/unit/builder.spec.ts
+++ b/packages/docutils/test/unit/builder.spec.ts
@@ -4,8 +4,8 @@ import {describe, it, before, after} from 'node:test';
 import {fs, tempDir} from '@appium/support';
 import {expect} from 'chai';
 
-import {findDeployVersion} from '../../lib/builder/deploy';
-import {NAME_PACKAGE_JSON} from '../../lib/constants';
+import {findDeployVersion} from '../../lib/builder/deploy.js';
+import {NAME_PACKAGE_JSON} from '../../lib/constants.js';
 
 /**
  * Helper function to create a project directory with package.json

--- a/packages/docutils/test/unit/util.spec.ts
+++ b/packages/docutils/test/unit/util.spec.ts
@@ -2,7 +2,7 @@ import {describe, it} from 'node:test';
 
 import {expect} from 'chai';
 
-import {argify} from '../../lib/utils';
+import {argify} from '../../lib/utils/index.js';
 
 describe('argify', function () {
   it('should create args from params', function () {

--- a/packages/docutils/tsconfig.json
+++ b/packages/docutils/tsconfig.json
@@ -4,6 +4,8 @@
     "rootDir": ".",
     "outDir": "build",
     "checkJs": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "types": ["node"],
     "paths": {
       "@appium/support": ["../support"],


### PR DESCRIPTION
## Summary

- Migrates @appium/docutils to a native ESM package ("type": "module"), following the same pattern already applied to @appium/universal-xml-plugin (#22557), @appium/strongbox (#22563), @appium/relaxed-caps-plugin (#22573), @appium/images-plugin (#22574), and @appium/execute-driver-plugin (#22576).
- Adds "type": "module" and an explicit exports map (., ./package.json) to package.json, and sets module/moduleResolution to "NodeNext" in tsconfig.json.
- Adds .js extensions to all relative imports across lib/, bin/, and test/, including directory-index imports that resolved implicitly under CommonJS (./utils → ./utils/index.js, ./builder → ./builder/index.js, ./command → ./command/index.js).
- Replaces `require('consola')` in lib/constants.ts and lib/logger.ts with proper `import`/`import type` statements. The original code destructured `LogLevel` and `ConsolaInstance` off a `require()` call purely to reference their types (since `require()` types as `any`); these are now imported as types directly from `consola`.
- Replaces `__dirname` in lib/constants.ts (used to compute `PKG_ROOT_DIR`) with `path.dirname(fileURLToPath(import.meta.url))`.
- Replaces `require.main === module` in lib/cli/index.ts with `process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]`, matching the check used in the "stawhere in this migration series.
- Converts bin/appium-docs.js to ESM import syntax with explicit .js extensions.
- No test-mocking rewrite was needed here (unlike #22563/#22574) — none of docutils' unit/e2e tests stub internal modules, so the existing test:unit/test:e2e scripts are unchanged.

BREAKING CHANGE: @appium/docutils is now an ESM-only package. It can no longer be loaded via CommonJS require(); consumers must use import or dynamic import(). Deep imports into the package's internals are no longer possible — only the public entry point is exposed via exports.