### PR TITLE
feat(storage-plugin)!: Migrate to ESM

### DIFF
--- a/packages/storage-plugin/lib/index.ts
+++ b/packages/storage-plugin/lib/index.ts
@@ -1,2 +1,2 @@
-export {StoragePlugin} from './plugin';
-export type * from './types';
+export {StoragePlugin} from './plugin.js';
+export type * from './types.js';

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -17,6 +17,7 @@ const log = logger.getLogger('StoragePlugin');
 // @appium/types is still CommonJS, so its `ws` Server type resolves through the "require"
 // condition, while this ESM package resolves the same class through "import" — TypeScript
 // treats them as structurally distinct even though they are identical at runtime.
+// TODO: Remove this workaround once @appium/types is migrated to ESM.
 type WSHandlerServer = Parameters<AppiumServer['addWebSocketHandler']>[1];
 
 let SHARED_STORAGE: Storage | null = null;

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -1,17 +1,23 @@
-import {EventEmitter} from 'node:stream';
+import {EventEmitter} from 'node:events';
 
 import {fs, logger, tempDir, util} from '@appium/support';
 import type {AppiumServer} from '@appium/types';
-import {getResponseForW3CError} from 'appium/driver';
-import {BasePlugin} from 'appium/plugin';
+import {getResponseForW3CError} from 'appium/driver.js';
+import {BasePlugin} from 'appium/plugin.js';
 import type {Express, Request, Response} from 'express';
 import {LRUCache} from 'lru-cache';
-import WebSocket from 'ws';
+import {WebSocketServer} from 'ws';
+import type WebSocket from 'ws';
 
-import {requireValidItemOptions, Storage, StorageArgumentError, validateStorageItemName} from './storage';
-import type {AddRequestResult, ItemOptions, StorageItem} from './types';
+import {requireValidItemOptions, Storage, StorageArgumentError, validateStorageItemName} from './storage.js';
+import type {AddRequestResult, ItemOptions, StorageItem} from './types.js';
 
 const log = logger.getLogger('StoragePlugin');
+
+// @appium/types is still CommonJS, so its `ws` Server type resolves through the "require"
+// condition, while this ESM package resolves the same class through "import" — TypeScript
+// treats them as structurally distinct even though they are identical at runtime.
+type WSHandlerServer = Parameters<AppiumServer['addWebSocketHandler']>[1];
 
 let SHARED_STORAGE: Storage | null = null;
 const STORAGE_PREFIX = '/appium/storage';
@@ -155,10 +161,10 @@ async function prepareWebSockets(
     return [streamPathname, eventsPathname];
   }
 
-  const streamServer = new WebSocket.Server({
+  const streamServer = new WebSocketServer({
     noServer: true,
   });
-  const eventsServer = new WebSocket.Server({
+  const eventsServer = new WebSocketServer({
     noServer: true,
   });
   const signaler = new EventEmitter();
@@ -206,8 +212,8 @@ async function prepareWebSockets(
     log.info(`The ${streamPathname} web socket server has notified about an error: ${e.message}`);
   });
   await Promise.all([
-    httpServer.addWebSocketHandler(streamPathname, streamServer),
-    httpServer.addWebSocketHandler(eventsPathname, eventsServer),
+    httpServer.addWebSocketHandler(streamPathname, streamServer as unknown as WSHandlerServer),
+    httpServer.addWebSocketHandler(eventsPathname, eventsServer as unknown as WSHandlerServer),
   ]);
 
   return [streamPathname, eventsPathname];

--- a/packages/storage-plugin/lib/storage.ts
+++ b/packages/storage-plugin/lib/storage.ts
@@ -10,7 +10,7 @@ import {asyncmap} from 'asyncbox';
 import type {Path} from 'path-scurry';
 import type WebSocket from 'ws';
 
-import type {ItemOptions, StorageItem} from './types';
+import type {ItemOptions, StorageItem} from './types.js';
 
 const MAX_TASKS = 5;
 const TMP_EXT = '.filepart';

--- a/packages/storage-plugin/package.json
+++ b/packages/storage-plugin/package.json
@@ -32,8 +32,16 @@
     "build/lib",
     "tsconfig.json"
   ],
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
+++ b/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
@@ -1,6 +1,7 @@
 import type {AddressInfo} from 'node:net';
 import path from 'node:path';
 import {after, afterEach, before, beforeEach, describe, it} from 'node:test';
+import {fileURLToPath} from 'node:url';
 
 import {pluginE2EHarness} from '@appium/plugin-test-support';
 import {fs, node, tempDir} from '@appium/support';
@@ -11,7 +12,7 @@ import {remote as wdio} from 'webdriverio';
 import {WebSocket} from 'ws';
 
 const BUFFER_SIZE = 0xffff;
-const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/storage-plugin', __filename)!;
+const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/storage-plugin', fileURLToPath(import.meta.url))!;
 const APPIUM_HOME = path.join(THIS_PLUGIN_DIR, 'local_appium_home');
 const FAKE_DRIVER_DIR = path.join(THIS_PLUGIN_DIR, '..', 'fake-driver');
 const TEST_HOST = '127.0.0.1';

--- a/packages/storage-plugin/test/unit/storage.spec.ts
+++ b/packages/storage-plugin/test/unit/storage.spec.ts
@@ -5,7 +5,7 @@ import {fs, logger, tempDir} from '@appium/support';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
-import {Storage, StorageArgumentError, validateStorageItemName} from '../../lib/storage';
+import {Storage, StorageArgumentError, validateStorageItemName} from '../../lib/storage.js';
 
 use(chaiAsPromised);
 

--- a/packages/storage-plugin/tsconfig.json
+++ b/packages/storage-plugin/tsconfig.json
@@ -4,7 +4,14 @@
     "rootDir": ".",
     "outDir": "build",
     "checkJs": true,
-    "types": ["node"]
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "paths": {
+      "appium": ["../appium"],
+      "appium/driver.js": ["../appium/driver.d.ts"],
+      "appium/plugin.js": ["../appium/plugin.d.ts"]
+    }
   },
   "extends": "@appium/tsconfig/tsconfig.plugin.json",
   "include": ["lib", "test"],


### PR DESCRIPTION
## Summary
- Migrate `@appium/storage-plugin` to a pure ESM package (`"type": "module"`), following the same pattern used for `@appium/docutils` (#22585), `@appium/relaxed-caps-plugin`, and `@appium/images-plugin`.
- Add `.js` extensions to relative and `appium/*` subpath imports and switch `tsconfig.json` to `module`/`moduleResolution: "NodeNext"`, as required for ESM.
- Fix two latent bugs only caught by strict ESM module resolution:
  - `EventEmitter` was imported from `node:stream`, which only worked because Node's CJS loader tolerates it as a legacy compat property; ESM has no such export, so it now imports from `node:events`.
  - `WebSocket.Server` doesn't exist on `ws`'s ESM entry point (it's a CJS-only static alias); switched to the named `WebSocketServer` export.
- Add a narrow, documented type cast where `@appium/types` (still CommonJS) and this now-ESM package resolve `ws`'s `Server` type through different conditional-export branches, producing structurally distinct (but runtime-identical) types — a known `@types/ws` dual-package hazard.

BREAKING CHANGE: `@appium/storage-plugin` is now an ESM-only package. It can no longer be loaded via CommonJS `require()`; consumers must use `import` or dynamic `import()`. Deep imports into the package's internals are no longer possible — only the public entry point is exposed via `exports`.
