### PR TITLE
feat(base-driver): add /appium-prefixed routes for JSONWP/MJSONWP end points

### DIFF
--- a/packages/base-driver/lib/protocol/routes/appium-device.ts
+++ b/packages/base-driver/lib/protocol/routes/appium-device.ts
@@ -4,6 +4,17 @@ import type {Driver, MethodMap} from '@appium/types';
  * Appium: Device interaction (apps, keyboard, files, clock).
  */
 export const APPIUM_DEVICE_ROUTES = {
+  '/session/:sessionId/appium/device/rotation': {
+    GET: {command: 'getRotation'},
+    POST: {command: 'setRotation', payloadParams: {required: ['x', 'y', 'z']}},
+  },
+  '/session/:sessionId/appium/device/orientation': {
+    GET: {command: 'getOrientation'},
+    POST: {
+      command: 'setOrientation',
+      payloadParams: {required: ['orientation']},
+    },
+  },
   '/session/:sessionId/appium/device/system_time': {
     GET: {command: 'getDeviceTime'},
     POST: {command: 'getDeviceTime', payloadParams: {optional: ['format']}},

--- a/packages/base-driver/lib/protocol/routes/appium.ts
+++ b/packages/base-driver/lib/protocol/routes/appium.ts
@@ -8,6 +8,24 @@ export const APPIUM_ROUTES = {
   '/appium/sessions': {
     GET: {command: 'getAppiumSessions'},
   },
+  '/session/:sessionId/appium/rotation': {
+    GET: {command: 'getRotation'},
+    POST: {command: 'setRotation', payloadParams: {required: ['x', 'y', 'z']}},
+  },
+  '/session/:sessionId/appium/context': {
+    GET: {command: 'getCurrentContext'},
+    POST: {command: 'setContext', payloadParams: {required: ['name']}},
+  },
+  '/session/:sessionId/appium/contexts': {
+    GET: {command: 'getContexts'},
+  },
+  '/session/:sessionId/appium/orientation': {
+    GET: {command: 'getOrientation'},
+    POST: {
+      command: 'setOrientation',
+      payloadParams: {required: ['orientation']},
+    },
+  },
   '/session/:sessionId/appium/capabilities': {
     GET: {command: 'getAppiumSessionCapabilities'},
   },

--- a/packages/base-driver/lib/protocol/routes/appium.ts
+++ b/packages/base-driver/lib/protocol/routes/appium.ts
@@ -8,23 +8,12 @@ export const APPIUM_ROUTES = {
   '/appium/sessions': {
     GET: {command: 'getAppiumSessions'},
   },
-  '/session/:sessionId/appium/rotation': {
-    GET: {command: 'getRotation'},
-    POST: {command: 'setRotation', payloadParams: {required: ['x', 'y', 'z']}},
-  },
   '/session/:sessionId/appium/context': {
     GET: {command: 'getCurrentContext'},
     POST: {command: 'setContext', payloadParams: {required: ['name']}},
   },
   '/session/:sessionId/appium/contexts': {
     GET: {command: 'getContexts'},
-  },
-  '/session/:sessionId/appium/orientation': {
-    GET: {command: 'getOrientation'},
-    POST: {
-      command: 'setOrientation',
-      payloadParams: {required: ['orientation']},
-    },
   },
   '/session/:sessionId/appium/capabilities': {
     GET: {command: 'getAppiumSessionCapabilities'},

--- a/packages/base-driver/lib/protocol/routes/jsonwp.ts
+++ b/packages/base-driver/lib/protocol/routes/jsonwp.ts
@@ -25,10 +25,11 @@ export const JSONWP_ROUTES = {
     },
   },
   '/session/:sessionId/orientation': {
-    GET: {command: 'getOrientation'},
+    GET: {command: 'getOrientation', deprecated: true},
     POST: {
       command: 'setOrientation',
       payloadParams: {required: ['orientation']},
+      deprecated: true,
     },
   },
   '/session/:sessionId/location': {
@@ -50,6 +51,6 @@ export const JSONWP_ROUTES = {
     },
   },
   '/session/:sessionId/element/:elementId': {
-    GET: {},
+    GET: {deprecated: true},
   },
 } as const satisfies MethodMap<Driver>;

--- a/packages/base-driver/lib/protocol/routes/mjsonwp.ts
+++ b/packages/base-driver/lib/protocol/routes/mjsonwp.ts
@@ -6,15 +6,15 @@ import type {Driver, MethodMap} from '@appium/types';
  */
 export const MJSONWP_ROUTES = {
   '/session/:sessionId/rotation': {
-    GET: {command: 'getRotation'},
-    POST: {command: 'setRotation', payloadParams: {required: ['x', 'y', 'z']}},
+    GET: {command: 'getRotation', deprecated: true},
+    POST: {command: 'setRotation', payloadParams: {required: ['x', 'y', 'z']}, deprecated: true},
   },
   '/session/:sessionId/context': {
-    GET: {command: 'getCurrentContext'},
-    POST: {command: 'setContext', payloadParams: {required: ['name']}},
+    GET: {command: 'getCurrentContext', deprecated: true},
+    POST: {command: 'setContext', payloadParams: {required: ['name']}, deprecated: true},
   },
   '/session/:sessionId/contexts': {
-    GET: {command: 'getContexts'},
+    GET: {command: 'getContexts', deprecated: true},
   },
   '/session/:sessionId/network_connection': {
     GET: {command: 'getNetworkConnection', deprecated: true},

--- a/packages/base-driver/test/unit/protocol/routes.spec.ts
+++ b/packages/base-driver/test/unit/protocol/routes.spec.ts
@@ -41,7 +41,7 @@ describe('Routes', function () {
       }
       const hash = shasum.digest('hex').substring(0, 8);
       // Update this value again only when an intentional route/command/param change is made.
-      assert.strictEqual(hash, 'a175e178');
+      assert.strictEqual(hash, 'f00c2414');
     });
   });
 

--- a/packages/base-driver/test/unit/protocol/routes.spec.ts
+++ b/packages/base-driver/test/unit/protocol/routes.spec.ts
@@ -41,7 +41,7 @@ describe('Routes', function () {
       }
       const hash = shasum.digest('hex').substring(0, 8);
       // Update this value again only when an intentional route/command/param change is made.
-      assert.strictEqual(hash, 'f00c2414');
+      assert.strictEqual(hash, '8b461b1a');
     });
   });
 


### PR DESCRIPTION
Adds /session/:sessionId/appium/{rotation,context,contexts,orientation} routes as non-deprecated aliases, and marks the legacy JSONWP/MJSONWP routes they replace as deprecated (routes already deprecated are untouched).