### PR TITLE
fix(support): do not treat a sibling folder as a subpath of the root

### DIFF
--- a/packages/appium/lib/cli/extension-command.ts
+++ b/packages/appium/lib/cli/extension-command.ts
@@ -589,7 +589,7 @@ export abstract class ExtensionCliCommand<ExtType extends ExtensionType = Extens
     const paths: string[] = doctorSpec.checks
       .map((p) => {
         const scriptPath = path.resolve(moduleRoot, p);
-        if (!path.normalize(scriptPath).startsWith(path.normalize(moduleRoot))) {
+        if (!util.isSubPath(scriptPath, moduleRoot)) {
           this.log.error(
             `The doctor check script '${p}' from the package manifest '${packageJsonPath}' must be located ` +
               `in the '${moduleRoot}' root folder. It will be skipped`,
@@ -694,8 +694,7 @@ export abstract class ExtensionCliCommand<ExtType extends ExtensionType = Extens
 
     const scriptPath = extScripts[scriptName];
     const moduleRoot = this.config.getInstallPath(installSpec);
-    const normalizedScriptPath = path.normalize(path.resolve(moduleRoot, scriptPath));
-    if (!normalizedScriptPath.startsWith(path.normalize(moduleRoot))) {
+    if (!util.isSubPath(path.resolve(moduleRoot, scriptPath), moduleRoot)) {
       throw this._createFatalError(`The '${scriptPath}' script must be located in the '${moduleRoot}' folder`);
     }
 

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -429,7 +429,7 @@ export function toReadableSizeString(bytes: number | string): string {
  * @param originalPath - The absolute file or folder path to test
  * @param root - The absolute root folder path
  * @param forcePosix - If true, interpret paths in POSIX format (e.g. on Windows)
- * @returns `true` if `originalPath` is under `root`
+ * @returns `true` if `originalPath` is under `root` or is equal to it
  * @throws {Error} If either path is not absolute
  */
 export function isSubPath(originalPath: string, root: string, forcePosix: boolean | null = null): boolean {
@@ -439,9 +439,11 @@ export function isSubPath(originalPath: string, root: string, forcePosix: boolea
       throw new Error(`'${p}' is expected to be an absolute path`);
     }
   }
-  const normalizedRoot = pathObj.normalize(root);
-  const normalizedPath = pathObj.normalize(originalPath);
-  return normalizedPath.startsWith(normalizedRoot);
+  // An empty relative path means both arguments point to the same location.
+  // Comparing the strings instead would accept any sibling whose name starts
+  // with the root folder name, like '/root-backup' for the '/root' root.
+  const relativePath = pathObj.relative(root, originalPath);
+  return relativePath !== '..' && !relativePath.startsWith(`..${pathObj.sep}`) && !pathObj.isAbsolute(relativePath);
 }
 
 /**

--- a/packages/support/test/unit/util.spec.ts
+++ b/packages/support/test/unit/util.spec.ts
@@ -389,6 +389,13 @@ describe('util', function () {
     it('should detect if a path is not a subpath', function () {
       expect(util.isSubPath('/root/some//../..', '/root')).to.be.false;
     });
+    it('should not detect a sibling whose name starts with the root name', function () {
+      expect(util.isSubPath('/root-backup/some', '/root')).to.be.false;
+      expect(util.isSubPath('/rootly', '/root')).to.be.false;
+    });
+    it('should detect a subpath whose name starts with a dot', function () {
+      expect(util.isSubPath('/root/..some', '/root')).to.be.true;
+    });
     it('should throw if any of the given paths is not absolute', function () {
       expect(() => util.isSubPath('some/..', '/root')).to.throw(/absolute/);
     });


### PR DESCRIPTION
## Proposed changes

`util.isSubPath` compared normalized path strings: return normalizedPath.startsWith(normalizedRoot);

Any sibling whose name begins with the root folder name therefore passed the check, so `/root-backup/some` and `/rootly` were both reported as being under `/root`. The comparison now uses the relative path between the two, which only accepts a path that really is inside the root, or the root itself.
`extension-command.ts` had the same comparison hand-written in two places, for the doctor check scripts and for `appium <ext> run`. Both guards mean to keep the executed script inside the extension folder, and both accepted a sibling folder
with a matching prefix. They now use the fixed helper instead of repeating the check.

Note that rejecting every relative path starting with `..` would be wrong, since that also rejects a legitimate entry such as `/root/..some`. The check looks for`..` on its own or followed by a path separator, and there is a test for it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

All existing `isSubPath` tests pass unchanged, including `isSubPath('/root/some/other/../../.', '/root')`, which resolves to the root itself and is expected to be `true`. Added tests for the sibling case (fails on master) and for a subpath name starting with a dot.