### PR TITLE
feat(driver-test-support)!: Migrate to ESM

### DIFF
--- a/packages/driver-test-support/lib/index.ts
+++ b/packages/driver-test-support/lib/index.ts
@@ -1,1 +1,1 @@
-export {createAppiumURL, getTestPort, TEST_HOST} from './helpers';
+export {createAppiumURL, getTestPort, TEST_HOST} from './helpers.js';

--- a/packages/driver-test-support/package.json
+++ b/packages/driver-test-support/package.json
@@ -32,8 +32,16 @@
     "lib",
     "tsconfig.json"
   ],
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "default": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/driver-test-support/test/unit/index.spec.ts
+++ b/packages/driver-test-support/test/unit/index.spec.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import {describe, it, before} from 'node:test';
 
-import {createAppiumURL, getTestPort, TEST_HOST} from '../../lib';
+import {createAppiumURL, getTestPort, TEST_HOST} from '../../lib/index.js';
 
 describe('TEST_HOST', function () {
   it('should be localhost', function () {

--- a/packages/driver-test-support/tsconfig.json
+++ b/packages/driver-test-support/tsconfig.json
@@ -10,6 +10,8 @@
     "strict": true,
     "rootDir": ".",
     "outDir": "build",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "paths": {
       "@appium/types": ["../types"]
     },


### PR DESCRIPTION
## Summary

- Convert @appium/driver-test-support to a native ESM package: add "type": "module" and an exports map in package.json.
- Switch tsconfig.json to module/moduleResolution: NodeNext and add explicit .js extensions to relative imports (lib/index.ts, test/unit/index.spec.ts), as required under NodeNext resolution.
- The exports map uses a default condition (rather than import-only) so existing CommonJS consumers can still require() the package — Node's require(esm) support (available on the Node versions this package already targets) loads it synchronously without any consumer changes.

BREAKING CHANGE: @appium/driver-test-support is now an ESM-only package. It can no longer be loaded via CommonJS require(); consumers must use import or dynamic import(). Deep imports into the package's internals are no longer possible — only the public entry point is exposed via exports.
