### PR TITLE
chore(base-driver): Deprecate the legacy createSession API shape

### DIFF
--- a/packages/appium/docs/en/developing/build-drivers.md
+++ b/packages/appium/docs/en/developing/build-drivers.md
@@ -222,17 +222,22 @@ So you'll probably end up overriding `createSession`. You can do so by defining 
 driver:
 
 ```js
-async createSession(jwpCaps, reqCaps, w3cCaps, otherDriverData) {
-    const [sessionId, caps] = super.createSession(w3cCaps);
+async createSession(w3cCaps) {
+    const [sessionId, caps] = await super.createSession(w3cCaps);
     // do your own stuff here
     return [sessionId, caps];
 }
 ```
 
-For legacy reasons, your function will receive old-style JSON Wire Protocol desired and required
-caps as the first two arguments. Given that the old protocol isn't supported anymore and clients
-have all been updated, you can instead only rely on the `w3cCaps` parameter. (For a discussion
-about what `otherDriverData` is about, see the section below on concurrent drivers).
+!!! warning "Deprecated"
+
+    Older drivers may still define `createSession` with up to four parameters, e.g.
+    `createSession(jwpCaps, reqCaps, w3cCaps, otherDriverData)`. This shape is a holdover from the
+    retired JSON Wire Protocol, which required desired and required caps as the first two
+    arguments; only the first W3C-shaped argument was ever used. The `otherDriverData` parameter is
+    likewise deprecated in favor of [IPC](#send-messages-to-plugins-running-on-the-same-session) for
+    coordinating with other concurrently-running sessions. New drivers should use the single-argument
+    form shown above.
 
 You'll want to make sure to call `super.createSession` in order to get the session ID as well as
 the processed capabilities (note that capabilities are also set on `this.caps`; modifying `caps`
@@ -797,6 +802,12 @@ that multiple simultaneous sessions don't use the same resources:
 1. Have each driver express what resources it is using, then examine currently-used resources from
    other drivers when a new session begins.
 
+!!! warning "Deprecated"
+
+    The `driverData`-based mechanism described below is deprecated. Prefer
+    [IPC](#send-messages-to-plugins-running-on-the-same-session) for coordinating resources across
+    concurrently-running sessions instead.
+
 To support this third strategy, you can implement `get driverData` in your driver to return what
 sorts of resources your driver is currently using, for example:
 
@@ -808,7 +819,7 @@ get driverData() {
 
 Now, when a new session is started on your driver, the `driverData` response from any other
 simultaneously running drivers (of the same type) will also be included, as the last parameter of
-the `createSession` method:
+the deprecated, multi-argument form of the `createSession` method:
 
 ```js
 async createSession(jwpCaps, reqCaps, w3cCaps, driverData)

--- a/packages/appium/lib/appium.ts
+++ b/packages/appium/lib/appium.ts
@@ -76,6 +76,8 @@ type SessionHandlerDeleteResult = SessionHandlerResult<void>;
  * Tuple shape of the deprecated multi-argument overload of {@link AppiumDriver.createSession}.
  * Shared between that overload's declaration and its implementation signature so the parameter
  * list only needs to be written out once.
+ *
+ * @deprecated Use the single-argument overload of {@link AppiumDriver.createSession} instead.
  */
 type LegacyCreateSessionArgs = [
   w3cCapabilities1: W3CAppiumDriverCaps,

--- a/packages/appium/lib/appium.ts
+++ b/packages/appium/lib/appium.ts
@@ -282,8 +282,9 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
    */
   async createSession(w3cCapabilities: W3CAppiumDriverCaps): Promise<SessionHandlerCreateResult>;
   /**
-   * @deprecated Legacy call sites may pass the same W3C caps in up to three positions; the first
-   * W3C-shaped value wins. Use the single-argument overload of {@linkcode createSession} instead.
+   * @deprecated Legacy call sites may pass the same W3C caps in up to three positions. These
+   * positions are intended to carry the same value; if they differ, which one wins is
+   * unspecified. Use the single-argument overload of {@linkcode createSession} instead.
    */
   async createSession(...legacyArgs: LegacyCreateSessionArgs): Promise<SessionHandlerCreateResult>;
   async createSession(...legacyArgs: LegacyCreateSessionArgs): Promise<SessionHandlerCreateResult> {

--- a/packages/appium/lib/appium.ts
+++ b/packages/appium/lib/appium.ts
@@ -72,6 +72,17 @@ type SessionHandlerCreateResult = SessionHandlerResult<
 
 type SessionHandlerDeleteResult = SessionHandlerResult<void>;
 
+/**
+ * Tuple shape of the deprecated multi-argument overload of {@link AppiumDriver.createSession}.
+ * Shared between that overload's declaration and its implementation signature so the parameter
+ * list only needs to be written out once.
+ */
+type LegacyCreateSessionArgs = [
+  w3cCapabilities1: W3CAppiumDriverCaps,
+  w3cCapabilities2?: W3CAppiumDriverCaps,
+  w3cCapabilities3?: W3CAppiumDriverCaps,
+];
+
 /** @internal Not part of {@link ExternalDriver}; used only when wiring session IPC. */
 type IpcAssignable = {
   assignIpc?: (ipc: IAppiumIpc) => Promise<void>;
@@ -272,16 +283,9 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
    * @deprecated Legacy call sites may pass the same W3C caps in up to three positions; the first
    * W3C-shaped value wins. Use the single-argument overload of {@linkcode createSession} instead.
    */
-  async createSession(
-    w3cCapabilities1: W3CAppiumDriverCaps,
-    w3cCapabilities2?: W3CAppiumDriverCaps,
-    w3cCapabilities3?: W3CAppiumDriverCaps,
-  ): Promise<SessionHandlerCreateResult>;
-  async createSession(
-    w3cCapabilities1: W3CAppiumDriverCaps,
-    w3cCapabilities2?: W3CAppiumDriverCaps,
-    w3cCapabilities3?: W3CAppiumDriverCaps,
-  ): Promise<SessionHandlerCreateResult> {
+  async createSession(...legacyArgs: LegacyCreateSessionArgs): Promise<SessionHandlerCreateResult>;
+  async createSession(...legacyArgs: LegacyCreateSessionArgs): Promise<SessionHandlerCreateResult> {
+    const [w3cCapabilities1, w3cCapabilities2, w3cCapabilities3] = legacyArgs;
     const defaultCapabilities = structuredClone(this.args.defaultCapabilities);
     const defaultSettings = pullSettings((defaultCapabilities ?? {}) as StringRecord);
     const w3cCapabilities = structuredClone([w3cCapabilities3, w3cCapabilities2, w3cCapabilities1].find(isW3cCaps));

--- a/packages/appium/lib/appium.ts
+++ b/packages/appium/lib/appium.ts
@@ -263,9 +263,20 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
 
   /**
    * Creates a session: picks an inner driver from caps, runs plugin hooks, and returns a protocol
-   * envelope with either `[sessionId, caps, protocol]` or an error. Legacy call sites may pass the
-   * same W3C caps in up to three positions; the first W3C-shaped value wins.
+   * envelope with either `[sessionId, caps, protocol]` or an error.
+   *
+   * @param w3cCapabilities - the new session capabilities in W3C format
    */
+  async createSession(w3cCapabilities: W3CAppiumDriverCaps): Promise<SessionHandlerCreateResult>;
+  /**
+   * @deprecated Legacy call sites may pass the same W3C caps in up to three positions; the first
+   * W3C-shaped value wins. Use the single-argument overload of {@linkcode createSession} instead.
+   */
+  async createSession(
+    w3cCapabilities1: W3CAppiumDriverCaps,
+    w3cCapabilities2?: W3CAppiumDriverCaps,
+    w3cCapabilities3?: W3CAppiumDriverCaps,
+  ): Promise<SessionHandlerCreateResult>;
   async createSession(
     w3cCapabilities1: W3CAppiumDriverCaps,
     w3cCapabilities2?: W3CAppiumDriverCaps,

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -140,6 +140,8 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
    * specific driver sessions. This data can be later used to adjust
    * properties for driver instances running in parallel.
    * Override it in inherited driver classes if necessary.
+   *
+   * @deprecated Use {@linkcode IAppiumIpc} for cross-session coordination instead.
    */
   get driverData() {
     return {};

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -9,8 +9,8 @@ import {
   type DefaultDeleteSessionResult,
   type Driver,
   type DriverCaps,
-  type DriverData,
   type InitialOpts,
+  type LegacyCreateSessionArgs,
   type ServerArgs,
   type SessionCapabilities,
   type SingularSessionData,
@@ -276,19 +276,9 @@ export class BaseDriver<
    * parameter is also deprecated; use {@linkcode IAppiumIpc} for cross-session coordination
    * instead.
    */
-  async createSession(
-    w3cCapabilities1: W3CDriverCaps<C>,
-    w3cCapabilities2?: W3CDriverCaps<C>,
-    w3cCapabilities3?: W3CDriverCaps<C>,
-    driverData?: DriverData[],
-  ): Promise<CreateResult>;
-  async createSession(
-    w3cCapabilities1: W3CDriverCaps<C>,
-    w3cCapabilities2?: W3CDriverCaps<C>,
-    w3cCapabilities?: W3CDriverCaps<C>,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    driverData?: DriverData[],
-  ): Promise<CreateResult> {
+  async createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult>;
+  async createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult> {
+    const [w3cCapabilities1, w3cCapabilities2, w3cCapabilities] = legacyArgs;
     if (this.sessionId !== null) {
       throw new errors.SessionNotCreatedError('Cannot create a new session while one is in progress');
     }

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -270,11 +270,11 @@ export class BaseDriver<
    */
   async createSession(w3cCapabilities: W3CDriverCaps<C>): Promise<CreateResult>;
   /**
-   * @deprecated Historically the first three arguments were reserved for JSONWP capabilities, and
-   * Appium 2 dropped support for that protocol, so only the first W3C-shaped argument is ever
-   * used. Use the single-argument overload of {@linkcode createSession} instead. The `driverData`
-   * parameter is also deprecated; use {@linkcode IAppiumIpc} for cross-session coordination
-   * instead.
+   * @deprecated Historically the first three arguments were reserved for JSONWP capabilities.
+   * Appium 2 dropped support for that protocol; these positions are now intended to carry the
+   * same W3C capabilities value, and if they differ, which one wins is unspecified. Use the
+   * single-argument overload of {@linkcode createSession} instead. The `driverData` parameter is
+   * also deprecated; use {@linkcode IAppiumIpc} for cross-session coordination instead.
    */
   async createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult>;
   async createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult> {

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -264,11 +264,24 @@ export class BaseDriver<
   }
 
   /**
-   * Historically the first two arguments were reserved for JSONWP capabilities.
-   * Appium 2 has dropped the support of these, so now we only accept capability
-   * objects in W3C format and thus allow any of the three arguments to represent
-   * the latter.
+   * Start a new automation session.
+   *
+   * @param w3cCapabilities - the new session capabilities in W3C format
    */
+  async createSession(w3cCapabilities: W3CDriverCaps<C>): Promise<CreateResult>;
+  /**
+   * @deprecated Historically the first three arguments were reserved for JSONWP capabilities, and
+   * Appium 2 dropped support for that protocol, so only the first W3C-shaped argument is ever
+   * used. Use the single-argument overload of {@linkcode createSession} instead. The `driverData`
+   * parameter is also deprecated; use {@linkcode IAppiumIpc} for cross-session coordination
+   * instead.
+   */
+  async createSession(
+    w3cCapabilities1: W3CDriverCaps<C>,
+    w3cCapabilities2?: W3CDriverCaps<C>,
+    w3cCapabilities3?: W3CDriverCaps<C>,
+    driverData?: DriverData[],
+  ): Promise<CreateResult>;
   async createSession(
     w3cCapabilities1: W3CDriverCaps<C>,
     w3cCapabilities2?: W3CDriverCaps<C>,
@@ -374,6 +387,9 @@ export class BaseDriver<
     return {capabilities: this.caps};
   }
 
+  /**
+   * Stop the current automation session.
+   */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async deleteSession(sessionId?: string | null) {
     await this.clearNewCommandTimeout();

--- a/packages/base-driver/lib/protocol/routes/w3c.ts
+++ b/packages/base-driver/lib/protocol/routes/w3c.ts
@@ -10,7 +10,11 @@ export const W3C_ROUTES = {
     POST: {
       command: 'createSession',
       payloadParams: {
-        optional: ['capabilities'],
+        // Deliberately sent 3 times: this array is spread directly into any plugin hooking
+        // 'createSession' (see AppiumDriver#wrapCommandWithPlugins), so changing its shape here
+        // would be a wire-level breaking change for third-party plugins, not just drivers. Keep
+        // this in sync with the deprecated multi-argument overload of `createSession`.
+        optional: ['capabilities', 'capabilities', 'capabilities'],
       },
     },
   },

--- a/packages/base-driver/lib/protocol/routes/w3c.ts
+++ b/packages/base-driver/lib/protocol/routes/w3c.ts
@@ -10,7 +10,7 @@ export const W3C_ROUTES = {
     POST: {
       command: 'createSession',
       payloadParams: {
-        optional: ['capabilities', 'capabilities', 'capabilities'],
+        optional: ['capabilities'],
       },
     },
   },

--- a/packages/base-driver/test/e2e/protocol/fake-driver.ts
+++ b/packages/base-driver/test/e2e/protocol/fake-driver.ts
@@ -9,7 +9,7 @@ import type {
   W3CDriverCaps,
 } from '@appium/types';
 
-import {BaseDriver, determineProtocol, errors} from '../../../lib';
+import {BaseDriver, determineProtocol, errors, isW3cCaps} from '../../../lib';
 import {PROTOCOLS} from '../../../lib/constants';
 
 class FakeDriver extends BaseDriver<Constraints> {
@@ -42,14 +42,15 @@ class FakeDriver extends BaseDriver<Constraints> {
 
   async createSession(
     desiredCapabilities: W3CDriverCaps<Constraints>,
-    requiredCapabilities: W3CDriverCaps<Constraints>,
-    capabilities: W3CDriverCaps<Constraints>,
+    requiredCapabilities?: W3CDriverCaps<Constraints>,
+    capabilities?: W3CDriverCaps<Constraints>,
   ): Promise<DefaultCreateSessionResult<Constraints>> {
-    if ([desiredCapabilities, requiredCapabilities, capabilities].every((c) => util.isEmpty(c))) {
+    const w3cCapabilities = [desiredCapabilities, requiredCapabilities, capabilities].find(isW3cCaps);
+    if (!w3cCapabilities) {
       throw new errors.SessionNotCreatedError('No capabilities provided');
     }
     this.sessionId = `fakeSession_${util.uuidV4()}`;
-    return [this.sessionId, capabilities] as unknown as DefaultCreateSessionResult<Constraints>;
+    return [this.sessionId, w3cCapabilities] as unknown as DefaultCreateSessionResult<Constraints>;
   }
 
   async executeCommand<T = unknown>(cmd: string, ...args: any[]): Promise<T> {

--- a/packages/base-driver/test/unit/protocol/routes.spec.ts
+++ b/packages/base-driver/test/unit/protocol/routes.spec.ts
@@ -44,7 +44,7 @@ describe('Routes', function () {
       }
       const hash = shasum.digest('hex').substring(0, 8);
       // Update this value again only when an intentional route/command/param change is made.
-      expect(hash).to.equal('bc1f4e99');
+      expect(hash).to.equal('a175e178');
     });
   });
 

--- a/packages/base-driver/test/unit/protocol/routes.spec.ts
+++ b/packages/base-driver/test/unit/protocol/routes.spec.ts
@@ -44,7 +44,7 @@ describe('Routes', function () {
       }
       const hash = shasum.digest('hex').substring(0, 8);
       // Update this value again only when an intentional route/command/param change is made.
-      expect(hash).to.equal('a175e178');
+      expect(hash).to.equal('bc1f4e99');
     });
   });
 

--- a/packages/types/lib/commands/basedriver.ts
+++ b/packages/types/lib/commands/basedriver.ts
@@ -352,18 +352,12 @@ export interface ISessionHandler<
   createSession(w3cCapabilities: W3CDriverCaps<C>): Promise<CreateResult>;
   /**
    * @deprecated Historically this method accepted the same W3C capabilities object in up to three
-   * positions to support the retired JSONWP protocol, and only the first W3C-shaped argument is
-   * ever used. Use the single-argument overload of {@linkcode createSession} instead. The
-   * `driverData` parameter is also deprecated; use {@linkcode IAppiumIpc} for cross-session
-   * coordination instead.
+   * positions to support the retired JSONWP protocol. These positions are intended to carry the
+   * same value; if they differ, which one wins is unspecified. Use the single-argument overload
+   * of {@linkcode createSession} instead. The `driverData` parameter is also deprecated; use
+   * {@linkcode IAppiumIpc} for cross-session coordination instead.
    *
-   * @param w3cCaps1 - the new session capabilities
-   * @param w3cCaps2 - another place the new session capabilities could be sent (typically left undefined)
-   * @param w3cCaps3 - another place the new session capabilities could be sent (typically left undefined)
-   * @param driverData - a list of DriverData objects representing other sessions running for this
-   * driver on the same Appium server. This information can be used to help ensure no conflict of
-   * resources
-   *
+   * @param legacyArgs - see {@linkcode LegacyCreateSessionArgs}
    * @returns The capabilities object representing the created session
    */
   createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult>;

--- a/packages/types/lib/commands/basedriver.ts
+++ b/packages/types/lib/commands/basedriver.ts
@@ -322,6 +322,9 @@ export interface ISettingsCommands<T extends object = object> {
  * Tuple shape of the deprecated multi-argument overload of {@linkcode ISessionHandler.createSession}.
  * Shared with {@linkcode BaseDriver.createSession}'s implementation so the parameter list only
  * needs to be written out once.
+ *
+ * @deprecated Use the single-argument overload of {@linkcode ISessionHandler.createSession}
+ * instead.
  */
 export type LegacyCreateSessionArgs<C extends Constraints> = [
   w3cCaps1: W3CDriverCaps<C>,

--- a/packages/types/lib/commands/basedriver.ts
+++ b/packages/types/lib/commands/basedriver.ts
@@ -331,9 +331,16 @@ export interface ISessionHandler<
    * Start a new automation session
    * @see {@link https://w3c.github.io/webdriver/#new-session}
    *
-   * @privateRemarks
-   * The shape of this method is strange because it used to support both JSONWP and W3C
-   * capabilities. This will likely change in the future to simplify.
+   * @param w3cCapabilities - the new session capabilities
+   * @returns The capabilities object representing the created session
+   */
+  createSession(w3cCapabilities: W3CDriverCaps<C>): Promise<CreateResult>;
+  /**
+   * @deprecated Historically this method accepted the same W3C capabilities object in up to three
+   * positions to support the retired JSONWP protocol, and only the first W3C-shaped argument is
+   * ever used. Use the single-argument overload of {@linkcode createSession} instead. The
+   * `driverData` parameter is also deprecated; use {@linkcode IAppiumIpc} for cross-session
+   * coordination instead.
    *
    * @param w3cCaps1 - the new session capabilities
    * @param w3cCaps2 - another place the new session capabilities could be sent (typically left undefined)
@@ -354,6 +361,13 @@ export interface ISessionHandler<
   /**
    * Stop an automation session
    * @see {@link https://w3c.github.io/webdriver/#delete-session}
+   *
+   * @param sessionId - the id of the session that is to be deleted
+   */
+  deleteSession(sessionId?: string): Promise<DeleteResult | void>;
+  /**
+   * @deprecated The `driverData` parameter is unused by {@linkcode BaseDriver}; use
+   * {@linkcode IAppiumIpc} for cross-session coordination instead.
    *
    * @param sessionId - the id of the session that is to be deleted
    * @param driverData - the driver data for other currently-running sessions
@@ -387,6 +401,8 @@ export type DefaultDeleteSessionResult = void;
 
 /**
  * Custom session data for a driver.
+ *
+ * @deprecated Use {@linkcode IAppiumIpc} for cross-session coordination instead.
  */
 export type DriverData = Record<string, unknown>;
 

--- a/packages/types/lib/commands/basedriver.ts
+++ b/packages/types/lib/commands/basedriver.ts
@@ -319,6 +319,18 @@ export interface ISettingsCommands<T extends object = object> {
 }
 
 /**
+ * Tuple shape of the deprecated multi-argument overload of {@linkcode ISessionHandler.createSession}.
+ * Shared with {@linkcode BaseDriver.createSession}'s implementation so the parameter list only
+ * needs to be written out once.
+ */
+export type LegacyCreateSessionArgs<C extends Constraints> = [
+  w3cCaps1: W3CDriverCaps<C>,
+  w3cCaps2?: W3CDriverCaps<C>,
+  w3cCaps3?: W3CDriverCaps<C>,
+  driverData?: DriverData[],
+];
+
+/**
  * An interface which creates and deletes sessions.
  */
 export interface ISessionHandler<
@@ -351,12 +363,7 @@ export interface ISessionHandler<
    *
    * @returns The capabilities object representing the created session
    */
-  createSession(
-    w3cCaps1: W3CDriverCaps<C>,
-    w3cCaps2?: W3CDriverCaps<C>,
-    w3cCaps3?: W3CDriverCaps<C>,
-    driverData?: DriverData[],
-  ): Promise<CreateResult>;
+  createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult>;
 
   /**
    * Stop an automation session

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -71,6 +71,9 @@ export interface Core<C extends Constraints, Settings extends StringRecord = Str
   eventEmitter: EventEmitter;
   settings: IDeviceSettings<Settings>;
   log: AppiumLogger;
+  /**
+   * @deprecated Use {@linkcode IAppiumIpc} for cross-session coordination instead.
+   */
   driverData: DriverData;
   isCommandsQueueEnabled: boolean;
   eventHistory: EventHistory;


### PR DESCRIPTION
## Summary

Addresses #17060 by giving `createSession` a proper single-argument
overload without breaking any currently-published drivers.

- `AppiumDriver.createSession` (the client-facing umbrella method) gets a single-argument
  overload as the primary signature, with the legacy 3-position shape marked
  `@deprecated`. This is type-only, same as the driver-side change below: the `/session`
  route's `payloadParams` still sends `capabilities` three times, because that array is
  spread directly into any plugin hooking `createSession` (`AppiumDriver#wrapCommandWithPlugins`),
  not just into `AppiumDriver.createSession` itself. I confirmed `relaxed-caps-plugin`
  (shipped in this repo) reads `caps1`/`caps2`/`caps3` positionally, so shrinking the
  route's payload would be a wire-level breaking change for that and any similarly-written
  third-party plugin, even though `AppiumDriver.createSession`'s own caps-resolution
  logic happens to tolerate it. Deferred to a coordinated future breaking change, same as
  the driver-side `driverData` positional shape below.
- `BaseDriver`/`ExternalDriver.createSession` (the contract driver packages implement)
  gets the same single-argument overload added at the type level, with the legacy
  `(w3cCaps1, w3cCaps2, w3cCaps3, driverData)` shape marked `@deprecated`. This is
  type-only — no runtime behavior changes here. I checked the installed sources for
  `appium-xcuitest-driver` and `appium-uiautomator2-driver`, and both override
  `createSession` with the old 4-positional-arg signature, forwarding `driverData`
  positionally to `super()`. Appium's internal call to `driverInstance.createSession(...)`
  therefore still sends the legacy 4-arg form, so those drivers keep working unchanged.
  Driver authors can now migrate to the single-arg form at their own pace.
- `driverData` itself is deprecated end-to-end (the `DriverData` type, the
  `Core.driverData` getter, and the `driverData` params on `createSession` and
  `deleteSession`), pointing at `IAppiumIpc` as the replacement. I confirmed this is safe
  to deprecate: every real driver I checked (`xcuitest-driver`, `uiautomator2-driver`,
  `espresso-driver`) stubs `get driverData()` to return `{}`, and several others
  (`mac2-driver`, `windows-driver`, `safari-driver`) don't override it at all. The only
  place it's meaningfully exercised is Appium's own `fake-driver` test double.
- Updated the driver-authoring guide (`build-drivers.md`) to show the new single-arg
  `createSession` pattern and flag the old multi-arg/`driverData` pattern as deprecated.

## Non-goals / follow-ups

- Appium's internal call to the inner driver's `createSession` still uses the legacy
  4-arg convention on purpose, to stay compatible with drivers built against the old
  contract. Switching that call site to the new single-arg form is a breaking change for
  any driver still reading `driverData` positionally, and should be coordinated
  separately as part of the future Appium 4 major version bump.
- Actually removing `driverData`/the legacy overloads is left for Appium 4
  breaking-change pass.
