### PR TITLE
fix(strongbox): custom container paths are always rejected on Windows

### DIFF
--- a/packages/strongbox/lib/index.ts
+++ b/packages/strongbox/lib/index.ts
@@ -330,10 +330,12 @@ export class Strongbox<Options extends StrongboxOpts = StrongboxOpts> implements
       if (!path.isAbsolute(opts.container)) {
         throw new TypeError(`container slug ${opts.container} must be an absolute path`);
       }
-      // the root has to be left alone, otherwise a windows drive letter loses its colon and the
-      // path stops being absolute
-      const {root} = path.parse(opts.container);
-      const segments = opts.container.slice(root.length).split(path.sep).filter(Boolean);
+      // slugify the folders only. the root is what makes the path absolute (a drive letter or UNC
+      // share on windows), and slugify would strip the colon. normalize first so mixed slashes
+      // still split into real segments.
+      const normalized = path.normalize(opts.container);
+      const {root} = path.parse(normalized);
+      const segments = normalized.slice(root.length).split(path.sep).filter(Boolean);
       opts.container = path.join(root, ...segments.map(slugify));
     } else {
       opts.container = path.join(envPaths(this.id).data, opts.suffix);

--- a/packages/strongbox/lib/index.ts
+++ b/packages/strongbox/lib/index.ts
@@ -327,10 +327,14 @@ export class Strongbox<Options extends StrongboxOpts = StrongboxOpts> implements
   protected checkOptions(opts: Options): Options {
     opts.suffix = slugify(opts.suffix);
     if (opts.container) {
-      opts.container = opts.container.split(path.sep).map(slugify).join(path.sep);
       if (!path.isAbsolute(opts.container)) {
         throw new TypeError(`container slug ${opts.container} must be an absolute path`);
       }
+      // the root has to be left alone, otherwise a windows drive letter loses its colon and the
+      // path stops being absolute
+      const {root} = path.parse(opts.container);
+      const segments = opts.container.slice(root.length).split(path.sep).filter(Boolean);
+      opts.container = path.join(root, ...segments.map(slugify));
     } else {
       opts.container = path.join(envPaths(this.id).data, opts.suffix);
     }

--- a/packages/strongbox/test/unit/strongbox-windows.spec.ts
+++ b/packages/strongbox/test/unit/strongbox-windows.spec.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import {before, describe, it, mock} from 'node:test';
+
+import type {Strongbox as TStrongbox, StrongboxOpts} from '../../lib/index.js';
+
+describe('Strongbox windows container paths', function () {
+  let strongbox: (name: string, opts?: Partial<StrongboxOpts>) => TStrongbox;
+
+  before(async function () {
+    // this file only: Strongbox should see windows paths, even on linux
+    mock.module('node:path', {defaultExport: path.win32});
+    ({strongbox} = await import('../../lib/index.js'));
+  });
+
+  it('should slugify a windows drive path without dropping the root', function () {
+    const container = 'C:\\some dir\\another one';
+    const {container: actual} = strongbox('test', {container});
+
+    assert.ok(path.win32.isAbsolute(actual));
+    assert.strictEqual(path.win32.parse(actual).root, path.win32.parse(container).root);
+    assert.strictEqual(actual, 'C:\\some-dir\\another-one');
+  });
+
+  it('should slugify a UNC path without dropping the share', function () {
+    const container = '\\\\server\\share\\some dir\\another one';
+    const {container: actual} = strongbox('test', {container});
+
+    assert.ok(path.win32.isAbsolute(actual));
+    assert.strictEqual(path.win32.parse(actual).root, path.win32.parse(container).root);
+    assert.strictEqual(actual, '\\\\server\\share\\some-dir\\another-one');
+  });
+});

--- a/packages/strongbox/test/unit/strongbox.spec.ts
+++ b/packages/strongbox/test/unit/strongbox.spec.ts
@@ -63,6 +63,16 @@ describe('Strongbox', function () {
           const container = path.resolve(path.sep, 'somewhere');
           assert.strictEqual(strongbox('test', {container}).container, container);
         });
+
+        it('should slugify the path segments but keep the path absolute', function () {
+          const container = path.resolve(path.sep, 'some dir', 'another one');
+          const {container: actual} = strongbox('test', {container});
+
+          assert.ok(path.isAbsolute(actual));
+          // the root is what makes the path absolute, so it must survive untouched
+          assert.strictEqual(path.parse(actual).root, path.parse(container).root);
+          assert.strictEqual(actual, path.join(path.parse(container).root, 'some-dir', 'another-one'));
+        });
       });
 
       describe('when provided a relative container path', function () {

--- a/packages/strongbox/test/unit/strongbox.spec.ts
+++ b/packages/strongbox/test/unit/strongbox.spec.ts
@@ -73,6 +73,13 @@ describe('Strongbox', function () {
           assert.strictEqual(path.parse(actual).root, path.parse(container).root);
           assert.strictEqual(actual, path.join(path.parse(container).root, 'some-dir', 'another-one'));
         });
+
+        it('should handle a path written with forward slashes', function () {
+          const {root} = path.parse(path.resolve(path.sep));
+          const {container} = strongbox('test', {container: `${root}some dir/another one`});
+
+          assert.strictEqual(container, path.join(root, 'some-dir', 'another-one'));
+        });
       });
 
       describe('when provided a relative container path', function () {


### PR DESCRIPTION
On Windows every custom container path is rejected, so `strongbox(name, {container})` cannot be used there at all.

`checkOptions` slugifies the container one path segment at a time, and on Windows the drive letter is just another segment. `slugify` drops everything that is not alphanumeric, so `C:` turns into `C`, the path stops being absolute, and the very next line throws:

```
input   : C:\Users\me\appium-data
slugged : C\Users\me\appium-data   (isAbsolute=false)
result  : TypeError: container slug C\Users\me\appium-data must be an absolute path
```

The existing `should use the provided container path` test already covers this. It builds its path with `path.resolve(path.sep, 'somewhere')`, which is `/somewhere` on Linux but `C:\somewhere` on Windows, so it fails there today. It just never runs on Windows, since unit tests only run on `ubuntu-latest`.

The fix checks that the path is absolute first, then slugifies only the segments below the path root, leaving the root alone. Relative paths still throw, and the error message now shows what was actually passed in rather than the slugified version.

## Tests
- [x] `npm run test:unit` in packages/strongbox on Windows, 34 pass (2 fail on master, including the pre-existing container path test)
- [x] `npm run test:e2e` in packages/strongbox, 12 pass
- [x] default container path behaviour is unchanged, only the custom container branch is touched
