### PR TITLE
feat(release): add next-major beta-branch support to release tooling

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -13,6 +13,11 @@ on:
         required: true
         type: boolean
         default: false
+      bootstrap_packages:
+        description: 'One-time beta-branch bootstrap only: comma-separated package names (e.g. @appium/base-driver,@appium/support) to force-bump to their next-major beta (premajor --preid beta), bypassing conventional-commit detection. Leave empty for a normal release.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write
@@ -23,7 +28,11 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && contains(fromJSON('["mykola-mokhnach", "jlipps", "eglitise", "KazuCocoa"]'), github.actor)
+    # keep this branch name in sync with env.BETA_BRANCH below - the `env` context isn't available
+    # to jobs.<job_id>.if (GitHub Actions resolves it before job-level env is set up)
+    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/appium4') && contains(fromJSON('["mykola-mokhnach", "jlipps", "eglitise", "KazuCocoa"]'), github.actor)
+    env:
+      BETA_BRANCH: appium4
 
     steps:
       - name: Checkout repository
@@ -49,8 +58,42 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run }}
           RECOVER_MISSING_ONLY: ${{ inputs.recover_missing_only }}
+          BOOTSTRAP_PACKAGES: ${{ inputs.bootstrap_packages }}
         run: |
           set -euo pipefail
+
+          # On the beta branch ($BETA_BRANCH), every release is a beta prerelease anchored at its
+          # target major (see packages/semantic-release-config's "Next-major beta branches" docs
+          # for the equivalent semantic-release behavior this mirrors).
+          BETA_FLAGS=""
+          DIST_TAG_FLAGS=""
+          if [ "${{ github.ref_name }}" = "$BETA_BRANCH" ]; then
+            BETA_FLAGS="--conventional-prerelease --preid beta"
+            DIST_TAG_FLAGS="--dist-tag beta"
+          fi
+
+          # One-time bootstrap for packages just starting their beta train: force them
+          # straight to <next-major>.0.0-beta.0 instead of waiting for/relying on a commit that
+          # happens to be marked as breaking. Not part of the normal release flow below - this
+          # exits early on its own.
+          if [ -n "$BOOTSTRAP_PACKAGES" ]; then
+            if [ "${{ github.ref_name }}" != "$BETA_BRANCH" ]; then
+              echo "bootstrap_packages is only meaningful on the $BETA_BRANCH branch" >&2
+              exit 1
+            fi
+            if [ "$RECOVER_MISSING_ONLY" = "true" ]; then
+              echo "bootstrap_packages cannot be combined with recover_missing_only" >&2
+              exit 1
+            fi
+
+            echo "Bootstrapping ${BOOTSTRAP_PACKAGES} to their next-major beta (premajor --preid beta), bypassing conventional-commit detection"
+            if [ "$DRY_RUN" = "true" ]; then
+              printf "n\n" | npx lerna version premajor --preid beta --exact --no-git-tag-version --no-push --force-publish="$BOOTSTRAP_PACKAGES"
+            else
+              npx lerna publish premajor --preid beta --exact --force-publish="$BOOTSTRAP_PACKAGES" --dist-tag beta --yes
+            fi
+            exit 0
+          fi
 
           # Prints "<pkg_name>@<pkg_version>" to stdout for each non-private workspace package
           # whose current package.json version is not yet on npm.
@@ -112,7 +155,7 @@ jobs:
 
               echo "Publishing ${pkg_spec}"
               set +e
-              (cd "$pkg_dir" && npm publish)
+              (cd "$pkg_dir" && npm publish $DIST_TAG_FLAGS)
               publish_exit_code=$?
               set -e
               if [ $publish_exit_code -ne 0 ]; then
@@ -151,11 +194,11 @@ jobs:
 
           if [ "$DRY_RUN" = "true" ]; then
             echo "Running lerna publish in dry-run mode"
-            printf "n\n" | npx lerna version --exact --no-git-tag-version --no-push
+            printf "n\n" | npx lerna version --exact --no-git-tag-version --no-push $BETA_FLAGS
           else
             echo "Running lerna publish for real"
             set +e
-            release_output="$(npm run release -- --yes 2>&1)"
+            release_output="$(npm run release -- --yes $BETA_FLAGS $DIST_TAG_FLAGS 2>&1)"
             release_exit_code=$?
             set -e
             printf '%s\n' "$release_output"

--- a/.github/workflows/manual-version.yml
+++ b/.github/workflows/manual-version.yml
@@ -15,7 +15,11 @@ permissions:
 jobs:
   version:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' && contains(fromJSON('["mykola-mokhnach", "jlipps", "eglitise", "KazuCocoa"]'), github.actor)
+    # keep this branch name in sync with env.BETA_BRANCH below - the `env` context isn't available
+    # to jobs.<job_id>.if (GitHub Actions resolves it before job-level env is set up)
+    if: (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/appium4') && contains(fromJSON('["mykola-mokhnach", "jlipps", "eglitise", "KazuCocoa"]'), github.actor)
+    env:
+      BETA_BRANCH: appium4
 
     steps:
       - name: Checkout repository
@@ -38,4 +42,9 @@ jobs:
       - name: Run Lerna version
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx lerna version --exact --yes
+        run: |
+          BETA_FLAGS=""
+          if [ "${{ github.ref_name }}" = "$BETA_BRANCH" ]; then
+            BETA_FLAGS="--conventional-prerelease --preid beta"
+          fi
+          npx lerna version --exact --yes $BETA_FLAGS

--- a/lerna.json
+++ b/lerna.json
@@ -14,7 +14,7 @@
     "version": {
       "conventionalCommits": true,
       "createRelease": "github",
-      "allowBranch": ["master", "appium3"],
+      "allowBranch": ["master", "appium4"],
       "exact": true
     }
   },

--- a/packages/semantic-release-config/README.md
+++ b/packages/semantic-release-config/README.md
@@ -53,12 +53,50 @@ export default releaseConfig({
 | Option | Type | Default | Effect |
 | --- | --- | --- | --- |
 | `flavor` | `'library' \| 'app'` | `'library'` | `'app'` switches to the `conventionalcommits` commit-analyzer preset, sets `npmPublish: false`, disables GitHub success/fail PR & issue comments, and defaults `@semantic-release/github`'s `assets` to `[]`. |
-| `branches` | `string[]` | _(omitted)_ | Sets the top-level `branches` option. Omit to fall back to semantic-release's own default branches. |
+| `branches` | `string[]` | _(omitted)_ | Sets the top-level `branches` option. Omit to fall back to `['master']` (or semantic-release's own defaults if `betaBranch` is also omitted). |
+| `betaBranch` | `string` | _(none)_ | Name of a long-lived next-major prerelease branch, e.g. `'next-major'`. Appended to `branches` as a prerelease branch entry — see "Next-major beta branches" below. |
+| `betaChannel` | `string` | `'beta'` | Prerelease identifier / npm dist-tag used for `betaBranch`. |
 | `extraGitAssets` | `string[]` | `[]` | Appended to `@semantic-release/git`'s `assets`. |
 | `removeGitAssets` | `string[]` | `[]` | Removed from `@semantic-release/git`'s `assets` (applied after `extraGitAssets`). |
 | `githubAssets` | `Array` | _(flavor default)_ | `@semantic-release/github`'s `assets` option — plain path strings or `{path, label}` objects. |
 | `commitAnalyzerReleaseRules` | `Array` | _(flavor default)_ | Full override of commit-analyzer's `releaseRules`. |
 | `releaseNotesTypeOverrides` | `Record<string, {hidden?: boolean, section?: string}>` | _(none)_ | Shallow-patched onto the default `presetConfig.types`, keyed by commit type, e.g. `{chore: {hidden: true}}`. |
+
+## Next-major beta branches
+
+Some appium-org repos develop a next major version on a long-lived branch (e.g. `next-major`) in
+parallel with normal releases off `master`. Pass `betaBranch` to have every commit on that branch —
+patch, minor, or breaking alike — publish as a `-beta.N` prerelease instead of a stable release:
+
+```js
+export default releaseConfig({
+  flavor: 'library',
+  betaBranch: 'next-major', // whatever your repo actually calls this branch
+});
+```
+
+This appends `{name: <betaBranch>, channel: 'beta', prerelease: 'beta'}` to `branches`, so releases
+from that branch publish to the `beta` npm dist-tag (`npm install my-pkg@beta`) as
+`X.0.0-beta.0`, `X.0.0-beta.1`, etc.
+
+**How the version stays anchored:** once a package's first release on that branch lands on a clean
+`X.0.0-beta.0` (i.e. minor and patch are both `0`), semantic-release's own prerelease logic
+guarantees every subsequent commit on that branch — no matter its conventional-commit type or
+whether it's a breaking change — only advances the `beta.N` counter; it never re-bumps the major
+version underneath the prerelease train. That first release is what has to land cleanly: if the
+earliest commits on the branch are only patch/minor-level, the first beta versions will reflect
+that lower bump and self-correct upward **exactly once**, the moment a genuinely breaking commit
+lands — expected behavior, not a bug. Once the major is settled, it holds until the branch is
+graduated to a stable release.
+
+**Don't rely on remembering to mark the first commit as breaking.** `semantic-release` has no CLI
+override to force a specific version — it's always driven by analyzing actual commits. So
+deliberately land a real breaking-change commit (`BREAKING CHANGE:` footer or `feat!:`) as part of
+the first PR merged after creating the beta branch, rather than depending on one showing up
+naturally. If that slips, manually publishing the very first prerelease by hand (bump
+`package.json` to `X.0.0-beta.0`, tag it, `npm publish --tag beta`) before handing off to
+automated `semantic-release` runs works just as well — either way, what matters is that the
+*first* release on the branch lands on a clean `X.0.0-beta.0`.
 
 ## Gotchas
 

--- a/packages/semantic-release-config/index.mjs
+++ b/packages/semantic-release-config/index.mjs
@@ -62,7 +62,13 @@ const APP_GIT_ASSETS = ['package.json', 'package-lock.json', 'CHANGELOG.md'];
  * flavor (`conventionalcommits` commit-analyzer preset, `npmPublish: false`, no GitHub release
  * assets by default, PR/issue comments disabled).
  * @param {string[]} [opts.branches] - Passed through as the top-level `branches` option; omit to
- * use semantic-release's own default branches.
+ * default to `['master']` (or semantic-release's own defaults if `betaBranch` is also omitted).
+ * @param {string} [opts.betaBranch] - Name of a long-lived next-major prerelease branch (e.g.
+ * `'next-major'`). When set, appended to `branches` as `{name, channel: betaChannel, prerelease:
+ * betaChannel}` so every commit on that branch - patch, minor, or breaking alike - only advances
+ * the `-<betaChannel>.N` prerelease counter once anchored at a clean `X.0.0-<betaChannel>.0`.
+ * @param {string} [opts.betaChannel='beta'] - Prerelease identifier / npm dist-tag used for
+ * `betaBranch`.
  * @param {string[]} [opts.extraGitAssets] - Appended to `@semantic-release/git`'s `assets`.
  * @param {string[]} [opts.removeGitAssets] - Removed from `@semantic-release/git`'s `assets`.
  * @param {Array} [opts.githubAssets] - `@semantic-release/github`'s `assets` option.
@@ -78,6 +84,8 @@ export default function semanticReleaseConfig(opts = {}) {
   const {
     flavor = 'library',
     branches,
+    betaBranch,
+    betaChannel = 'beta',
     extraGitAssets = [],
     removeGitAssets = [],
     githubAssets,
@@ -131,8 +139,11 @@ export default function semanticReleaseConfig(opts = {}) {
     plugins: [commitAnalyzerPlugin, releaseNotesGeneratorPlugin, changelogPlugin, npmPlugin, gitPlugin, githubPlugin],
   };
 
-  if (branches) {
-    config.branches = branches;
+  if (branches || betaBranch) {
+    config.branches = [
+      ...(branches ?? ['master']),
+      ...(betaBranch ? [{name: betaBranch, channel: betaChannel, prerelease: betaChannel}] : []),
+    ];
   }
 
   return config;

--- a/packages/semantic-release-config/scripts/test-smoke.mjs
+++ b/packages/semantic-release-config/scripts/test-smoke.mjs
@@ -24,7 +24,7 @@ if (appConfig.branches?.[0] !== 'main') {
 const betaConfig = releaseConfig({betaBranch: 'next-major'});
 const expectedBetaBranches = ['master', {name: 'next-major', channel: 'beta', prerelease: 'beta'}];
 if (JSON.stringify(betaConfig.branches) !== JSON.stringify(expectedBetaBranches)) {
-  throw new Error('expected betaBranch to default branches to [\'master\', <beta branch entry>]');
+  throw new Error("expected betaBranch to default branches to ['master', <beta branch entry>]");
 }
 
 const betaWithBranchesConfig = releaseConfig({branches: ['main'], betaBranch: 'next-major', betaChannel: 'next'});

--- a/packages/semantic-release-config/scripts/test-smoke.mjs
+++ b/packages/semantic-release-config/scripts/test-smoke.mjs
@@ -20,3 +20,15 @@ if (!npmPlugin || npmPlugin[1]?.npmPublish !== false) {
 if (appConfig.branches?.[0] !== 'main') {
   throw new Error('expected branches option to be passed through');
 }
+
+const betaConfig = releaseConfig({betaBranch: 'next-major'});
+const expectedBetaBranches = ['master', {name: 'next-major', channel: 'beta', prerelease: 'beta'}];
+if (JSON.stringify(betaConfig.branches) !== JSON.stringify(expectedBetaBranches)) {
+  throw new Error('expected betaBranch to default branches to [\'master\', <beta branch entry>]');
+}
+
+const betaWithBranchesConfig = releaseConfig({branches: ['main'], betaBranch: 'next-major', betaChannel: 'next'});
+const expectedComposedBranches = ['main', {name: 'next-major', channel: 'next', prerelease: 'next'}];
+if (JSON.stringify(betaWithBranchesConfig.branches) !== JSON.stringify(expectedComposedBranches)) {
+  throw new Error('expected betaBranch to compose with an explicit branches option and custom betaChannel');
+}


### PR DESCRIPTION
## Summary

- Add opt-in `betaBranch`/`betaChannel` options to `@appium/semantic-release-config` so driver/plugin repos can later publish a long-lived next-major branch as `-beta.N` prereleases, anchored at a fixed target major instead of escalating further on every breaking change.
- Extend this monorepo's own Lerna-based release workflows (`manual-release.yml`, `manual-version.yml`) to allow that beta branch alongside `master`, passing `--conventional-prerelease --preid beta` / `--dist-tag beta` when running on it.
- Add a one-time `bootstrap_packages` workflow input to force a package straight to its first `<major>.0.0-beta.0`, so the anchor doesn't depend on remembering to mark a commit as breaking.
- Update `lerna.json`'s `allowBranch` to match.
