### PR TITLE
fix(base-driver): reject a non-string url without throwing TypeError

### DIFF
--- a/packages/base-driver/lib/protocol/validators.ts
+++ b/packages/base-driver/lib/protocol/validators.ts
@@ -1,7 +1,11 @@
+import {util} from '@appium/support';
+
+const MAX_URL_ERROR_LENGTH = 100;
+
 export const validators = {
   setUrl: (url: any) => {
     if (!URL.canParse(url)) {
-      throw new Error('Url or Uri must be a valid URL');
+      throw new Error(`'${util.truncateString(String(url), {length: MAX_URL_ERROR_LENGTH})}' must be a valid URL`);
     }
   },
   setNetworkConnection: (type: any) => {

--- a/packages/base-driver/lib/protocol/validators.ts
+++ b/packages/base-driver/lib/protocol/validators.ts
@@ -1,8 +1,7 @@
 export const validators = {
   setUrl: (url: any) => {
-    // either an `xyz://`, `about:`, or `data:` scheme is allowed
-    if (typeof url !== 'string' || !url.match(/^([a-zA-Z0-9_+.-]+:\/\/)|(about:)|(data:)/)) {
-      throw new Error('Url or Uri must start with <scheme>://');
+    if (!URL.canParse(url)) {
+      throw new Error('Url or Uri must be a valid URL');
     }
   },
   setNetworkConnection: (type: any) => {

--- a/packages/base-driver/lib/protocol/validators.ts
+++ b/packages/base-driver/lib/protocol/validators.ts
@@ -1,7 +1,7 @@
 export const validators = {
   setUrl: (url: any) => {
     // either an `xyz://`, `about:`, or `data:` scheme is allowed
-    if (!url || !url.match(/^([a-zA-Z0-9_+.-]+:\/\/)|(about:)|(data:)/)) {
+    if (typeof url !== 'string' || !url.match(/^([a-zA-Z0-9_+.-]+:\/\/)|(about:)|(data:)/)) {
       throw new Error('Url or Uri must start with <scheme>://');
     }
   },

--- a/packages/base-driver/test/unit/protocol/validators.spec.ts
+++ b/packages/base-driver/test/unit/protocol/validators.spec.ts
@@ -13,8 +13,8 @@ describe('validators', function () {
     });
 
     it('should reject an empty or unparseable string', function () {
-      assert.throws(() => validators.setUrl(''), /must be a valid URL/);
-      assert.throws(() => validators.setUrl('example.com'), /must be a valid URL/);
+      assert.throws(() => validators.setUrl(''), /'' must be a valid URL/);
+      assert.throws(() => validators.setUrl('example.com'), /'example\.com' must be a valid URL/);
     });
 
     it('should reject a non-string url without throwing TypeError', function () {
@@ -24,6 +24,7 @@ describe('validators', function () {
           (err: Error) => {
             assert.equal(err.name, 'Error');
             assert.match(err.message, /must be a valid URL/);
+            assert.match(err.message, new RegExp(String(url).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
             return true;
           },
         );

--- a/packages/base-driver/test/unit/protocol/validators.spec.ts
+++ b/packages/base-driver/test/unit/protocol/validators.spec.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {validators} from '../../../lib/protocol/validators';
+
+describe('validators', function () {
+  describe('#setUrl', function () {
+    it('should accept a URL with a scheme', function () {
+      assert.doesNotThrow(() => validators.setUrl('http://example.com'));
+      assert.doesNotThrow(() => validators.setUrl('about:blank'));
+      assert.doesNotThrow(() => validators.setUrl('data:text/plain,hi'));
+    });
+
+    it('should reject an empty or schemeless string', function () {
+      assert.throws(() => validators.setUrl(''), /Url or Uri must start with/);
+      assert.throws(() => validators.setUrl('example.com'), /Url or Uri must start with/);
+    });
+
+    it('should reject a non-string url without throwing TypeError', function () {
+      for (const url of [123, true, {}, [], null, undefined]) {
+        assert.throws(
+          () => validators.setUrl(url),
+          (err: Error) => {
+            assert.equal(err.name, 'Error');
+            assert.match(err.message, /Url or Uri must start with/);
+            return true;
+          },
+        );
+      }
+    });
+  });
+});

--- a/packages/base-driver/test/unit/protocol/validators.spec.ts
+++ b/packages/base-driver/test/unit/protocol/validators.spec.ts
@@ -5,15 +5,16 @@ import {validators} from '../../../lib/protocol/validators';
 
 describe('validators', function () {
   describe('#setUrl', function () {
-    it('should accept a URL with a scheme', function () {
+    it('should accept a parseable URL', function () {
       assert.doesNotThrow(() => validators.setUrl('http://example.com'));
       assert.doesNotThrow(() => validators.setUrl('about:blank'));
       assert.doesNotThrow(() => validators.setUrl('data:text/plain,hi'));
+      assert.doesNotThrow(() => validators.setUrl('ftp://example.com'));
     });
 
-    it('should reject an empty or schemeless string', function () {
-      assert.throws(() => validators.setUrl(''), /Url or Uri must start with/);
-      assert.throws(() => validators.setUrl('example.com'), /Url or Uri must start with/);
+    it('should reject an empty or unparseable string', function () {
+      assert.throws(() => validators.setUrl(''), /must be a valid URL/);
+      assert.throws(() => validators.setUrl('example.com'), /must be a valid URL/);
     });
 
     it('should reject a non-string url without throwing TypeError', function () {
@@ -22,7 +23,7 @@ describe('validators', function () {
           () => validators.setUrl(url),
           (err: Error) => {
             assert.equal(err.name, 'Error');
-            assert.match(err.message, /Url or Uri must start with/);
+            assert.match(err.message, /must be a valid URL/);
             return true;
           },
         );


### PR DESCRIPTION
﻿## Proposed changes

`POST /session/:id/url` validates the url by calling `.match()` on it. That only works for strings, so a body like `{"url": 123}` blows up with:

```
TypeError: url.match is not a function
```

which comes back as an `unknown error` instead of the intended validation message.

The check now rejects anything that is not a string first, so those requests get the same `Url or Uri must start with <scheme>://` error as a missing or schemeless value.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Added a small unit test around `validators.setUrl`. On master it fails with `actual: 'TypeError'`; with this change it passes.
