### PR TITLE
test(appium): add e2e coverage for extension-provided CLI args

### DIFF
--- a/packages/appium/test/e2e/schema.e2e.spec.ts
+++ b/packages/appium/test/e2e/schema.e2e.spec.ts
@@ -4,8 +4,8 @@ import {describe, it, before, after} from 'node:test';
 
 import {fs, tempDir} from '@appium/support';
 
-import {DRIVER_TYPE} from '../../lib/constants';
-import {resolveFixture} from '../helpers';
+import {DRIVER_TYPE, PLUGIN_TYPE} from '../../lib/constants';
+import {FAKE_DRIVER_DIR, FAKE_PLUGIN_DIR, resolveFixture} from '../helpers';
 import {installLocalExtension, runAppium} from './e2e-helpers';
 
 describe('CLI behavior controlled by schema', function () {
@@ -41,6 +41,44 @@ describe('CLI behavior controlled by schema', function () {
       it.skip('should mark the argument as deprecated', function () {
         assert.match(help, /\[DEPRECATED\] funkytelechy/);
       });
+    });
+  });
+
+  describe('extension-provided arguments', function () {
+    let help: string;
+
+    before(async function () {
+      await installLocalExtension(appiumHome, DRIVER_TYPE, FAKE_DRIVER_DIR);
+      help = await runAppium(appiumHome, ['server', '--help']);
+    });
+
+    it('should list arguments contributed by an installed driver', function () {
+      assert.match(help, /--driver-fake-silly-web-server-port/);
+      assert.match(help, /--driver-fake-silly-web-server-host/);
+    });
+
+    it("should show each argument's help text", function () {
+      assert.match(help, /The port to use for the fake web server/);
+      assert.match(help, /The host to use for the fake web server/);
+    });
+  });
+
+  describe('extension-provided arguments (plugin)', function () {
+    let help: string;
+
+    before(async function () {
+      await installLocalExtension(appiumHome, PLUGIN_TYPE, FAKE_PLUGIN_DIR);
+      help = await runAppium(appiumHome, ['server', '--help']);
+    });
+
+    it('should list arguments contributed by an installed plugin', function () {
+      assert.match(help, /--plugin-fake-silly-web-server-port/);
+      assert.match(help, /--plugin-fake-host/);
+    });
+
+    it("should show each argument's help text", function () {
+      assert.match(help, /The port to use for the fake web server/);
+      assert.match(help, /The host to use for the fake web server/);
     });
   });
 });

--- a/packages/fake-plugin/lib/fake-plugin-schema.ts
+++ b/packages/fake-plugin/lib/fake-plugin-schema.ts
@@ -1,0 +1,41 @@
+/**
+ * JSON Schema for Fake Plugin CLI/server arguments.
+ * Could be a .json file; kept as TS for consistency and type export.
+ */
+export interface FakePluginSchema {
+  type: 'object';
+  title: string;
+  description: string;
+  properties: {
+    'silly-web-server-port'?: {
+      type: 'integer';
+      minimum: number;
+      maximum: number;
+      description: string;
+    };
+    host?: {
+      type: 'string';
+      description: string;
+    };
+  };
+}
+
+const schema: FakePluginSchema = {
+  type: 'object',
+  title: 'Fake Plugin Configuration',
+  description: 'A schema for Fake Plugin arguments',
+  properties: {
+    'silly-web-server-port': {
+      type: 'integer',
+      minimum: 1,
+      maximum: 65535,
+      description: 'The port to use for the fake web server',
+    },
+    host: {
+      type: 'string',
+      description: 'The host to use for the fake web server',
+    },
+  },
+};
+
+export default schema;

--- a/packages/fake-plugin/package.json
+++ b/packages/fake-plugin/package.json
@@ -61,6 +61,7 @@
   "appium": {
     "pluginName": "fake",
     "mainClass": "FakePlugin",
+    "schema": "./build/lib/fake-plugin-schema.js",
     "scripts": {
       "fake-error": "./build/lib/scripts/fake-error.js",
       "fake-success": "./build/lib/scripts/fake-success.js"


### PR DESCRIPTION
Verifies that CLI arguments contributed by installed drivers/plugins are recognized by the parser and appear in `appium server --help` along with their descriptions (#17576). fake-driver already declared such args; fake-plugin gains a matching schema so it has args to assert against too.
