### PR TITLE
fix(execute-driver-plugin): fail fast if the script process dies

### DIFF
--- a/packages/execute-driver-plugin/lib/plugin.ts
+++ b/packages/execute-driver-plugin/lib/plugin.ts
@@ -95,8 +95,19 @@ export class ExecuteDriverPlugin extends BasePlugin {
 
         // promise that deals with the result from the child process
         const waitForResult = async () => {
-          const res = await new Promise<{error?: {message: string}; success?: any}>((resolve) => {
+          const res = await new Promise<{error?: {message: string}; success?: any}>((resolve, reject) => {
             scriptProc.once('message', resolve); // this is node IPC
+            // the child reports script errors over IPC as well, so reaching any of the
+            // handlers below means it died before it could tell us anything
+            scriptProc.once('error', reject);
+            scriptProc.once('exit', (code, signal) => {
+              reject(
+                new Error(
+                  `The driver script process ended without returning a result ` +
+                    `(exit code: ${code}, signal: ${signal})`,
+                ),
+              );
+            });
           });
 
           this.log.info('Received execute driver script result from child process, shutting it down');

--- a/packages/execute-driver-plugin/lib/plugin.ts
+++ b/packages/execute-driver-plugin/lib/plugin.ts
@@ -101,6 +101,11 @@ export class ExecuteDriverPlugin extends BasePlugin {
             // handlers below means it died before it could tell us anything
             scriptProc.once('error', reject);
             scriptProc.once('exit', (code, signal) => {
+              // a clean exit is left to the script timeout, since only an abnormal
+              // one tells us for sure that no result is coming
+              if (code === 0) {
+                return;
+              }
               reject(
                 new Error(
                   `The driver script process ended without returning a result ` +

--- a/packages/execute-driver-plugin/lib/plugin.ts
+++ b/packages/execute-driver-plugin/lib/plugin.ts
@@ -101,10 +101,11 @@ export class ExecuteDriverPlugin extends BasePlugin {
             // handlers below means it died before it could tell us anything
             scriptProc.once('error', reject);
             scriptProc.once('exit', (code, signal) => {
-              // a clean exit is left to the script timeout, since only an abnormal
-              // one tells us for sure that no result is coming
+              // a clean exit with no IPC result should not wait on the (possibly
+              // hour-long) script timeout; treat it as an empty success instead
               if (code === 0) {
-                return;
+                this.log.info('The driver script process exited with code 0 before returning a result');
+                return resolve({});
               }
               reject(
                 new Error(

--- a/packages/execute-driver-plugin/test/unit/plugin.spec.ts
+++ b/packages/execute-driver-plugin/test/unit/plugin.spec.ts
@@ -1,10 +1,47 @@
 import assert from 'node:assert/strict';
+import cp from 'node:child_process';
+import {EventEmitter} from 'node:events';
 import {describe, it} from 'node:test';
 
+import type {ExternalDriver} from '@appium/types';
+
 import {ExecuteDriverPlugin} from '../../lib/plugin.js';
+
+function fakeDriver() {
+  return {
+    isFeatureEnabled: () => true,
+    serverHost: '127.0.0.1',
+    serverPort: 4723,
+    serverPath: '/',
+    sessionId: 'fake-session-id',
+    caps: {},
+    opts: {},
+  } as unknown as ExternalDriver;
+}
 
 describe('execute driver plugin', function () {
   it('should exist', function () {
     assert.ok(ExecuteDriverPlugin);
+  });
+
+  it('should reject if the child process ends before it returns a result', async function () {
+    const scriptProc = new EventEmitter() as any;
+    scriptProc.connected = false;
+    scriptProc.exitCode = 1;
+    scriptProc.kill = () => {};
+    // a real child process cannot exit in the same tick as the message we send to it
+    scriptProc.send = () => setImmediate(() => scriptProc.emit('exit', 1, null));
+
+    const originalFork = cp.fork;
+    (cp as any).fork = () => scriptProc;
+    try {
+      const plugin = new ExecuteDriverPlugin('execute-driver');
+      await assert.rejects(
+        plugin.executeDriverScript(async () => {}, fakeDriver(), 'return 1', 'webdriverio', 60000),
+        /ended without returning a result/,
+      );
+    } finally {
+      (cp as any).fork = originalFork;
+    }
   });
 });

--- a/packages/execute-driver-plugin/test/unit/plugin.spec.ts
+++ b/packages/execute-driver-plugin/test/unit/plugin.spec.ts
@@ -19,29 +19,44 @@ function fakeDriver() {
   } as unknown as ExternalDriver;
 }
 
+/**
+ * A child process which ends the given way instead of ever returning a result
+ */
+function dyingProcess(code: number | null, signal: string | null) {
+  const scriptProc = new EventEmitter() as any;
+  scriptProc.connected = false;
+  scriptProc.exitCode = code;
+  scriptProc.kill = () => {};
+  // a real child process cannot exit in the same tick as the message we send to it
+  scriptProc.send = () => setImmediate(() => scriptProc.emit('exit', code, signal));
+  return scriptProc;
+}
+
+async function runScript(scriptProc: any, timeoutMs: number) {
+  const originalFork = cp.fork;
+  (cp as any).fork = () => scriptProc;
+  try {
+    const plugin = new ExecuteDriverPlugin('execute-driver');
+    return await plugin.executeDriverScript(async () => {}, fakeDriver(), 'return 1', 'webdriverio', timeoutMs);
+  } finally {
+    (cp as any).fork = originalFork;
+  }
+}
+
 describe('execute driver plugin', function () {
   it('should exist', function () {
     assert.ok(ExecuteDriverPlugin);
   });
 
-  it('should reject if the child process ends before it returns a result', async function () {
-    const scriptProc = new EventEmitter() as any;
-    scriptProc.connected = false;
-    scriptProc.exitCode = 1;
-    scriptProc.kill = () => {};
-    // a real child process cannot exit in the same tick as the message we send to it
-    scriptProc.send = () => setImmediate(() => scriptProc.emit('exit', 1, null));
+  it('should reject if the child process ends with an error code', async function () {
+    await assert.rejects(runScript(dyingProcess(1, null), 60000), /ended without returning a result/);
+  });
 
-    const originalFork = cp.fork;
-    (cp as any).fork = () => scriptProc;
-    try {
-      const plugin = new ExecuteDriverPlugin('execute-driver');
-      await assert.rejects(
-        plugin.executeDriverScript(async () => {}, fakeDriver(), 'return 1', 'webdriverio', 60000),
-        /ended without returning a result/,
-      );
-    } finally {
-      (cp as any).fork = originalFork;
-    }
+  it('should reject if the child process is killed by a signal', async function () {
+    await assert.rejects(runScript(dyingProcess(null, 'SIGKILL'), 60000), /ended without returning a result/);
+  });
+
+  it('should leave a clean exit to the script timeout', async function () {
+    await assert.rejects(runScript(dyingProcess(0, null), 1), /timed out/);
   });
 });

--- a/packages/execute-driver-plugin/test/unit/plugin.spec.ts
+++ b/packages/execute-driver-plugin/test/unit/plugin.spec.ts
@@ -56,7 +56,7 @@ describe('execute driver plugin', function () {
     await assert.rejects(runScript(dyingProcess(null, 'SIGKILL'), 60000), /ended without returning a result/);
   });
 
-  it('should leave a clean exit to the script timeout', async function () {
-    await assert.rejects(runScript(dyingProcess(0, null), 1), /timed out/);
+  it('should resolve with an undefined result if the child exits cleanly without a message', async function () {
+    assert.equal(await runScript(dyingProcess(0, null), 60000), undefined);
   });
 });


### PR DESCRIPTION
﻿## Proposed changes

`executeDriverScript` waits for the child process through IPC only:

```js
const res = await new Promise((resolve) => {
  scriptProc.once('message', resolve); // this is node IPC
});
```

Nothing watches the process itself, so a child that dies before it can send anything leaves that promise pending and the only thing left to settle the race is the timeout, which defaults to an hour. The script errors you would normally expect are caught in `execute-child.js` and reported over IPC, so this is about the cases where the child never gets that far: killed by the OOM killer, a crash on startup, or the unhandled rejection you get when `process.send` itself fails.

The wait now also listens for `exit` and `error` and rejects. A child that answers first wins the race, so the `exit` that follows a normal run lands on an already settled promise and changes nothing. Instead of hanging, the client now gets:

```
Could not execute driver script. Original error was: Error: The driver script process ended without returning a result (exit code: 1, signal: null)
```

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The new unit test stubs the fork so the child exits without sending a result. It rejects in about 8ms with this change; on master it sits there until the 5s test timeout kills it. The e2e suite still passes, so real scripts that do return a result are unaffected.
