### PR TITLE
fix(appium): do not treat a directory as a CLI argument file

### DIFF
--- a/packages/appium/lib/schema/cli-transformers.ts
+++ b/packages/appium/lib/schema/cli-transformers.ts
@@ -1,4 +1,4 @@
-import {existsSync, readFileSync} from 'node:fs';
+import {readFileSync, statSync} from 'node:fs';
 
 import {ArgumentTypeError} from 'argparse';
 
@@ -28,7 +28,7 @@ export const transformers = {
     let csv = csvOrPath;
     let loadedFromFile = false;
     // Value could be a single CSV token or a filepath; attempt file first.
-    if (existsSync(csvOrPath)) {
+    if (isRegularFile(csvOrPath)) {
       try {
         csv = readFileSync(csvOrPath, 'utf8');
       } catch (err) {
@@ -52,7 +52,7 @@ export const transformers = {
   json: (jsonOrPath: string): Record<string, any> => {
     let json = jsonOrPath;
     let loadedFromFile = false;
-    if (existsSync(jsonOrPath)) {
+    if (isRegularFile(jsonOrPath)) {
       try {
         // Intentionally sync: argparse type hooks are synchronous.
         json = readFileSync(jsonOrPath, 'utf8');
@@ -69,6 +69,21 @@ export const transformers = {
     }
   },
 } as const;
+
+/**
+ * Whether `filepath` is an existing regular file.
+ *
+ * Directories are not files: `--allow-insecure adb_shell` names a feature, not the `./adb_shell`
+ * folder. Any other stat failure means "not a file" too, since these values are usually not paths
+ * at all (a long JSON blob fails with ENAMETOOLONG, not ENOENT).
+ */
+function isRegularFile(filepath: string): boolean {
+  try {
+    return statSync(filepath).isFile();
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Split a file by newline then calls {@link parseCsvLine} on each line.

--- a/packages/appium/test/unit/parser.spec.ts
+++ b/packages/appium/test/unit/parser.spec.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import {mkdirSync, mkdtempSync, rmSync} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {describe, it, beforeEach, before, after} from 'node:test';
 
 import {readConfigFile} from '../../lib/bootstrap/config-file';
@@ -95,6 +98,13 @@ describe('parser', function () {
         assert.deepStrictEqual(args.defaultCapabilities, defaultCapabilities);
       });
 
+      it('should parse default capabilities which are longer than the max filename length', function () {
+        // a value this long fails stat() with ENAMETOOLONG instead of ENOENT on posix systems
+        const defaultCapabilities = {'appium:app': 'a'.repeat(300)};
+        const args = p.parseArgs(['--default-capabilities', JSON.stringify(defaultCapabilities)]);
+        assert.deepStrictEqual(args.defaultCapabilities, defaultCapabilities);
+      });
+
       it('should parse default capabilities correctly from a file', function () {
         const defaultCapabilities = {a: 'b'};
         const args = p.parseArgs(['--default-capabilities', CAPS_FIXTURE]);
@@ -141,6 +151,19 @@ describe('parser', function () {
         const parsed = p.parseArgs(['--allow-insecure', ALLOW_FIXTURE, '--deny-insecure', DENY_FIXTURE]);
         assert.deepStrictEqual(parsed.allowInsecure, ['*:feature1', '*:feature2', '*:feature3']);
         assert.deepStrictEqual(parsed.denyInsecure, ['*:nofeature1', '*:nofeature2', '*:nofeature3']);
+      });
+
+      it('should treat --allow-insecure as a feature name even if a directory with that name exists', function () {
+        const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'appium-allow-insecure-'));
+        mkdirSync(path.join(tmpDir, 'adb_shell'));
+        const prevCwd = process.cwd();
+        try {
+          process.chdir(tmpDir);
+          assert.deepStrictEqual(p.parseArgs(['--allow-insecure', 'adb_shell']).allowInsecure, ['adb_shell']);
+        } finally {
+          process.chdir(prevCwd);
+          rmSync(tmpDir, {recursive: true, force: true});
+        }
       });
 
       it('should allow a string for --use-drivers', function () {

--- a/packages/appium/test/unit/schema/cli-transformers.spec.ts
+++ b/packages/appium/test/unit/schema/cli-transformers.spec.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {after, before, describe, it} from 'node:test';
+
+import {transformers} from '../../../lib/schema/cli-transformers';
+
+describe('cli-transformers', function () {
+  let tmpDir: string;
+  let prevCwd: string;
+
+  before(function () {
+    prevCwd = process.cwd();
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'appium-cli-transformers-'));
+    process.chdir(tmpDir);
+  });
+
+  after(function () {
+    process.chdir(prevCwd);
+    rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  describe('csv', function () {
+    it('should parse a comma-delimited string', function () {
+      assert.deepStrictEqual(transformers.csv('adb_shell,get_server_logs'), ['adb_shell', 'get_server_logs']);
+    });
+
+    it('should treat a directory as a literal value instead of reading it', function () {
+      mkdirSync(path.join(tmpDir, 'adb_shell'));
+      assert.deepStrictEqual(transformers.csv('adb_shell'), ['adb_shell']);
+    });
+
+    it('should still load a CSV file when the path is a regular file', function () {
+      const file = path.join(tmpDir, 'features.csv');
+      writeFileSync(file, 'adb_shell\nget_server_logs\n', 'utf8');
+      assert.deepStrictEqual(transformers.csv(file), ['adb_shell', 'get_server_logs']);
+    });
+  });
+
+  describe('json', function () {
+    it('should parse a JSON string', function () {
+      assert.deepStrictEqual(transformers.json('{"foo":1}'), {foo: 1});
+    });
+
+    it('should parse a JSON string longer than the max filename length', function () {
+      // a value this long fails stat() with ENAMETOOLONG instead of ENOENT on posix systems
+      const caps = {'appium:app': 'a'.repeat(300)};
+      assert.deepStrictEqual(transformers.json(JSON.stringify(caps)), caps);
+    });
+
+    it('should treat a directory as a literal value instead of reading it', function () {
+      mkdirSync(path.join(tmpDir, 'caps'));
+      assert.throws(() => transformers.json('caps'), /must be a valid JSON/i);
+    });
+
+    it('should still load a JSON file when the path is a regular file', function () {
+      const file = path.join(tmpDir, 'caps.json');
+      writeFileSync(file, '{"foo":1}', 'utf8');
+      assert.deepStrictEqual(transformers.json(file), {foo: 1});
+    });
+  });
+});


### PR DESCRIPTION
Starting the server from a folder that happens to contain a directory named after the argument value makes the server refuse to start:

```
$ mkdir adb_shell && appium --allow-insecure adb_shell
appium server: error: argument --allow-insecure: Could not read file 'adb_shell': EISDIR: illegal operation on a directory, read
```

The `csv` and `json` transformers accept either a literal value or a path to a file holding that value, and they tell the two apart with `existsSync`. That returns `true` for a directory, so `readFileSync` runs against the folder and fails with `EISDIR`. The value is never given a chance to be parsed as what the user actually meant.

This affects every argument that goes through a transformer: `--allow-insecure` and `--deny-insecure` (`appiumCliTransformer: 'csv'`), `--log-filters` (`appiumCliTransformer: 'json'`), `--default-capabilities` and any `object`-typed extension argument (the `json` transformer is applied automatically). `--use-drivers` and `--use-plugins` are not affected, since array-typed properties without an explicit transformer only ever get `parseCsvLine`.

The fix replaces `existsSync` with a `statSync().isFile()` check, so a directory falls through and gets parsed as a literal value like any other non-path string.

One detail worth calling out: the helper has to treat *every* stat failure as "not a file", not just `ENOENT`. `existsSync` already swallowed everything, and these arguments are usually not paths at all. On Linux a single path component over 255 bytes fails with `ENAMETOOLONG`, and `--default-capabilities` with a realistic caps blob is well past that, so an `ENOENT`-only check would break passing capabilities inline.

## Tests

- [x] `csv` and `json` are covered directly in a new `test/unit/schema/cli-transformers.spec.ts`: a directory stays a literal value, a real file is still read, and a JSON string longer than the max filename length still parses
- [x] `--allow-insecure` with a same-named directory in the cwd is covered in `parser.spec.ts`, alongside the existing `--default-capabilities` cases
- [x] the three new directory/length tests fail on `master` (two with `EISDIR`, one on the parser) and pass with this change
- [x] `npm run test:unit` in packages/appium, 67 pass in the two touched spec files; the remaining suite failures on Windows are pre-existing and unrelated (ESM loader in `extension-config.spec.ts`)
- [x] `npm run lint` clean
