### PR TITLE
fix(universal-xml-plugin): iOS findElements drops matches after the first one

### DIFF
--- a/packages/universal-xml-plugin/lib/plugin.ts
+++ b/packages/universal-xml-plugin/lib/plugin.ts
@@ -109,8 +109,12 @@ export class UniversalXMLPlugin extends BasePlugin {
     if (platformName.toLowerCase() === 'ios') {
       // with the XCUITest driver, the <AppiumAUT> wrapper element is present in the source but is
       // not present in the source considered by WDA, so our index path based xpath queries will
-      // not work with WDA as-is. We need to remove the first path segment.
-      newSelector = newSelector.replace(/^\/\*\[1\]/, '');
+      // not work with WDA as-is. We need to remove the first path segment. A query matching
+      // multiple nodes is a union of paths, so every branch needs the segment removed.
+      newSelector = newSelector
+        .split('|')
+        .map((branch) => branch.trim().replace(/^\/\*\[1\]/, ''))
+        .join(' | ');
     }
     this.log.info(`Selector was translated to: ${newSelector}`);
 

--- a/packages/universal-xml-plugin/lib/plugin.ts
+++ b/packages/universal-xml-plugin/lib/plugin.ts
@@ -82,7 +82,6 @@ export class UniversalXMLPlugin extends BasePlugin {
     strategy: string,
     selector: string,
   ): Promise<Element | Element[]> {
-    const platformName = getPlatformName(driver);
     if (
       strategy.toLowerCase() !== 'xpath' ||
       !driver.getCurrentContext ||
@@ -91,7 +90,7 @@ export class UniversalXMLPlugin extends BasePlugin {
       return (await next()) as Element | Element[];
     }
     const xml = await this.getPageSource(null, driver, null, true);
-    let newSelector = transformQuery(selector, xml, multiple);
+    const newSelector = transformQuery(selector, xml, multiple);
 
     // if the selector was not able to be transformed, that means no elements were found that
     // matched, so do the appropriate thing based on element vs elements
@@ -106,16 +105,6 @@ export class UniversalXMLPlugin extends BasePlugin {
       throw new errors.NoSuchElementError();
     }
 
-    if (platformName.toLowerCase() === 'ios') {
-      // with the XCUITest driver, the <AppiumAUT> wrapper element is present in the source but is
-      // not present in the source considered by WDA, so our index path based xpath queries will
-      // not work with WDA as-is. We need to remove the first path segment. A query matching
-      // multiple nodes is a union of paths, so every branch needs the segment removed.
-      newSelector = newSelector
-        .split('|')
-        .map((branch) => branch.trim().replace(/^\/\*\[1\]/, ''))
-        .join(' | ');
-    }
     this.log.info(`Selector was translated to: ${newSelector}`);
 
     // otherwise just run the transformed query!

--- a/packages/universal-xml-plugin/lib/source.ts
+++ b/packages/universal-xml-plugin/lib/source.ts
@@ -34,9 +34,9 @@ export async function transformSourceXml(
   platform: string,
   {metadata = {} as TransformMetadata, addIndexPath = false}: TransformSourceXmlOptions = {},
 ): Promise<{xml: string; unknowns: NodesAndAttributes}> {
-  // first thing we want to do is modify the ios source root node, because it doesn't include the
-  // necessary index attribute, so we add it if it's not there
-  xmlStr = xmlStr.replace('<AppiumAUT>', '<AppiumAUT index="0">');
+  // the ios <AppiumAUT> root has no index attribute, so it gets no index path. that is on purpose:
+  // the XCUITest driver leaves that wrapper out of the hierarchy it runs queries against, so index
+  // paths have to be relative to the node below it
   const xmlObj = singletonXmlParser().parse(xmlStr);
   const unknowns = transformNode(xmlObj, platform, {
     metadata,

--- a/packages/universal-xml-plugin/lib/source.ts
+++ b/packages/universal-xml-plugin/lib/source.ts
@@ -34,9 +34,10 @@ export async function transformSourceXml(
   platform: string,
   {metadata = {} as TransformMetadata, addIndexPath = false}: TransformSourceXmlOptions = {},
 ): Promise<{xml: string; unknowns: NodesAndAttributes}> {
-  // the ios <AppiumAUT> root has no index attribute, so it gets no index path. that is on purpose:
-  // the XCUITest driver leaves that wrapper out of the hierarchy it runs queries against, so index
-  // paths have to be relative to the node below it
+  // the ios <AppiumAUT> root deliberately gets no index path: the XCUITest driver leaves that
+  // wrapper out of the hierarchy it runs queries against, so index paths have to be relative to
+  // the node below it. the android <hierarchy> root does carry an index attribute and is part of
+  // the queried hierarchy, so it keeps its index path
   const xmlObj = singletonXmlParser().parse(xmlStr);
   const unknowns = transformNode(xmlObj, platform, {
     metadata,

--- a/packages/universal-xml-plugin/lib/xpath.ts
+++ b/packages/universal-xml-plugin/lib/xpath.ts
@@ -28,22 +28,26 @@ export function transformQuery(query: string, xmlStr: string, multiple: boolean)
     return null;
   }
 
-  const newQueries = nodes.map((node) => {
-    const indexPath = getNodeAttrVal(node, 'indexPath');
-    // at this point indexPath will look like /0/0/1/1/0/1/0/2
-    const newQuery = indexPath
-      .substring(1) // remove leading / so we can split
-      .split('/') // split into indexes
-      .map((indexStr) => {
-        // map to xpath node indexes (1-based)
-        const xpathIndex = parseInt(indexStr, 10) + 1;
-        return `*[${xpathIndex}]`;
-      })
-      .join('/'); // reapply /
+  const newQueries = nodes
+    // the ios root node has no index path because the driver does not include it in the hierarchy
+    // it queries, so there is no locator we can build for it
+    .filter((node) => hasNodeAttr(node, 'indexPath'))
+    .map((node) => {
+      const indexPath = getNodeAttrVal(node, 'indexPath');
+      // at this point indexPath will look like /0/0/1/1/0/1/0/2
+      const newQuery = indexPath
+        .substring(1) // remove leading / so we can split
+        .split('/') // split into indexes
+        .map((indexStr) => {
+          // map to xpath node indexes (1-based)
+          const xpathIndex = parseInt(indexStr, 10) + 1;
+          return `*[${xpathIndex}]`;
+        })
+        .join('/'); // reapply /
 
-    // now to make this a valid xpath from the root, prepend the / we removed earlier
-    return `/${newQuery}`;
-  });
+      // now to make this a valid xpath from the root, prepend the / we removed earlier
+      return `/${newQuery}`;
+    });
 
   if (newQueries.length === 0) {
     return null;
@@ -65,4 +69,15 @@ export function getNodeAttrVal(node: any, attr: string): string {
     throw new Error(`Tried to retrieve a node attribute '${attr}' but the node didn't have it`);
   }
   return (attrObjs[0] as any).value;
+}
+
+/**
+ * Checks whether a node has a given attribute
+ *
+ * @param node - The XML node
+ * @param attr - The attribute name
+ * @returns True if the node has the attribute
+ */
+export function hasNodeAttr(node: any, attr: string): boolean {
+  return Object.values(node.attributes || {}).some((obj: any) => obj.name === attr);
 }

--- a/packages/universal-xml-plugin/lib/xpath.ts
+++ b/packages/universal-xml-plugin/lib/xpath.ts
@@ -1,3 +1,4 @@
+import type {Element} from '@xmldom/xmldom';
 import {DOMParser, MIME_TYPE} from '@xmldom/xmldom';
 import {select as xpathQuery} from 'xpath';
 
@@ -6,12 +7,14 @@ import {select as xpathQuery} from 'xpath';
  * @param query XPath query.
  * @param xmlStr XML source.
  */
-export function runQuery(query: string, xmlStr: string): any[] {
+export function runQuery(query: string, xmlStr: string): Element[] {
   const dom = new DOMParser().parseFromString(xmlStr, MIME_TYPE.XML_TEXT);
   // @ts-expect-error Missing Node properties are not needed.
   // https://github.com/xmldom/xmldom/issues/724
   const nodes = xpathQuery(query, dom);
-  return nodes as any[];
+  // the xpath typings describe lib.dom nodes rather than xmldom ones, so this is the one place
+  // where the two type worlds have to be bridged
+  return nodes as unknown as Element[];
 }
 
 /**
@@ -29,9 +32,9 @@ export function transformQuery(query: string, xmlStr: string, multiple: boolean)
   }
 
   const newQueries = nodes
-    // the ios root node has no index path because the driver does not include it in the hierarchy
-    // it queries, so there is no locator we can build for it
-    .filter((node) => hasNodeAttr(node, 'indexPath'))
+    // nodes with no indexPath cannot be located on the device, so skip them deliberately.
+    // the only such node is the ios AppiumAUT root (see transformSourceXml)
+    .filter((node) => node.hasAttribute('indexPath'))
     .map((node) => {
       const indexPath = getNodeAttrVal(node, 'indexPath');
       // at this point indexPath will look like /0/0/1/1/0/1/0/2
@@ -63,21 +66,10 @@ export function transformQuery(query: string, xmlStr: string, multiple: boolean)
  * @returns The attribute value
  * @throws {Error} If the attribute doesn't exist
  */
-export function getNodeAttrVal(node: any, attr: string): string {
-  const attrObjs = Object.values(node.attributes || {}).filter((obj: any) => obj.name === attr);
-  if (!attrObjs.length) {
+export function getNodeAttrVal(node: Element, attr: string): string {
+  const value = node.getAttribute(attr);
+  if (value === null) {
     throw new Error(`Tried to retrieve a node attribute '${attr}' but the node didn't have it`);
   }
-  return (attrObjs[0] as any).value;
-}
-
-/**
- * Checks whether a node has a given attribute
- *
- * @param node - The XML node
- * @param attr - The attribute name
- * @returns True if the node has the attribute
- */
-export function hasNodeAttr(node: any, attr: string): boolean {
-  return Object.values(node.attributes || {}).some((obj: any) => obj.name === attr);
+  return value;
 }

--- a/packages/universal-xml-plugin/test/fixtures/ios-transformed-path.xml
+++ b/packages/universal-xml-plugin/test/fixtures/ios-transformed-path.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<UI indexPath="/0">
-  <App visible="true" x="0" y="0" width="414" height="896" indexPath="/0/0" axId="TheApp" text="TheApp">
-    <Window visible="true" x="0" y="0" width="414" height="896" indexPath="/0/0/0">
-      <Element visible="true" x="0" y="0" width="414" height="896" indexPath="/0/0/0/0">
-        <Nav visible="true" x="0" y="48" width="414" height="44" indexPath="/0/0/0/0/0" axId="RCCView">
-          <Button visible="true" x="0" y="48" width="96" height="44" indexPath="/0/0/0/0/0/0" axId="The App" text="The App"></Button>
+<UI>
+  <App visible="true" x="0" y="0" width="414" height="896" indexPath="/0" axId="TheApp" text="TheApp">
+    <Window visible="true" x="0" y="0" width="414" height="896" indexPath="/0/0">
+      <Element visible="true" x="0" y="0" width="414" height="896" indexPath="/0/0/0">
+        <Nav visible="true" x="0" y="48" width="414" height="44" indexPath="/0/0/0/0" axId="RCCView">
+          <Button visible="true" x="0" y="48" width="96" height="44" indexPath="/0/0/0/0/0" axId="The App" text="The App"></Button>
         </Nav>
-        <Element visible="true" x="0" y="0" width="414" height="896" indexPath="/0/0/0/0/1">
-          <Element visible="true" x="0" y="0" width="414" height="896" indexPath="/0/0/0/0/1/0">
-            <Element visible="true" x="0" y="92" width="414" height="804" indexPath="/0/0/0/0/1/0/0">
-              <Element visible="true" x="0" y="92" width="414" height="804" indexPath="/0/0/0/0/1/0/0/0" axId="Login username password loginBtn" text="Login username password loginBtn">
-                <Element visible="true" x="0" y="92" width="414" height="804" indexPath="/0/0/0/0/1/0/0/0/0" axId="Login username password loginBtn" text="Login username password loginBtn">
-                  <Element visible="true" x="0" y="92" width="414" height="804" indexPath="/0/0/0/0/1/0/0/0/0/0" axId="Login username password loginBtn" text="Login username password loginBtn">
-                    <Element visible="true" x="0" y="92" width="414" height="273" indexPath="/0/0/0/0/1/0/0/0/0/0/0" axId="Login username password loginBtn" text="Login username password loginBtn">
-                      <Text value="Login" visible="true" x="157" y="132" width="101" height="51" indexPath="/0/0/0/0/1/0/0/0/0/0/0/0" axId="Login" text="Login"></Text>
-                      <Element visible="true" x="50" y="183" width="314" height="40" indexPath="/0/0/0/0/1/0/0/0/0/0/0/1" axId="username" text="username">
-                        <Element visible="true" x="50" y="183" width="314" height="40" indexPath="/0/0/0/0/1/0/0/0/0/0/0/1/0" axId="username" text="username">
-                          <Element visible="true" x="50" y="185" width="314" height="51" indexPath="/0/0/0/0/1/0/0/0/0/0/0/1/0/0" axId="username" text="username">
-                            <TextInput value="alice" visible="true" x="50" y="185" width="314" height="51" indexPath="/0/0/0/0/1/0/0/0/0/0/0/1/0/0/0" axId="username" text="username"></TextInput>
-                            <Button visible="true" x="50" y="185" width="314" height="51" indexPath="/0/0/0/0/1/0/0/0/0/0/0/1/0/0/1" axId="fakeTab" text=""></Button>
-                            <Button visible="true" x="50" y="185" width="314" height="51" indexPath="/0/0/0/0/1/0/0/0/0/0/0/1/0/0/2" axId="fakeKey" text=""></Button>
+        <Element visible="true" x="0" y="0" width="414" height="896" indexPath="/0/0/0/1">
+          <Element visible="true" x="0" y="0" width="414" height="896" indexPath="/0/0/0/1/0">
+            <Element visible="true" x="0" y="92" width="414" height="804" indexPath="/0/0/0/1/0/0">
+              <Element visible="true" x="0" y="92" width="414" height="804" indexPath="/0/0/0/1/0/0/0" axId="Login username password loginBtn" text="Login username password loginBtn">
+                <Element visible="true" x="0" y="92" width="414" height="804" indexPath="/0/0/0/1/0/0/0/0" axId="Login username password loginBtn" text="Login username password loginBtn">
+                  <Element visible="true" x="0" y="92" width="414" height="804" indexPath="/0/0/0/1/0/0/0/0/0" axId="Login username password loginBtn" text="Login username password loginBtn">
+                    <Element visible="true" x="0" y="92" width="414" height="273" indexPath="/0/0/0/1/0/0/0/0/0/0" axId="Login username password loginBtn" text="Login username password loginBtn">
+                      <Text value="Login" visible="true" x="157" y="132" width="101" height="51" indexPath="/0/0/0/1/0/0/0/0/0/0/0" axId="Login" text="Login"></Text>
+                      <Element visible="true" x="50" y="183" width="314" height="40" indexPath="/0/0/0/1/0/0/0/0/0/0/1" axId="username" text="username">
+                        <Element visible="true" x="50" y="183" width="314" height="40" indexPath="/0/0/0/1/0/0/0/0/0/0/1/0" axId="username" text="username">
+                          <Element visible="true" x="50" y="185" width="314" height="51" indexPath="/0/0/0/1/0/0/0/0/0/0/1/0/0" axId="username" text="username">
+                            <TextInput value="alice" visible="true" x="50" y="185" width="314" height="51" indexPath="/0/0/0/1/0/0/0/0/0/0/1/0/0/0" axId="username" text="username"></TextInput>
+                            <Button visible="true" x="50" y="185" width="314" height="51" indexPath="/0/0/0/1/0/0/0/0/0/0/1/0/0/1" axId="fakeTab" text=""></Button>
+                            <Button visible="true" x="50" y="185" width="314" height="51" indexPath="/0/0/0/1/0/0/0/0/0/0/1/0/0/2" axId="fakeKey" text=""></Button>
                           </Element>
                         </Element>
                       </Element>
-                      <Element visible="true" x="50" y="223" width="314" height="40" indexPath="/0/0/0/0/1/0/0/0/0/0/0/2" axId="password" text="password">
-                        <Element visible="true" x="50" y="223" width="314" height="40" indexPath="/0/0/0/0/1/0/0/0/0/0/0/2/0" axId="password" text="password">
-                          <Element visible="true" x="50" y="225" width="314" height="51" indexPath="/0/0/0/0/1/0/0/0/0/0/0/2/0/0" axId="password" text="password">
-                            <TextInput value="•••••••••" visible="true" x="50" y="225" width="314" height="51" indexPath="/0/0/0/0/1/0/0/0/0/0/0/2/0/0/0" axId="password" text="password"></TextInput>
+                      <Element visible="true" x="50" y="223" width="314" height="40" indexPath="/0/0/0/1/0/0/0/0/0/0/2" axId="password" text="password">
+                        <Element visible="true" x="50" y="223" width="314" height="40" indexPath="/0/0/0/1/0/0/0/0/0/0/2/0" axId="password" text="password">
+                          <Element visible="true" x="50" y="225" width="314" height="51" indexPath="/0/0/0/1/0/0/0/0/0/0/2/0/0" axId="password" text="password">
+                            <TextInput value="•••••••••" visible="true" x="50" y="225" width="314" height="51" indexPath="/0/0/0/1/0/0/0/0/0/0/2/0/0/0" axId="password" text="password"></TextInput>
                           </Element>
                         </Element>
                       </Element>
-                      <Element visible="true" x="177" y="263" width="60" height="102" indexPath="/0/0/0/0/1/0/0/0/0/0/0/3" axId="loginBtn" text="loginBtn">
-                        <Element visible="true" x="177" y="327" width="60" height="38" indexPath="/0/0/0/0/1/0/0/0/0/0/0/3/0" axId="loginBtn" text="loginBtn"></Element>
+                      <Element visible="true" x="177" y="263" width="60" height="102" indexPath="/0/0/0/1/0/0/0/0/0/0/3" axId="loginBtn" text="loginBtn">
+                        <Element visible="true" x="177" y="327" width="60" height="38" indexPath="/0/0/0/1/0/0/0/0/0/0/3/0" axId="loginBtn" text="loginBtn"></Element>
                       </Element>
                     </Element>
                   </Element>
@@ -42,11 +42,11 @@
         </Element>
       </Element>
     </Window>
-    <Window visible="false" x="0" y="0" width="414" height="896" indexPath="/0/0/1">
-      <Element visible="false" x="0" y="0" width="414" height="896" indexPath="/0/0/1/0">
-        <Element visible="false" x="0" y="0" width="414" height="896" indexPath="/0/0/1/0/0"></Element>
-        <Element visible="false" x="0" y="896" width="414" height="71" indexPath="/0/0/1/0/1">
-          <Element visible="false" x="0" y="896" width="414" height="71" indexPath="/0/0/1/0/1/0"></Element>
+    <Window visible="false" x="0" y="0" width="414" height="896" indexPath="/0/1">
+      <Element visible="false" x="0" y="0" width="414" height="896" indexPath="/0/1/0">
+        <Element visible="false" x="0" y="0" width="414" height="896" indexPath="/0/1/0/0"></Element>
+        <Element visible="false" x="0" y="896" width="414" height="71" indexPath="/0/1/0/1">
+          <Element visible="false" x="0" y="896" width="414" height="71" indexPath="/0/1/0/1/0"></Element>
         </Element>
       </Element>
     </Window>

--- a/packages/universal-xml-plugin/test/unit/plugin.spec.ts
+++ b/packages/universal-xml-plugin/test/unit/plugin.spec.ts
@@ -45,6 +45,19 @@ describe('UniversalXMLPlugin', function () {
       assert.equal((node as any).nodeName, 'XCUIElementTypeTextField');
     });
 
+    it('should return every match when an ios xpath query matches multiple nodes', async function () {
+      (driver as any).getCurrentContext = () => 'NATIVE_APP';
+      next = (driver as any).getPageSource = () => readFixture(FIXTURES.XML_IOS);
+      (driver as any).caps = {platformName: 'iOS'};
+      (driver as any).findElements = async (strategy: string, selector: string) =>
+        runQuery(selector, (await readFixture(FIXTURES.XML_IOS)).replace(/<\/?AppiumAUT>/g, ''));
+      const nodes = await p.findElements(next, driver as any, 'xpath', '//Window');
+      assert.equal(nodes.length, 2);
+      for (const node of nodes) {
+        assert.equal((node as any).nodeName, 'XCUIElementTypeWindow');
+      }
+    });
+
     it('should turn an xpath query into another query run on the original android source', async function () {
       (driver as any).getCurrentContext = () => 'NATIVE_APP';
       next = (driver as any).getPageSource = () => readFixture(FIXTURES.XML_ANDROID);

--- a/packages/universal-xml-plugin/test/unit/xpath.spec.ts
+++ b/packages/universal-xml-plugin/test/unit/xpath.spec.ts
@@ -19,14 +19,21 @@ describe('xpath functions', function () {
       });
       assert.equal(
         transformQuery('//TextInput', xml, false),
-        '/*[1]/*[1]/*[1]/*[1]/*[2]/*[1]/*[1]/*[1]/*[1]/*[1]/*[1]/*[2]/*[1]/*[1]/*[1]',
+        '/*[1]/*[1]/*[1]/*[2]/*[1]/*[1]/*[1]/*[1]/*[1]/*[1]/*[2]/*[1]/*[1]/*[1]',
       );
     });
     it('should transform a query into a multiple new queries if asked', async function () {
       const {xml} = await transformSourceXml(await readFixture(FIXTURES.XML_IOS), 'ios', {
         addIndexPath: true,
       });
-      assert.equal(transformQuery('//Window', xml, true)?.split('|').length, 2);
+      assert.equal(transformQuery('//Window', xml, true), '/*[1]/*[1] | /*[1]/*[2]');
+    });
+    it('should skip nodes that have no index path', async function () {
+      const {xml} = await transformSourceXml(await readFixture(FIXTURES.XML_IOS), 'ios', {
+        addIndexPath: true,
+      });
+      // the ios root node is not part of the hierarchy the driver queries, so it cannot be located
+      assert.equal(transformQuery('//UI', xml, false), null);
     });
     it('should return null for queries that dont find anything', async function () {
       const {xml} = await transformSourceXml(await readFixture(FIXTURES.XML_IOS), 'ios', {

--- a/packages/universal-xml-plugin/test/unit/xpath.spec.ts
+++ b/packages/universal-xml-plugin/test/unit/xpath.spec.ts
@@ -34,6 +34,16 @@ describe('xpath functions', function () {
       });
       // the ios root node is not part of the hierarchy the driver queries, so it cannot be located
       assert.equal(transformQuery('//UI', xml, false), null);
+      assert.equal(transformQuery('//UI', xml, true), null);
+    });
+    it('should keep the ios root out of a union query', async function () {
+      const {xml} = await transformSourceXml(await readFixture(FIXTURES.XML_IOS), 'ios', {
+        addIndexPath: true,
+      });
+      const branches = transformQuery('//*', xml, true)?.split(' | ') ?? [];
+      // the App node below the root is the first thing the driver can actually match
+      assert.equal(branches[0], '/*[1]');
+      assert.equal(branches.length, runQuery('//*', xml).length - 1);
     });
     it('should return null for queries that dont find anything', async function () {
       const {xml} = await transformSourceXml(await readFixture(FIXTURES.XML_IOS), 'ios', {


### PR DESCRIPTION
Found this while testing the universal-xml plugin on iOS.

If you call findElements with an xpath that matches more than one node, the plugin turns it into a union query like \/*[1]/*[1]/*[1] | /*[1]/*[1]/*[2]\. Before sending it to WDA we strip the leading \/*[1]\ because AppiumAUT shows up in our transformed page source but not in the source WDA actually queries.

The problem is that strip only happened on the first branch. The second path still had the extra segment, so WDA could not match it. You end up with fewer elements than the xpath should return and no error to tell you something went wrong.

The fix just runs the same strip on each branch of the union. Added a unit test with the existing iOS fixture (two Window nodes) that fails on master and passes with the fix.

## Tests
- [x] \
pm run test:unit\ in packages/universal-xml-plugin (22 tests pass)
- [x] new test fails without the fix (returns 1 instead of 2)