### PR TITLE
 docs: update TestMu AI sponsor branding on archived doc versions

### DIFF
--- a/docs/en/2.19/404.html
+++ b/docs/en/2.19/404.html
@@ -2472,8 +2472,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/2024/03/07/hello-world/index.html
+++ b/docs/en/2.19/blog/2024/03/07/hello-world/index.html
@@ -2616,8 +2616,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
+++ b/docs/en/2.19/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
@@ -2648,8 +2648,8 @@ contribution level.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
+++ b/docs/en/2.19/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
@@ -2648,8 +2648,8 @@ HeadSpin as our first official Development Partner!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
+++ b/docs/en/2.19/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
@@ -2645,8 +2645,8 @@ teams can move fast while delivering an amazing experience for every customer.</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
+++ b/docs/en/2.19/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
@@ -2636,8 +2636,8 @@ Needless to say, we are extremely grateful for Sauce Labs's support!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
+++ b/docs/en/2.19/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
@@ -2705,8 +2705,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/en/2.19/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -2543,12 +2543,12 @@
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -2641,8 +2641,8 @@ infrastructure, execution, RCA, and reporting.</em></p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/archive/2024/index.html
+++ b/docs/en/2.19/blog/archive/2024/index.html
@@ -2764,8 +2764,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/archive/2025/index.html
+++ b/docs/en/2.19/blog/archive/2025/index.html
@@ -2481,7 +2481,7 @@
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -2539,8 +2539,8 @@ is coming on board as one of our Strategic Partners!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/blog/index.html
+++ b/docs/en/2.19/blog/index.html
@@ -2499,7 +2499,7 @@
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -2828,8 +2828,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/cli/args/index.html
+++ b/docs/en/2.19/cli/args/index.html
@@ -2864,8 +2864,8 @@ a configuration file.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/cli/env-vars/index.html
+++ b/docs/en/2.19/cli/env-vars/index.html
@@ -2598,8 +2598,8 @@ environment variables that the Appium server understands:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/cli/extensions/index.html
+++ b/docs/en/2.19/cli/extensions/index.html
@@ -2984,8 +2984,8 @@ unintended breaking changes.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/cli/index.html
+++ b/docs/en/2.19/cli/index.html
@@ -2569,8 +2569,8 @@ or run <code>appium -h</code> or <code>appium --help</code> to return the help m
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/cli/setup/index.html
+++ b/docs/en/2.19/cli/setup/index.html
@@ -2598,8 +2598,8 @@ By running <code>appium setup reset</code> the server would uninstall all instal
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/commands/base-driver/index.html
+++ b/docs/en/2.19/commands/base-driver/index.html
@@ -4729,8 +4729,8 @@ Each session data object will be returned with <code>id</code> and the session's
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/commands/execute-driver-plugin/index.html
+++ b/docs/en/2.19/commands/execute-driver-plugin/index.html
@@ -2677,8 +2677,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/commands/images-plugin/index.html
+++ b/docs/en/2.19/commands/images-plugin/index.html
@@ -2962,8 +2962,8 @@ commands</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/commands/index.html
+++ b/docs/en/2.19/commands/index.html
@@ -2562,8 +2562,8 @@ documentation for the exact syntax of that command.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/commands/relaxed-caps-plugin/index.html
+++ b/docs/en/2.19/commands/relaxed-caps-plugin/index.html
@@ -2687,8 +2687,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/commands/storage-plugin/index.html
+++ b/docs/en/2.19/commands/storage-plugin/index.html
@@ -3025,8 +3025,8 @@ and only the incomplete uploads will be stopped.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/commands/universal-xml-plugin/index.html
+++ b/docs/en/2.19/commands/universal-xml-plugin/index.html
@@ -2829,8 +2829,8 @@ commands</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/contributing/index.html
+++ b/docs/en/2.19/contributing/index.html
@@ -2868,8 +2868,8 @@ corresponding translated resources included.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/developing/build-docs/index.html
+++ b/docs/en/2.19/developing/build-docs/index.html
@@ -2737,8 +2737,8 @@ examples:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/developing/build-doctor-checks/index.html
+++ b/docs/en/2.19/developing/build-doctor-checks/index.html
@@ -2788,8 +2788,8 @@ as</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/developing/build-drivers/index.html
+++ b/docs/en/2.19/developing/build-drivers/index.html
@@ -3886,8 +3886,8 @@ unexpected shutdown).</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/developing/build-plugins/index.html
+++ b/docs/en/2.19/developing/build-plugins/index.html
@@ -3486,8 +3486,8 @@ keeping in mind that the function is not <code>await</code>ed you could implemen
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/developing/config-system/index.html
+++ b/docs/en/2.19/developing/config-system/index.html
@@ -3274,8 +3274,8 @@ schema:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/developing/index.html
+++ b/docs/en/2.19/developing/index.html
@@ -2558,8 +2558,8 @@ own Appium extension:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/developing/sensitive/index.html
+++ b/docs/en/2.19/developing/sensitive/index.html
@@ -2660,8 +2660,8 @@ In order to get some value in logs replaced by a generic mask it is necessary:</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/ecosystem/clients/index.html
+++ b/docs/en/2.19/ecosystem/clients/index.html
@@ -2692,8 +2692,8 @@ to make a PR to add it to this section with a link to the documentation for the 
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/ecosystem/drivers/index.html
+++ b/docs/en/2.19/ecosystem/drivers/index.html
@@ -2772,8 +2772,8 @@ to make a PR to add it to this section with a link to the driver documentation.<
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/ecosystem/index.html
+++ b/docs/en/2.19/ecosystem/index.html
@@ -2574,8 +2574,8 @@ aims to compile a listing of various officially-supported and community-supporte
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/ecosystem/plugins/index.html
+++ b/docs/en/2.19/ecosystem/plugins/index.html
@@ -2726,8 +2726,8 @@ to make a PR to add it to this section with a link to the documentation for the 
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/ecosystem/tools/index.html
+++ b/docs/en/2.19/ecosystem/tools/index.html
@@ -2674,8 +2674,8 @@ For driver/plugin developers, please read <a href="../../developing/build-doctor
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/branch-testing/index.html
+++ b/docs/en/2.19/guides/branch-testing/index.html
@@ -2715,8 +2715,8 @@ to switch back to the package managed by NPM. Follow the next steps for that:</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/caching/index.html
+++ b/docs/en/2.19/guides/caching/index.html
@@ -2747,8 +2747,8 @@ would be performed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/caps/index.html
+++ b/docs/en/2.19/guides/caps/index.html
@@ -3119,8 +3119,8 @@ running Appium on their own.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/config/index.html
+++ b/docs/en/2.19/guides/config/index.html
@@ -2785,8 +2785,8 @@ For example, <code>callback-port</code> is allowed, but <code>callbackPort</code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/context/index.html
+++ b/docs/en/2.19/guides/context/index.html
@@ -2617,8 +2617,8 @@ visit the documentation for a given library.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/event-timing/index.html
+++ b/docs/en/2.19/guides/event-timing/index.html
@@ -2677,8 +2677,8 @@ on.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/execute-methods/index.html
+++ b/docs/en/2.19/guides/execute-methods/index.html
@@ -2654,8 +2654,8 @@ has made any alterations to the standard access method.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/grid/index.html
+++ b/docs/en/2.19/guides/grid/index.html
@@ -2856,8 +2856,8 @@ will prevent Selenium Grid from connecting correctly.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/headers/index.html
+++ b/docs/en/2.19/guides/headers/index.html
@@ -2654,8 +2654,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/log-filters/index.html
+++ b/docs/en/2.19/guides/log-filters/index.html
@@ -2724,8 +2724,8 @@ these errors are addressed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/managing-exts/index.html
+++ b/docs/en/2.19/guides/managing-exts/index.html
@@ -2691,8 +2691,8 @@ Otherwise, it is recommended that you use Appium's Extension CLI and, if necessa
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/migrating-1-to-2/index.html
+++ b/docs/en/2.19/guides/migrating-1-to-2/index.html
@@ -3280,8 +3280,8 @@ an industry-compatible way!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/security/index.html
+++ b/docs/en/2.19/guides/security/index.html
@@ -2786,8 +2786,8 @@ raise an error. Note that the behavior of the <code>--relaxed-security</code> fl
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/settings/index.html
+++ b/docs/en/2.19/guides/settings/index.html
@@ -2688,8 +2688,8 @@ specific client library, visit the documentation for that client.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/guides/tls/index.html
+++ b/docs/en/2.19/guides/tls/index.html
@@ -2687,8 +2687,8 @@ client setup, e.g. make sure it does not reject unauthorized certificates.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/index.html
+++ b/docs/en/2.19/index.html
@@ -2553,9 +2553,9 @@ Android TV, Samsung), and more!</p>
       </a>
     </div>
     <div class="homepageSponsor">
-      <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-        <img src="assets/images/sponsor-logo-lambdatest-dark.png#only-dark" style="width: 220px;" />
-        <img src="assets/images/sponsor-logo-lambdatest-light.png#only-light" style="width: 220px;" />
+      <a href="https://www.testmuai.com">
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" style="width: 220px;" />
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" style="width: 220px;" />
       </a>
     </div>
   </div>
@@ -2645,8 +2645,8 @@ Android TV, Samsung), and more!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/intro/appium/index.html
+++ b/docs/en/2.19/intro/appium/index.html
@@ -2843,8 +2843,8 @@ principles, which we also encourage for Appium extension developers:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/intro/clients/index.html
+++ b/docs/en/2.19/intro/clients/index.html
@@ -2662,8 +2662,8 @@ both the Appium client documentation as well as the Selenium client documentatio
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/intro/drivers/index.html
+++ b/docs/en/2.19/intro/drivers/index.html
@@ -2823,8 +2823,8 @@ you can look there for the appropriate implementation.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/intro/history/index.html
+++ b/docs/en/2.19/intro/history/index.html
@@ -2914,8 +2914,8 @@ possibilities for automation-related development for platforms far beyond iOS an
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/intro/index.html
+++ b/docs/en/2.19/intro/index.html
@@ -2575,8 +2575,8 @@ program is a very daunting, if not impossible task!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/index.html
+++ b/docs/en/2.19/quickstart/index.html
@@ -2629,8 +2629,8 @@ and persist environment variables, etc...</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/install/index.html
+++ b/docs/en/2.19/quickstart/install/index.html
@@ -2637,8 +2637,8 @@ Android - continue to <a href="../uiauto2-driver/">Installing the UiAutomator2 D
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/next-steps/index.html
+++ b/docs/en/2.19/quickstart/next-steps/index.html
@@ -2561,8 +2561,8 @@ helps you to discover element locators for use in your test scripts.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/requirements/index.html
+++ b/docs/en/2.19/quickstart/requirements/index.html
@@ -2627,8 +2627,8 @@ the <a href="../../cli/extensions/#doctor">Command-Line Usage documentation</a>.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/test-dotnet/index.html
+++ b/docs/en/2.19/quickstart/test-dotnet/index.html
@@ -2636,8 +2636,8 @@ to one. Then, you can execute the script:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/test-java/index.html
+++ b/docs/en/2.19/quickstart/test-java/index.html
@@ -2561,8 +2561,8 @@ how to invoke Java client features from your test framework.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/test-js/index.html
+++ b/docs/en/2.19/quickstart/test-js/index.html
@@ -2630,8 +2630,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/test-py/index.html
+++ b/docs/en/2.19/quickstart/test-py/index.html
@@ -2622,8 +2622,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/test-rb/index.html
+++ b/docs/en/2.19/quickstart/test-rb/index.html
@@ -2634,8 +2634,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/quickstart/uiauto2-driver/index.html
+++ b/docs/en/2.19/quickstart/uiauto2-driver/index.html
@@ -2863,8 +2863,8 @@ first test! Now select your preferred language and give it a shot:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/resources/index.html
+++ b/docs/en/2.19/resources/index.html
@@ -2628,8 +2628,8 @@ maintainers, Jonathan Lipps, with lots of useful guides</li>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/2.19/sponsors/index.html
+++ b/docs/en/2.19/sponsors/index.html
@@ -2619,9 +2619,9 @@ contributors!</p>
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png#only-dark" width="250" alt="BrowserStack" />
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-light.png#only-light" width="250" alt="BrowserStack" />
 </a></p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="gold-sponsors">Gold Sponsors<a class="headerlink" href="#gold-sponsors" title="Permanent link">&para;</a></h2>
 <div class="sponsor-section">
@@ -2712,8 +2712,8 @@ contributors!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/404.html
+++ b/docs/en/3.0/404.html
@@ -2796,8 +2796,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/2024/03/07/hello-world/index.html
+++ b/docs/en/3.0/blog/2024/03/07/hello-world/index.html
@@ -2940,8 +2940,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
+++ b/docs/en/3.0/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
@@ -2972,8 +2972,8 @@ contribution level.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
+++ b/docs/en/3.0/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
@@ -2972,8 +2972,8 @@ HeadSpin as our first official Development Partner!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
+++ b/docs/en/3.0/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
@@ -2969,8 +2969,8 @@ teams can move fast while delivering an amazing experience for every customer.</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
+++ b/docs/en/3.0/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
@@ -2960,8 +2960,8 @@ Needless to say, we are extremely grateful for Sauce Labs's support!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
+++ b/docs/en/3.0/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
@@ -3029,8 +3029,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/en/3.0/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -2869,12 +2869,12 @@
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -2967,8 +2967,8 @@ infrastructure, execution, RCA, and reporting.</em></p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/2025/08/07/-appium-3/index.html
+++ b/docs/en/3.0/blog/2025/08/07/-appium-3/index.html
@@ -2990,8 +2990,8 @@ and W3C-compliant test automation pipelines. Happy testing!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/archive/2024/index.html
+++ b/docs/en/3.0/blog/archive/2024/index.html
@@ -3088,8 +3088,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/archive/2025/index.html
+++ b/docs/en/3.0/blog/archive/2025/index.html
@@ -2848,7 +2848,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -2906,8 +2906,8 @@ is coming on board as one of our Strategic Partners!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/blog/index.html
+++ b/docs/en/3.0/blog/index.html
@@ -2866,7 +2866,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -3195,8 +3195,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/contributing/index.html
+++ b/docs/en/3.0/contributing/index.html
@@ -3068,8 +3068,8 @@ corresponding translated resources included.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/developing/build-docs/index.html
+++ b/docs/en/3.0/developing/build-docs/index.html
@@ -3061,8 +3061,8 @@ examples:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/developing/build-doctor-checks/index.html
+++ b/docs/en/3.0/developing/build-doctor-checks/index.html
@@ -3112,8 +3112,8 @@ as</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/developing/build-drivers/index.html
+++ b/docs/en/3.0/developing/build-drivers/index.html
@@ -4210,8 +4210,8 @@ unexpected shutdown).</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/developing/build-plugins/index.html
+++ b/docs/en/3.0/developing/build-plugins/index.html
@@ -3810,8 +3810,8 @@ keeping in mind that the function is not <code>await</code>ed you could implemen
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/developing/config-system/index.html
+++ b/docs/en/3.0/developing/config-system/index.html
@@ -3598,8 +3598,8 @@ schema:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/developing/index.html
+++ b/docs/en/3.0/developing/index.html
@@ -2874,8 +2874,8 @@ own Appium extension:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/developing/sensitive/index.html
+++ b/docs/en/3.0/developing/sensitive/index.html
@@ -2984,8 +2984,8 @@ In order to get some value in logs replaced by a generic mask it is necessary:</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/ecosystem/clients/index.html
+++ b/docs/en/3.0/ecosystem/clients/index.html
@@ -3229,8 +3229,8 @@ some Appium-specific commands may not be implemented in other clients.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/ecosystem/drivers/index.html
+++ b/docs/en/3.0/ecosystem/drivers/index.html
@@ -3433,8 +3433,8 @@ along with their installation commands and links to their documentation.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/ecosystem/index.html
+++ b/docs/en/3.0/ecosystem/index.html
@@ -2890,8 +2890,8 @@ aims to compile a listing of various officially-supported and community-supporte
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/ecosystem/plugins/index.html
+++ b/docs/en/3.0/ecosystem/plugins/index.html
@@ -3268,8 +3268,8 @@ Appium server installation</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/ecosystem/tools/index.html
+++ b/docs/en/3.0/ecosystem/tools/index.html
@@ -3082,8 +3082,8 @@ prerequisites for iOS or Android emulators or real devices.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/branch-testing/index.html
+++ b/docs/en/3.0/guides/branch-testing/index.html
@@ -3039,8 +3039,8 @@ to switch back to the package managed by NPM. Follow the next steps for that:</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/caching/index.html
+++ b/docs/en/3.0/guides/caching/index.html
@@ -3071,8 +3071,8 @@ would be performed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/caps/index.html
+++ b/docs/en/3.0/guides/caps/index.html
@@ -3443,8 +3443,8 @@ running Appium on their own.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/config/index.html
+++ b/docs/en/3.0/guides/config/index.html
@@ -3109,8 +3109,8 @@ For example, <code>callback-port</code> is allowed, but <code>callbackPort</code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/context/index.html
+++ b/docs/en/3.0/guides/context/index.html
@@ -2941,8 +2941,8 @@ visit the documentation for a given library.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/event-timing/index.html
+++ b/docs/en/3.0/guides/event-timing/index.html
@@ -2996,8 +2996,8 @@ command can be used to retrieve named events' timestamps later on.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/execute-methods/index.html
+++ b/docs/en/3.0/guides/execute-methods/index.html
@@ -2978,8 +2978,8 @@ has made any alterations to the standard access method.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/grid/index.html
+++ b/docs/en/3.0/guides/grid/index.html
@@ -3180,8 +3180,8 @@ will prevent Selenium Grid from connecting correctly.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/headers/index.html
+++ b/docs/en/3.0/guides/headers/index.html
@@ -2978,8 +2978,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/log-filters/index.html
+++ b/docs/en/3.0/guides/log-filters/index.html
@@ -3048,8 +3048,8 @@ these errors are addressed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/managing-exts/index.html
+++ b/docs/en/3.0/guides/managing-exts/index.html
@@ -3015,8 +3015,8 @@ Otherwise, it is recommended that you use Appium's Extension CLI and, if necessa
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/migrating-1-to-2/index.html
+++ b/docs/en/3.0/guides/migrating-1-to-2/index.html
@@ -3603,8 +3603,8 @@ an industry-compatible way!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/migrating-2-to-3/index.html
+++ b/docs/en/3.0/guides/migrating-2-to-3/index.html
@@ -3802,8 +3802,8 @@ longer accepts, as well as the parameters it continues to accept in Appium 3.</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/security/index.html
+++ b/docs/en/3.0/guides/security/index.html
@@ -3083,8 +3083,8 @@ these features requires using the wildcard prefix:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/settings/index.html
+++ b/docs/en/3.0/guides/settings/index.html
@@ -3012,8 +3012,8 @@ specific client library, visit the documentation for that client.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/guides/tls/index.html
+++ b/docs/en/3.0/guides/tls/index.html
@@ -3011,8 +3011,8 @@ client setup, e.g. make sure it does not reject unauthorized certificates.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/index.html
+++ b/docs/en/3.0/index.html
@@ -2877,9 +2877,9 @@ Android TV, Samsung), and more!</p>
       </a>
     </div>
     <div class="homepageSponsor">
-      <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-        <img src="assets/images/sponsor-logo-lambdatest-dark.png#only-dark" style="width: 220px;" />
-        <img src="assets/images/sponsor-logo-lambdatest-light.png#only-light" style="width: 220px;" />
+      <a href="https://www.testmuai.com">
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" style="width: 220px;" />
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" style="width: 220px;" />
       </a>
     </div>
   </div>
@@ -2969,8 +2969,8 @@ Android TV, Samsung), and more!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/intro/appium/index.html
+++ b/docs/en/3.0/intro/appium/index.html
@@ -3167,8 +3167,8 @@ principles, which we also encourage for Appium extension developers:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/intro/clients/index.html
+++ b/docs/en/3.0/intro/clients/index.html
@@ -2986,8 +2986,8 @@ both the Appium client documentation as well as the Selenium client documentatio
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/intro/drivers/index.html
+++ b/docs/en/3.0/intro/drivers/index.html
@@ -3147,8 +3147,8 @@ you can look there for the appropriate implementation.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/intro/history/index.html
+++ b/docs/en/3.0/intro/history/index.html
@@ -3267,8 +3267,8 @@ gone through multiple major updates during the Appium 2 era.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/intro/index.html
+++ b/docs/en/3.0/intro/index.html
@@ -2891,8 +2891,8 @@ program is a very daunting, if not impossible task!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/index.html
+++ b/docs/en/3.0/quickstart/index.html
@@ -2908,8 +2908,8 @@ and persist environment variables, etc...</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/install/index.html
+++ b/docs/en/3.0/quickstart/install/index.html
@@ -2961,8 +2961,8 @@ Android - continue to <a href="../uiauto2-driver/">Installing the UiAutomator2 D
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/next-steps/index.html
+++ b/docs/en/3.0/quickstart/next-steps/index.html
@@ -2885,8 +2885,8 @@ helps you to discover element locators for use in your test scripts.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/requirements/index.html
+++ b/docs/en/3.0/quickstart/requirements/index.html
@@ -2951,8 +2951,8 @@ the <a href="../../reference/cli/extensions/#doctor">Command-Line Usage document
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/test-dotnet/index.html
+++ b/docs/en/3.0/quickstart/test-dotnet/index.html
@@ -2960,8 +2960,8 @@ to one. Then, you can execute the script:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/test-java/index.html
+++ b/docs/en/3.0/quickstart/test-java/index.html
@@ -2885,8 +2885,8 @@ how to invoke Java client features from your test framework.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/test-js/index.html
+++ b/docs/en/3.0/quickstart/test-js/index.html
@@ -2954,8 +2954,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/test-py/index.html
+++ b/docs/en/3.0/quickstart/test-py/index.html
@@ -2946,8 +2946,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/test-rb/index.html
+++ b/docs/en/3.0/quickstart/test-rb/index.html
@@ -2958,8 +2958,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/quickstart/uiauto2-driver/index.html
+++ b/docs/en/3.0/quickstart/uiauto2-driver/index.html
@@ -3187,8 +3187,8 @@ first test! Now select your preferred language and give it a shot:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/api/appium/index.html
+++ b/docs/en/3.0/reference/api/appium/index.html
@@ -4641,8 +4641,8 @@ may never return a <code>false</code> value.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/api/bidi/index.html
+++ b/docs/en/3.0/reference/api/bidi/index.html
@@ -3178,8 +3178,8 @@ sent as a websocket event, that both drivers and clients can emit or listen to.<
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/api/index.html
+++ b/docs/en/3.0/reference/api/index.html
@@ -2887,8 +2887,8 @@ Refer to the documentation of your client for the exact commands used to invoke 
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/api/jsonwp/index.html
+++ b/docs/en/3.0/reference/api/jsonwp/index.html
@@ -3658,8 +3658,8 @@ For retrieving event history, please use <a href="../appium/#getlogevents"><code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/api/mjsonwp/index.html
+++ b/docs/en/3.0/reference/api/mjsonwp/index.html
@@ -3509,8 +3509,8 @@ endpoints used in Appium.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/api/others/index.html
+++ b/docs/en/3.0/reference/api/others/index.html
@@ -3912,8 +3912,8 @@ identified by <code>:authenticatorId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/api/plugins/index.html
+++ b/docs/en/3.0/reference/api/plugins/index.html
@@ -4057,8 +4057,8 @@ preserved, and only the incomplete uploads will be stopped.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/api/webdriver/index.html
+++ b/docs/en/3.0/reference/api/webdriver/index.html
@@ -7371,8 +7371,8 @@ identified by <code>:elementId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/cli/env-vars/index.html
+++ b/docs/en/3.0/reference/cli/env-vars/index.html
@@ -2942,8 +2942,8 @@ used by official plugins:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/cli/extensions/index.html
+++ b/docs/en/3.0/reference/cli/extensions/index.html
@@ -3795,8 +3795,8 @@ Appium will only update minor and patch versions, in order to prevent any breaki
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/cli/index.html
+++ b/docs/en/3.0/reference/cli/index.html
@@ -2894,8 +2894,8 @@ advanced configuration.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/cli/server/index.html
+++ b/docs/en/3.0/reference/cli/server/index.html
@@ -3227,8 +3227,8 @@ set on the command line will override any options found in a configuration file.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/cli/setup/index.html
+++ b/docs/en/3.0/reference/cli/setup/index.html
@@ -3162,8 +3162,8 @@ example, due to a failed upgrade attempt from an older Appium version.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/reference/index.html
+++ b/docs/en/3.0/reference/index.html
@@ -2882,8 +2882,8 @@ Appium server: the command-line executable, and the supported API endpoints.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/resources/index.html
+++ b/docs/en/3.0/resources/index.html
@@ -2920,8 +2920,8 @@ maintainers, Jonathan Lipps, with lots of useful guides</li>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.0/sponsors/index.html
+++ b/docs/en/3.0/sponsors/index.html
@@ -2867,9 +2867,9 @@ contributors!</p>
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png#only-dark" width="250" alt="BrowserStack" />
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-light.png#only-light" width="250" alt="BrowserStack" />
 </a></p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="gold-sponsors">Gold Sponsors<a class="headerlink" href="#gold-sponsors" title="Permanent link">&para;</a></h2>
 <div class="sponsor-section">
@@ -2960,8 +2960,8 @@ contributors!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/404.html
+++ b/docs/en/3.1/404.html
@@ -2809,8 +2809,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/2024/03/07/hello-world/index.html
+++ b/docs/en/3.1/blog/2024/03/07/hello-world/index.html
@@ -2953,8 +2953,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
+++ b/docs/en/3.1/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
@@ -2985,8 +2985,8 @@ contribution level.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
+++ b/docs/en/3.1/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
@@ -2985,8 +2985,8 @@ HeadSpin as our first official Development Partner!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
+++ b/docs/en/3.1/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
@@ -2982,8 +2982,8 @@ teams can move fast while delivering an amazing experience for every customer.</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
+++ b/docs/en/3.1/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
@@ -2973,8 +2973,8 @@ Needless to say, we are extremely grateful for Sauce Labs's support!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
+++ b/docs/en/3.1/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
@@ -3042,8 +3042,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/en/3.1/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -2882,12 +2882,12 @@
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -2980,8 +2980,8 @@ infrastructure, execution, RCA, and reporting.</em></p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/2025/08/07/-appium-3/index.html
+++ b/docs/en/3.1/blog/2025/08/07/-appium-3/index.html
@@ -3005,8 +3005,8 @@ and W3C-compliant test automation pipelines. Happy testing!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/en/3.1/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -2898,7 +2898,7 @@ This kind of hands-on contribution is crucial for ensuring Appium continues to e
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -2984,8 +2984,8 @@ The Appium project is proud to recognize LambdaTest as our newest official Devel
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/archive/2024/index.html
+++ b/docs/en/3.1/blog/archive/2024/index.html
@@ -3101,8 +3101,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/archive/2025/index.html
+++ b/docs/en/3.1/blog/archive/2025/index.html
@@ -2905,7 +2905,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -2963,8 +2963,8 @@ is coming on board as one of our Strategic Partners!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/blog/index.html
+++ b/docs/en/3.1/blog/index.html
@@ -2923,7 +2923,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -3252,8 +3252,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/contributing/index.html
+++ b/docs/en/3.1/contributing/index.html
@@ -3081,8 +3081,8 @@ corresponding translated resources included.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/developing/build-docs/index.html
+++ b/docs/en/3.1/developing/build-docs/index.html
@@ -3074,8 +3074,8 @@ examples:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/developing/build-doctor-checks/index.html
+++ b/docs/en/3.1/developing/build-doctor-checks/index.html
@@ -3125,8 +3125,8 @@ as</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/developing/build-drivers/index.html
+++ b/docs/en/3.1/developing/build-drivers/index.html
@@ -4223,8 +4223,8 @@ unexpected shutdown).</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/developing/build-plugins/index.html
+++ b/docs/en/3.1/developing/build-plugins/index.html
@@ -3823,8 +3823,8 @@ keeping in mind that the function is not <code>await</code>ed you could implemen
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/developing/config-system/index.html
+++ b/docs/en/3.1/developing/config-system/index.html
@@ -3611,8 +3611,8 @@ schema:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/developing/index.html
+++ b/docs/en/3.1/developing/index.html
@@ -2887,8 +2887,8 @@ own Appium extension:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/developing/sensitive/index.html
+++ b/docs/en/3.1/developing/sensitive/index.html
@@ -2997,8 +2997,8 @@ In order to get some value in logs replaced by a generic mask it is necessary:</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/ecosystem/clients/index.html
+++ b/docs/en/3.1/ecosystem/clients/index.html
@@ -3242,8 +3242,8 @@ some Appium-specific commands may not be implemented in other clients.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/ecosystem/drivers/index.html
+++ b/docs/en/3.1/ecosystem/drivers/index.html
@@ -3446,8 +3446,8 @@ along with their installation commands and links to their documentation.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/ecosystem/index.html
+++ b/docs/en/3.1/ecosystem/index.html
@@ -2903,8 +2903,8 @@ aims to compile a listing of various officially-supported and community-supporte
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/ecosystem/plugins/index.html
+++ b/docs/en/3.1/ecosystem/plugins/index.html
@@ -3281,8 +3281,8 @@ Appium server installation</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/ecosystem/tools/index.html
+++ b/docs/en/3.1/ecosystem/tools/index.html
@@ -3141,8 +3141,8 @@ prerequisites for iOS or Android emulators or real devices.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/branch-testing/index.html
+++ b/docs/en/3.1/guides/branch-testing/index.html
@@ -3052,8 +3052,8 @@ to switch back to the package managed by NPM. Follow the next steps for that:</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/caching/index.html
+++ b/docs/en/3.1/guides/caching/index.html
@@ -3084,8 +3084,8 @@ would be performed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/caps/index.html
+++ b/docs/en/3.1/guides/caps/index.html
@@ -3456,8 +3456,8 @@ running Appium on their own.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/config/index.html
+++ b/docs/en/3.1/guides/config/index.html
@@ -3122,8 +3122,8 @@ For example, <code>callback-port</code> is allowed, but <code>callbackPort</code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/context/index.html
+++ b/docs/en/3.1/guides/context/index.html
@@ -2954,8 +2954,8 @@ visit the documentation for a given library.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/event-timing/index.html
+++ b/docs/en/3.1/guides/event-timing/index.html
@@ -3009,8 +3009,8 @@ command can be used to retrieve named events' timestamps later on.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/execute-methods/index.html
+++ b/docs/en/3.1/guides/execute-methods/index.html
@@ -2991,8 +2991,8 @@ has made any alterations to the standard access method.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/grid/index.html
+++ b/docs/en/3.1/guides/grid/index.html
@@ -3205,8 +3205,8 @@ will prevent Selenium Grid from connecting correctly.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/headers/index.html
+++ b/docs/en/3.1/guides/headers/index.html
@@ -2991,8 +2991,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/log-filters/index.html
+++ b/docs/en/3.1/guides/log-filters/index.html
@@ -3061,8 +3061,8 @@ these errors are addressed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/managing-exts/index.html
+++ b/docs/en/3.1/guides/managing-exts/index.html
@@ -3028,8 +3028,8 @@ Otherwise, it is recommended that you use Appium's Extension CLI and, if necessa
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/migrating-1-to-2/index.html
+++ b/docs/en/3.1/guides/migrating-1-to-2/index.html
@@ -3616,8 +3616,8 @@ an industry-compatible way!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/migrating-2-to-3/index.html
+++ b/docs/en/3.1/guides/migrating-2-to-3/index.html
@@ -3815,8 +3815,8 @@ longer accepts, as well as the parameters it continues to accept in Appium 3.</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/security/index.html
+++ b/docs/en/3.1/guides/security/index.html
@@ -3099,8 +3099,8 @@ these features require using the wildcard prefix:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/settings/index.html
+++ b/docs/en/3.1/guides/settings/index.html
@@ -3025,8 +3025,8 @@ specific client library, visit the documentation for that client.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/guides/tls/index.html
+++ b/docs/en/3.1/guides/tls/index.html
@@ -3024,8 +3024,8 @@ client setup, e.g. make sure it does not reject unauthorized certificates.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/index.html
+++ b/docs/en/3.1/index.html
@@ -2890,9 +2890,9 @@ Android TV, Samsung), and more!</p>
       </a>
     </div>
     <div class="homepageSponsor">
-      <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-        <img src="assets/images/sponsor-logo-lambdatest-dark.png#only-dark" style="width: 220px;" />
-        <img src="assets/images/sponsor-logo-lambdatest-light.png#only-light" style="width: 220px;" />
+      <a href="https://www.testmuai.com">
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" style="width: 220px;" />
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" style="width: 220px;" />
       </a>
     </div>
   </div>
@@ -2982,8 +2982,8 @@ Android TV, Samsung), and more!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/intro/appium/index.html
+++ b/docs/en/3.1/intro/appium/index.html
@@ -3180,8 +3180,8 @@ principles, which we also encourage for Appium extension developers:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/intro/clients/index.html
+++ b/docs/en/3.1/intro/clients/index.html
@@ -2999,8 +2999,8 @@ both the Appium client documentation as well as the Selenium client documentatio
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/intro/drivers/index.html
+++ b/docs/en/3.1/intro/drivers/index.html
@@ -3160,8 +3160,8 @@ you can look there for the appropriate implementation.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/intro/history/index.html
+++ b/docs/en/3.1/intro/history/index.html
@@ -3280,8 +3280,8 @@ gone through multiple major updates during the Appium 2 era.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/intro/index.html
+++ b/docs/en/3.1/intro/index.html
@@ -2904,8 +2904,8 @@ program is a very daunting, if not impossible task!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/index.html
+++ b/docs/en/3.1/quickstart/index.html
@@ -2921,8 +2921,8 @@ and persist environment variables, etc...</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/install/index.html
+++ b/docs/en/3.1/quickstart/install/index.html
@@ -2974,8 +2974,8 @@ Android - continue to <a href="../uiauto2-driver/">Installing the UiAutomator2 D
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/next-steps/index.html
+++ b/docs/en/3.1/quickstart/next-steps/index.html
@@ -2898,8 +2898,8 @@ helps you to discover element locators for use in your test scripts.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/requirements/index.html
+++ b/docs/en/3.1/quickstart/requirements/index.html
@@ -2964,8 +2964,8 @@ the <a href="../../reference/cli/extensions/#doctor">Command-Line Usage document
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/test-dotnet/index.html
+++ b/docs/en/3.1/quickstart/test-dotnet/index.html
@@ -2973,8 +2973,8 @@ to one. Then, you can execute the script:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/test-java/index.html
+++ b/docs/en/3.1/quickstart/test-java/index.html
@@ -2898,8 +2898,8 @@ how to invoke Java client features from your test framework.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/test-js/index.html
+++ b/docs/en/3.1/quickstart/test-js/index.html
@@ -2967,8 +2967,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/test-py/index.html
+++ b/docs/en/3.1/quickstart/test-py/index.html
@@ -2959,8 +2959,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/test-rb/index.html
+++ b/docs/en/3.1/quickstart/test-rb/index.html
@@ -2971,8 +2971,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/quickstart/uiauto2-driver/index.html
+++ b/docs/en/3.1/quickstart/uiauto2-driver/index.html
@@ -3200,8 +3200,8 @@ first test! Now select your preferred language and give it a shot:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/api/appium/index.html
+++ b/docs/en/3.1/reference/api/appium/index.html
@@ -4654,8 +4654,8 @@ may never return a <code>false</code> value.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/api/bidi/index.html
+++ b/docs/en/3.1/reference/api/bidi/index.html
@@ -3191,8 +3191,8 @@ sent as a websocket event, that both drivers and clients can emit or listen to.<
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/api/index.html
+++ b/docs/en/3.1/reference/api/index.html
@@ -2900,8 +2900,8 @@ Refer to the documentation of your client for the exact commands used to invoke 
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/api/jsonwp/index.html
+++ b/docs/en/3.1/reference/api/jsonwp/index.html
@@ -3671,8 +3671,8 @@ For retrieving event history, please use <a href="../appium/#getlogevents"><code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/api/mjsonwp/index.html
+++ b/docs/en/3.1/reference/api/mjsonwp/index.html
@@ -3522,8 +3522,8 @@ endpoints supported in Appium.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/api/others/index.html
+++ b/docs/en/3.1/reference/api/others/index.html
@@ -5932,8 +5932,8 @@ identified by <code>:authenticatorId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/api/plugins/index.html
+++ b/docs/en/3.1/reference/api/plugins/index.html
@@ -4070,8 +4070,8 @@ preserved, and only the incomplete uploads will be stopped.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/api/webdriver/index.html
+++ b/docs/en/3.1/reference/api/webdriver/index.html
@@ -7624,8 +7624,8 @@ identified by <code>:elementId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/cli/env-vars/index.html
+++ b/docs/en/3.1/reference/cli/env-vars/index.html
@@ -2955,8 +2955,8 @@ used by official plugins:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/cli/extensions/index.html
+++ b/docs/en/3.1/reference/cli/extensions/index.html
@@ -3813,8 +3813,8 @@ Appium will only update minor and patch versions, in order to prevent any breaki
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/cli/index.html
+++ b/docs/en/3.1/reference/cli/index.html
@@ -2907,8 +2907,8 @@ advanced configuration.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/cli/server/index.html
+++ b/docs/en/3.1/reference/cli/server/index.html
@@ -3240,8 +3240,8 @@ set on the command line will override any options found in a configuration file.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/cli/setup/index.html
+++ b/docs/en/3.1/reference/cli/setup/index.html
@@ -3175,8 +3175,8 @@ example, due to a failed upgrade attempt from an older Appium version.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/reference/index.html
+++ b/docs/en/3.1/reference/index.html
@@ -2895,8 +2895,8 @@ Appium server: the command-line executable, and the supported API endpoints.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/resources/index.html
+++ b/docs/en/3.1/resources/index.html
@@ -2933,8 +2933,8 @@ maintainers, Jonathan Lipps, with lots of useful guides</li>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.1/sponsors/index.html
+++ b/docs/en/3.1/sponsors/index.html
@@ -2872,9 +2872,9 @@ Hub</a>.</p>
 <h2 id="development-partners">Development Partners<a class="headerlink" href="#development-partners" title="Permanent link">&para;</a></h2>
 <p>We are very grateful for the support of our Development Partners, who donate Appium development and
 maintenance as part of their employees' core job duties!</p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="strategic-partners">Strategic Partners<a class="headerlink" href="#strategic-partners" title="Permanent link">&para;</a></h2>
 <p>We are very grateful for the financial and marketing support of our exclusive Strategic Partners,
@@ -2884,9 +2884,9 @@ contributors!</p>
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png#only-dark" width="250" alt="BrowserStack" />
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-light.png#only-light" width="250" alt="BrowserStack" />
 </a></p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="gold-sponsors">Gold Sponsors<a class="headerlink" href="#gold-sponsors" title="Permanent link">&para;</a></h2>
 <div class="sponsor-section">
@@ -2977,8 +2977,8 @@ contributors!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/en/3.2/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/en/3.2/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3639,12 +3639,12 @@
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/en/3.2/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/en/3.2/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3655,7 +3655,7 @@ This kind of hands-on contribution is crucial for ensuring Appium continues to e
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/en/3.2/blog/archive/2025/index.html
+++ b/docs/en/3.2/blog/archive/2025/index.html
@@ -3663,7 +3663,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/en/3.2/blog/index.html
+++ b/docs/en/3.2/blog/index.html
@@ -3681,7 +3681,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/en/3.3/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/en/3.3/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3639,12 +3639,12 @@
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/en/3.3/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/en/3.3/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3655,7 +3655,7 @@ This kind of hands-on contribution is crucial for ensuring Appium continues to e
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/en/3.3/blog/archive/2025/index.html
+++ b/docs/en/3.3/blog/archive/2025/index.html
@@ -3663,7 +3663,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/en/3.3/blog/index.html
+++ b/docs/en/3.3/blog/index.html
@@ -3681,7 +3681,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/en/3.4/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/en/3.4/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3639,12 +3639,12 @@
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/en/3.4/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/en/3.4/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3655,7 +3655,7 @@ This kind of hands-on contribution is crucial for ensuring Appium continues to e
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/en/3.4/blog/archive/2025/index.html
+++ b/docs/en/3.4/blog/archive/2025/index.html
@@ -3663,7 +3663,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/en/3.4/blog/index.html
+++ b/docs/en/3.4/blog/index.html
@@ -3681,7 +3681,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/en/3.5/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/en/3.5/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3626,12 +3626,12 @@
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/en/3.5/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/en/3.5/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3642,7 +3642,7 @@ This kind of hands-on contribution is crucial for ensuring Appium continues to e
 <!-- more -->
 
 <div style="text-align:center;width:100%">
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+  <a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/en/3.5/blog/archive/2025/index.html
+++ b/docs/en/3.5/blog/archive/2025/index.html
@@ -3650,7 +3650,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/en/3.5/blog/index.html
+++ b/docs/en/3.5/blog/index.html
@@ -3668,7 +3668,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our <a href="https://appium.io/docs/en/latest/blog/2024/05/14/announcing-appiums-sponsorship-program/">Sponsorship Program and Compensation
 Scheme</a>,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/ja/2.19/404.html
+++ b/docs/ja/2.19/404.html
@@ -2472,8 +2472,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/blog/2024/03/07/hello-world/index.html
+++ b/docs/ja/2.19/blog/2024/03/07/hello-world/index.html
@@ -2616,8 +2616,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
+++ b/docs/ja/2.19/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
@@ -2648,8 +2648,8 @@ contribution level.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
+++ b/docs/ja/2.19/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
@@ -2648,8 +2648,8 @@ HeadSpin as our first official Development Partner!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
+++ b/docs/ja/2.19/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
@@ -2645,8 +2645,8 @@ teams can move fast while delivering an amazing experience for every customer.</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
+++ b/docs/ja/2.19/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
@@ -2636,8 +2636,8 @@ Needless to say, we are extremely grateful for Sauce Labs's support!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
+++ b/docs/ja/2.19/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
@@ -2704,8 +2704,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/blog/archive/2024/index.html
+++ b/docs/ja/2.19/blog/archive/2024/index.html
@@ -2764,8 +2764,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/blog/index.html
+++ b/docs/ja/2.19/blog/index.html
@@ -2782,8 +2782,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/cli/args/index.html
+++ b/docs/ja/2.19/cli/args/index.html
@@ -2865,8 +2865,8 @@ below.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/cli/env-vars/index.html
+++ b/docs/ja/2.19/cli/env-vars/index.html
@@ -2598,8 +2598,8 @@ environment variables that the Appium server understands:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/cli/extensions/index.html
+++ b/docs/ja/2.19/cli/extensions/index.html
@@ -2983,8 +2983,8 @@ unintended breaking changes.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/cli/index.html
+++ b/docs/ja/2.19/cli/index.html
@@ -2561,8 +2561,8 @@ or run <code>appium -h</code> or <code>appium --help</code> to return the help m
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/cli/setup/index.html
+++ b/docs/ja/2.19/cli/setup/index.html
@@ -2598,8 +2598,8 @@ By running <code>appium setup reset</code> the server would uninstall all instal
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/commands/base-driver/index.html
+++ b/docs/ja/2.19/commands/base-driver/index.html
@@ -4739,8 +4739,8 @@ Each session data object will be returned with <code>id</code> and the session's
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/commands/execute-driver-plugin/index.html
+++ b/docs/ja/2.19/commands/execute-driver-plugin/index.html
@@ -2677,8 +2677,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/commands/images-plugin/index.html
+++ b/docs/ja/2.19/commands/images-plugin/index.html
@@ -2962,8 +2962,8 @@ commands</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/commands/index.html
+++ b/docs/ja/2.19/commands/index.html
@@ -2563,8 +2563,8 @@ well as the commands available in several plugins.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/commands/relaxed-caps-plugin/index.html
+++ b/docs/ja/2.19/commands/relaxed-caps-plugin/index.html
@@ -2687,8 +2687,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/commands/storage-plugin/index.html
+++ b/docs/ja/2.19/commands/storage-plugin/index.html
@@ -3025,8 +3025,8 @@ and only the incomplete uploads will be stopped.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/commands/universal-xml-plugin/index.html
+++ b/docs/ja/2.19/commands/universal-xml-plugin/index.html
@@ -2829,8 +2829,8 @@ commands</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/contributing/index.html
+++ b/docs/ja/2.19/contributing/index.html
@@ -2870,8 +2870,8 @@ corresponding translated resources included.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/developing/build-docs/index.html
+++ b/docs/ja/2.19/developing/build-docs/index.html
@@ -2735,8 +2735,8 @@ examples:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/developing/build-doctor-checks/index.html
+++ b/docs/ja/2.19/developing/build-doctor-checks/index.html
@@ -2788,8 +2788,8 @@ as</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/developing/build-drivers/index.html
+++ b/docs/ja/2.19/developing/build-drivers/index.html
@@ -3892,8 +3892,8 @@ unexpected shutdown).</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/developing/build-plugins/index.html
+++ b/docs/ja/2.19/developing/build-plugins/index.html
@@ -3488,8 +3488,8 @@ keeping in mind that the function is not <code>await</code>ed you could implemen
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/developing/config-system/index.html
+++ b/docs/ja/2.19/developing/config-system/index.html
@@ -3282,8 +3282,8 @@ schema:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/developing/index.html
+++ b/docs/ja/2.19/developing/index.html
@@ -2558,8 +2558,8 @@ own Appium extension:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/developing/sensitive/index.html
+++ b/docs/ja/2.19/developing/sensitive/index.html
@@ -2662,8 +2662,8 @@ this.log.info(&#39;Value: %s&#39;, logger.markSensitive(value));
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/ecosystem/clients/index.html
+++ b/docs/ja/2.19/ecosystem/clients/index.html
@@ -2693,8 +2693,8 @@ some Appium-specific commands may not be implemented in other clients.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/ecosystem/drivers/index.html
+++ b/docs/ja/2.19/ecosystem/drivers/index.html
@@ -2773,8 +2773,8 @@ specific installation instructions and documentation for that driver.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/ecosystem/index.html
+++ b/docs/ja/2.19/ecosystem/index.html
@@ -2572,8 +2572,8 @@ aims to compile a listing of various officially-supported and community-supporte
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/ecosystem/plugins/index.html
+++ b/docs/ja/2.19/ecosystem/plugins/index.html
@@ -2727,8 +2727,8 @@ for more specialised automation workflows.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/ecosystem/tools/index.html
+++ b/docs/ja/2.19/ecosystem/tools/index.html
@@ -2674,8 +2674,8 @@ For driver/plugin developers, please read <a href="../../developing/build-doctor
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/branch-testing/index.html
+++ b/docs/ja/2.19/guides/branch-testing/index.html
@@ -2715,8 +2715,8 @@ to switch back to the package managed by NPM. Follow the next steps for that:</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/caching/index.html
+++ b/docs/ja/2.19/guides/caching/index.html
@@ -2748,8 +2748,8 @@ of it. It is a <a href="https://www.npmjs.com/package/lru-cache">LRU Cache</a> w
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/caps/index.html
+++ b/docs/ja/2.19/guides/caps/index.html
@@ -3124,8 +3124,8 @@ running Appium on their own.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/config/index.html
+++ b/docs/ja/2.19/guides/config/index.html
@@ -2787,8 +2787,8 @@ For example, <code>callback-port</code> is allowed, but <code>callbackPort</code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/context/index.html
+++ b/docs/ja/2.19/guides/context/index.html
@@ -2617,8 +2617,8 @@ visit the documentation for a given library.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/event-timing/index.html
+++ b/docs/ja/2.19/guides/event-timing/index.html
@@ -2679,8 +2679,8 @@ on.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/execute-methods/index.html
+++ b/docs/ja/2.19/guides/execute-methods/index.html
@@ -2657,8 +2657,8 @@ has made any alterations to the standard access method.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/grid/index.html
+++ b/docs/ja/2.19/guides/grid/index.html
@@ -2856,8 +2856,8 @@ will prevent Selenium Grid from connecting correctly.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/headers/index.html
+++ b/docs/ja/2.19/guides/headers/index.html
@@ -2654,8 +2654,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/log-filters/index.html
+++ b/docs/ja/2.19/guides/log-filters/index.html
@@ -2724,8 +2724,8 @@ these errors are addressed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/managing-exts/index.html
+++ b/docs/ja/2.19/guides/managing-exts/index.html
@@ -2692,8 +2692,8 @@ Otherwise, it is recommended that you use Appium's Extension CLI and, if necessa
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/migrating-1-to-2/index.html
+++ b/docs/ja/2.19/guides/migrating-1-to-2/index.html
@@ -3294,8 +3294,8 @@ various Appium drivers and plugins that end users may wish to use.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/security/index.html
+++ b/docs/ja/2.19/guides/security/index.html
@@ -2787,8 +2787,8 @@ These prefix rules apply to both the <code>--allow-insecure</code> and <code>--d
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/settings/index.html
+++ b/docs/ja/2.19/guides/settings/index.html
@@ -2689,8 +2689,8 @@ specific client library, visit the documentation for that client.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/guides/tls/index.html
+++ b/docs/ja/2.19/guides/tls/index.html
@@ -2687,8 +2687,8 @@ client setup, e.g. make sure it does not reject unauthorized certificates.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/index.html
+++ b/docs/ja/2.19/index.html
@@ -2635,8 +2635,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/intro/appium/index.html
+++ b/docs/ja/2.19/intro/appium/index.html
@@ -2833,8 +2833,8 @@ that can be used with Appium.&#160;<a class="footnote-backref" href="#fnref:3" t
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/intro/clients/index.html
+++ b/docs/ja/2.19/intro/clients/index.html
@@ -2664,8 +2664,8 @@ They all mean the same thing!&#160;<a class="footnote-backref" href="#fnref:1" t
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/intro/drivers/index.html
+++ b/docs/ja/2.19/intro/drivers/index.html
@@ -2823,8 +2823,8 @@ will generate different session IDs, but these differences will be handled trans
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/intro/history/index.html
+++ b/docs/ja/2.19/intro/history/index.html
@@ -2914,8 +2914,8 @@ possibilities for automation-related development for platforms far beyond iOS an
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/intro/index.html
+++ b/docs/ja/2.19/intro/index.html
@@ -2575,8 +2575,8 @@ program is a very daunting, if not impossible task!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/index.html
+++ b/docs/ja/2.19/quickstart/index.html
@@ -2619,8 +2619,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/install/index.html
+++ b/docs/ja/2.19/quickstart/install/index.html
@@ -2632,8 +2632,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/next-steps/index.html
+++ b/docs/ja/2.19/quickstart/next-steps/index.html
@@ -2561,8 +2561,8 @@ helps you to discover element locators for use in your test scripts.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/requirements/index.html
+++ b/docs/ja/2.19/quickstart/requirements/index.html
@@ -2625,8 +2625,8 @@ the <a href="../../cli/extensions/#doctor">Command-Line Usage documentation</a>.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/test-dotnet/index.html
+++ b/docs/ja/2.19/quickstart/test-dotnet/index.html
@@ -2637,8 +2637,8 @@ to one. Then, you can execute the script:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/test-java/index.html
+++ b/docs/ja/2.19/quickstart/test-java/index.html
@@ -2561,8 +2561,8 @@ how to invoke Java client features from your test framework.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/test-js/index.html
+++ b/docs/ja/2.19/quickstart/test-js/index.html
@@ -2632,8 +2632,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/test-py/index.html
+++ b/docs/ja/2.19/quickstart/test-py/index.html
@@ -2623,8 +2623,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/test-rb/index.html
+++ b/docs/ja/2.19/quickstart/test-rb/index.html
@@ -2635,8 +2635,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/quickstart/uiauto2-driver/index.html
+++ b/docs/ja/2.19/quickstart/uiauto2-driver/index.html
@@ -2865,8 +2865,8 @@ first test! Now select your preferred language and give it a shot:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/resources/index.html
+++ b/docs/ja/2.19/resources/index.html
@@ -2628,8 +2628,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/2.19/sponsors/index.html
+++ b/docs/ja/2.19/sponsors/index.html
@@ -2708,8 +2708,8 @@ contributors!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/404.html
+++ b/docs/ja/3.0/404.html
@@ -2796,8 +2796,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/2024/03/07/hello-world/index.html
+++ b/docs/ja/3.0/blog/2024/03/07/hello-world/index.html
@@ -2940,8 +2940,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
+++ b/docs/ja/3.0/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
@@ -2972,8 +2972,8 @@ contribution level.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
+++ b/docs/ja/3.0/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
@@ -2972,8 +2972,8 @@ HeadSpin as our first official Development Partner!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
+++ b/docs/ja/3.0/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
@@ -2969,8 +2969,8 @@ teams can move fast while delivering an amazing experience for every customer.</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
+++ b/docs/ja/3.0/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
@@ -2960,8 +2960,8 @@ Needless to say, we are extremely grateful for Sauce Labs's support!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
+++ b/docs/ja/3.0/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
@@ -3030,8 +3030,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/ja/3.0/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -2869,11 +2869,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -2966,8 +2966,8 @@ infrastructure, execution, RCA, and reporting.</em></p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/2025/08/07/-appium-3/index.html
+++ b/docs/ja/3.0/blog/2025/08/07/-appium-3/index.html
@@ -2990,8 +2990,8 @@ and W3C-compliant test automation pipelines. Happy testing!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/archive/2024/index.html
+++ b/docs/ja/3.0/blog/archive/2024/index.html
@@ -3088,8 +3088,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/archive/2025/index.html
+++ b/docs/ja/3.0/blog/archive/2025/index.html
@@ -2848,7 +2848,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -2906,8 +2906,8 @@ is coming on board as one of our Strategic Partners!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/blog/index.html
+++ b/docs/ja/3.0/blog/index.html
@@ -2866,7 +2866,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -3195,8 +3195,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/contributing/index.html
+++ b/docs/ja/3.0/contributing/index.html
@@ -3068,8 +3068,8 @@ corresponding translated resources included.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/developing/build-docs/index.html
+++ b/docs/ja/3.0/developing/build-docs/index.html
@@ -3059,8 +3059,8 @@ examples:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/developing/build-doctor-checks/index.html
+++ b/docs/ja/3.0/developing/build-doctor-checks/index.html
@@ -3112,8 +3112,8 @@ as</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/developing/build-drivers/index.html
+++ b/docs/ja/3.0/developing/build-drivers/index.html
@@ -4216,8 +4216,8 @@ unexpected shutdown).</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/developing/build-plugins/index.html
+++ b/docs/ja/3.0/developing/build-plugins/index.html
@@ -3812,8 +3812,8 @@ keeping in mind that the function is not <code>await</code>ed you could implemen
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/developing/config-system/index.html
+++ b/docs/ja/3.0/developing/config-system/index.html
@@ -3606,8 +3606,8 @@ schema:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/developing/index.html
+++ b/docs/ja/3.0/developing/index.html
@@ -2874,8 +2874,8 @@ own Appium extension:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/developing/sensitive/index.html
+++ b/docs/ja/3.0/developing/sensitive/index.html
@@ -2986,8 +2986,8 @@ this.log.info(&#39;Value: %s&#39;, logger.markSensitive(value));
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/ecosystem/clients/index.html
+++ b/docs/ja/3.0/ecosystem/clients/index.html
@@ -3226,8 +3226,8 @@ some Appium-specific commands may not be implemented in other clients.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/ecosystem/drivers/index.html
+++ b/docs/ja/3.0/ecosystem/drivers/index.html
@@ -3439,8 +3439,8 @@ along with their installation commands and links to their documentation.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/ecosystem/index.html
+++ b/docs/ja/3.0/ecosystem/index.html
@@ -2888,8 +2888,8 @@ aims to compile a listing of various officially-supported and community-supporte
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/ecosystem/plugins/index.html
+++ b/docs/ja/3.0/ecosystem/plugins/index.html
@@ -3269,8 +3269,8 @@ Appium server installation</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/ecosystem/tools/index.html
+++ b/docs/ja/3.0/ecosystem/tools/index.html
@@ -3084,8 +3084,8 @@ prerequisites for iOS or Android emulators or real devices.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/branch-testing/index.html
+++ b/docs/ja/3.0/guides/branch-testing/index.html
@@ -3039,8 +3039,8 @@ to switch back to the package managed by NPM. Follow the next steps for that:</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/caching/index.html
+++ b/docs/ja/3.0/guides/caching/index.html
@@ -3072,8 +3072,8 @@ of it. It is a <a href="https://www.npmjs.com/package/lru-cache">LRU Cache</a> w
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/caps/index.html
+++ b/docs/ja/3.0/guides/caps/index.html
@@ -3423,8 +3423,8 @@ running Appium on their own.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/config/index.html
+++ b/docs/ja/3.0/guides/config/index.html
@@ -3111,8 +3111,8 @@ For example, <code>callback-port</code> is allowed, but <code>callbackPort</code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/context/index.html
+++ b/docs/ja/3.0/guides/context/index.html
@@ -2941,8 +2941,8 @@ visit the documentation for a given library.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/event-timing/index.html
+++ b/docs/ja/3.0/guides/event-timing/index.html
@@ -2997,8 +2997,8 @@ command can be used to retrieve named events' timestamps later on.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/execute-methods/index.html
+++ b/docs/ja/3.0/guides/execute-methods/index.html
@@ -2981,8 +2981,8 @@ has made any alterations to the standard access method.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/grid/index.html
+++ b/docs/ja/3.0/guides/grid/index.html
@@ -3180,8 +3180,8 @@ will prevent Selenium Grid from connecting correctly.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/headers/index.html
+++ b/docs/ja/3.0/guides/headers/index.html
@@ -2978,8 +2978,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/log-filters/index.html
+++ b/docs/ja/3.0/guides/log-filters/index.html
@@ -3048,8 +3048,8 @@ these errors are addressed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/managing-exts/index.html
+++ b/docs/ja/3.0/guides/managing-exts/index.html
@@ -3016,8 +3016,8 @@ Otherwise, it is recommended that you use Appium's Extension CLI and, if necessa
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/migrating-1-to-2/index.html
+++ b/docs/ja/3.0/guides/migrating-1-to-2/index.html
@@ -3609,8 +3609,8 @@ various Appium drivers and plugins that end users may wish to use.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/migrating-2-to-3/index.html
+++ b/docs/ja/3.0/guides/migrating-2-to-3/index.html
@@ -3778,8 +3778,8 @@ longer accepts, as well as the parameters it continues to accept in Appium 3.</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/security/index.html
+++ b/docs/ja/3.0/guides/security/index.html
@@ -3083,8 +3083,8 @@ these features requires using the wildcard prefix:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/settings/index.html
+++ b/docs/ja/3.0/guides/settings/index.html
@@ -3013,8 +3013,8 @@ specific client library, visit the documentation for that client.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/guides/tls/index.html
+++ b/docs/ja/3.0/guides/tls/index.html
@@ -3011,8 +3011,8 @@ client setup, e.g. make sure it does not reject unauthorized certificates.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/index.html
+++ b/docs/ja/3.0/index.html
@@ -2873,9 +2873,9 @@
       </a>
     </div>
     <div class="homepageSponsor">
-      <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-        <img src="assets/images/sponsor-logo-lambdatest-dark.png#only-dark" style="width: 220px;" />
-        <img src="assets/images/sponsor-logo-lambdatest-light.png#only-light" style="width: 220px;" />
+      <a href="https://www.testmuai.com">
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" style="width: 220px;" />
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" style="width: 220px;" />
       </a>
     </div>
   </div>
@@ -2965,8 +2965,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/intro/appium/index.html
+++ b/docs/ja/3.0/intro/appium/index.html
@@ -3157,8 +3157,8 @@ that can be used with Appium.&#160;<a class="footnote-backref" href="#fnref:3" t
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/intro/clients/index.html
+++ b/docs/ja/3.0/intro/clients/index.html
@@ -2988,8 +2988,8 @@ They all mean the same thing!&#160;<a class="footnote-backref" href="#fnref:1" t
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/intro/drivers/index.html
+++ b/docs/ja/3.0/intro/drivers/index.html
@@ -3147,8 +3147,8 @@ will generate different session IDs, but these differences will be handled trans
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/intro/history/index.html
+++ b/docs/ja/3.0/intro/history/index.html
@@ -3267,8 +3267,8 @@ gone through multiple major updates during the Appium 2 era.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/intro/index.html
+++ b/docs/ja/3.0/intro/index.html
@@ -2891,8 +2891,8 @@ program is a very daunting, if not impossible task!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/index.html
+++ b/docs/ja/3.0/quickstart/index.html
@@ -2898,8 +2898,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/install/index.html
+++ b/docs/ja/3.0/quickstart/install/index.html
@@ -2956,8 +2956,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/next-steps/index.html
+++ b/docs/ja/3.0/quickstart/next-steps/index.html
@@ -2881,8 +2881,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/requirements/index.html
+++ b/docs/ja/3.0/quickstart/requirements/index.html
@@ -2949,8 +2949,8 @@ the <a href="../../reference/cli/extensions/#doctor">Command-Line Usage document
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/test-dotnet/index.html
+++ b/docs/ja/3.0/quickstart/test-dotnet/index.html
@@ -2961,8 +2961,8 @@ to one. Then, you can execute the script:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/test-java/index.html
+++ b/docs/ja/3.0/quickstart/test-java/index.html
@@ -2885,8 +2885,8 @@ how to invoke Java client features from your test framework.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/test-js/index.html
+++ b/docs/ja/3.0/quickstart/test-js/index.html
@@ -2956,8 +2956,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/test-py/index.html
+++ b/docs/ja/3.0/quickstart/test-py/index.html
@@ -2947,8 +2947,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/test-rb/index.html
+++ b/docs/ja/3.0/quickstart/test-rb/index.html
@@ -2959,8 +2959,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/quickstart/uiauto2-driver/index.html
+++ b/docs/ja/3.0/quickstart/uiauto2-driver/index.html
@@ -3185,8 +3185,8 @@ first test! Now select your preferred language and give it a shot:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/api/appium/index.html
+++ b/docs/ja/3.0/reference/api/appium/index.html
@@ -4639,8 +4639,8 @@ may never return a <code>false</code> value.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/api/bidi/index.html
+++ b/docs/ja/3.0/reference/api/bidi/index.html
@@ -3178,8 +3178,8 @@ sent as a websocket event, that both drivers and clients can emit or listen to.<
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/api/index.html
+++ b/docs/ja/3.0/reference/api/index.html
@@ -2887,8 +2887,8 @@ Refer to the documentation of your client for the exact commands used to invoke 
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/api/jsonwp/index.html
+++ b/docs/ja/3.0/reference/api/jsonwp/index.html
@@ -3658,8 +3658,8 @@ For retrieving event history, please use <a href="../appium/#getlogevents"><code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/api/mjsonwp/index.html
+++ b/docs/ja/3.0/reference/api/mjsonwp/index.html
@@ -3509,8 +3509,8 @@ endpoints used in Appium.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/api/others/index.html
+++ b/docs/ja/3.0/reference/api/others/index.html
@@ -3912,8 +3912,8 @@ identified by <code>:authenticatorId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/api/plugins/index.html
+++ b/docs/ja/3.0/reference/api/plugins/index.html
@@ -4055,8 +4055,8 @@ preserved, and only the incomplete uploads will be stopped.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/api/webdriver/index.html
+++ b/docs/ja/3.0/reference/api/webdriver/index.html
@@ -7371,8 +7371,8 @@ identified by <code>:elementId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/cli/env-vars/index.html
+++ b/docs/ja/3.0/reference/cli/env-vars/index.html
@@ -2942,8 +2942,8 @@ used by official plugins:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/cli/extensions/index.html
+++ b/docs/ja/3.0/reference/cli/extensions/index.html
@@ -3795,8 +3795,8 @@ Appium will only update minor and patch versions, in order to prevent any breaki
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/cli/index.html
+++ b/docs/ja/3.0/reference/cli/index.html
@@ -2892,8 +2892,8 @@ advanced configuration.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/cli/server/index.html
+++ b/docs/ja/3.0/reference/cli/server/index.html
@@ -3227,8 +3227,8 @@ set on the command line will override any options found in a configuration file.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/cli/setup/index.html
+++ b/docs/ja/3.0/reference/cli/setup/index.html
@@ -3162,8 +3162,8 @@ example, due to a failed upgrade attempt from an older Appium version.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/reference/index.html
+++ b/docs/ja/3.0/reference/index.html
@@ -2880,8 +2880,8 @@ Appium server: the command-line executable, and the supported API endpoints.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/resources/index.html
+++ b/docs/ja/3.0/resources/index.html
@@ -2920,8 +2920,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.0/sponsors/index.html
+++ b/docs/ja/3.0/sponsors/index.html
@@ -2867,9 +2867,9 @@ contributors!</p>
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png#only-dark" width="250" alt="BrowserStack" />
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-light.png#only-light" width="250" alt="BrowserStack" />
 </a></p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="gold-sponsors">Gold Sponsors<a class="headerlink" href="#gold-sponsors" title="Permanent link">&para;</a></h2>
 <div class="sponsor-section"><a href="https://jetify.com/" target="_blank"><img src="https://images.opencollective.com/jetify/415824c/avatar/64.png" alt="Jetify" /></a>
@@ -2957,8 +2957,8 @@ contributors!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/404.html
+++ b/docs/ja/3.1/404.html
@@ -2809,8 +2809,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/2024/03/07/hello-world/index.html
+++ b/docs/ja/3.1/blog/2024/03/07/hello-world/index.html
@@ -2953,8 +2953,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
+++ b/docs/ja/3.1/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
@@ -2985,8 +2985,8 @@ contribution level.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
+++ b/docs/ja/3.1/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
@@ -2985,8 +2985,8 @@ HeadSpin as our first official Development Partner!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
+++ b/docs/ja/3.1/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
@@ -2982,8 +2982,8 @@ teams can move fast while delivering an amazing experience for every customer.</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
+++ b/docs/ja/3.1/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
@@ -2973,8 +2973,8 @@ Needless to say, we are extremely grateful for Sauce Labs's support!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
+++ b/docs/ja/3.1/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
@@ -3043,8 +3043,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/ja/3.1/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -2882,11 +2882,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -2979,8 +2979,8 @@ infrastructure, execution, RCA, and reporting.</em></p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/2025/08/07/-appium-3/index.html
+++ b/docs/ja/3.1/blog/2025/08/07/-appium-3/index.html
@@ -3005,8 +3005,8 @@ and W3C-compliant test automation pipelines. Happy testing!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/ja/3.1/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -2897,7 +2897,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -2983,8 +2983,8 @@ The Appium project is proud to recognize LambdaTest as our newest official Devel
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/archive/2024/index.html
+++ b/docs/ja/3.1/blog/archive/2024/index.html
@@ -3101,8 +3101,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/archive/2025/index.html
+++ b/docs/ja/3.1/blog/archive/2025/index.html
@@ -2905,7 +2905,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -2963,8 +2963,8 @@ is coming on board as one of our Strategic Partners!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/blog/index.html
+++ b/docs/ja/3.1/blog/index.html
@@ -2923,7 +2923,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -3252,8 +3252,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/contributing/index.html
+++ b/docs/ja/3.1/contributing/index.html
@@ -3081,8 +3081,8 @@ corresponding translated resources included.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/developing/build-docs/index.html
+++ b/docs/ja/3.1/developing/build-docs/index.html
@@ -3072,8 +3072,8 @@ examples:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/developing/build-doctor-checks/index.html
+++ b/docs/ja/3.1/developing/build-doctor-checks/index.html
@@ -3125,8 +3125,8 @@ as</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/developing/build-drivers/index.html
+++ b/docs/ja/3.1/developing/build-drivers/index.html
@@ -4229,8 +4229,8 @@ unexpected shutdown).</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/developing/build-plugins/index.html
+++ b/docs/ja/3.1/developing/build-plugins/index.html
@@ -3825,8 +3825,8 @@ keeping in mind that the function is not <code>await</code>ed you could implemen
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/developing/config-system/index.html
+++ b/docs/ja/3.1/developing/config-system/index.html
@@ -3619,8 +3619,8 @@ schema:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/developing/index.html
+++ b/docs/ja/3.1/developing/index.html
@@ -2887,8 +2887,8 @@ own Appium extension:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/developing/sensitive/index.html
+++ b/docs/ja/3.1/developing/sensitive/index.html
@@ -2999,8 +2999,8 @@ this.log.info(&#39;Value: %s&#39;, logger.markSensitive(value));
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/ecosystem/clients/index.html
+++ b/docs/ja/3.1/ecosystem/clients/index.html
@@ -3239,8 +3239,8 @@ some Appium-specific commands may not be implemented in other clients.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/ecosystem/drivers/index.html
+++ b/docs/ja/3.1/ecosystem/drivers/index.html
@@ -3452,8 +3452,8 @@ along with their installation commands and links to their documentation.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/ecosystem/index.html
+++ b/docs/ja/3.1/ecosystem/index.html
@@ -2901,8 +2901,8 @@ aims to compile a listing of various officially-supported and community-supporte
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/ecosystem/plugins/index.html
+++ b/docs/ja/3.1/ecosystem/plugins/index.html
@@ -3282,8 +3282,8 @@ Appium server installation</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/ecosystem/tools/index.html
+++ b/docs/ja/3.1/ecosystem/tools/index.html
@@ -3140,8 +3140,8 @@ prerequisites for iOS or Android emulators or real devices.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/branch-testing/index.html
+++ b/docs/ja/3.1/guides/branch-testing/index.html
@@ -3052,8 +3052,8 @@ to switch back to the package managed by NPM. Follow the next steps for that:</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/caching/index.html
+++ b/docs/ja/3.1/guides/caching/index.html
@@ -3085,8 +3085,8 @@ of it. It is a <a href="https://www.npmjs.com/package/lru-cache">LRU Cache</a> w
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/caps/index.html
+++ b/docs/ja/3.1/guides/caps/index.html
@@ -3436,8 +3436,8 @@ running Appium on their own.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/config/index.html
+++ b/docs/ja/3.1/guides/config/index.html
@@ -3124,8 +3124,8 @@ For example, <code>callback-port</code> is allowed, but <code>callbackPort</code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/context/index.html
+++ b/docs/ja/3.1/guides/context/index.html
@@ -2954,8 +2954,8 @@ visit the documentation for a given library.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/event-timing/index.html
+++ b/docs/ja/3.1/guides/event-timing/index.html
@@ -3010,8 +3010,8 @@ command can be used to retrieve named events' timestamps later on.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/execute-methods/index.html
+++ b/docs/ja/3.1/guides/execute-methods/index.html
@@ -2994,8 +2994,8 @@ has made any alterations to the standard access method.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/grid/index.html
+++ b/docs/ja/3.1/guides/grid/index.html
@@ -3205,8 +3205,8 @@ will prevent Selenium Grid from connecting correctly.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/headers/index.html
+++ b/docs/ja/3.1/guides/headers/index.html
@@ -2991,8 +2991,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/log-filters/index.html
+++ b/docs/ja/3.1/guides/log-filters/index.html
@@ -3061,8 +3061,8 @@ these errors are addressed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/managing-exts/index.html
+++ b/docs/ja/3.1/guides/managing-exts/index.html
@@ -3029,8 +3029,8 @@ Otherwise, it is recommended that you use Appium's Extension CLI and, if necessa
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/migrating-1-to-2/index.html
+++ b/docs/ja/3.1/guides/migrating-1-to-2/index.html
@@ -3622,8 +3622,8 @@ various Appium drivers and plugins that end users may wish to use.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/migrating-2-to-3/index.html
+++ b/docs/ja/3.1/guides/migrating-2-to-3/index.html
@@ -3791,8 +3791,8 @@ longer accepts, as well as the parameters it continues to accept in Appium 3.</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/security/index.html
+++ b/docs/ja/3.1/guides/security/index.html
@@ -3099,8 +3099,8 @@ these features require using the wildcard prefix:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/settings/index.html
+++ b/docs/ja/3.1/guides/settings/index.html
@@ -3026,8 +3026,8 @@ specific client library, visit the documentation for that client.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/guides/tls/index.html
+++ b/docs/ja/3.1/guides/tls/index.html
@@ -3024,8 +3024,8 @@ client setup, e.g. make sure it does not reject unauthorized certificates.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/index.html
+++ b/docs/ja/3.1/index.html
@@ -2886,9 +2886,9 @@
       </a>
     </div>
     <div class="homepageSponsor">
-      <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-        <img src="assets/images/sponsor-logo-lambdatest-dark.png#only-dark" style="width: 220px;" />
-        <img src="assets/images/sponsor-logo-lambdatest-light.png#only-light" style="width: 220px;" />
+      <a href="https://www.testmuai.com">
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" style="width: 220px;" />
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" style="width: 220px;" />
       </a>
     </div>
   </div>
@@ -2978,8 +2978,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/intro/appium/index.html
+++ b/docs/ja/3.1/intro/appium/index.html
@@ -3170,8 +3170,8 @@ that can be used with Appium.&#160;<a class="footnote-backref" href="#fnref:3" t
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/intro/clients/index.html
+++ b/docs/ja/3.1/intro/clients/index.html
@@ -3001,8 +3001,8 @@ They all mean the same thing!&#160;<a class="footnote-backref" href="#fnref:1" t
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/intro/drivers/index.html
+++ b/docs/ja/3.1/intro/drivers/index.html
@@ -3160,8 +3160,8 @@ will generate different session IDs, but these differences will be handled trans
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/intro/history/index.html
+++ b/docs/ja/3.1/intro/history/index.html
@@ -3280,8 +3280,8 @@ gone through multiple major updates during the Appium 2 era.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/intro/index.html
+++ b/docs/ja/3.1/intro/index.html
@@ -2904,8 +2904,8 @@ program is a very daunting, if not impossible task!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/index.html
+++ b/docs/ja/3.1/quickstart/index.html
@@ -2911,8 +2911,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/install/index.html
+++ b/docs/ja/3.1/quickstart/install/index.html
@@ -2969,8 +2969,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/next-steps/index.html
+++ b/docs/ja/3.1/quickstart/next-steps/index.html
@@ -2894,8 +2894,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/requirements/index.html
+++ b/docs/ja/3.1/quickstart/requirements/index.html
@@ -2962,8 +2962,8 @@ the <a href="../../reference/cli/extensions/#doctor">Command-Line Usage document
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/test-dotnet/index.html
+++ b/docs/ja/3.1/quickstart/test-dotnet/index.html
@@ -2974,8 +2974,8 @@ to one. Then, you can execute the script:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/test-java/index.html
+++ b/docs/ja/3.1/quickstart/test-java/index.html
@@ -2898,8 +2898,8 @@ how to invoke Java client features from your test framework.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/test-js/index.html
+++ b/docs/ja/3.1/quickstart/test-js/index.html
@@ -2969,8 +2969,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/test-py/index.html
+++ b/docs/ja/3.1/quickstart/test-py/index.html
@@ -2960,8 +2960,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/test-rb/index.html
+++ b/docs/ja/3.1/quickstart/test-rb/index.html
@@ -2972,8 +2972,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/quickstart/uiauto2-driver/index.html
+++ b/docs/ja/3.1/quickstart/uiauto2-driver/index.html
@@ -3198,8 +3198,8 @@ first test! Now select your preferred language and give it a shot:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/api/appium/index.html
+++ b/docs/ja/3.1/reference/api/appium/index.html
@@ -4652,8 +4652,8 @@ may never return a <code>false</code> value.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/api/bidi/index.html
+++ b/docs/ja/3.1/reference/api/bidi/index.html
@@ -3191,8 +3191,8 @@ sent as a websocket event, that both drivers and clients can emit or listen to.<
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/api/index.html
+++ b/docs/ja/3.1/reference/api/index.html
@@ -2900,8 +2900,8 @@ Refer to the documentation of your client for the exact commands used to invoke 
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/api/jsonwp/index.html
+++ b/docs/ja/3.1/reference/api/jsonwp/index.html
@@ -3671,8 +3671,8 @@ For retrieving event history, please use <a href="../appium/#getlogevents"><code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/api/mjsonwp/index.html
+++ b/docs/ja/3.1/reference/api/mjsonwp/index.html
@@ -3522,8 +3522,8 @@ endpoints supported in Appium.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/api/others/index.html
+++ b/docs/ja/3.1/reference/api/others/index.html
@@ -5932,8 +5932,8 @@ identified by <code>:authenticatorId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/api/plugins/index.html
+++ b/docs/ja/3.1/reference/api/plugins/index.html
@@ -4068,8 +4068,8 @@ preserved, and only the incomplete uploads will be stopped.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/api/webdriver/index.html
+++ b/docs/ja/3.1/reference/api/webdriver/index.html
@@ -7624,8 +7624,8 @@ identified by <code>:elementId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/cli/env-vars/index.html
+++ b/docs/ja/3.1/reference/cli/env-vars/index.html
@@ -2955,8 +2955,8 @@ used by official plugins:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/cli/extensions/index.html
+++ b/docs/ja/3.1/reference/cli/extensions/index.html
@@ -3813,8 +3813,8 @@ Appium will only update minor and patch versions, in order to prevent any breaki
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/cli/index.html
+++ b/docs/ja/3.1/reference/cli/index.html
@@ -2905,8 +2905,8 @@ advanced configuration.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/cli/server/index.html
+++ b/docs/ja/3.1/reference/cli/server/index.html
@@ -3240,8 +3240,8 @@ set on the command line will override any options found in a configuration file.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/cli/setup/index.html
+++ b/docs/ja/3.1/reference/cli/setup/index.html
@@ -3175,8 +3175,8 @@ example, due to a failed upgrade attempt from an older Appium version.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/reference/index.html
+++ b/docs/ja/3.1/reference/index.html
@@ -2893,8 +2893,8 @@ Appium server: the command-line executable, and the supported API endpoints.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/resources/index.html
+++ b/docs/ja/3.1/resources/index.html
@@ -2933,8 +2933,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.1/sponsors/index.html
+++ b/docs/ja/3.1/sponsors/index.html
@@ -2872,9 +2872,9 @@ Hub.</p>
 <h2 id="development-partners">Development Partners<a class="headerlink" href="#development-partners" title="Permanent link">&para;</a></h2>
 <p>We are very grateful for the support of our Development Partners, who donate Appium development and
 maintenance as part of their employees' core job duties!</p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="strategic-partners">Strategic Partners<a class="headerlink" href="#strategic-partners" title="Permanent link">&para;</a></h2>
 <p>We are very grateful for the financial and marketing support of our exclusive Strategic Partners,
@@ -2884,9 +2884,9 @@ contributors!</p>
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png#only-dark" width="250" alt="BrowserStack" />
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-light.png#only-light" width="250" alt="BrowserStack" />
 </a></p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="gold-sponsors">Gold Sponsors<a class="headerlink" href="#gold-sponsors" title="Permanent link">&para;</a></h2>
 <div class="sponsor-section"><a href="https://jetify.com/" target="_blank"><img src="https://images.opencollective.com/jetify/415824c/avatar/64.png" alt="Jetify" /></a>
@@ -2974,8 +2974,8 @@ contributors!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/ja/3.2/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/ja/3.2/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3639,11 +3639,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/ja/3.2/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/ja/3.2/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3654,7 +3654,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/ja/3.2/blog/archive/2025/index.html
+++ b/docs/ja/3.2/blog/archive/2025/index.html
@@ -3663,7 +3663,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/ja/3.2/blog/index.html
+++ b/docs/ja/3.2/blog/index.html
@@ -3681,7 +3681,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/ja/3.3/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/ja/3.3/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3639,11 +3639,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/ja/3.3/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/ja/3.3/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3654,7 +3654,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/ja/3.3/blog/archive/2025/index.html
+++ b/docs/ja/3.3/blog/archive/2025/index.html
@@ -3663,7 +3663,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/ja/3.3/blog/index.html
+++ b/docs/ja/3.3/blog/index.html
@@ -3681,7 +3681,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/ja/3.4/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/ja/3.4/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3639,11 +3639,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/ja/3.4/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/ja/3.4/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3654,7 +3654,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/ja/3.4/blog/archive/2025/index.html
+++ b/docs/ja/3.4/blog/archive/2025/index.html
@@ -3663,7 +3663,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/ja/3.4/blog/index.html
+++ b/docs/ja/3.4/blog/index.html
@@ -3681,7 +3681,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/ja/3.5/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/ja/3.5/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3626,11 +3626,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/ja/3.5/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/ja/3.5/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3641,7 +3641,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/ja/3.5/blog/archive/2025/index.html
+++ b/docs/ja/3.5/blog/archive/2025/index.html
@@ -3650,7 +3650,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/ja/3.5/blog/index.html
+++ b/docs/ja/3.5/blog/index.html
@@ -3668,7 +3668,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/zh/2.19/404.html
+++ b/docs/zh/2.19/404.html
@@ -2394,8 +2394,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/blog/2024/03/07/hello-world/index.html
+++ b/docs/zh/2.19/blog/2024/03/07/hello-world/index.html
@@ -2538,8 +2538,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
+++ b/docs/zh/2.19/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
@@ -2570,8 +2570,8 @@ contribution level.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
+++ b/docs/zh/2.19/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
@@ -2570,8 +2570,8 @@ HeadSpin as our first official Development Partner!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
+++ b/docs/zh/2.19/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
@@ -2567,8 +2567,8 @@ teams can move fast while delivering an amazing experience for every customer.</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
+++ b/docs/zh/2.19/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
@@ -2558,8 +2558,8 @@ Needless to say, we are extremely grateful for Sauce Labs's support!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
+++ b/docs/zh/2.19/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
@@ -2625,8 +2625,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/blog/archive/2024/index.html
+++ b/docs/zh/2.19/blog/archive/2024/index.html
@@ -2686,8 +2686,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/blog/index.html
+++ b/docs/zh/2.19/blog/index.html
@@ -2704,8 +2704,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/cli/args/index.html
+++ b/docs/zh/2.19/cli/args/index.html
@@ -2774,8 +2774,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/cli/env-vars/index.html
+++ b/docs/zh/2.19/cli/env-vars/index.html
@@ -2518,8 +2518,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/cli/extensions/index.html
+++ b/docs/zh/2.19/cli/extensions/index.html
@@ -2881,8 +2881,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/cli/index.html
+++ b/docs/zh/2.19/cli/index.html
@@ -2489,8 +2489,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/cli/setup/index.html
+++ b/docs/zh/2.19/cli/setup/index.html
@@ -2511,8 +2511,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/commands/base-driver/index.html
+++ b/docs/zh/2.19/commands/base-driver/index.html
@@ -4583,8 +4583,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/commands/execute-driver-plugin/index.html
+++ b/docs/zh/2.19/commands/execute-driver-plugin/index.html
@@ -2599,8 +2599,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/commands/images-plugin/index.html
+++ b/docs/zh/2.19/commands/images-plugin/index.html
@@ -2791,8 +2791,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/commands/index.html
+++ b/docs/zh/2.19/commands/index.html
@@ -2481,8 +2481,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/commands/relaxed-caps-plugin/index.html
+++ b/docs/zh/2.19/commands/relaxed-caps-plugin/index.html
@@ -2609,8 +2609,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/commands/universal-xml-plugin/index.html
+++ b/docs/zh/2.19/commands/universal-xml-plugin/index.html
@@ -2750,8 +2750,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/contributing/config-system/index.html
+++ b/docs/zh/2.19/contributing/config-system/index.html
@@ -3082,8 +3082,8 @@ Appium会使用<code>appiumCliTransformer: 'csv'</code>。</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/contributing/develop/index.html
+++ b/docs/zh/2.19/contributing/develop/index.html
@@ -2688,8 +2688,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/contributing/index.html
+++ b/docs/zh/2.19/contributing/index.html
@@ -2547,8 +2547,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/developing/build-docs/index.html
+++ b/docs/zh/2.19/developing/build-docs/index.html
@@ -2656,8 +2656,8 @@ examples:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/developing/build-doctor-checks/index.html
+++ b/docs/zh/2.19/developing/build-doctor-checks/index.html
@@ -2707,8 +2707,8 @@ as</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/developing/build-drivers/index.html
+++ b/docs/zh/2.19/developing/build-drivers/index.html
@@ -3638,8 +3638,8 @@ Appium 有一个 <a href="../../guides/settings/">设置</a> API用于此目的.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/developing/build-plugins/index.html
+++ b/docs/zh/2.19/developing/build-plugins/index.html
@@ -3279,8 +3279,8 @@ keeping in mind that the function is not <code>await</code>ed you could implemen
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/developing/index.html
+++ b/docs/zh/2.19/developing/index.html
@@ -2477,8 +2477,8 @@ own Appium extension:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/ecosystem/clients/index.html
+++ b/docs/zh/2.19/ecosystem/clients/index.html
@@ -2606,8 +2606,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/ecosystem/drivers/index.html
+++ b/docs/zh/2.19/ecosystem/drivers/index.html
@@ -2692,8 +2692,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/ecosystem/index.html
+++ b/docs/zh/2.19/ecosystem/index.html
@@ -2495,8 +2495,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/ecosystem/plugins/index.html
+++ b/docs/zh/2.19/ecosystem/plugins/index.html
@@ -2640,8 +2640,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/ecosystem/tools/index.html
+++ b/docs/zh/2.19/ecosystem/tools/index.html
@@ -2592,8 +2592,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/branch-testing/index.html
+++ b/docs/zh/2.19/guides/branch-testing/index.html
@@ -2637,8 +2637,8 @@ to switch back to the package managed by NPM. Follow the next steps for that:</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/caching/index.html
+++ b/docs/zh/2.19/guides/caching/index.html
@@ -2669,8 +2669,8 @@ would be performed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/caps/index.html
+++ b/docs/zh/2.19/guides/caps/index.html
@@ -3003,8 +3003,8 @@ running Appium on their own.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/config/index.html
+++ b/docs/zh/2.19/guides/config/index.html
@@ -2707,8 +2707,8 @@ For example, <code>callback-port</code> is allowed, but <code>callbackPort</code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/context/index.html
+++ b/docs/zh/2.19/guides/context/index.html
@@ -2539,8 +2539,8 @@ visit the documentation for a given library.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/event-timing/index.html
+++ b/docs/zh/2.19/guides/event-timing/index.html
@@ -2599,8 +2599,8 @@ on.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/execute-methods/index.html
+++ b/docs/zh/2.19/guides/execute-methods/index.html
@@ -2576,8 +2576,8 @@ has made any alterations to the standard access method.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/grid/index.html
+++ b/docs/zh/2.19/guides/grid/index.html
@@ -2778,8 +2778,8 @@ will prevent Selenium Grid from connecting correctly.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/log-filters/index.html
+++ b/docs/zh/2.19/guides/log-filters/index.html
@@ -2646,8 +2646,8 @@ these errors are addressed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/managing-exts/index.html
+++ b/docs/zh/2.19/guides/managing-exts/index.html
@@ -2613,8 +2613,8 @@ Otherwise, it is recommended that you use Appium's Extension CLI and, if necessa
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/migrating-1-to-2/index.html
+++ b/docs/zh/2.19/guides/migrating-1-to-2/index.html
@@ -3283,8 +3283,8 @@ an industry-compatible way!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/security/index.html
+++ b/docs/zh/2.19/guides/security/index.html
@@ -2654,8 +2654,8 @@ might use. Here is an incomplete list of examples from some of Appium's official
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/settings/index.html
+++ b/docs/zh/2.19/guides/settings/index.html
@@ -2610,8 +2610,8 @@ specific client library, visit the documentation for that client.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/guides/tls/index.html
+++ b/docs/zh/2.19/guides/tls/index.html
@@ -2609,8 +2609,8 @@ client setup, e.g. make sure it does not reject unauthorized certificates.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/index.html
+++ b/docs/zh/2.19/index.html
@@ -2561,8 +2561,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/intro/appium/index.html
+++ b/docs/zh/2.19/intro/appium/index.html
@@ -2653,8 +2653,8 @@ Driver</a>，因为它最终的作用是将WebDriver协议转换为XCUITest库�
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/intro/clients/index.html
+++ b/docs/zh/2.19/intro/clients/index.html
@@ -2585,8 +2585,8 @@ WebDriver 规范</a>.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/intro/drivers/index.html
+++ b/docs/zh/2.19/intro/drivers/index.html
@@ -2659,8 +2659,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/intro/history/index.html
+++ b/docs/zh/2.19/intro/history/index.html
@@ -2763,8 +2763,8 @@ Sauce Labs增加了捐赠给Appium开发人员的数量，但整个社区都参�
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/intro/index.html
+++ b/docs/zh/2.19/intro/index.html
@@ -2494,8 +2494,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/index.html
+++ b/docs/zh/2.19/quickstart/index.html
@@ -2547,8 +2547,8 @@ JavaScript、Python、Java、Ruby 和 .NET 的选项）。</li>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/install/index.html
+++ b/docs/zh/2.19/quickstart/install/index.html
@@ -2491,8 +2491,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/next-steps/index.html
+++ b/docs/zh/2.19/quickstart/next-steps/index.html
@@ -2483,8 +2483,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/requirements/index.html
+++ b/docs/zh/2.19/quickstart/requirements/index.html
@@ -2544,8 +2544,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/test-dotnet/index.html
+++ b/docs/zh/2.19/quickstart/test-dotnet/index.html
@@ -2553,8 +2553,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/test-java/index.html
+++ b/docs/zh/2.19/quickstart/test-java/index.html
@@ -2483,8 +2483,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/test-js/index.html
+++ b/docs/zh/2.19/quickstart/test-js/index.html
@@ -2550,8 +2550,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/test-py/index.html
+++ b/docs/zh/2.19/quickstart/test-py/index.html
@@ -2537,8 +2537,8 @@ Appium Python客户端自动添加<code>appium:</code>供应商前缀。
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/test-rb/index.html
+++ b/docs/zh/2.19/quickstart/test-rb/index.html
@@ -2553,8 +2553,8 @@ appium_lib_core 继承自 Selenium Ruby，appium_lib 继承自 appium_lib_core�
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/quickstart/uiauto2-driver/index.html
+++ b/docs/zh/2.19/quickstart/uiauto2-driver/index.html
@@ -2672,8 +2672,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/2.19/resources/index.html
+++ b/docs/zh/2.19/resources/index.html
@@ -2550,8 +2550,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/404.html
+++ b/docs/zh/3.0/404.html
@@ -2796,8 +2796,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/2024/03/07/hello-world/index.html
+++ b/docs/zh/3.0/blog/2024/03/07/hello-world/index.html
@@ -2940,8 +2940,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
+++ b/docs/zh/3.0/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
@@ -2972,8 +2972,8 @@ contribution level.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
+++ b/docs/zh/3.0/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
@@ -2972,8 +2972,8 @@ HeadSpin as our first official Development Partner!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
+++ b/docs/zh/3.0/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
@@ -2969,8 +2969,8 @@ teams can move fast while delivering an amazing experience for every customer.</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
+++ b/docs/zh/3.0/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
@@ -2960,8 +2960,8 @@ Needless to say, we are extremely grateful for Sauce Labs's support!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
+++ b/docs/zh/3.0/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
@@ -3030,8 +3030,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/zh/3.0/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -2869,11 +2869,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -2966,8 +2966,8 @@ infrastructure, execution, RCA, and reporting.</em></p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/2025/08/07/-appium-3/index.html
+++ b/docs/zh/3.0/blog/2025/08/07/-appium-3/index.html
@@ -2990,8 +2990,8 @@ and W3C-compliant test automation pipelines. Happy testing!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/archive/2024/index.html
+++ b/docs/zh/3.0/blog/archive/2024/index.html
@@ -3088,8 +3088,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/archive/2025/index.html
+++ b/docs/zh/3.0/blog/archive/2025/index.html
@@ -2848,7 +2848,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -2906,8 +2906,8 @@ is coming on board as one of our Strategic Partners!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/blog/index.html
+++ b/docs/zh/3.0/blog/index.html
@@ -2866,7 +2866,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -3195,8 +3195,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/contributing/index.html
+++ b/docs/zh/3.0/contributing/index.html
@@ -3068,8 +3068,8 @@ corresponding translated resources included.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/developing/build-docs/index.html
+++ b/docs/zh/3.0/developing/build-docs/index.html
@@ -3059,8 +3059,8 @@ examples:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/developing/build-doctor-checks/index.html
+++ b/docs/zh/3.0/developing/build-doctor-checks/index.html
@@ -3112,8 +3112,8 @@ as</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/developing/build-drivers/index.html
+++ b/docs/zh/3.0/developing/build-drivers/index.html
@@ -4216,8 +4216,8 @@ unexpected shutdown).</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/developing/build-plugins/index.html
+++ b/docs/zh/3.0/developing/build-plugins/index.html
@@ -3812,8 +3812,8 @@ keeping in mind that the function is not <code>await</code>ed you could implemen
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/developing/config-system/index.html
+++ b/docs/zh/3.0/developing/config-system/index.html
@@ -3606,8 +3606,8 @@ schema:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/developing/index.html
+++ b/docs/zh/3.0/developing/index.html
@@ -2874,8 +2874,8 @@ own Appium extension:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/developing/sensitive/index.html
+++ b/docs/zh/3.0/developing/sensitive/index.html
@@ -2986,8 +2986,8 @@ this.log.info(&#39;Value: %s&#39;, logger.markSensitive(value));
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/ecosystem/clients/index.html
+++ b/docs/zh/3.0/ecosystem/clients/index.html
@@ -3226,8 +3226,8 @@ some Appium-specific commands may not be implemented in other clients.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/ecosystem/drivers/index.html
+++ b/docs/zh/3.0/ecosystem/drivers/index.html
@@ -3439,8 +3439,8 @@ along with their installation commands and links to their documentation.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/ecosystem/index.html
+++ b/docs/zh/3.0/ecosystem/index.html
@@ -2888,8 +2888,8 @@ aims to compile a listing of various officially-supported and community-supporte
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/ecosystem/plugins/index.html
+++ b/docs/zh/3.0/ecosystem/plugins/index.html
@@ -3269,8 +3269,8 @@ Appium server installation</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/ecosystem/tools/index.html
+++ b/docs/zh/3.0/ecosystem/tools/index.html
@@ -3084,8 +3084,8 @@ prerequisites for iOS or Android emulators or real devices.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/branch-testing/index.html
+++ b/docs/zh/3.0/guides/branch-testing/index.html
@@ -3039,8 +3039,8 @@ to switch back to the package managed by NPM. Follow the next steps for that:</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/caching/index.html
+++ b/docs/zh/3.0/guides/caching/index.html
@@ -3072,8 +3072,8 @@ of it. It is a <a href="https://www.npmjs.com/package/lru-cache">LRU Cache</a> w
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/caps/index.html
+++ b/docs/zh/3.0/guides/caps/index.html
@@ -3448,8 +3448,8 @@ running Appium on their own.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/config/index.html
+++ b/docs/zh/3.0/guides/config/index.html
@@ -3111,8 +3111,8 @@ For example, <code>callback-port</code> is allowed, but <code>callbackPort</code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/context/index.html
+++ b/docs/zh/3.0/guides/context/index.html
@@ -2941,8 +2941,8 @@ visit the documentation for a given library.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/event-timing/index.html
+++ b/docs/zh/3.0/guides/event-timing/index.html
@@ -2997,8 +2997,8 @@ command can be used to retrieve named events' timestamps later on.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/execute-methods/index.html
+++ b/docs/zh/3.0/guides/execute-methods/index.html
@@ -2981,8 +2981,8 @@ has made any alterations to the standard access method.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/grid/index.html
+++ b/docs/zh/3.0/guides/grid/index.html
@@ -3180,8 +3180,8 @@ will prevent Selenium Grid from connecting correctly.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/headers/index.html
+++ b/docs/zh/3.0/guides/headers/index.html
@@ -2978,8 +2978,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/log-filters/index.html
+++ b/docs/zh/3.0/guides/log-filters/index.html
@@ -3048,8 +3048,8 @@ these errors are addressed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/managing-exts/index.html
+++ b/docs/zh/3.0/guides/managing-exts/index.html
@@ -3016,8 +3016,8 @@ Otherwise, it is recommended that you use Appium's Extension CLI and, if necessa
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/migrating-1-to-2/index.html
+++ b/docs/zh/3.0/guides/migrating-1-to-2/index.html
@@ -3617,8 +3617,8 @@ an industry-compatible way!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/migrating-2-to-3/index.html
+++ b/docs/zh/3.0/guides/migrating-2-to-3/index.html
@@ -3779,8 +3779,8 @@ longer accepts, as well as the parameters it continues to accept in Appium 3.</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/security/index.html
+++ b/docs/zh/3.0/guides/security/index.html
@@ -3083,8 +3083,8 @@ these features requires using the wildcard prefix:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/settings/index.html
+++ b/docs/zh/3.0/guides/settings/index.html
@@ -3013,8 +3013,8 @@ specific client library, visit the documentation for that client.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/guides/tls/index.html
+++ b/docs/zh/3.0/guides/tls/index.html
@@ -3011,8 +3011,8 @@ client setup, e.g. make sure it does not reject unauthorized certificates.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/index.html
+++ b/docs/zh/3.0/index.html
@@ -2872,9 +2872,9 @@
       </a>
     </div>
     <div class="homepageSponsor">
-      <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-        <img src="assets/images/sponsor-logo-lambdatest-dark.png#only-dark" style="width: 220px;" />
-        <img src="assets/images/sponsor-logo-lambdatest-light.png#only-light" style="width: 220px;" />
+      <a href="https://www.testmuai.com">
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" style="width: 220px;" />
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" style="width: 220px;" />
       </a>
     </div>
   </div>
@@ -2964,8 +2964,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/intro/appium/index.html
+++ b/docs/zh/3.0/intro/appium/index.html
@@ -3166,8 +3166,8 @@ that can be used with Appium.&#160;<a class="footnote-backref" href="#fnref:3" t
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/intro/clients/index.html
+++ b/docs/zh/3.0/intro/clients/index.html
@@ -2988,8 +2988,8 @@ They all mean the same thing!&#160;<a class="footnote-backref" href="#fnref:1" t
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/intro/drivers/index.html
+++ b/docs/zh/3.0/intro/drivers/index.html
@@ -3147,8 +3147,8 @@ will generate different session IDs, but these differences will be handled trans
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/intro/history/index.html
+++ b/docs/zh/3.0/intro/history/index.html
@@ -3267,8 +3267,8 @@ gone through multiple major updates during the Appium 2 era.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/intro/index.html
+++ b/docs/zh/3.0/intro/index.html
@@ -2891,8 +2891,8 @@ program is a very daunting, if not impossible task!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/index.html
+++ b/docs/zh/3.0/quickstart/index.html
@@ -2904,8 +2904,8 @@ and persist environment variables, etc...</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/install/index.html
+++ b/docs/zh/3.0/quickstart/install/index.html
@@ -2963,8 +2963,8 @@ Android - continue to <a href="../uiauto2-driver/">Installing the UiAutomator2 D
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/next-steps/index.html
+++ b/docs/zh/3.0/quickstart/next-steps/index.html
@@ -2885,8 +2885,8 @@ helps you to discover element locators for use in your test scripts.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/requirements/index.html
+++ b/docs/zh/3.0/quickstart/requirements/index.html
@@ -2949,8 +2949,8 @@ the <a href="../../reference/cli/extensions/#doctor">Command-Line Usage document
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/test-dotnet/index.html
+++ b/docs/zh/3.0/quickstart/test-dotnet/index.html
@@ -2961,8 +2961,8 @@ to one. Then, you can execute the script:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/test-java/index.html
+++ b/docs/zh/3.0/quickstart/test-java/index.html
@@ -2885,8 +2885,8 @@ how to invoke Java client features from your test framework.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/test-js/index.html
+++ b/docs/zh/3.0/quickstart/test-js/index.html
@@ -2956,8 +2956,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/test-py/index.html
+++ b/docs/zh/3.0/quickstart/test-py/index.html
@@ -2947,8 +2947,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/test-rb/index.html
+++ b/docs/zh/3.0/quickstart/test-rb/index.html
@@ -2959,8 +2959,8 @@ app closes again.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/quickstart/uiauto2-driver/index.html
+++ b/docs/zh/3.0/quickstart/uiauto2-driver/index.html
@@ -3185,8 +3185,8 @@ first test! Now select your preferred language and give it a shot:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/api/appium/index.html
+++ b/docs/zh/3.0/reference/api/appium/index.html
@@ -4639,8 +4639,8 @@ may never return a <code>false</code> value.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/api/bidi/index.html
+++ b/docs/zh/3.0/reference/api/bidi/index.html
@@ -3178,8 +3178,8 @@ sent as a websocket event, that both drivers and clients can emit or listen to.<
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/api/index.html
+++ b/docs/zh/3.0/reference/api/index.html
@@ -2887,8 +2887,8 @@ Refer to the documentation of your client for the exact commands used to invoke 
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/api/jsonwp/index.html
+++ b/docs/zh/3.0/reference/api/jsonwp/index.html
@@ -3658,8 +3658,8 @@ For retrieving event history, please use <a href="../appium/#getlogevents"><code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/api/mjsonwp/index.html
+++ b/docs/zh/3.0/reference/api/mjsonwp/index.html
@@ -3509,8 +3509,8 @@ endpoints used in Appium.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/api/others/index.html
+++ b/docs/zh/3.0/reference/api/others/index.html
@@ -3912,8 +3912,8 @@ identified by <code>:authenticatorId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/api/plugins/index.html
+++ b/docs/zh/3.0/reference/api/plugins/index.html
@@ -4055,8 +4055,8 @@ preserved, and only the incomplete uploads will be stopped.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/api/webdriver/index.html
+++ b/docs/zh/3.0/reference/api/webdriver/index.html
@@ -7371,8 +7371,8 @@ identified by <code>:elementId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/cli/env-vars/index.html
+++ b/docs/zh/3.0/reference/cli/env-vars/index.html
@@ -2942,8 +2942,8 @@ used by official plugins:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/cli/extensions/index.html
+++ b/docs/zh/3.0/reference/cli/extensions/index.html
@@ -3795,8 +3795,8 @@ Appium will only update minor and patch versions, in order to prevent any breaki
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/cli/index.html
+++ b/docs/zh/3.0/reference/cli/index.html
@@ -2892,8 +2892,8 @@ advanced configuration.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/cli/server/index.html
+++ b/docs/zh/3.0/reference/cli/server/index.html
@@ -3227,8 +3227,8 @@ set on the command line will override any options found in a configuration file.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/cli/setup/index.html
+++ b/docs/zh/3.0/reference/cli/setup/index.html
@@ -3162,8 +3162,8 @@ example, due to a failed upgrade attempt from an older Appium version.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/reference/index.html
+++ b/docs/zh/3.0/reference/index.html
@@ -2880,8 +2880,8 @@ Appium server: the command-line executable, and the supported API endpoints.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/resources/index.html
+++ b/docs/zh/3.0/resources/index.html
@@ -2920,8 +2920,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.0/sponsors/index.html
+++ b/docs/zh/3.0/sponsors/index.html
@@ -2867,9 +2867,9 @@ contributors!</p>
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png#only-dark" width="250" alt="BrowserStack" />
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-light.png#only-light" width="250" alt="BrowserStack" />
 </a></p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="gold-sponsors">Gold Sponsors<a class="headerlink" href="#gold-sponsors" title="Permanent link">&para;</a></h2>
 <div class="sponsor-section"><a href="https://jetify.com/" target="_blank"><img src="https://images.opencollective.com/jetify/415824c/avatar/64.png" alt="Jetify" /></a>
@@ -2957,8 +2957,8 @@ contributors!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/404.html
+++ b/docs/zh/3.1/404.html
@@ -821,8 +821,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/2024/03/07/hello-world/index.html
+++ b/docs/zh/3.1/blog/2024/03/07/hello-world/index.html
@@ -965,8 +965,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
+++ b/docs/zh/3.1/blog/2024/05/14/announcing-appiums-sponsorship-program/index.html
@@ -997,8 +997,8 @@ contribution level.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
+++ b/docs/zh/3.1/blog/2024/06/06/announcing-headspin-as-appiums-development-partner/index.html
@@ -997,8 +997,8 @@ HeadSpin as our first official Development Partner!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
+++ b/docs/zh/3.1/blog/2024/06/10/announcing-browserstack-as-appiums-strategic-partner/index.html
@@ -994,8 +994,8 @@ teams can move fast while delivering an amazing experience for every customer.</
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
+++ b/docs/zh/3.1/blog/2024/06/10/announcing-sauce-labs-as-appiums-strategic-partner/index.html
@@ -985,8 +985,8 @@ Needless to say, we are extremely grateful for Sauce Labs's support!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
+++ b/docs/zh/3.1/blog/2024/07/13/appium-conf-2024-call-for-proposals-now-open/index.html
@@ -1055,8 +1055,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/zh/3.1/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -894,11 +894,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -991,8 +991,8 @@ infrastructure, execution, RCA, and reporting.</em></p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/2025/08/07/-appium-3/index.html
+++ b/docs/zh/3.1/blog/2025/08/07/-appium-3/index.html
@@ -1017,8 +1017,8 @@ and W3C-compliant test automation pipelines. Happy testing!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/zh/3.1/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -909,7 +909,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>
@@ -995,8 +995,8 @@ The Appium project is proud to recognize LambdaTest as our newest official Devel
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/archive/2024/index.html
+++ b/docs/zh/3.1/blog/archive/2024/index.html
@@ -1113,8 +1113,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/archive/2025/index.html
+++ b/docs/zh/3.1/blog/archive/2025/index.html
@@ -917,7 +917,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -975,8 +975,8 @@ is coming on board as one of our Strategic Partners!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/blog/index.html
+++ b/docs/zh/3.1/blog/index.html
@@ -933,7 +933,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     
@@ -1262,8 +1262,8 @@ really fit inside the documentation itself.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/contributing/index.html
+++ b/docs/zh/3.1/contributing/index.html
@@ -1056,8 +1056,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/developing/build-docs/index.html
+++ b/docs/zh/3.1/developing/build-docs/index.html
@@ -989,8 +989,8 @@ examples:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/developing/build-doctor-checks/index.html
+++ b/docs/zh/3.1/developing/build-doctor-checks/index.html
@@ -1045,8 +1045,8 @@ as</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/developing/build-drivers/index.html
+++ b/docs/zh/3.1/developing/build-drivers/index.html
@@ -1867,8 +1867,8 @@ unexpected shutdown).</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/developing/build-plugins/index.html
+++ b/docs/zh/3.1/developing/build-plugins/index.html
@@ -1538,8 +1538,8 @@ keeping in mind that the function is not <code>await</code>ed you could implemen
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/developing/config-system/index.html
+++ b/docs/zh/3.1/developing/config-system/index.html
@@ -1429,8 +1429,8 @@ schema:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/developing/index.html
+++ b/docs/zh/3.1/developing/index.html
@@ -885,8 +885,8 @@ own Appium extension:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/developing/sensitive/index.html
+++ b/docs/zh/3.1/developing/sensitive/index.html
@@ -943,8 +943,8 @@ this.log.info(&#39;Value: %s&#39;, logger.markSensitive(value));
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/ecosystem/clients/index.html
+++ b/docs/zh/3.1/ecosystem/clients/index.html
@@ -1084,8 +1084,8 @@ some Appium-specific commands may not be implemented in other clients.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/ecosystem/drivers/index.html
+++ b/docs/zh/3.1/ecosystem/drivers/index.html
@@ -1234,8 +1234,8 @@ along with their installation commands and links to their documentation.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/ecosystem/index.html
+++ b/docs/zh/3.1/ecosystem/index.html
@@ -902,8 +902,8 @@ aims to compile a listing of various officially-supported and community-supporte
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/ecosystem/plugins/index.html
+++ b/docs/zh/3.1/ecosystem/plugins/index.html
@@ -1100,8 +1100,8 @@ Appium server installation</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/ecosystem/tools/index.html
+++ b/docs/zh/3.1/ecosystem/tools/index.html
@@ -1024,8 +1024,8 @@ prerequisites for iOS or Android emulators or real devices.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/branch-testing/index.html
+++ b/docs/zh/3.1/guides/branch-testing/index.html
@@ -968,8 +968,8 @@ to switch back to the package managed by NPM. Follow the next steps for that:</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/caching/index.html
+++ b/docs/zh/3.1/guides/caching/index.html
@@ -992,8 +992,8 @@ of it. It is a <a href="https://www.npmjs.com/package/lru-cache">LRU Cache</a> w
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/caps/index.html
+++ b/docs/zh/3.1/guides/caps/index.html
@@ -1326,8 +1326,8 @@ running Appium on their own.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/config/index.html
+++ b/docs/zh/3.1/guides/config/index.html
@@ -1019,8 +1019,8 @@ For example, <code>callback-port</code> is allowed, but <code>callbackPort</code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/context/index.html
+++ b/docs/zh/3.1/guides/context/index.html
@@ -934,8 +934,8 @@ visit the documentation for a given library.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/event-timing/index.html
+++ b/docs/zh/3.1/guides/event-timing/index.html
@@ -953,8 +953,8 @@ command can be used to retrieve named events' timestamps later on.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/execute-methods/index.html
+++ b/docs/zh/3.1/guides/execute-methods/index.html
@@ -974,8 +974,8 @@ has made any alterations to the standard access method.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/grid/index.html
+++ b/docs/zh/3.1/guides/grid/index.html
@@ -1091,8 +1091,8 @@ will prevent Selenium Grid from connecting correctly.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/headers/index.html
+++ b/docs/zh/3.1/guides/headers/index.html
@@ -915,8 +915,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/log-filters/index.html
+++ b/docs/zh/3.1/guides/log-filters/index.html
@@ -980,8 +980,8 @@ these errors are addressed.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/managing-exts/index.html
+++ b/docs/zh/3.1/guides/managing-exts/index.html
@@ -963,8 +963,8 @@ Otherwise, it is recommended that you use Appium's Extension CLI and, if necessa
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/migrating-1-to-2/index.html
+++ b/docs/zh/3.1/guides/migrating-1-to-2/index.html
@@ -1408,8 +1408,8 @@ an industry-compatible way!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/migrating-2-to-3/index.html
+++ b/docs/zh/3.1/guides/migrating-2-to-3/index.html
@@ -1434,8 +1434,8 @@ longer accepts, as well as the parameters it continues to accept in Appium 3.</p
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/security/index.html
+++ b/docs/zh/3.1/guides/security/index.html
@@ -1024,8 +1024,8 @@ these features require using the wildcard prefix:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/settings/index.html
+++ b/docs/zh/3.1/guides/settings/index.html
@@ -969,8 +969,8 @@ specific client library, visit the documentation for that client.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/guides/tls/index.html
+++ b/docs/zh/3.1/guides/tls/index.html
@@ -943,8 +943,8 @@ client setup, e.g. make sure it does not reject unauthorized certificates.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/index.html
+++ b/docs/zh/3.1/index.html
@@ -897,9 +897,9 @@
       </a>
     </div>
     <div class="homepageSponsor">
-      <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-        <img src="assets/images/sponsor-logo-lambdatest-dark.png#only-dark" style="width: 220px;" />
-        <img src="assets/images/sponsor-logo-lambdatest-light.png#only-light" style="width: 220px;" />
+      <a href="https://www.testmuai.com">
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" style="width: 220px;" />
+        <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" style="width: 220px;" />
       </a>
     </div>
   </div>
@@ -989,8 +989,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/intro/appium/index.html
+++ b/docs/zh/3.1/intro/appium/index.html
@@ -994,8 +994,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/intro/clients/index.html
+++ b/docs/zh/3.1/intro/clients/index.html
@@ -950,8 +950,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/intro/drivers/index.html
+++ b/docs/zh/3.1/intro/drivers/index.html
@@ -997,8 +997,8 @@ WebDriver 协议！ 没错，XCUITest 驱动程序的 Objective-C 端本身就�
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/intro/history/index.html
+++ b/docs/zh/3.1/intro/history/index.html
@@ -1141,8 +1141,8 @@ gone through multiple major updates during the Appium 2 era.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/intro/index.html
+++ b/docs/zh/3.1/intro/index.html
@@ -899,8 +899,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/index.html
+++ b/docs/zh/3.1/quickstart/index.html
@@ -909,8 +909,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/install/index.html
+++ b/docs/zh/3.1/quickstart/install/index.html
@@ -922,8 +922,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/next-steps/index.html
+++ b/docs/zh/3.1/quickstart/next-steps/index.html
@@ -884,8 +884,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/requirements/index.html
+++ b/docs/zh/3.1/quickstart/requirements/index.html
@@ -907,8 +907,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/test-dotnet/index.html
+++ b/docs/zh/3.1/quickstart/test-dotnet/index.html
@@ -954,8 +954,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/test-java/index.html
+++ b/docs/zh/3.1/quickstart/test-java/index.html
@@ -883,8 +883,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/test-js/index.html
+++ b/docs/zh/3.1/quickstart/test-js/index.html
@@ -942,8 +942,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/test-py/index.html
+++ b/docs/zh/3.1/quickstart/test-py/index.html
@@ -942,8 +942,8 @@ Appium Python 客户端自动添加 <code>appium:</code> 前缀。
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/test-rb/index.html
+++ b/docs/zh/3.1/quickstart/test-rb/index.html
@@ -955,8 +955,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/quickstart/uiauto2-driver/index.html
+++ b/docs/zh/3.1/quickstart/uiauto2-driver/index.html
@@ -1047,8 +1047,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/api/appium/index.html
+++ b/docs/zh/3.1/reference/api/appium/index.html
@@ -2003,8 +2003,8 @@ may never return a <code>false</code> value.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/api/bidi/index.html
+++ b/docs/zh/3.1/reference/api/bidi/index.html
@@ -1058,8 +1058,8 @@ sent as a websocket event, that both drivers and clients can emit or listen to.<
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/api/index.html
+++ b/docs/zh/3.1/reference/api/index.html
@@ -893,8 +893,8 @@ Refer to the documentation of your client for the exact commands used to invoke 
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/api/jsonwp/index.html
+++ b/docs/zh/3.1/reference/api/jsonwp/index.html
@@ -1361,8 +1361,8 @@ For retrieving event history, please use <a href="../appium/#getlogevents"><code
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/api/mjsonwp/index.html
+++ b/docs/zh/3.1/reference/api/mjsonwp/index.html
@@ -1284,8 +1284,8 @@ endpoints supported in Appium.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/api/others/index.html
+++ b/docs/zh/3.1/reference/api/others/index.html
@@ -2827,8 +2827,8 @@ identified by <code>:authenticatorId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/api/plugins/index.html
+++ b/docs/zh/3.1/reference/api/plugins/index.html
@@ -1707,8 +1707,8 @@ preserved, and only the incomplete uploads will be stopped.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/api/webdriver/index.html
+++ b/docs/zh/3.1/reference/api/webdriver/index.html
@@ -3889,8 +3889,8 @@ identified by <code>:elementId</code>.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/cli/env-vars/index.html
+++ b/docs/zh/3.1/reference/cli/env-vars/index.html
@@ -940,8 +940,8 @@ used by official plugins:</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/cli/extensions/index.html
+++ b/docs/zh/3.1/reference/cli/extensions/index.html
@@ -1509,8 +1509,8 @@ Appium will only update minor and patch versions, in order to prevent any breaki
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/cli/index.html
+++ b/docs/zh/3.1/reference/cli/index.html
@@ -898,8 +898,8 @@ advanced configuration.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/cli/server/index.html
+++ b/docs/zh/3.1/reference/cli/server/index.html
@@ -1179,8 +1179,8 @@ set on the command line will override any options found in a configuration file.
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/cli/setup/index.html
+++ b/docs/zh/3.1/reference/cli/setup/index.html
@@ -1036,8 +1036,8 @@ example, due to a failed upgrade attempt from an older Appium version.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/reference/index.html
+++ b/docs/zh/3.1/reference/index.html
@@ -888,8 +888,8 @@ Appium server: the command-line executable, and the supported API endpoints.</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/resources/index.html
+++ b/docs/zh/3.1/resources/index.html
@@ -934,8 +934,8 @@
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.1/sponsors/index.html
+++ b/docs/zh/3.1/sponsors/index.html
@@ -875,9 +875,9 @@ Hub.</p>
 <h2 id="development-partners">Development Partners<a class="headerlink" href="#development-partners" title="Permanent link">&para;</a></h2>
 <p>We are very grateful for the support of our Development Partners, who donate Appium development and
 maintenance as part of their employees' core job duties!</p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="strategic-partners">Strategic Partners<a class="headerlink" href="#strategic-partners" title="Permanent link">&para;</a></h2>
 <p>We are very grateful for the financial and marketing support of our exclusive Strategic Partners,
@@ -887,9 +887,9 @@ contributors!</p>
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png#only-dark" width="250" alt="BrowserStack" />
   <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-light.png#only-light" width="250" alt="BrowserStack" />
 </a></p>
-<p><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="250" alt="LambdaTest" />
-  <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="250" alt="LambdaTest" />
+<p><a href="https://www.testmuai.com">
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png#only-dark" width="250" alt="TestMu AI (formerly LambdaTest)" />
+  <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-light.png#only-light" width="250" alt="TestMu AI (formerly LambdaTest)" />
 </a></p>
 <h2 id="gold-sponsors">Gold Sponsors<a class="headerlink" href="#gold-sponsors" title="Permanent link">&para;</a></h2>
 <div class="sponsor-section"><a href="https://jetify.com/" target="_blank"><img src="https://images.opencollective.com/jetify/415824c/avatar/64.png" alt="Jetify" /></a>
@@ -977,8 +977,8 @@ contributors!</p>
     <img src="/docs/en/latest/assets/images/sponsor-logo-browserstack-dark.png" />
   </a>
 
-  <a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
-    <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png" />
+  <a href="https://www.testmuai.com">
+    <img src="/docs/en/latest/assets/images/sponsor-logo-testmuai-dark.png" />
   </a>
 </div>
 

--- a/docs/zh/3.2/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/zh/3.2/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3639,11 +3639,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/zh/3.2/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/zh/3.2/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3654,7 +3654,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/zh/3.2/blog/archive/2025/index.html
+++ b/docs/zh/3.2/blog/archive/2025/index.html
@@ -3663,7 +3663,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/zh/3.2/blog/index.html
+++ b/docs/zh/3.2/blog/index.html
@@ -3681,7 +3681,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/zh/3.3/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/zh/3.3/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3639,11 +3639,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/zh/3.3/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/zh/3.3/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3654,7 +3654,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/zh/3.3/blog/archive/2025/index.html
+++ b/docs/zh/3.3/blog/archive/2025/index.html
@@ -3663,7 +3663,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/zh/3.3/blog/index.html
+++ b/docs/zh/3.3/blog/index.html
@@ -3681,7 +3681,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/zh/3.4/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/zh/3.4/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3639,11 +3639,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/zh/3.4/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/zh/3.4/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3654,7 +3654,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/zh/3.4/blog/archive/2025/index.html
+++ b/docs/zh/3.4/blog/archive/2025/index.html
@@ -3663,7 +3663,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/zh/3.4/blog/index.html
+++ b/docs/zh/3.4/blog/index.html
@@ -3681,7 +3681,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/zh/3.5/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
+++ b/docs/zh/3.5/blog/2025/07/01/announcing-lambdatest-as-appium-strategic-partner/index.html
@@ -3626,11 +3626,11 @@
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/zh/3.5/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
+++ b/docs/zh/3.5/blog/2025/11/25/announcing-lambdatest-as-appiums-newest-development-partner/index.html
@@ -3641,7 +3641,7 @@ LambdaTest has long been an active participant in the automated testing ecosyste
 This kind of hands-on contribution is crucial for ensuring Appium continues to evolve. We deeply value partners who empower their engineering teams to contribute code directly to open source rather than just sponsorship.</p>
 <!-- more -->
 
-<div style="text-align:center;width:100%"><a href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">
+<div style="text-align:center;width:100%"><a href="https://www.testmuai.com">
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-dark.png#only-dark" width="300" />
     <img src="/docs/en/latest/assets/images/sponsor-logo-lambdatest-light.png#only-light" width="300" />
   </a>

--- a/docs/zh/3.5/blog/archive/2025/index.html
+++ b/docs/zh/3.5/blog/archive/2025/index.html
@@ -3650,7 +3650,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     

--- a/docs/zh/3.5/blog/index.html
+++ b/docs/zh/3.5/blog/index.html
@@ -3668,7 +3668,7 @@ breaking changes that developers and QA engineers should be aware of.</p>
 <p>After recently celebrating the 1-year anniversary of our Sponsorship Program and Compensation
 Scheme,
 the Appium project is very excited to announce that <a
-href="https://lambdatest.com/?utm_source=appium.io&utm_medium=organic&utm_campaign=june_25&utm_term=sk&utm_content=webpage">LambdaTest</a>
+href="https://www.testmuai.com">LambdaTest</a>
 is coming on board as one of our Strategic Partners!</p>
 
     


### PR DESCRIPTION
## Proposed changes

Archived docs (2.19, 3.0, 3.1) still show the retired LambdaTest logo, including https://appium.io/docs/en/3.1/sponsors/, which currently outranks latest in search results and is causing confusion.

These are frozen builds: `mike` only rewrites the version being deployed plus the latest alias, so this can't be fixed from master - hence a PR against `gh-pages`. For the same reason, it won't be clobbered by future releases.

Verified by serving the patched tree locally: 3.1 sponsors renders TestMu AI logo.

## Types of changes

What types of changes does your code introduce to Appium?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
