### PR TITLE
docs: update extension script options

### DIFF
--- a/packages/appium/docs/en/reference/cli/extensions.md
+++ b/packages/appium/docs/en/reference/cli/extensions.md
@@ -158,13 +158,13 @@ extensions include scripts.
 #### Usage
 
 ```
-appium {driver|plugin} run <extension-name> <script-name> [script-args]
+appium {driver|plugin} run <extension-name> [<script-name> [<script-args>]]
 ```
 
 |Argument|Description|
 |--|--|
 |`extension-name`|The short name of the installed extension|
-|`script-name`|The name of the script to be run|
+|`script-name`|The name of the script to run. If not provided, a list of available scripts is returned.|
 |`script-args`|Any additional arguments passed to the script|
 
 #### Options
@@ -179,6 +179,12 @@ appium {driver|plugin} run <extension-name> <script-name> [script-args]
 
     ```
     appium driver run uiautomator2 reset
+    ```
+
+- List all available scripts included in the XCUITest driver:
+
+    ```
+    appium driver run xcuitest
     ```
 
 ## `update`


### PR DESCRIPTION
The docs for the CLI `run` command were missing the option to list all scripts by omitting the script name.