### PR TITLE
ci: adjust publish docs workflow trigger condition

### DIFF
--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -3,10 +3,10 @@ name: Publish docs
 on:
   workflow_dispatch:
   push:
-    # Runs when any new tag is pushed = there is a new release
-    # Pattern matched against refs/tags, so does not trigger for tags with a slash, e.g. 1.0/beta
+    # Runs when any new Appium tag is pushed = there is a new release
+    # Does not trigger for tags with a slash, e.g. 1.0/beta
     tags:        
-      - '*'
+      - 'appium@*'
 
 jobs:
   build:

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -2,10 +2,11 @@ name: Publish docs
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ['Appium Server Release']
-    types:
-      - completed
+  push:
+    # Runs when any new tag is pushed = there is a new release
+    # Pattern matched against refs/tags, so does not trigger for tags with a slash, e.g. 1.0/beta
+    tags:        
+      - '*'
 
 jobs:
   build:


### PR DESCRIPTION
This should prevent the publish docs workflow from triggering for a dry-run version of the release workflow.