### PR TITLE
fix(base-driver): return a W3C error for a malformed JSON body

### DIFF
--- a/packages/base-driver/lib/express/middleware.ts
+++ b/packages/base-driver/lib/express/middleware.ts
@@ -155,8 +155,18 @@ export function catchAllHandler(err: Error, _req: Request, res: Response, next: 
   }
 
   log.error(`Uncaught error: ${err.message}`);
-  const [status, body] = getResponseForW3CError(err);
+  const [status, body] = getResponseForW3CError(
+    isBodyParseError(err) ? new errors.InvalidArgumentError(err.message) : err,
+  );
   res.status(status).json(body);
+}
+
+/**
+ * Detects the error body-parser raises for a request body that is not valid JSON.
+ * The protocol expects such a request to be rejected as an invalid argument.
+ */
+function isBodyParseError(err: Error): boolean {
+  return (err as Error & {type?: string}).type === 'entity.parse.failed';
 }
 
 /**

--- a/packages/base-driver/lib/express/middleware.ts
+++ b/packages/base-driver/lib/express/middleware.ts
@@ -166,7 +166,7 @@ export function catchAllHandler(err: Error, _req: Request, res: Response, next: 
  * The protocol expects such a request to be rejected as an invalid argument.
  */
 function isBodyParseError(err: Error): boolean {
-  return (err as Error & {type?: string}).type === 'entity.parse.failed';
+  return (err as Error & {type?: string})?.type === 'entity.parse.failed';
 }
 
 /**

--- a/packages/base-driver/lib/express/server.ts
+++ b/packages/base-driver/lib/express/server.ts
@@ -214,7 +214,6 @@ export function configureServer(opts: ConfigureServerOpts): void {
   app.use(defaultToJSONContentType);
   app.use(bodyParser.urlencoded({extended: true}));
   app.use(methodOverride());
-  app.use(catchAllHandler);
 
   // make sure appium never fails because of a file size upload limit
   app.use(bodyParser.json({limit: '1gb'}));
@@ -223,6 +222,10 @@ export function configureServer(opts: ConfigureServerOpts): void {
   app.use(startLogFormatter);
 
   addRoutes(app, {basePath, extraMethodMap});
+
+  // Express only passes errors to an error handler registered after the middleware
+  // that raised them, so this one must be the last of all.
+  app.use(catchAllHandler);
 }
 
 /**

--- a/packages/base-driver/test/unit/express/server.spec.ts
+++ b/packages/base-driver/test/unit/express/server.spec.ts
@@ -106,6 +106,26 @@ describe('server configuration', function () {
     }
   });
 
+  it('should respond with a W3C error when the request body is not valid JSON', async function () {
+    const driver = fakeDriver();
+    const _server = await server({
+      routeConfiguringFunction: routeConfiguringFunction(driver as any),
+      port,
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/session`, {
+        method: 'POST',
+        headers: {'content-type': 'application/json'},
+        body: '{"capabilities": not valid json}',
+      });
+      expect(res.status).to.equal(400);
+      expect(res.headers.get('content-type')).to.include('application/json');
+      expect(await res.json()).to.have.nested.property('value.error', 'invalid argument');
+    } finally {
+      await _server.close();
+    }
+  });
+
   it('should reject if error thrown in configureRoutes parameter', async function () {
     const configureRoutes = () => {
       throw new Error('I am Mr. MeeSeeks look at me!');

--- a/packages/base-driver/test/unit/express/server.spec.ts
+++ b/packages/base-driver/test/unit/express/server.spec.ts
@@ -118,9 +118,9 @@ describe('server configuration', function () {
         headers: {'content-type': 'application/json'},
         body: '{"capabilities": not valid json}',
       });
-      expect(res.status).to.equal(400);
-      expect(res.headers.get('content-type')).to.include('application/json');
-      expect(await res.json()).to.have.nested.property('value.error', 'invalid argument');
+      assert.equal(res.status, 400);
+      assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+      assert.equal(((await res.json()) as any).value.error, 'invalid argument');
     } finally {
       await _server.close();
     }


### PR DESCRIPTION
﻿## Proposed changes

A request body that is not valid JSON currently gets an HTML error page back instead of a WebDriver error:

```
$ curl -i -X POST http://127.0.0.1:4723/session -H 'content-type: application/json' -d '{"capabilities": not json}'

HTTP/1.1 400 Bad Request
Content-Type: text/html; charset=utf-8

<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Error</title></head>
<body><pre>SyntaxError: Unexpected token &#39;o&#39; ... </pre></body></html>
```

The spec says a POST body that fails to parse should come back as `invalid argument`, so clients try to read `value.error` and get a parser error of their own instead of a useful message.

Two things are going on:

`catchAllHandler` is registered before `bodyParser.json()` and before the routes. Express only hands an error to an error handler that sits after the middleware which raised it, so the one meant to be the last handler never ran for body parse failures and Express fell back to its own HTML page. It is now registered last.

That alone would return `unknown error` / 500, since a body-parser `SyntaxError` means nothing to `getResponseForW3CError`. Parse failures are now translated to `InvalidArgumentError` first, which keeps the 400 and gives the response the error code the spec asks for:

```json
{"value":{"error":"invalid argument","message":"Unexpected token 'o' ...","stacktrace":"..."}}
```

Extension routes added through `serverUpdaters` still register after this handler, so their uncaught errors keep the old behaviour. That looked like a separate change to me, happy to pull it in here if you would rather have it in one go.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The new test posts a broken body to a running server and checks the response. On master it fails with `expected 'text/html; charset=utf-8' to include 'application/json'`.
