### PR TITLE
fix(appium): parse --webhook as a URI instead of host:port

### DIFF
--- a/packages/appium/docs/en/reference/cli/server.md
+++ b/packages/appium/docs/en/reference/cli/server.md
@@ -65,7 +65,7 @@ appium
 |`--tmp`|Absolute path to the directory used for temporary files|string|[`os.tmpdir()`](https://nodejs.org/api/os.html#ostmpdir)|
 |`--use-drivers`|List of drivers to activate. By default, all installed drivers are activated.|array<string>|`[]`|
 |`--use-plugins`|List of plugins to activate. By default, no plugins are activated. Set to `["all"]` to activate all installed plugins.|array<string>|`[]`|
-|`--webhook`, `-G`|URL for an HTTP listener where the server logs should be output. This does not affect output on the console.|string||
+|`--webhook`, `-G`|URL for an HTTP listener where the server logs should be output. This does not affect output on the console. A bare `host:port` is also accepted, which posts the logs to the root path over plain http; a value having neither a scheme nor a port falls back to `127.0.0.1:9003`.|string||
 
 ### Info Options
 

--- a/packages/appium/lib/logsink.ts
+++ b/packages/appium/lib/logsink.ts
@@ -185,7 +185,12 @@ export function parseWebhookUri(
     };
   }
   const [host, port] = webhook.split(':');
-  return {host, port: parseInt(port, 10), path: '/', ssl: false};
+  return {
+    host: host || DEFAULT_LEGACY_WEBHOOK_HOST,
+    port: parseInt(port, 10) || undefined,
+    path: '/',
+    ssl: false,
+  };
 }
 
 function createHttpTransport(args: ParsedArgs, logLvl: string): transports.HttpTransportInstance {

--- a/packages/appium/lib/logsink.ts
+++ b/packages/appium/lib/logsink.ts
@@ -153,20 +153,23 @@ function createFileTransport(args: ParsedArgs, logLvl: string): transports.FileT
 /**
  * Parse a `--webhook` / `server.webhook` value into Winston Http transport options.
  *
- * The schema documents this option as a URI (e.g. `http://0.0.0.0/hook`), and such a
- * value has its host, port, path and ssl flag taken from `URL`. A bare `host:port`
- * keeps the meaning it had before, where log records are always posted to the root
- * path of a plain http listener.
+ * The schema documents it as a URI (e.g. `http://0.0.0.0/hook`). A bare `host:port`
+ * is still accepted and always posts to the root path over plain http.
  *
  * @internal
  */
 export function parseWebhookUri(
   webhook: string,
 ): Pick<transports.HttpTransportOptions, 'host' | 'port' | 'path' | 'ssl'> {
-  // `host:port` is parseable as well, but as a URI whose scheme is the host name,
-  // hence the protocol must be verified before the parsing result can be used
+  // `host:port` parses too, into a URI whose scheme is the host name and no host at all
   const url = URL.parse(webhook);
-  if (url && SUPPORTED_WEBHOOK_PROTOCOLS.includes(url.protocol)) {
+  if (url?.hostname) {
+    if (!SUPPORTED_WEBHOOK_PROTOCOLS.includes(url.protocol)) {
+      throw new Error(
+        `The logging webhook must be an http(s) URL, for example 'http://localhost:9003/logs'. ` +
+          `'${webhook}' is given instead`,
+      );
+    }
     const isSsl = url.protocol === HTTPS_PROTOCOL;
     const defaultPort = isSsl ? DEFAULT_HTTPS_WEBHOOK_PORT : DEFAULT_HTTP_WEBHOOK_PORT;
     return {
@@ -176,18 +179,10 @@ export function parseWebhookUri(
       ssl: isSsl,
     };
   }
-  if (!webhook.includes(':')) {
-    return {
-      host: DEFAULT_LEGACY_WEBHOOK_HOST,
-      port: DEFAULT_LEGACY_WEBHOOK_PORT,
-      path: '/',
-      ssl: false,
-    };
-  }
-  const [host, port] = webhook.split(':');
+  const [host, port] = webhook.includes(':') ? webhook.split(':') : ['', ''];
   return {
     host: host || DEFAULT_LEGACY_WEBHOOK_HOST,
-    port: parseInt(port, 10) || undefined,
+    port: parseInt(port, 10) || DEFAULT_LEGACY_WEBHOOK_PORT,
     path: '/',
     ssl: false,
   };

--- a/packages/appium/lib/logsink.ts
+++ b/packages/appium/lib/logsink.ts
@@ -34,8 +34,10 @@ const COLOR_CODE_PATTERN = /\u001b\[(\d+(;\d+)*)?m/g; // eslint-disable-line no-
 
 const HTTPS_PROTOCOL = 'https:';
 const SUPPORTED_WEBHOOK_PROTOCOLS = ['http:', HTTPS_PROTOCOL];
-const DEFAULT_HTTP_PORT = 80;
-const DEFAULT_HTTPS_PORT = 443;
+const DEFAULT_HTTP_WEBHOOK_PORT = 80;
+const DEFAULT_HTTPS_WEBHOOK_PORT = 443;
+const DEFAULT_LEGACY_WEBHOOK_HOST = '127.0.0.1';
+const DEFAULT_LEGACY_WEBHOOK_PORT = 9003;
 
 // https://www.ditig.com/publications/256-colors-cheat-sheet
 const MIN_COLOR = 17;
@@ -149,32 +151,41 @@ function createFileTransport(args: ParsedArgs, logLvl: string): transports.FileT
 }
 
 /**
- * Parse a `--webhook` / `server.webhook` URI into Winston Http transport options.
- * The schema requires a URI (e.g. `http://0.0.0.0/hook`), so host/port/path/ssl
- * are taken from `URL` rather than a naive `host:port` split.
+ * Parse a `--webhook` / `server.webhook` value into Winston Http transport options.
+ *
+ * The schema documents this option as a URI (e.g. `http://0.0.0.0/hook`), and such a
+ * value has its host, port, path and ssl flag taken from `URL`. A bare `host:port`
+ * keeps the meaning it had before, where log records are always posted to the root
+ * path of a plain http listener.
  *
  * @internal
  */
 export function parseWebhookUri(
   webhook: string,
 ): Pick<transports.HttpTransportOptions, 'host' | 'port' | 'path' | 'ssl'> {
-  // 'host:port' is a parseable URI whose scheme is the host name, so the protocol
-  // must be verified as well, otherwise the host would be empty and the port a path
+  // `host:port` is parseable as well, but as a URI whose scheme is the host name,
+  // hence the protocol must be verified before the parsing result can be used
   const url = URL.parse(webhook);
-  if (!url || !SUPPORTED_WEBHOOK_PROTOCOLS.includes(url.protocol)) {
-    throw new Error(
-      `The logging webhook must be an http(s) URL, for example 'http://localhost:9003/logs'. ` +
-        `'${webhook}' is given instead`,
-    );
+  if (url && SUPPORTED_WEBHOOK_PROTOCOLS.includes(url.protocol)) {
+    const isSsl = url.protocol === HTTPS_PROTOCOL;
+    const defaultPort = isSsl ? DEFAULT_HTTPS_WEBHOOK_PORT : DEFAULT_HTTP_WEBHOOK_PORT;
+    return {
+      host: url.hostname,
+      port: url.port ? parseInt(url.port, 10) : defaultPort,
+      path: `${url.pathname}${url.search}`,
+      ssl: isSsl,
+    };
   }
-  const isSsl = url.protocol === HTTPS_PROTOCOL;
-  const defaultPort = isSsl ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
-  return {
-    host: url.hostname,
-    port: url.port ? parseInt(url.port, 10) : defaultPort,
-    path: `${url.pathname}${url.search}`,
-    ssl: isSsl,
-  };
+  if (!webhook.includes(':')) {
+    return {
+      host: DEFAULT_LEGACY_WEBHOOK_HOST,
+      port: DEFAULT_LEGACY_WEBHOOK_PORT,
+      path: '/',
+      ssl: false,
+    };
+  }
+  const [host, port] = webhook.split(':');
+  return {host, port: parseInt(port, 10), path: '/', ssl: false};
 }
 
 function createHttpTransport(args: ParsedArgs, logLvl: string): transports.HttpTransportInstance {

--- a/packages/appium/lib/logsink.ts
+++ b/packages/appium/lib/logsink.ts
@@ -143,20 +143,26 @@ function createFileTransport(args: ParsedArgs, logLvl: string): transports.FileT
   return new transports.File(opt);
 }
 
+/**
+ * Parse a `--webhook` / `server.webhook` URI into Winston Http transport options.
+ * The schema requires a URI (e.g. `http://0.0.0.0/hook`), so host/port/path/ssl
+ * are taken from `URL` rather than a naive `host:port` split.
+ */
+export function parseWebhookUri(
+  webhook: string,
+): Pick<transports.HttpTransportOptions, 'host' | 'port' | 'path' | 'ssl'> {
+  const url = new URL(webhook);
+  return {
+    host: url.hostname,
+    port: url.port ? parseInt(url.port, 10) : url.protocol === 'https:' ? 443 : 80,
+    path: `${url.pathname}${url.search}` || '/',
+    ssl: url.protocol === 'https:',
+  };
+}
+
 function createHttpTransport(args: ParsedArgs, logLvl: string): transports.HttpTransportInstance {
-  let host = '127.0.0.1';
-  let port = 9003;
-
-  if (args.webhook?.match(':')) {
-    const hostAndPort = args.webhook.split(':');
-    host = hostAndPort[0];
-    port = parseInt(hostAndPort[1], 10);
-  }
-
   const opt: transports.HttpTransportOptions = {
-    host,
-    port,
-    path: '/',
+    ...parseWebhookUri(args.webhook as string),
     level: logLvl,
     format: format.combine(stripColorFormat, formatLog(args, false)),
   };

--- a/packages/appium/lib/logsink.ts
+++ b/packages/appium/lib/logsink.ts
@@ -152,11 +152,17 @@ export function parseWebhookUri(
   webhook: string,
 ): Pick<transports.HttpTransportOptions, 'host' | 'port' | 'path' | 'ssl'> {
   const url = new URL(webhook);
+  // 'host:port' parses into a URL whose scheme is the host name, which would
+  // otherwise leave us with an empty host and the port as the path
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error(`Expected an http(s) URL, for example 'http://localhost:9003/logs'`);
+  }
+  const isSsl = url.protocol === 'https:';
   return {
     host: url.hostname,
-    port: url.port ? parseInt(url.port, 10) : url.protocol === 'https:' ? 443 : 80,
-    path: `${url.pathname}${url.search}` || '/',
-    ssl: url.protocol === 'https:',
+    port: url.port ? parseInt(url.port, 10) : isSsl ? 443 : 80,
+    path: `${url.pathname}${url.search}`,
+    ssl: isSsl,
   };
 }
 

--- a/packages/appium/lib/logsink.ts
+++ b/packages/appium/lib/logsink.ts
@@ -32,6 +32,11 @@ const TO_WINSTON_LEVELS_MAP = {
 } as const;
 const COLOR_CODE_PATTERN = /\u001b\[(\d+(;\d+)*)?m/g; // eslint-disable-line no-control-regex
 
+const HTTPS_PROTOCOL = 'https:';
+const SUPPORTED_WEBHOOK_PROTOCOLS = ['http:', HTTPS_PROTOCOL];
+const DEFAULT_HTTP_PORT = 80;
+const DEFAULT_HTTPS_PORT = 443;
+
 // https://www.ditig.com/publications/256-colors-cheat-sheet
 const MIN_COLOR = 17;
 const MAX_COLOR = 231;
@@ -147,20 +152,26 @@ function createFileTransport(args: ParsedArgs, logLvl: string): transports.FileT
  * Parse a `--webhook` / `server.webhook` URI into Winston Http transport options.
  * The schema requires a URI (e.g. `http://0.0.0.0/hook`), so host/port/path/ssl
  * are taken from `URL` rather than a naive `host:port` split.
+ *
+ * @internal
  */
 export function parseWebhookUri(
   webhook: string,
 ): Pick<transports.HttpTransportOptions, 'host' | 'port' | 'path' | 'ssl'> {
-  const url = new URL(webhook);
-  // 'host:port' parses into a URL whose scheme is the host name, which would
-  // otherwise leave us with an empty host and the port as the path
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error(`Expected an http(s) URL, for example 'http://localhost:9003/logs'`);
+  // 'host:port' is a parseable URI whose scheme is the host name, so the protocol
+  // must be verified as well, otherwise the host would be empty and the port a path
+  const url = URL.parse(webhook);
+  if (!url || !SUPPORTED_WEBHOOK_PROTOCOLS.includes(url.protocol)) {
+    throw new Error(
+      `The logging webhook must be an http(s) URL, for example 'http://localhost:9003/logs'. ` +
+        `'${webhook}' is given instead`,
+    );
   }
-  const isSsl = url.protocol === 'https:';
+  const isSsl = url.protocol === HTTPS_PROTOCOL;
+  const defaultPort = isSsl ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT;
   return {
     host: url.hostname,
-    port: url.port ? parseInt(url.port, 10) : isSsl ? 443 : 80,
+    port: url.port ? parseInt(url.port, 10) : defaultPort,
     path: `${url.pathname}${url.search}`,
     ssl: isSsl,
   };

--- a/packages/appium/test/unit/logsink.spec.ts
+++ b/packages/appium/test/unit/logsink.spec.ts
@@ -32,10 +32,10 @@ describe('parseWebhookUri', function () {
   });
 
   it('should reject a value that is not a URI', function () {
-    assert.throws(() => parseWebhookUri('not-a-uri'), /Invalid URL/);
+    assert.throws(() => parseWebhookUri('not-a-uri'), /'not-a-uri' is given instead/);
   });
 
   it('should reject a host:port value, which the schema accepts as a URI', function () {
-    assert.throws(() => parseWebhookUri('localhost:9003'), /Expected an http\(s\) URL/);
+    assert.throws(() => parseWebhookUri('localhost:9003'), /must be an http\(s\) URL/);
   });
 });

--- a/packages/appium/test/unit/logsink.spec.ts
+++ b/packages/appium/test/unit/logsink.spec.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {parseWebhookUri} from '../../lib/logsink';
+
+describe('parseWebhookUri', function () {
+  it('should parse an http webhook with a path', function () {
+    assert.deepStrictEqual(parseWebhookUri('http://0.0.0.0/hook'), {
+      host: '0.0.0.0',
+      port: 80,
+      path: '/hook',
+      ssl: false,
+    });
+  });
+
+  it('should parse an https webhook and default the port', function () {
+    assert.deepStrictEqual(parseWebhookUri('https://some-url.com'), {
+      host: 'some-url.com',
+      port: 443,
+      path: '/',
+      ssl: true,
+    });
+  });
+
+  it('should preserve an explicit port and query string', function () {
+    assert.deepStrictEqual(parseWebhookUri('https://example.com:8443/a/b?x=1'), {
+      host: 'example.com',
+      port: 8443,
+      path: '/a/b?x=1',
+      ssl: true,
+    });
+  });
+
+  it('should reject a value that is not a URI', function () {
+    assert.throws(() => parseWebhookUri('not-a-uri'), /Invalid URL/);
+  });
+});

--- a/packages/appium/test/unit/logsink.spec.ts
+++ b/packages/appium/test/unit/logsink.spec.ts
@@ -49,10 +49,10 @@ describe('parseWebhookUri', function () {
     });
   });
 
-  it('should leave the port to the transport if it is not a number', function () {
+  it('should fall back to the legacy port if it is not a number', function () {
     assert.deepStrictEqual(parseWebhookUri('localhost:nope'), {
       host: 'localhost',
-      port: undefined,
+      port: 9003,
       path: '/',
       ssl: false,
     });
@@ -65,5 +65,9 @@ describe('parseWebhookUri', function () {
       path: '/',
       ssl: false,
     });
+  });
+
+  it('should reject a parseable url with an unsupported protocol', function () {
+    assert.throws(() => parseWebhookUri('ftp://host/x'), /must be an http\(s\) URL/);
   });
 });

--- a/packages/appium/test/unit/logsink.spec.ts
+++ b/packages/appium/test/unit/logsink.spec.ts
@@ -31,11 +31,21 @@ describe('parseWebhookUri', function () {
     });
   });
 
-  it('should reject a value that is not a URI', function () {
-    assert.throws(() => parseWebhookUri('not-a-uri'), /'not-a-uri' is given instead/);
+  it('should keep understanding the legacy host:port form', function () {
+    assert.deepStrictEqual(parseWebhookUri('localhost:9003'), {
+      host: 'localhost',
+      port: 9003,
+      path: '/',
+      ssl: false,
+    });
   });
 
-  it('should reject a host:port value, which the schema accepts as a URI', function () {
-    assert.throws(() => parseWebhookUri('localhost:9003'), /must be an http\(s\) URL/);
+  it('should fall back to the legacy defaults if there is nothing to parse', function () {
+    assert.deepStrictEqual(parseWebhookUri('not-a-uri'), {
+      host: '127.0.0.1',
+      port: 9003,
+      path: '/',
+      ssl: false,
+    });
   });
 });

--- a/packages/appium/test/unit/logsink.spec.ts
+++ b/packages/appium/test/unit/logsink.spec.ts
@@ -40,6 +40,24 @@ describe('parseWebhookUri', function () {
     });
   });
 
+  it('should fall back to the legacy host if only a port is given', function () {
+    assert.deepStrictEqual(parseWebhookUri(':9003'), {
+      host: '127.0.0.1',
+      port: 9003,
+      path: '/',
+      ssl: false,
+    });
+  });
+
+  it('should leave the port to the transport if it is not a number', function () {
+    assert.deepStrictEqual(parseWebhookUri('localhost:nope'), {
+      host: 'localhost',
+      port: undefined,
+      path: '/',
+      ssl: false,
+    });
+  });
+
   it('should fall back to the legacy defaults if there is nothing to parse', function () {
     assert.deepStrictEqual(parseWebhookUri('not-a-uri'), {
       host: '127.0.0.1',

--- a/packages/appium/test/unit/logsink.spec.ts
+++ b/packages/appium/test/unit/logsink.spec.ts
@@ -34,4 +34,8 @@ describe('parseWebhookUri', function () {
   it('should reject a value that is not a URI', function () {
     assert.throws(() => parseWebhookUri('not-a-uri'), /Invalid URL/);
   });
+
+  it('should reject a host:port value, which the schema accepts as a URI', function () {
+    assert.throws(() => parseWebhookUri('localhost:9003'), /Expected an http\(s\) URL/);
+  });
 });


### PR DESCRIPTION
## Proposed changes

`--webhook` / `server.webhook` is documented and schema-validated as a URI (`format: "uri"`). The fixtures even use values like `http://0.0.0.0/hook`. The Http transport setup still treated it as `host:port`:

```js
const hostAndPort = args.webhook.split(':');
host = hostAndPort[0];
port = parseInt(hostAndPort[1], 10);
```

So `http://0.0.0.0/hook` became `host: "http"`, `port: NaN`, and the path was always `/`. Log shipping never reached the listener people actually configured.

It now uses `URL` and passes `host`, `port`, `path`, and `ssl` into Winston.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

One thing worth a second opinion: `localhost:9003` passes the `uri` format check, and `new URL()` reads it as scheme `localhost:` with path `9003`, so it would silently produce an empty host. That is also the one shape the old code handled correctly, so I made it throw with a message pointing at the expected form instead of quietly shipping logs nowhere. The error is caught where the transport is created, so the server still starts and the reason ends up in the log. Happy to keep accepting `host:port` for compatibility if you would rather not change that, though the `$comment` in the schema suggests restricting to http/https was the intent.

Added unit coverage around `parseWebhookUri` for the fixture-style URL, https defaults, an explicit port + query string, and the two rejected forms.
