### PR TITLE
fix(base-driver): skip unknown events in session.unsubscribe

### DIFF
--- a/packages/base-driver/lib/basedriver/commands/bidi.ts
+++ b/packages/base-driver/lib/basedriver/commands/bidi.ts
@@ -18,9 +18,10 @@ const BidiCommands: IBidiCommands = {
 
   async bidiUnsubscribe<C extends Constraints>(this: BaseDriver<C>, events: string[], contexts: string[] = ['']) {
     for (const event of events) {
-      if (this.bidiEventSubs[event]) {
-        this.bidiEventSubs[event] = this.bidiEventSubs[event].filter((c) => !contexts.includes(c));
+      if (!this.bidiEventSubs[event]) {
+        continue;
       }
+      this.bidiEventSubs[event] = this.bidiEventSubs[event].filter((c) => !contexts.includes(c));
       if (this.bidiEventSubs[event].length === 0) {
         delete this.bidiEventSubs[event];
       }

--- a/packages/base-driver/test/unit/basedriver/commands/bidi.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/commands/bidi.spec.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import {beforeEach, describe, it} from 'node:test';
+
+import type {InitialOpts} from '@appium/types';
+
+import {BaseDriver} from '../../../../lib';
+
+describe('bidi commands -', function () {
+  let driver: BaseDriver<any, any, any, any, any, any>;
+
+  beforeEach(function () {
+    driver = new BaseDriver({} as InitialOpts);
+  });
+
+  describe('bidiUnsubscribe', function () {
+    it('should not throw when the event was never subscribed', async function () {
+      await driver.bidiUnsubscribe(['log.entryAdded'], ['']);
+      assert.deepStrictEqual(driver.bidiEventSubs, {});
+    });
+
+    it('should still unsubscribe a matching event when the list also has an unknown one', async function () {
+      await driver.bidiSubscribe(['log.entryAdded'], ['']);
+      await driver.bidiUnsubscribe(['log.entryAdded', 'browsingContext.domContentLoaded'], ['']);
+      assert.deepStrictEqual(driver.bidiEventSubs, {});
+    });
+  });
+});


### PR DESCRIPTION
## Proposed changes

`session.unsubscribe` for an event that was never subscribed throws `TypeError: Cannot read properties of undefined (reading 'length')`.

The existence check skipped the filter, then `.length` still ran on `undefined`. Skip those events instead.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The new unit test fails on master with that TypeError.