### PR TITLE
feat(base-driver)!: replace spdy with native https transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9045,12 +9045,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/detect-node": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-      "optional": true
-    },
     "node_modules/diff": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
@@ -11591,12 +11585,6 @@
       "version": "1.0.4",
       "license": "MIT"
     },
-    "node_modules/handle-thing": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
-      "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
-      "optional": true
-    },
     "node_modules/handlebars": {
       "version": "4.7.9",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
@@ -11715,54 +11703,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/hpack.js": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-      "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "obuf": "^1.0.0",
-        "readable-stream": "^2.0.1",
-        "wbuf": "^1.1.0"
-      }
-    },
-    "node_modules/hpack.js/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "optional": true
-    },
-    "node_modules/hpack.js/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "optional": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/hpack.js/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "optional": true
-    },
-    "node_modules/hpack.js/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -11810,12 +11750,6 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "dev": true,
       "license": "BSD-2-Clause"
-    },
-    "node_modules/http-deceiver": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-      "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
-      "optional": true
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -13650,11 +13584,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/minimatch": {
       "version": "3.1.4",
@@ -16571,12 +16500,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/obuf": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
-      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
-      "optional": true
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -18602,12 +18525,6 @@
         "truncate-utf8-bytes": "^1.0.0"
       }
     },
-    "node_modules/select-hose": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
-      "optional": true
-    },
     "node_modules/semantic-release": {
       "version": "25.0.9",
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-25.0.9.tgz",
@@ -19456,36 +19373,6 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.12",
       "license": "CC0-1.0"
-    },
-    "node_modules/spdy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
-      "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.1.0",
-        "handle-thing": "^2.0.0",
-        "http-deceiver": "^1.2.7",
-        "select-hose": "^2.0.0",
-        "spdy-transport": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/spdy-transport": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
-      "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.1.0",
-        "detect-node": "^2.0.4",
-        "hpack.js": "^2.1.6",
-        "obuf": "^1.1.2",
-        "readable-stream": "^3.0.6",
-        "wbuf": "^1.7.3"
-      }
     },
     "node_modules/split2": {
       "version": "4.2.0",
@@ -20878,15 +20765,6 @@
         "node": "20 || >=22"
       }
     },
-    "node_modules/wbuf": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
-      "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
-      "optional": true,
-      "dependencies": {
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "license": "MIT",
@@ -21420,7 +21298,6 @@
     },
     "packages/appium": {
       "version": "3.7.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/base-driver": "10.8.0",
@@ -21576,9 +21453,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
-      },
-      "optionalDependencies": {
-        "spdy": "4.0.2"
       }
     },
     "packages/base-driver/node_modules/agent-base": {

--- a/packages/appium/docs/en/guides/tls.md
+++ b/packages/appium/docs/en/guides/tls.md
@@ -2,7 +2,7 @@
 hide:
   - toc
 
-title: SSL/TLS/SPDY Support
+title: SSL/TLS Support
 ---
 
 Appium 2.2 introduces the option to start the Appium server with SSL/TLS support. 
@@ -19,15 +19,14 @@ Both arguments must be provided and should contain paths to a valid
 [X509 PEM](https://www.ssl.com/guide/pem-der-crt-and-cer-x-509-encodings-and-conversions/)
 certificate and its corresponding private key.
 
-After the server is started use the `https` protocol and a client supporting SSL/TLS or
-[SPDY](https://en.wikipedia.org/wiki/SPDY) to communicate to it.
+After the server is started use the `https` protocol and a client supporting SSL/TLS to
+communicate to it.
 
 ### Supported Features
 
-Once a secure server socket is established it supports the following protocols:
-`['h2', 'spdy/3.1', 'spdy/3', 'spdy/2', 'http/1.1', 'http/1.0']`. See
-[the SPDY node module documentation](https://www.npmjs.com/package/spdy) to get more details about
-its features. All insecure client connections will be rejected by the server.
+Once a secure server socket is established it uses Node.js' native
+[`https`](https://nodejs.org/api/https.html) module to serve connections. All insecure client
+connections will be rejected by the server.
 
 ### Self-Signed Certificates
 

--- a/packages/appium/test/e2e/driver.e2e.spec.ts
+++ b/packages/appium/test/e2e/driver.e2e.spec.ts
@@ -726,8 +726,7 @@ describe('FakeDriver via HTTP', function () {
   });
 });
 
-// TODO: This test is skipped due to spdy package incompatibility
-describe('Bidi over SSL', {skip: true}, function () {
+describe('Bidi over SSL', function () {
   async function generateCertificate(certPath: string, keyPath: string) {
     await exec('openssl', [
       'req',
@@ -782,8 +781,11 @@ describe('Bidi over SSL', {skip: true}, function () {
   });
 
   afterEach(async function () {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = previousEnvValue;
-    await driver?.deleteSession();
+    try {
+      await driver?.deleteSession();
+    } finally {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = previousEnvValue;
+    }
   });
 
   it('should still run bidi over ssl', async function () {

--- a/packages/base-driver/lib/express/server.ts
+++ b/packages/base-driver/lib/express/server.ts
@@ -1,6 +1,6 @@
 import http from 'node:http';
 import type {Server as HttpServer} from 'node:http';
-import {createRequire} from 'node:module';
+import https from 'node:https';
 
 // Import env helper directly — not from the test-pages barrel — so Express handlers and
 // fixture code stay unloaded unless APPIUM_ENABLE_LEGACY_TEST_PAGES is set.
@@ -15,7 +15,7 @@ import type {
 } from '@appium/types';
 import bodyParser from 'body-parser';
 import express from 'express';
-import type {Express, RequestHandler, Router} from 'express';
+import type {Express, Router} from 'express';
 import methodOverride from 'method-override';
 
 import {DEFAULT_BASE_PATH} from '../constants.js';
@@ -39,8 +39,6 @@ import {
   removeAllWebSocketHandlers,
   removeWebSocketHandler,
 } from './websocket.js';
-
-const require = createRequire(import.meta.url);
 
 const KEEP_ALIVE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -279,25 +277,9 @@ async function createServer(app: Express, cliArgs?: Partial<ServerArgs>): Promis
     }
   }
   const [cert, key] = (await Promise.all(certKey.map((p) => fs.readFile(p, 'utf8')))) as [string, string];
-  log.debug('Enabling TLS/SPDY on the server using the provided certificate');
+  log.debug('Enabling TLS on the server using the provided certificate');
 
-  const spdy = require('spdy') as {
-    createServer: (
-      options: {cert: string; key: string; spdy: {plain: boolean; ssl: boolean}},
-      requestListener: RequestHandler,
-    ) => HttpServer;
-  };
-  return spdy.createServer(
-    {
-      cert,
-      key,
-      spdy: {
-        plain: false,
-        ssl: true,
-      },
-    },
-    app,
-  );
+  return https.createServer({cert, key}, app) as unknown as HttpServer;
 }
 
 /**
@@ -320,9 +302,7 @@ function configureHttp({
   appiumServer.removeWebSocketHandler = removeWebSocketHandler;
   appiumServer.removeAllWebSocketHandlers = removeAllWebSocketHandlers;
   appiumServer.getWebSocketHandlers = getWebSocketHandlers;
-  appiumServer.isSecure = function isSecure() {
-    return Boolean((this as unknown as {_spdyState?: {secure?: boolean}})._spdyState?.secure);
-  };
+  appiumServer.isSecure = () => httpServer instanceof https.Server;
 
   // This avoids Express middleware timeout issues with long-lived WebSocket connections
   // See: https://github.com/appium/appium/issues/20760

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -70,9 +70,6 @@
     "serve-favicon": "2.5.1",
     "type-fest": "5.8.0"
   },
-  "optionalDependencies": {
-    "spdy": "4.0.2"
-  },
   "tsd": {
     "compilerOptions": {
       "composite": false,


### PR DESCRIPTION
## Summary
- Replace the legacy/unsupported `spdy` package with Node's native `https` module for TLS-enabled Appium servers (appium/appium#22051)
- `isSecure()` now checks `httpServer instanceof https.Server` instead of reaching into spdy's private `_spdyState`
- Drop `spdy` from `base-driver`'s `optionalDependencies`
- Un-skip the "Bidi over SSL" e2e test (previously disabled for spdy incompatibility) and fix a bug in its teardown where `NODE_TLS_REJECT_UNAUTHORIZED` was restored before `deleteSession()` ran, causing the DELETE request to fail cert validation
- Update the SSL/TLS docs to drop SPDY-specific protocol negotiation details

BREAKING CHANGE: TLS-enabled Appium servers no longer negotiate SPDY/HTTP2 (`spdy/2`, `spdy/3`, `spdy/3.1`, `h2`) via ALPN; connections are now served as plain HTTPS (HTTP/1.1) using Node's native `https` module. Clients relying on SPDY or HTTP/2 multiplexing against Appium's TLS listener must switch to HTTP/1.1.
