### PR TITLE
fix(appium): match insecure feature prefixes by automationName, case-insensitively

### DIFF
--- a/packages/appium/lib/insecure-features.ts
+++ b/packages/appium/lib/insecure-features.ts
@@ -48,6 +48,9 @@ export function configureGlobalFeatures(this: AppiumDriver) {
  * @param driverName
  */
 export function configureDriverFeatures(this: AppiumDriver, driver: ExternalDriver, driverName: string) {
+  // the docs tell users to scope a feature with the driver's automationName, which is also what
+  // the driver itself compares against in `isFeatureEnabled`
+  const automationName = this.driverConfig?.installedExtensions?.[driverName]?.automationName;
   if (this.relaxedSecurityEnabled) {
     this.log.info(
       `Enabling relaxed security for this session as per the server configuration. ` +
@@ -55,13 +58,13 @@ export function configureDriverFeatures(this: AppiumDriver, driver: ExternalDriv
     );
     driver.relaxedSecurityEnabled = true;
   }
-  const allowedDriverFeatures = filterInsecureFeatures(this.allowInsecure, driverName);
+  const allowedDriverFeatures = filterInsecureFeatures(this.allowInsecure, driverName, automationName);
   if (!util.isEmpty(allowedDriverFeatures)) {
     this.log.info('Explicitly enabling insecure features for this session ' + 'as per the server configuration:');
     allowedDriverFeatures.forEach((a) => this.log.info(`    ${a}`));
     driver.allowInsecure = allowedDriverFeatures;
   }
-  const deniedDriverFeatures = filterInsecureFeatures(this.denyInsecure, driverName);
+  const deniedDriverFeatures = filterInsecureFeatures(this.denyInsecure, driverName, automationName);
   if (util.isEmpty(deniedDriverFeatures)) {
     return;
   }
@@ -97,20 +100,29 @@ function validateFeatures(features: string[]): string[] {
 
 /**
  * Filters the list of insecure features to only those that are
- * applicable to the given driver name.
+ * applicable to the given driver.
  * Assumes that all feature names have already been validated
+ *
+ * The prefix may be the driver's install name or its automationName, which is the one the
+ * security guide documents. Both are compared case-insensitively, like the prefix check
+ * `isFeatureEnabled` does on the driver side.
  *
  * @param features
  * @param driverName
+ * @param automationName
  */
-function filterInsecureFeatures(features: string[], driverName: string = ALL_DRIVERS_MATCH): string[] {
+function filterInsecureFeatures(features: string[], driverName?: string, automationName?: string): string[] {
+  const acceptedPrefixes = new Set(
+    [ALL_DRIVERS_MATCH, driverName, automationName]
+      .filter((name): name is string => Boolean(name))
+      .map((name) => name.toLowerCase()),
+  );
   const filterFn = (fullName: string) => {
     const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
     if (separatorPos <= 0) {
       return false;
     }
-    const automationName = fullName.substring(0, separatorPos);
-    return [driverName, ALL_DRIVERS_MATCH].includes(automationName);
+    return acceptedPrefixes.has(fullName.substring(0, separatorPos).toLowerCase());
   };
   return features.filter(filterFn);
 }

--- a/packages/appium/test/unit/appiumdriver.spec.ts
+++ b/packages/appium/test/unit/appiumdriver.spec.ts
@@ -309,7 +309,10 @@ describe('AppiumDriver', function () {
     describe('configureDriverFeatures', function () {
       let appium: InstanceType<typeof AppiumModule.AppiumDriver>;
 
-      async function getDriverInstance(appiumArgs: any): Promise<FakeDriver> {
+      async function getDriverInstance(
+        appiumArgs: any,
+        {driverName = 'fake', automationName = 'Fake'} = {},
+      ): Promise<FakeDriver> {
         appium = new AppiumDriver(appiumArgs);
         appium.configureGlobalFeatures();
         const fakeDriver = new FakeDriver();
@@ -320,10 +323,11 @@ describe('AppiumDriver', function () {
 
         // stub does not satisfy DriverConfig typing
         (appium as any).driverConfig = {
+          installedExtensions: {[driverName]: {automationName}},
           findMatchingDriver: sandbox.stub().returns({
             driver: mockedDriverReturnerClass,
             version: '1.2.3',
-            driverName: 'fake',
+            driverName,
           }),
         };
 
@@ -360,6 +364,25 @@ describe('AppiumDriver', function () {
       it(`should apply driver-scope insecure features only if the driver name matches`, async function () {
         fakeDriver = await getDriverInstance({allowInsecure: ['fake:foo', 'real:bar']});
         assert.deepStrictEqual(fakeDriver.allowInsecure, ['fake:foo']);
+      });
+
+      it(`should apply driver-scope features when the prefix is the automationName`, async function () {
+        // the docs tell users to prefix with the automationName, which does not have to be
+        // the name the driver is installed under
+        fakeDriver = await getDriverInstance(
+          {allowInsecure: ['MyAutomation:foo', 'real:bar']},
+          {driverName: 'my-driver', automationName: 'MyAutomation'},
+        );
+        assert.deepStrictEqual(fakeDriver.allowInsecure, ['MyAutomation:foo']);
+      });
+
+      it(`should match the feature prefix case-insensitively`, async function () {
+        fakeDriver = await getDriverInstance({
+          allowInsecure: ['FAKE:foo'],
+          denyInsecure: ['Fake:bar'],
+        });
+        assert.deepStrictEqual(fakeDriver.allowInsecure, ['FAKE:foo']);
+        assert.deepStrictEqual(fakeDriver.denyInsecure, ['Fake:bar']);
       });
     });
     describe('getAppiumSessions', function () {


### PR DESCRIPTION
The security guide says the prefix on `--allow-insecure` / `--deny-insecure` is the driver's `automationName`:

> The prefix can be either the driver's `automationName`, or the wildcard (`*`) symbol

But when a session starts, `filterInsecureFeatures` compares that prefix against the name the driver is installed under, and it does so case-sensitively. Those are two different strings: UiAutomator2 is installed as `uiautomator2` and its automationName is `UiAutomator2`.

So this:

```bash
appium --allow-insecure=UiAutomator2:adb_shell
```

is accepted at startup, the session starts fine, and `adb_shell` is never enabled. The entry is dropped while being copied onto the driver, and nothing is logged about it.

`isFeatureEnabled` on the driver side already lowercases the prefix before comparing, so the two ends of this disagreed.

This makes the filter accept either the install name or the automationName, and compares case-insensitively so it lines up with `isFeatureEnabled`. The automationName is read from the manifest via `findMatchingDriver`, not from the session capabilities, so nothing the client sends can influence which features get switched on.

Worth being precise about the scope: for every officially maintained driver the install name is just the lowercased automationName (`xcuitest`/`XCUITest`, `espresso`/`Espresso`), so in practice it is the case-sensitivity that bites people following the docs. The automationName lookup matters for third-party drivers that pick a `driverName` unrelated to their `automationName`, which the manifest allows.

Two tests added, both failing before the change:

- a driver installed as `my-driver` with automationName `MyAutomation`, allowed via `MyAutomation:foo`
- `FAKE:foo` and `Fake:bar` against a driver whose names are `fake` / `Fake`
