### PR TITLE
docs: add Itsmeaj Linux driver listing

### DIFF
--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -126,21 +126,14 @@ appium driver install --source=npm appium-flutter-integration-driver
 appium driver install --source=npm appium-lg-webos-driver
 ```
 
-### [Linux](https://github.com/fantonglang/appium-linux-driver)
+### [Linux](https://github.com/Itsmeaj/appium)
 
-!!! warning
-
-    This driver has not been maintained since 2022 and requires a custom Appium installation
-
-* Target: Linux applications
+* Target: Linux desktop applications on X11 and Wayland
 * Mode: Native
-* Supported by: `@fantonglang`
+* Supported by: Community / `@Itsmeaj`
 
 ```sh title="Install This Driver"
-git clone https://github.com/fantonglang/appium
-cd appium
-yarn install
-node ./
+appium driver install --source=npm @stdspa/appium-linux-driver
 ```
 
 ### [NovaWindows](https://github.com/AutomateThePlanet/appium-novawindows-driver)

--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -133,7 +133,7 @@ appium driver install --source=npm appium-lg-webos-driver
 * Supported by: Community / `@Itsmeaj`
 
 ```sh title="Install This Driver"
-appium driver install --source=npm @stdspa/appium-linux-driver
+appium driver install --source=npm @itsmeaj/appium-linux-driver
 ```
 
 ### [NovaWindows](https://github.com/AutomateThePlanet/appium-novawindows-driver)

--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -126,7 +126,24 @@ appium driver install --source=npm appium-flutter-integration-driver
 appium driver install --source=npm appium-lg-webos-driver
 ```
 
-### [Linux](https://github.com/Itsmeaj/appium)
+### [Linux](https://github.com/fantonglang/appium-linux-driver)
+
+!!! warning
+
+    This driver has not been maintained since 2022 and requires a custom Appium installation
+
+* Target: Linux applications
+* Mode: Native
+* Supported by: `@fantonglang`
+
+```sh title="Install This Driver"
+git clone https://github.com/fantonglang/appium
+cd appium
+yarn install
+node ./
+```
+
+### [Linux (AT-SPI2)](https://github.com/Itsmeaj/appium)
 
 * Target: Linux desktop applications on X11 and Wayland
 * Mode: Native

--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -126,7 +126,7 @@ appium driver install --source=npm appium-flutter-integration-driver
 appium driver install --source=npm appium-lg-webos-driver
 ```
 
-### [Linux](https://github.com/fantonglang/appium-linux-driver)
+### [Linux (@fantonglang)](https://github.com/fantonglang/appium-linux-driver)
 
 !!! warning
 
@@ -143,7 +143,7 @@ yarn install
 node ./
 ```
 
-### [Linux (AT-SPI2)](https://github.com/Itsmeaj/appium)
+### [Linux (@Itsmeaj)](https://github.com/Itsmeaj/appium)
 
 * Target: Linux desktop applications on X11 and Wayland
 * Mode: Native

--- a/packages/appium/docs/en/ecosystem/drivers.md
+++ b/packages/appium/docs/en/ecosystem/drivers.md
@@ -130,7 +130,7 @@ appium driver install --source=npm appium-lg-webos-driver
 
 * Target: Linux desktop applications on X11 and Wayland
 * Mode: Native
-* Supported by: Community / `@Itsmeaj`
+* Supported by: `@Itsmeaj`
 
 ```sh title="Install This Driver"
 appium driver install --source=npm @itsmeaj/appium-linux-driver


### PR DESCRIPTION
## Proposed changes

This documentation-only change preserves the existing Linux driver details and adds a separate entry for the community-maintained `@itsmeaj/appium-linux-driver` package. The two entries are distinguished by maintainer in their section headings. The new entry documents its X11 and Wayland target environments and provides the standard Appium npm installation command.

This changes one English documentation file and does not modify Appium behavior. Translated documentation is intentionally unchanged because Appium synchronizes it through Crowdin.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Validation and release evidence

- npm package: https://www.npmjs.com/package/@itsmeaj/appium-linux-driver
- GitHub release: https://github.com/Itsmeaj/appium/releases/tag/v0.1.1
- Appium 2.19 and 3.4 published-package smoke test: https://github.com/Itsmeaj/appium/actions/runs/32690899705
- Node.js 20/22, Appium 2/3, `.deb`, and `.rpm` checks: https://github.com/Itsmeaj/appium/actions/runs/32691483940
- CodeQL analysis: https://github.com/Itsmeaj/appium/actions/runs/32691483765

The npm package is maintained by `itsmeaj`, and its downstream release is published before this documentation update.

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes (not applicable to this documentation-only change; the upstream Docs workflow provides the relevant build check)
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable to a driver-listing update)
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The diff is intentionally limited to distinguishing the two Linux entries by maintainer and adding the separate `@Itsmeaj` driver details in `packages/appium/docs/en/ecosystem/drivers.md`.
