### PR TITLE
refactor!: remove deprecated driverData mechanism

### DIFF
--- a/packages/appium/docs/en/developing/build-drivers.md
+++ b/packages/appium/docs/en/developing/build-drivers.md
@@ -231,13 +231,10 @@ async createSession(w3cCaps) {
 
 !!! warning "Deprecated"
 
-    Older drivers may still define `createSession` with up to four parameters, e.g.
-    `createSession(jwpCaps, reqCaps, w3cCaps, otherDriverData)`. This shape is a holdover from the
-    retired JSON Wire Protocol, which required desired and required caps as the first two
-    arguments; only the first W3C-shaped argument was ever used. The `otherDriverData` parameter is
-    likewise deprecated in favor of [IPC](#send-messages-to-plugins-running-on-the-same-session) for
-    coordinating with other concurrently-running sessions. New drivers should use the single-argument
-    form shown above.
+    Older drivers may still define `createSession` with up to three parameters, e.g.
+    `createSession(jwpCaps, reqCaps, w3cCaps)`. This shape is a holdover from the retired JSON Wire
+    Protocol, which required desired and required caps as the first two arguments; only the first
+    W3C-shaped argument was ever used. New drivers should use the single-argument form shown above.
 
 You'll want to make sure to call `super.createSession` in order to get the session ID as well as
 the processed capabilities (note that capabilities are also set on `this.caps`; modifying `caps`
@@ -798,50 +795,19 @@ that multiple simultaneous sessions don't use the same resources:
 
 1. Have your users specify resource IDs via capabilities (`appium:driverPort` etc)
 1. Just always use free resources (find a new random port for each session)
-1. Have each driver express what resources it is using, then examine currently-used resources from
-   other drivers when a new session begins.
-
-!!! warning "Deprecated"
-
-    The `driverData`-based mechanism described below is deprecated. Prefer
-    [IPC](#send-messages-to-plugins-running-on-the-same-session) for coordinating resources across
-    concurrently-running sessions instead.
-
-To support this third strategy, you can implement `get driverData` in your driver to return what
-sorts of resources your driver is currently using, for example:
-
-```js
-get driverData() {
-  return {specialPort: 1234, specialFile: /path/to/file}
-}
-```
-
-Now, when a new session is started on your driver, the `driverData` response from any other
-simultaneously running drivers (of the same type) will also be included, as the last parameter of
-the deprecated, multi-argument form of the `createSession` method:
-
-```js
-async createSession(jwpCaps, reqCaps, w3cCaps, driverData)
-```
-
-You can dig into this `driverData` array to see what resources other drivers are using to help
-determine which ones you want to use for this particular session.
 
 !!! warning
 
-    Be careful here, since `driverData` is only passed between sessions of a single running Appium
-    server. There's nothing to stop a user from running multiple Appium servers and requesting your
-    driver simultaneously on each of them. In this case, you won't be able to ensure independence
-    of resources via `driverData`, so you might consider using file-based locking mechanisms or
-    something similar.
+    Appium doesn't provide any built-in mechanism for a driver to discover what resources other
+    concurrently-running sessions of the same driver are using. If you need this, consider
+    file-based locking or a similar out-of-process mechanism, since sessions may be running on
+    different Appium server processes entirely.
 
 !!! warning
 
-    It's also important to note you will only receive `driverData` for other instances of *your*
-    driver. So unrelated drivers also running may still be using some system resources. In general
-    Appium doesn't provide any features for ensuring unrelated drivers don't interfere with one
-    another, so it's up to the drivers to allow users to specify resource locations or addresses to
-    avoid clashes.
+    Appium also doesn't provide any features for ensuring unrelated drivers don't interfere with
+    one another, so it's up to the drivers to allow users to specify resource locations or
+    addresses to avoid clashes.
 
 ### Log events to the Appium event timeline
 

--- a/packages/appium/docs/en/developing/build-drivers.md
+++ b/packages/appium/docs/en/developing/build-drivers.md
@@ -799,9 +799,12 @@ that multiple simultaneous sessions don't use the same resources:
 !!! warning
 
     Appium doesn't provide any built-in mechanism for a driver to discover what resources other
-    concurrently-running sessions of the same driver are using. If you need this, consider
-    file-based locking or a similar out-of-process mechanism, since sessions may be running on
-    different Appium server processes entirely.
+    concurrently-running sessions of the same driver are using. This is *not* something the
+    [IPC feature](#send-messages-to-plugins-running-on-the-same-session) can help with either:
+    each session gets its own isolated IPC channel, shared only by the driver and plugins active
+    in that one session, so it cannot be used to coordinate across sessions. If you need
+    cross-session coordination, consider file-based locking or a similar out-of-process mechanism,
+    since sessions may even be running on different Appium server processes entirely.
 
 !!! warning
 
@@ -959,6 +962,9 @@ There are some important things to keep in mind when using Appium's IPC feature:
   It cannot be used statically or in `createSession` hooks
 - In sum, IPC is only for use during a session (this is also to prevent drivers/plugins from
   accessing or reading data sent on IPC channels in other sessions.)
+- Each session gets its own isolated IPC channel, shared only by the driver and plugins active
+  in that session. Even multiple concurrent sessions of the *same* driver do not share a channel,
+  so IPC cannot be used to coordinate state or resources across sessions.
 - The default max size of an IPC message is 1MB. This can be configured by the server-admin by
   using the `--max-ipc-data-size` arg (value is a number in bytes).
 - If a message exceeds the configured size, any call to `publish` methods will throw, so be

--- a/packages/appium/docs/en/developing/build-drivers.md
+++ b/packages/appium/docs/en/developing/build-drivers.md
@@ -795,16 +795,26 @@ that multiple simultaneous sessions don't use the same resources:
 
 1. Have your users specify resource IDs via capabilities (`appium:driverPort` etc)
 1. Just always use free resources (find a new random port for each session)
+1. Have each running instance of your driver publish and subscribe to messages on a shared IPC
+   channel, so sessions can coordinate directly with one another.
+
+The per-session IPC channel described in [Send messages to plugins running on the same
+session](#send-messages-to-plugins-running-on-the-same-session) is isolated per session, so it
+can't be used for this: it doesn't let you talk to *other* sessions of your driver. Instead,
+construct and hold on to your own `AppiumIpc` instance (exported from `appium/driver.js`) at
+module scope in your driver's package, for example as a memoized singleton. Since Node.js caches
+modules, every instance of your driver loaded within the same Appium server process will share
+that one `AppiumIpc` object, and can use it to publish and subscribe to topics across sessions —
+the same way the per-session channel works, just not scoped to a single session. See
+[xcuitest-driver's `session-claim-handler.ts`](https://github.com/appium/appium-xcuitest-driver/blob/master/lib/session-claim-handler.ts)
+for a real example, which uses this technique to detect and resolve conflicting sessions targeting
+the same device UDID.
 
 !!! warning
 
-    Appium doesn't provide any built-in mechanism for a driver to discover what resources other
-    concurrently-running sessions of the same driver are using. This is *not* something the
-    [IPC feature](#send-messages-to-plugins-running-on-the-same-session) can help with either:
-    each session gets its own isolated IPC channel, shared only by the driver and plugins active
-    in that one session, so it cannot be used to coordinate across sessions. If you need
-    cross-session coordination, consider file-based locking or a similar out-of-process mechanism,
-    since sessions may even be running on different Appium server processes entirely.
+    This only works for sessions running within the same Node.js process (i.e. the same Appium
+    server). It cannot coordinate sessions running on different Appium server processes; for that,
+    consider file-based locking or a similar out-of-process mechanism.
 
 !!! warning
 
@@ -958,13 +968,15 @@ export type IpcMessage<T> = {
 #### IPC Notes
 
 There are some important things to keep in mind when using Appium's IPC feature:
-- IPC is only available once `onIpcInit` has been called, at the end of the `createSession` flow.
-  It cannot be used statically or in `createSession` hooks
-- In sum, IPC is only for use during a session (this is also to prevent drivers/plugins from
-  accessing or reading data sent on IPC channels in other sessions.)
-- Each session gets its own isolated IPC channel, shared only by the driver and plugins active
-  in that session. Even multiple concurrent sessions of the *same* driver do not share a channel,
-  so IPC cannot be used to coordinate state or resources across sessions.
+- The `ipcSubscribe` method (and the IPC channel it subscribes to) is only available once
+  `onIpcInit` has been called, at the end of the `createSession` flow. It cannot be used statically
+  or in `createSession` hooks
+- The channel that `ipcSubscribe` gives you access to is scoped to the current session, and is
+  shared only with the plugins active in that same session (this is also to prevent drivers/plugins
+  from accessing or reading data sent on IPC channels in other sessions.) To coordinate across
+  multiple concurrent sessions of your own driver instead, see [Make itself aware of resources
+  other concurrent drivers are
+  using](#make-itself-aware-of-resources-other-concurrent-drivers-are-using).
 - The default max size of an IPC message is 1MB. This can be configured by the server-admin by
   using the `--max-ipc-data-size` arg (value is a number in bytes).
 - If a message exceeds the configured size, any call to `publish` methods will throw, so be

--- a/packages/appium/lib/appium.ts
+++ b/packages/appium/lib/appium.ts
@@ -4,7 +4,6 @@ import {
   CREATE_SESSION_COMMAND,
   DELETE_SESSION_COMMAND,
   DriverCore,
-  errors,
   type ExtensionCore,
   generateDriverLogPrefix,
   GET_STATUS_COMMAND,
@@ -20,7 +19,6 @@ import {util} from '@appium/support';
 import type {
   AppiumServer,
   DriverCaps,
-  DriverData,
   DriverOpts,
   ExternalDriver,
   IAppiumIpc,
@@ -48,7 +46,7 @@ import {
 import * as insecureFeatures from './insecure-features.js';
 import * as inspectorCommands from './inspector-commands.js';
 import {getDefaultsForExtension} from './schema/index.js';
-import {compact, pickBy, pull} from './utils/index.js';
+import {pickBy} from './utils/index.js';
 
 const desiredCapabilityConstraints = {
   automationName: {
@@ -101,8 +99,6 @@ type IpcAssignable = {
  */
 export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
   readonly sessions: Record<string, ExternalDriver> = {};
-
-  readonly pendingDrivers: Record<string, ExternalDriver[]> = {};
 
   /**
    * The umbrella driver does not observe its own command timeout; inner session drivers do.
@@ -335,9 +331,6 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
         await this.deleteAllSessions();
       }
 
-      let runningDriversData: DriverData[] = [];
-      let otherPendingDriversData: DriverData[] = [];
-
       const driverInstance = new InnerDriver(this.args, true) as unknown as ExternalDriver;
 
       this.configureDriverFeatures(driverInstance, driverName);
@@ -365,37 +358,22 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
       driverInstance.serverPort = this.args.port;
       driverInstance.serverPath = this.args.basePath;
 
-      try {
-        runningDriversData = (await this.curSessionDataForDriver(InnerDriver)) ?? [];
-      } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
-        throw new errors.SessionNotCreatedError(msg);
-      }
-      this.pendingDrivers[InnerDriver.name] = this.pendingDrivers[InnerDriver.name] || [];
-      otherPendingDriversData = compact(this.pendingDrivers[InnerDriver.name].map((drv) => drv.driverData));
-      this.pendingDrivers[InnerDriver.name].push(driverInstance);
-
-      try {
-        [innerSessionId, dCaps] = (await driverInstance.createSession(
-          processedW3CCapabilities as never,
-          processedW3CCapabilities,
-          processedW3CCapabilities,
-          [...runningDriversData, ...otherPendingDriversData],
-        )) as [string, DriverCaps<AppiumDriverConstraints> & {webSocketUrl?: string | boolean}];
-        this.sessions[innerSessionId] = driverInstance;
-        // create an IPC channel for the driver and all plugins on this session
-        this.sessionIpcs[innerSessionId] = new AppiumIpc({
-          maxObjSize: this.args.maxIpcDataSize,
-          maxTopics: this.args.maxIpcTopics,
-          log: driverInstance.log,
-        });
-        const extDriver = driverInstance as unknown as IpcAssignable;
-        if (typeof extDriver.assignIpc === 'function') {
-          // TODO remove this existence guard as a breaking change in Appium 3
-          await extDriver.assignIpc(this.sessionIpcs[innerSessionId]);
-        }
-      } finally {
-        pull(this.pendingDrivers[InnerDriver.name], driverInstance);
+      [innerSessionId, dCaps] = (await driverInstance.createSession(
+        processedW3CCapabilities as never,
+        processedW3CCapabilities,
+        processedW3CCapabilities,
+      )) as [string, DriverCaps<AppiumDriverConstraints> & {webSocketUrl?: string | boolean}];
+      this.sessions[innerSessionId] = driverInstance;
+      // create an IPC channel for the driver and all plugins on this session
+      this.sessionIpcs[innerSessionId] = new AppiumIpc({
+        maxObjSize: this.args.maxIpcDataSize,
+        maxTopics: this.args.maxIpcTopics,
+        log: driverInstance.log,
+      });
+      const extDriver = driverInstance as unknown as IpcAssignable;
+      if (typeof extDriver.assignIpc === 'function') {
+        // TODO remove this existence guard as a breaking change in Appium 3
+        await extDriver.assignIpc(this.sessionIpcs[innerSessionId]);
       }
 
       this.attachUnexpectedShutdownHandler(driverInstance, innerSessionId);
@@ -484,41 +462,14 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
   }
 
   /**
-   * Collects `driverData` for every active session whose driver class matches `InnerDriver.name`
-   * (used when creating another session of the same driver type).
-   * @remarks `InnerDriver` is expected to be the driver class; only `.name` is read.
-   */
-  async curSessionDataForDriver(InnerDriver: {name: string}): Promise<DriverData[]> {
-    const data = compact(
-      Object.values(this.sessions)
-        .filter((s) => s.constructor.name === InnerDriver.name)
-        .map((s) => s.driverData),
-    );
-    for (const datum of data) {
-      if (!datum) {
-        throw new Error(
-          `Problem getting session data for driver type ` + `${InnerDriver.name}; does it implement 'get driverData'?`,
-        );
-      }
-    }
-    return data;
-  }
-
-  /**
    * Ends one session: removes it from the master list immediately, then delegates to the inner
-   * driver’s `deleteSession` with sibling-session metadata.
+   * driver’s `deleteSession`.
    */
   async deleteSession(sessionId: string): Promise<SessionHandlerDeleteResult> {
     let protocol: Protocol | undefined;
     try {
-      let otherSessionsData: DriverData[] | undefined;
-      let dstSession: ExternalDriver | undefined;
-      if (this.sessions[sessionId]) {
-        const curConstructorName = this.sessions[sessionId].constructor.name;
-        otherSessionsData = Object.entries(this.sessions)
-          .filter(([key, value]) => value.constructor.name === curConstructorName && key !== sessionId)
-          .map(([, value]) => value.driverData);
-        dstSession = this.sessions[sessionId];
+      const dstSession: ExternalDriver | undefined = this.sessions[sessionId];
+      if (dstSession) {
         protocol = dstSession.protocol;
         this.cleanupBidiSockets(sessionId);
       }
@@ -530,7 +481,7 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
 
       return {
         protocol,
-        value: await dstSession.deleteSession(sessionId, otherSessionsData),
+        value: await dstSession.deleteSession(sessionId),
       };
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/packages/appium/test/e2e/driver.e2e.spec.ts
+++ b/packages/appium/test/e2e/driver.e2e.spec.ts
@@ -331,16 +331,6 @@ describe('FakeDriver via HTTP', function () {
       await driver2.deleteSession();
     });
 
-    it('should not be able to run two FakeDriver sessions simultaneously when one is unique', async function () {
-      const uniqueCaps = structuredClone(caps);
-      uniqueCaps['appium:uniqueApp'] = true;
-      const driver1 = await wdio({...wdOpts, capabilities: uniqueCaps});
-      assert.ok(driver1.sessionId);
-      assert.strictEqual(typeof driver1.sessionId, 'string');
-      await assert.rejects(wdio({...wdOpts, capabilities: caps}));
-      await driver1.deleteSession();
-    });
-
     it('should use the newCommandTimeout of the inner Driver on session creation', async function () {
       const localCaps = {
         'appium:newCommandTimeout': 0.25,

--- a/packages/appium/test/unit/appiumdriver.spec.ts
+++ b/packages/appium/test/unit/appiumdriver.spec.ts
@@ -185,7 +185,7 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withExactArgs(W3C_CAPS, W3C_CAPS, W3C_CAPS, [])
+          .withExactArgs(W3C_CAPS, W3C_CAPS, W3C_CAPS)
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS as NSCapabilities<Constraints>)]);
         await appium.createSession(W3C_CAPS);
         mockFakeDriver.verify();
@@ -241,7 +241,7 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withExactArgs(W3C_CAPS, W3C_CAPS, W3C_CAPS, [])
+          .withExactArgs(W3C_CAPS, W3C_CAPS, W3C_CAPS)
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS as NSCapabilities<Constraints>)]);
         await appium.createSession(W3C_CAPS, W3C_CAPS, W3C_CAPS);
 
@@ -319,7 +319,7 @@ describe('AppiumDriver', function () {
       });
       it("should call inner driver's deleteSession method", async function () {
         const [sessionId] = (await appium.createSession(null as any, null as any, W3C_CAPS)).value!;
-        mockFakeDriver.expects('deleteSession').once().withExactArgs(sessionId, []).returns(undefined);
+        mockFakeDriver.expects('deleteSession').once().withExactArgs(sessionId).returns(undefined);
         await appium.deleteSession(sessionId);
         mockFakeDriver.verify();
 
@@ -351,7 +351,7 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withExactArgs(undefined, null, W3C_CAPS, [])
+          .withExactArgs(undefined, null, W3C_CAPS)
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS as NSCapabilities<Constraints>)]);
         await appium.createSession(undefined as any, null as any, W3C_CAPS);
 

--- a/packages/base-driver/lib/basedriver/core.ts
+++ b/packages/base-driver/lib/basedriver/core.ts
@@ -136,18 +136,6 @@ export class DriverCore<const C extends Constraints, Settings extends StringReco
   }
 
   /**
-   * This property is used by AppiumDriver to store the data of the
-   * specific driver sessions. This data can be later used to adjust
-   * properties for driver instances running in parallel.
-   * Override it in inherited driver classes if necessary.
-   *
-   * @deprecated Use {@linkcode IAppiumIpc} for cross-session coordination instead.
-   */
-  get driverData() {
-    return {};
-  }
-
-  /**
    * This property controls the way the `executeCommand` method
    * handles new driver commands received from the client.
    * Override it for inherited classes only in special cases.

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -285,8 +285,7 @@ export class BaseDriver<
    * @deprecated Historically the first three arguments were reserved for JSONWP capabilities.
    * Appium 2 dropped support for that protocol; these positions are now intended to carry the
    * same W3C capabilities value, and if they differ, which one wins is unspecified. Use the
-   * single-argument overload of {@linkcode createSession} instead. The `driverData` parameter is
-   * also deprecated; use {@linkcode IAppiumIpc} for cross-session coordination instead.
+   * single-argument overload of {@linkcode createSession} instead.
    */
   async createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult>;
   async createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult> {

--- a/packages/fake-driver/lib/desired-caps.ts
+++ b/packages/fake-driver/lib/desired-caps.ts
@@ -5,9 +5,6 @@ export const desiredCapConstraints = {
     presence: true,
     isString: true,
   },
-  uniqueApp: {
-    isBoolean: true,
-  },
   runClock: {
     isBoolean: true,
   },

--- a/packages/fake-driver/lib/driver.ts
+++ b/packages/fake-driver/lib/driver.ts
@@ -197,11 +197,10 @@ export class FakeDriver<Thing extends IpcData = null> extends BaseDriver<FakeDri
     w3cCapabilities2?: W3CFakeDriverCaps,
     w3cCapabilities3?: W3CFakeDriverCaps,
   ): Promise<[string, FakeDriverCaps]> {
-    const [sessionId, caps] = (await super.createSession(
-      w3cCapabilities1,
-      w3cCapabilities2,
-      w3cCapabilities3,
-    )) as [string, FakeDriverCaps];
+    const [sessionId, caps] = (await super.createSession(w3cCapabilities1, w3cCapabilities2, w3cCapabilities3)) as [
+      string,
+      FakeDriverCaps,
+    ];
     this.caps = caps;
     await this.appModel.loadApp(caps.app);
     if (this.caps.runClock) {

--- a/packages/fake-driver/lib/driver.ts
+++ b/packages/fake-driver/lib/driver.ts
@@ -1,7 +1,7 @@
 import type {Server as HttpServer} from 'node:http';
 
-import type {DriverData, IIpcSubscription, InitialOpts, IpcData, IpcMessage} from '@appium/types';
-import {BaseDriver, errors} from 'appium/driver.js';
+import type {IIpcSubscription, InitialOpts, IpcData, IpcMessage} from '@appium/types';
+import {BaseDriver} from 'appium/driver.js';
 import {sleep} from 'asyncbox';
 import type {Express, Request, Response} from 'express';
 
@@ -137,12 +137,6 @@ export class FakeDriver<Thing extends IpcData = null> extends BaseDriver<FakeDri
     return this._bidiProxyUrl;
   }
 
-  override get driverData(): {isUnique: boolean} {
-    return {
-      isUnique: !!this.caps.uniqueApp,
-    };
-  }
-
   static fakeRoute(_req: Request, res: Response): void {
     res.send(JSON.stringify({fakedriver: 'fakeResponse'}));
   }
@@ -202,21 +196,11 @@ export class FakeDriver<Thing extends IpcData = null> extends BaseDriver<FakeDri
     w3cCapabilities1: W3CFakeDriverCaps,
     w3cCapabilities2?: W3CFakeDriverCaps,
     w3cCapabilities3?: W3CFakeDriverCaps,
-    driverData: DriverData[] = [],
   ): Promise<[string, FakeDriverCaps]> {
-    for (const d of driverData) {
-      if (d.isUnique) {
-        throw new errors.SessionNotCreatedError(
-          'Cannot start session; another ' + 'unique session is in progress that requires all resources',
-        );
-      }
-    }
-
     const [sessionId, caps] = (await super.createSession(
       w3cCapabilities1,
       w3cCapabilities2,
       w3cCapabilities3,
-      driverData,
     )) as [string, FakeDriverCaps];
     this.caps = caps;
     await this.appModel.loadApp(caps.app);

--- a/packages/fake-driver/test/unit/driver.spec.ts
+++ b/packages/fake-driver/test/unit/driver.spec.ts
@@ -524,27 +524,6 @@ describe('.isFeatureEnabled', function () {
 });
 
 describe('FakeDriver', function () {
-  it('should not start a session when a unique session is already running', async function () {
-    const d1 = new FakeDriver();
-    const [uniqueSession] = await d1.createSession(null as any, null as any, {
-      alwaysMatch: {
-        ...structuredClone(W3C_PREFIXED_CAPS),
-        'appium:uniqueApp': true,
-      },
-      firstMatch: [{}],
-    });
-    assert.strictEqual(typeof uniqueSession, 'string');
-    const d2 = new FakeDriver();
-    const otherSessionData = [d1.driverData];
-    try {
-      await assert.rejects(
-        d2.createSession(null as any, null as any, structuredClone(W3C_CAPS), otherSessionData),
-        /unique/,
-      );
-    } finally {
-      await d1.deleteSession(uniqueSession);
-    }
-  });
   it('should start a new session when another non-unique session is running', async function () {
     const d1 = new FakeDriver();
     const [session1Id] = await d1.createSession(null as any, null as any, structuredClone(W3C_CAPS));

--- a/packages/types/lib/commands/basedriver.ts
+++ b/packages/types/lib/commands/basedriver.ts
@@ -330,7 +330,6 @@ export type LegacyCreateSessionArgs<C extends Constraints> = [
   w3cCaps1: W3CDriverCaps<C>,
   w3cCaps2?: W3CDriverCaps<C>,
   w3cCaps3?: W3CDriverCaps<C>,
-  driverData?: DriverData[],
 ];
 
 /**
@@ -354,8 +353,7 @@ export interface ISessionHandler<
    * @deprecated Historically this method accepted the same W3C capabilities object in up to three
    * positions to support the retired JSONWP protocol. These positions are intended to carry the
    * same value; if they differ, which one wins is unspecified. Use the single-argument overload
-   * of {@linkcode createSession} instead. The `driverData` parameter is also deprecated; use
-   * {@linkcode IAppiumIpc} for cross-session coordination instead.
+   * of {@linkcode createSession} instead.
    *
    * @param legacyArgs - see {@linkcode LegacyCreateSessionArgs}
    * @returns The capabilities object representing the created session
@@ -369,14 +367,6 @@ export interface ISessionHandler<
    * @param sessionId - the id of the session that is to be deleted
    */
   deleteSession(sessionId?: string): Promise<DeleteResult | void>;
-  /**
-   * @deprecated The `driverData` parameter is unused by {@linkcode BaseDriver}; use
-   * {@linkcode IAppiumIpc} for cross-session coordination instead.
-   *
-   * @param sessionId - the id of the session that is to be deleted
-   * @param driverData - the driver data for other currently-running sessions
-   */
-  deleteSession(sessionId?: string, driverData?: DriverData[]): Promise<DeleteResult | void>;
 
   /**
    * Get the data for the current session
@@ -402,13 +392,6 @@ export type DefaultCreateSessionResult<C extends Constraints> = [sessionId: stri
  * @see {@linkcode ISessionHandler}
  */
 export type DefaultDeleteSessionResult = void;
-
-/**
- * Custom session data for a driver.
- *
- * @deprecated Use {@linkcode IAppiumIpc} for cross-session coordination instead.
- */
-export type DriverData = Record<string, unknown>;
 
 /**
  * Data returned by {@linkcode ISessionHandler.getSession}.

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -8,7 +8,6 @@ import type {BidiModuleMap, BiDiResultData, ExecuteMethodMap, MethodMap} from '.
 import type {
   DefaultCreateSessionResult,
   DefaultDeleteSessionResult,
-  DriverData,
   EventHistory,
   IAppiumCommands,
   IImplementedCommands,
@@ -71,10 +70,6 @@ export interface Core<C extends Constraints, Settings extends StringRecord = Str
   eventEmitter: EventEmitter;
   settings: IDeviceSettings<Settings>;
   log: AppiumLogger;
-  /**
-   * @deprecated Use {@linkcode IAppiumIpc} for cross-session coordination instead.
-   */
-  driverData: DriverData;
   isCommandsQueueEnabled: boolean;
   eventHistory: EventHistory;
   bidiEventSubs: Record<string, string[]>;


### PR DESCRIPTION
## Summary

- Removes the deprecated `driverData` mechanism (`Core.driverData`, the `driverData` param on `createSession`/`deleteSession`, and the `DriverData` type from `@appium/types`), which was superseded by `IAppiumIpc` for cross-session coordination.
- Drops `FakeDriver`'s `uniqueApp` capability and exclusivity check, the only real consumer of `driverData` — its cross-session coordination has no working replacement in the current `IAppiumIpc`, since IPC channels are scoped per-session and only wired up *after* `createSession` resolves.
- Updates the fake-driver unit test and appium e2e test that exercised `uniqueApp`, and the appium unit test mocks that asserted on the old `driverData` args.

BREAKING CHANGE: `Core.driverData`, `DriverData`, and the `driverData` parameter on `ISessionHandler.createSession`/`deleteSession` are gone. Any driver overriding `get driverData()` or relying on the umbrella driver passing sibling-session data into `createSession`/`deleteSession` needs to migrate off this mechanism.
BREAKING CHANGE: `FakeDriver` no longer supports the `uniqueApp` capability.
