### PR TITLE
test: use native WebSocket client in e2e tests instead of ws

### DIFF
--- a/packages/base-driver/test/e2e/basedriver/websockets.e2e.spec.ts
+++ b/packages/base-driver/test/e2e/basedriver/websockets.e2e.spec.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import {after, before, describe, it} from 'node:test';
 
 import {getTestPort, TEST_HOST} from '@appium/driver-test-support';
-import WebSocket, {WebSocketServer} from 'ws';
+import {WebSocketServer} from 'ws';
 
 import {DEFAULT_WS_PATHNAME_PREFIX, routeConfiguringFunction, server} from '../../../lib/index.js';
 import {FakeDriver} from '../protocol/fake-driver.js';
@@ -34,7 +34,7 @@ describe('Websockets (e2e)', function () {
         noServer: true,
       });
       wss.on('connection', (ws) => {
-        if (ws && ws.readyState === WebSocket.OPEN) {
+        if (ws && ws.readyState === ws.OPEN) {
           ws.send(WS_DATA);
         }
       });
@@ -44,19 +44,16 @@ describe('Websockets (e2e)', function () {
       assert.strictEqual(Object.keys(await baseServer.getWebSocketHandlers()).length, 1);
       await new Promise<void>((resolve, reject) => {
         const client = new WebSocket(`ws://${TEST_HOST}:${port}${endpoint}`);
-        client.once('upgrade', (res) => {
-          try {
-            assert.strictEqual(res.statusCode, 101);
-          } catch (e) {
-            reject(e);
-          }
-        });
-        client.once('message', (data) => {
-          const dataStr = typeof data === 'string' ? data : data.toString();
-          assert.strictEqual(dataStr, WS_DATA);
-          resolve();
-        });
-        client.once('error', reject);
+        client.addEventListener(
+          'message',
+          (event) => {
+            const dataStr = typeof event.data === 'string' ? event.data : event.data.toString();
+            assert.strictEqual(dataStr, WS_DATA);
+            resolve();
+          },
+          {once: true},
+        );
+        client.addEventListener('error', () => reject(new Error('WebSocket connection error')), {once: true});
         setTimeout(() => reject(new Error('No websocket messages have been received after the timeout')), timeout);
       });
 
@@ -64,15 +61,15 @@ describe('Websockets (e2e)', function () {
       assert.strictEqual(Object.keys(await baseServer.getWebSocketHandlers()).length, 0);
       await new Promise<void>((resolve, reject) => {
         const client = new WebSocket(`ws://${TEST_HOST}:${port}${endpoint}`);
-        client.on('message', (data) =>
+        client.addEventListener('message', (event) =>
           reject(
             new Error(
               `No websocket messages are expected after the handler ` +
-                `has been removed. '${data}' is received instead. `,
+                `has been removed. '${event.data}' is received instead. `,
             ),
           ),
         );
-        client.on('error', resolve);
+        client.addEventListener('error', () => resolve());
         setTimeout(resolve, timeout);
       });
     });

--- a/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
+++ b/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
@@ -139,6 +139,8 @@ describe('StoragePlugin', function () {
           'message',
           async (event) => {
             const data = event.data;
+            // Native WebSocket.data for a text frame is always a plain string (never a Buffer),
+            // unlike 'ws', so only the string case needs handling here.
             if (typeof data !== 'string') {
               return;
             }

--- a/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
+++ b/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
@@ -8,7 +8,6 @@ import {pluginE2EHarness} from '@appium/plugin-test-support';
 import {fs, node, tempDir} from '@appium/support';
 import {exec} from 'teen_process';
 import {remote as wdio} from 'webdriverio';
-import {WebSocket} from 'ws';
 
 const BUFFER_SIZE = 0xffff;
 const THIS_PLUGIN_DIR = node.getModuleRootSync('@appium/storage-plugin', fileURLToPath(import.meta.url))!;
@@ -134,46 +133,50 @@ describe('StoragePlugin', function () {
     const eventsWs = new WebSocket(`ws://${TEST_HOST}:${WDIO_OPTS.port}${events}`);
     try {
       await new Promise<void>((resolve, reject) => {
-        streamWs.once('error', reject);
-        eventsWs.once('error', reject);
-        eventsWs.once('message', async (data: Buffer | string) => {
-          let strData: string;
-          if (Buffer.isBuffer(data)) {
-            strData = data.toString();
-          } else if (typeof data === 'string') {
-            strData = data;
-          } else {
-            return;
-          }
-          try {
-            const {value} = JSON.parse(strData);
-            if (value?.success) {
-              resolve();
-            } else {
-              reject(new Error(JSON.stringify(value)));
+        streamWs.addEventListener('error', () => reject(new Error('streamWs connection error')), {once: true});
+        eventsWs.addEventListener('error', () => reject(new Error('eventsWs connection error')), {once: true});
+        eventsWs.addEventListener(
+          'message',
+          async (event) => {
+            const data = event.data;
+            if (typeof data !== 'string') {
+              return;
             }
-          } catch {
-            // ignore
-          }
-        });
-        streamWs.once('open', async () => {
-          const fhandle = await fs.openFile(sourcePath, 'r');
-          try {
-            let bytesRead = 0;
-            while (bytesRead < size) {
-              const bufferSize = Math.min(BUFFER_SIZE, size - bytesRead);
-              const buffer = Buffer.alloc(bufferSize);
-              await fhandle.read(buffer, 0, bufferSize, bytesRead);
-              streamWs.send(buffer);
-              bytesRead += bufferSize;
+            try {
+              const {value} = JSON.parse(data);
+              if (value?.success) {
+                resolve();
+              } else {
+                reject(new Error(JSON.stringify(value)));
+              }
+            } catch {
+              // ignore
             }
-          } catch (e) {
-            reject(e);
-          } finally {
-            await fhandle.close();
-            streamWs.close();
-          }
-        });
+          },
+          {once: true},
+        );
+        streamWs.addEventListener(
+          'open',
+          async () => {
+            const fhandle = await fs.openFile(sourcePath, 'r');
+            try {
+              let bytesRead = 0;
+              while (bytesRead < size) {
+                const bufferSize = Math.min(BUFFER_SIZE, size - bytesRead);
+                const buffer = Buffer.alloc(bufferSize);
+                await fhandle.read(buffer, 0, bufferSize, bytesRead);
+                streamWs.send(buffer);
+                bytesRead += bufferSize;
+              }
+            } catch (e) {
+              reject(e);
+            } finally {
+              await fhandle.close();
+              streamWs.close();
+            }
+          },
+          {once: true},
+        );
       });
     } finally {
       streamWs.close();


### PR DESCRIPTION
Node 22+ ships a native WebSocket client global, so the outbound test sockets in these e2e specs no longer need the `ws` import. Server-side WebSocketServer/handleUpgrade usage is unaffected since Node has no native WebSocket server.