### PR TITLE
fix(images-plugin): compare yScale with the same float precision as xScale

### DIFF
--- a/packages/images-plugin/lib/finder.ts
+++ b/packages/images-plugin/lib/finder.ts
@@ -459,7 +459,7 @@ export class ImageElementFinder {
     // Return if the scale is default, 1, value
     if (
       Math.round(xScale * FLOAT_PRECISION) === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PRECISION) &&
-      Math.round(Number(yScale * FLOAT_PRECISION === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PRECISION)))
+      Math.round(yScale * FLOAT_PRECISION) === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PRECISION)
     ) {
       return template;
     }

--- a/packages/images-plugin/test/unit/finder.spec.ts
+++ b/packages/images-plugin/test/unit/finder.spec.ts
@@ -210,6 +210,20 @@ describe('finding elements by image', function () {
       );
     });
 
+    it('should not resize when scales are within float precision of 1', async function () {
+      // FLOAT_PRECISION is meant to treat near-1 values as the default scale.
+      // The yScale check previously compared a boolean, so a tiny float error
+      // on y forced an unnecessary resize.
+      assert.deepStrictEqual(
+        await f.fixImageTemplateScale(TINY_PNG_BUF, {
+          fixImageTemplateScale: true,
+          xScale: 1.000001,
+          yScale: 1.000001,
+        }),
+        TINY_PNG_BUF,
+      );
+    });
+
     it('should not fix template size scale if it is null', async function () {
       assert.deepStrictEqual(await f.fixImageTemplateScale(basicTemplateBuf, null as any), basicTemplateBuf);
     });


### PR DESCRIPTION
﻿## Proposed changes

When deciding whether a template is already at the default scale, `xScale` is compared with float rounding, but `yScale` accidentally compared a boolean:

```js
Math.round(Number(yScale * FLOAT_PRECISION === Math.round(DEFAULT_FIX_IMAGE_TEMPLATE_SCALE * FLOAT_PRECISION)))
```

So a value like `1.000001` that should count as scale `1` failed the early return and went through an unnecessary Sharp resize. The `yScale` check now mirrors `xScale`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Added a unit test with `xScale` / `yScale` of `1.000001`. It fails on master (template gets resized) and passes with this change.
