### PR TITLE
feat(plugin-test-support)!: Migrate to ESM

### DIFF
--- a/packages/plugin-test-support/lib/harness.ts
+++ b/packages/plugin-test-support/lib/harness.ts
@@ -4,14 +4,13 @@ import net from 'node:net';
 /* eslint-disable no-console */
 import type {AppiumServer} from '@appium/types';
 import {main as appiumServer} from 'appium';
-import {fs} from 'appium/support';
+import {fs} from 'appium/support.js';
 import AsyncLock from 'async-lock';
 import {exec} from 'teen_process';
 
-import type {AppiumEnv, E2ESetupOpts} from './types';
+import type {AppiumEnv, E2ESetupOpts} from './types.js';
 
-declare const __filename: string;
-const _require = createRequire(__filename);
+const _require = createRequire(import.meta.url);
 const APPIUM_BIN = _require.resolve('appium') as string;
 const lock = new AsyncLock();
 

--- a/packages/plugin-test-support/lib/index.ts
+++ b/packages/plugin-test-support/lib/index.ts
@@ -1,7 +1,9 @@
-export {getPort, pluginE2EHarness} from './harness';
-export type {AppiumEnv, E2ESetupOpts} from './types';
+import {fileURLToPath} from 'node:url';
+
+export {getPort, pluginE2EHarness} from './harness.js';
+export type {AppiumEnv, E2ESetupOpts} from './types.js';
 
 // Handle smoke test flag
-if (require.main === module && process.argv[2] === '--smoke-test') {
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1] && process.argv[2] === '--smoke-test') {
   process.exit(0);
 }

--- a/packages/plugin-test-support/package.json
+++ b/packages/plugin-test-support/package.json
@@ -32,8 +32,16 @@
     "lib",
     "tsconfig.json"
   ],
+  "type": "module",
   "main": "./build/lib/index.js",
   "types": "./build/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/plugin-test-support/tsconfig.json
+++ b/packages/plugin-test-support/tsconfig.json
@@ -4,9 +4,11 @@
     "strict": true,
     "rootDir": ".",
     "outDir": "build",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "paths": {
       "@appium/types": ["../types"],
-      "appium/support": ["../support"],
+      "appium/support.js": ["../appium/support.d.ts"],
       "appium": ["../appium"]
     },
     "types": ["node"]


### PR DESCRIPTION
## Summary
- Converts `@appium/plugin-test-support` from CommonJS to a native ESM package (`"type": "module"`), matching the recently-migrated `@appium/driver-test-support` and plugin packages (`storage-plugin`, `images-plugin`, `execute-driver-plugin`, `relaxed-caps-plugin`, etc.)
- Adds an `exports` map restricting the public surface to the compiled entry point, `./package.json`, with type declarations resolved via the `types` condition
- Replaces the CommonJS `require.main === module` smoke-test check in `lib/index.ts` with the `fileURLToPath(import.meta.url) === process.argv[1]` equivalent, and swaps `createRequire(__filename)` for `createRequire(import.meta.url)` in `lib/harness.ts`
- Updates relative imports to include explicit `.js` extensions and switches `tsconfig.json` to `module`/`moduleResolution: "NodeNext"`

BREAKING CHANGE: `@appium/plugin-test-support` is now an ESM-only package. It can no longer be loaded via CommonJS `require()`; consumers must use `import` or dynamic `import()`. Deep imports into the package's internals are no longer possible — only the public entry point is exposed via `exports`.