### PR TITLE
refactor(support): remove bluebird dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@appium/oxc-config": "1.0.0",
         "@tsconfig/node20": "20.1.10",
         "@types/async-lock": "1.4.2",
-        "@types/bluebird": "3.5.42",
         "@types/content-disposition": "0.5.9",
         "@types/express": "5.0.6",
         "@types/finalhandler": "1.2.4",
@@ -5011,12 +5010,6 @@
       "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
       "dev": true
     },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.42",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.42.tgz",
-      "integrity": "sha512-Jhy+MWRlro6UjVi578V/4ZGNfeCOcNCp0YaFNIUGFKlImowqwb1O/22wDVk3FDGMLqxdpOV3qQHD5fPEH4hK6A==",
-      "dev": true
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
       "dev": true,
@@ -6338,10 +6331,6 @@
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -19670,7 +19659,6 @@
         "archiver": "8.0.0",
         "asyncbox": "6.4.2",
         "axios": "1.19.0",
-        "bluebird": "3.7.2",
         "bplist-creator": "0.1.1",
         "bplist-parser": "0.3.2",
         "form-data": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@appium/oxc-config": "1.0.0",
     "@tsconfig/node20": "20.1.10",
     "@types/async-lock": "1.4.2",
-    "@types/bluebird": "3.5.42",
     "@types/content-disposition": "0.5.9",
     "@types/express": "5.0.6",
     "@types/finalhandler": "1.2.4",

--- a/packages/support/lib/fs.ts
+++ b/packages/support/lib/fs.ts
@@ -17,7 +17,6 @@ import {
 import path from 'node:path';
 import {promisify} from 'node:util';
 
-import B from 'bluebird';
 import {glob} from 'glob';
 import type {GlobOptions} from 'glob';
 import klaw from 'klaw';
@@ -382,8 +381,7 @@ export const fs = {
   stat: fsPromises.stat,
   symlink: fsPromises.symlink,
   unlink: fsPromises.unlink,
-  // TODO: replace with native promisify in Appium 4
-  write: B.promisify(write),
+  write: promisify(write),
   writeFile: fsPromises.writeFile,
 };
 

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -57,7 +57,6 @@
     "archiver": "8.0.0",
     "asyncbox": "6.4.2",
     "axios": "1.19.0",
-    "bluebird": "3.7.2",
     "bplist-creator": "0.1.1",
     "bplist-parser": "0.3.2",
     "form-data": "4.0.6",


### PR DESCRIPTION
Replace the last remaining bluebird usage (fs.write) with native util.promisify, matching the pattern already used for close/open/read.
