### PR TITLE
fix(driver-test-support): make import/require conditions explicit in exports map

### DIFF
--- a/packages/driver-test-support/package.json
+++ b/packages/driver-test-support/package.json
@@ -38,6 +38,8 @@
   "exports": {
     ".": {
       "types": "./build/lib/index.d.ts",
+      "import": "./build/lib/index.js",
+      "require": "./build/lib/index.js",
       "default": "./build/lib/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
The exports map only listed "default", which happens to satisfy both import and require(esm) resolution but doesn't say so. List "import" and "require" explicitly alongside "default" so the intent is clear without relying on prose in the PR description.

## Why this package needs `require`/`default` unlike other migrated packages

Other recently migrated packages (`storage-plugin`, `plugin-test-support`, `execute-driver-plugin`, ...) only expose `types` + `import` because their actual code consumers are themselves `"type": "module"` packages (e.g. `plugin-test-support` is only imported from `execute-driver-plugin`, `images-plugin`, `storage-plugin`, all ESM).

`driver-test-support`, however, is still imported from `base-driver` and `fake-driver` test files, and neither of those packages has been migrated to `"type": "module"` yet. Their compiled test files call this package via `require()`, not `import`. Dropping the `require`/`default` condition would break those two packages' tests until they're migrated to ESM as well, so this package needs the CJS bridge (backed by Node's require(esm) support) for now.

Related to https://github.com/appium/appium/pull/22591#issuecomment-5184881626