### PR TITLE
ci: tune docs publish workflow

### DIFF
--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -6,7 +6,8 @@ on:
     # Runs when any new Appium tag is pushed = there is a new release
     # Does not trigger for tags with a slash, e.g. 1.0/beta
     tags:        
-      - 'appium@*'
+      - appium@*
+      - '!appium@*beta*'
 
 jobs:
   build:
@@ -14,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0 # ensure the docs branch is also fetched
       - run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -25,9 +28,5 @@ jobs:
           run-build: 'true'
       - name: Install dependencies (Python)
         run: npm run install-docs-deps
-      - name: Fetch gh-pages
-        run: |
-          git fetch origin gh-pages:gh-pages || true
       - name: Publish docs
-        run: |
-          npm run docs:publish
+        run: npm run docs:publish


### PR DESCRIPTION
The latest release did not trigger this workflow, so it could use some tuning:
* Remove quotes around the filtered tag (may or may not have an effect)
* Add exclusion tag to not trigger for beta releases (quotes are needed since it begins with `!`)
* Simplify fetching of the docs branch similarly to https://github.com/appium/appium-inspector/pull/2965