### PR TITLE
chore(eslint-config-appium-ts): deprecate in favour of oxc-config

### DIFF
--- a/packages/eslint-config-appium-ts/README.md
+++ b/packages/eslint-config-appium-ts/README.md
@@ -1,5 +1,7 @@
 # @appium/eslint-config-appium-ts
 
+> **Deprecated:** This package is deprecated and will be removed from the Appium monorepo. Please migrate to [`@appium/oxc-config`](https://github.com/appium/appium/tree/master/packages/oxc-config).
+
 > Provides a reusable [ESLint](http://eslint.org/) [shared configuration](http://eslint.org/docs/developer-guide/shareable-configs) for [Appium](https://github.com/appium/appium) and Appium-adjacent projects.
 
 [![NPM version](https://img.shields.io/npm/v/@appium/eslint-config-appium-ts.svg)](https://npmjs.org/package/@appium/eslint-config-appium-ts)

--- a/packages/eslint-config-appium-ts/package.json
+++ b/packages/eslint-config-appium-ts/package.json
@@ -3,6 +3,7 @@
   "version": "3.2.4",
   "gitHead": "f7b20335eab4022e5cbbb627ec86866a994444f8",
   "description": "Shared ESLint config for Appium projects (TypeScript version)",
+  "deprecated": "This package is deprecated and will be removed from the Appium monorepo. Please migrate to @appium/oxc-config.",
   "keywords": [
     "appium",
     "eslint",

--- a/packages/eslint-config-appium-ts/package.json
+++ b/packages/eslint-config-appium-ts/package.json
@@ -3,7 +3,6 @@
   "version": "3.2.4",
   "gitHead": "f7b20335eab4022e5cbbb627ec86866a994444f8",
   "description": "Shared ESLint config for Appium projects (TypeScript version)",
-  "deprecated": "This package is deprecated and will be removed from the Appium monorepo. Please migrate to @appium/oxc-config.",
   "keywords": [
     "appium",
     "eslint",
@@ -54,5 +53,6 @@
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
     "npm": ">=10"
-  }
+  },
+  "deprecated": "This package is deprecated and will be removed from the Appium monorepo. Please migrate to @appium/oxc-config."
 }

--- a/packages/eslint-config-appium-ts/package.json
+++ b/packages/eslint-config-appium-ts/package.json
@@ -53,6 +53,5 @@
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
     "npm": ">=10"
-  },
-  "deprecated": "This package is deprecated and will be removed from the Appium monorepo. Please migrate to @appium/oxc-config."
+  }
 }


### PR DESCRIPTION
Consumers should migrate to @appium/oxc-config.