### PR TITLE
fix(base-driver): anchor CORS async-response regex and match on req.path

### DIFF
--- a/packages/base-driver/lib/express/middleware.ts
+++ b/packages/base-driver/lib/express/middleware.ts
@@ -44,9 +44,11 @@ export function allowCrossDomain(req: Request, res: Response, next: NextFunction
 export function allowCrossDomainAsyncExecute(basePath: string): RequestHandler {
   function allowCrossDomainAsyncExecuteHandler(req: Request, res: Response, next: NextFunction): void {
     const receiveAsyncResponseRegExp = new RegExp(
-      `${util.escapeRegExp(basePath)}/session/[a-f0-9-]+/(appium/)?receive_async_response`,
+      `^${util.escapeRegExp(basePath)}/session/[a-f0-9-]+/(appium/)?receive_async_response/?$`,
     );
-    if (!receiveAsyncResponseRegExp.test(req.url)) {
+    // Match against req.path (query-stripped) so query-string data cannot be used
+    // to smuggle a match for an otherwise unrelated endpoint.
+    if (!receiveAsyncResponseRegExp.test(req.path)) {
       next();
       return;
     }
@@ -63,7 +65,7 @@ export function allowCrossDomainAsyncExecute(basePath: string): RequestHandler {
 export function handleLogContext(req: Request, _res: Response, next: NextFunction): void {
   const requestId = fetchHeaderValue(req, 'x-request-id') || util.uuidV4();
 
-  const sessionId = SESSION_ID_PATTERN.exec(req.url)?.[1];
+  const sessionId = SESSION_ID_PATTERN.exec(req.path)?.[1];
   const sessionInfo = sessionId ? {sessionId, sessionSignature: calcSignature(sessionId)} : {};
   const isSensitiveHeaderValue = fetchHeaderValue(req, 'x-appium-is-sensitive');
 

--- a/packages/base-driver/test/unit/express/middleware.spec.ts
+++ b/packages/base-driver/test/unit/express/middleware.spec.ts
@@ -104,7 +104,11 @@ describe('middleware', function () {
     });
 
     it('should set CORS headers for a legitimate receive_async_response request', function () {
-      req = {method: 'GET', url: '/session/aaaaaaaa/receive_async_response', path: '/session/aaaaaaaa/receive_async_response'};
+      req = {
+        method: 'GET',
+        url: '/session/aaaaaaaa/receive_async_response',
+        path: '/session/aaaaaaaa/receive_async_response',
+      };
 
       allowCrossDomainAsyncExecute('')(req, res, next);
 

--- a/packages/base-driver/test/unit/express/middleware.spec.ts
+++ b/packages/base-driver/test/unit/express/middleware.spec.ts
@@ -5,7 +5,7 @@ import {match} from 'path-to-regexp';
 import sinon from 'sinon';
 
 import {log} from '../../../lib/express/logger';
-import {handleLogContext} from '../../../lib/express/middleware';
+import {allowCrossDomainAsyncExecute, handleLogContext} from '../../../lib/express/middleware';
 
 describe('middleware', function () {
   describe('match', function () {
@@ -34,6 +34,7 @@ describe('middleware', function () {
       req = {
         headers: {},
         url: '/some/path',
+        path: '/some/path',
       };
       res = {};
       next = sinon.spy();
@@ -42,6 +43,16 @@ describe('middleware', function () {
 
     afterEach(function () {
       updateAsyncContextStub.restore();
+    });
+
+    it('should not extract a sessionId smuggled in the query string', function () {
+      req.url = '/status?_=/session/aaaaaaaa/receive_async_response';
+      req.path = '/status';
+
+      handleLogContext(req, res, next);
+
+      assert.strictEqual(updateAsyncContextStub.calledOnce, true);
+      assert.strictEqual(updateAsyncContextStub.firstCall.args[0].sessionId, undefined);
     });
 
     it('should use provided x-request-id header', function () {
@@ -75,6 +86,63 @@ describe('middleware', function () {
         updateAsyncContextStub.firstCall.args[0].requestId,
         /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
       );
+      assert.strictEqual(next.calledOnce, true);
+    });
+  });
+
+  describe('allowCrossDomainAsyncExecute', function () {
+    let req: any;
+    let res: any;
+    let next: sinon.SinonSpy;
+
+    beforeEach(function () {
+      res = {
+        header: sinon.spy(),
+        sendStatus: sinon.spy(),
+      };
+      next = sinon.spy();
+    });
+
+    it('should set CORS headers for a legitimate receive_async_response request', function () {
+      req = {method: 'GET', url: '/session/aaaaaaaa/receive_async_response', path: '/session/aaaaaaaa/receive_async_response'};
+
+      allowCrossDomainAsyncExecute('')(req, res, next);
+
+      assert.strictEqual(res.header.calledWith('Access-Control-Allow-Origin', '*'), true);
+    });
+
+    it('should not set CORS headers for an unrelated endpoint', function () {
+      req = {method: 'POST', url: '/session', path: '/session'};
+
+      allowCrossDomainAsyncExecute('')(req, res, next);
+
+      assert.strictEqual(res.header.called, false);
+      assert.strictEqual(next.calledOnce, true);
+    });
+
+    it('should not set CORS headers when the target path is smuggled in the query string (GHSA-4356-hm4h-ww9c)', function () {
+      req = {
+        method: 'POST',
+        url: '/session?_=/session/aaaaaaaa/receive_async_response',
+        path: '/session',
+      };
+
+      allowCrossDomainAsyncExecute('')(req, res, next);
+
+      assert.strictEqual(res.header.called, false);
+      assert.strictEqual(next.calledOnce, true);
+    });
+
+    it('should not set CORS headers when the target path is smuggled behind an arbitrary prefix', function () {
+      req = {
+        method: 'GET',
+        url: '/appium/storage/reset/session/aaaaaaaa/receive_async_response',
+        path: '/appium/storage/reset/session/aaaaaaaa/receive_async_response',
+      };
+
+      allowCrossDomainAsyncExecute('')(req, res, next);
+
+      assert.strictEqual(res.header.called, false);
       assert.strictEqual(next.calledOnce, true);
     });
   });


### PR DESCRIPTION
allowCrossDomainAsyncExecute built an unanchored regex and tested it against req.url, which includes the raw query string. A request to any endpoint with a query param such as
`?_=/session/aaaaaaaa/receive_async_response` therefore matched, causing the server to emit permissive CORS headers even with --allow-cors disabled (the default), letting any origin read WebDriver responses.

Anchor the pattern and match against req.path instead so query-string data can no longer influence the allowlist decision. Apply the same req.path fix to the SESSION_ID_PATTERN lookup in handleLogContext, which was vulnerable to the same query-string smuggling for log context (session id spoofing in logs).
