### PR TITLE
docs(appium): prefer latest alias for SEO

### DIFF
--- a/packages/appium/docs/base-mkdocs.yml
+++ b/packages/appium/docs/base-mkdocs.yml
@@ -16,6 +16,8 @@ plugins:
   blog:
     enabled: true
     post_excerpt: required
+  mike:
+    canonical_version: 'latest'
   redirects:
     redirect_maps:
       'intro/requirements.md': 'quickstart/requirements.md'


### PR DESCRIPTION
This should make future docs versions appear in search engine results using the `latest` alias, thereby reducing preference for exact numerical versions.

We could probably also set this as the default behavior in `@appium/docutils` in Appium 4.

cc @navin772 