### PR TITLE
fix(base-driver): reject invalid timeout with InvalidArgumentError

### DIFF
--- a/packages/base-driver/lib/basedriver/commands/timeout.ts
+++ b/packages/base-driver/lib/basedriver/commands/timeout.ts
@@ -127,7 +127,7 @@ const TimeoutCommands: ITimeoutCommands = {
   parseTimeoutArgument<C extends Constraints>(this: BaseDriver<C>, ms: number | string) {
     const duration = parseInt(String(ms), 10);
     if (Number.isNaN(duration) || duration < MIN_TIMEOUT) {
-      throw new errors.UnknownError(`Invalid timeout value '${ms}'`);
+      throw new errors.InvalidArgumentError(`Invalid timeout value '${ms}'`);
     }
     return duration;
   },

--- a/packages/base-driver/test/unit/basedriver/timeout.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/timeout.spec.ts
@@ -4,7 +4,7 @@ import {after, afterEach, before, beforeEach, describe, it} from 'node:test';
 import type {InitialOpts} from '@appium/types';
 import {createSandbox} from 'sinon';
 
-import {BaseDriver} from '../../../lib';
+import {BaseDriver, errors} from '../../../lib';
 
 describe('timeout', function () {
   let driver: BaseDriver<any, any, any, any, any, any>;
@@ -27,6 +27,10 @@ describe('timeout', function () {
 
   describe('timeouts', function () {
     describe('errors', function () {
+      it('should reject an invalid timeout with InvalidArgumentError', function () {
+        assert.throws(() => driver.parseTimeoutArgument('abc'), errors.InvalidArgumentError);
+        assert.throws(() => driver.parseTimeoutArgument(-1), errors.InvalidArgumentError);
+      });
       it('should throw an error if something random is sent', async function () {
         await assert.rejects(driver.timeouts('random timeout', 'howdy'));
       });


### PR DESCRIPTION
## Proposed changes

Invalid timeout values (`-1`, `"abc"`, etc.) were returned as HTTP 500 `unknown error`. They should be `invalid argument`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The new unit test fails on master with `UnknownError`.