### PR TITLE
fix(strongbox): reject item names that slugify to an empty path

### DIFF
--- a/packages/strongbox/lib/index.ts
+++ b/packages/strongbox/lib/index.ts
@@ -223,6 +223,10 @@ export class Strongbox<Options extends StrongboxOpts = StrongboxOpts> implements
       encoding = encodingOrCtor;
       encodingOrCtor = this.defaultItemCtor;
     }
+    if (!slugify(name)) {
+      // the slug is the filename; an empty one would resolve to the container directory itself
+      throw new TypeError(`Item name '${name}' must contain at least one alphanumeric character`);
+    }
     const item = new (encodingOrCtor ?? (this.defaultItemCtor as ItemCtor<T>))(name, this, encoding);
     if (this.getLiveItem(item.id)) {
       throw new ReferenceError(`Item with id "${item.id}" already exists`);
@@ -388,7 +392,8 @@ export class Strongbox<Options extends StrongboxOpts = StrongboxOpts> implements
       throw e;
     }
     for await (const ent of dir) {
-      if (ent.isFile()) {
+      // a basename with no alphanumerics has no slug, so it cannot belong to an item
+      if (ent.isFile() && slugify(ent.name)) {
         yield ent.name;
       }
     }

--- a/packages/strongbox/test/unit/strongbox.spec.ts
+++ b/packages/strongbox/test/unit/strongbox.spec.ts
@@ -193,6 +193,17 @@ describe('Strongbox', function () {
           assert.strictEqual(item.encoding, 'base64');
         });
       });
+
+      describe('when the name has no alphanumeric characters', function () {
+        it('should reject instead of pointing the item at the container', async function () {
+          for (const name of ['---', '@#$', ' ', '']) {
+            await assert.rejects(box.createItem(name), {
+              name: 'TypeError',
+              message: `Item name '${name}' must contain at least one alphanumeric character`,
+            });
+          }
+        });
+      });
     });
 
     describe('clearAll()', function () {
@@ -281,6 +292,15 @@ describe('Strongbox', function () {
           ['zebra', 'alpha'],
         );
         assert.strictEqual(MockFs.opendir.calledWith(box.container), true);
+      });
+
+      it('should skip files whose name has no alphanumeric characters', async function () {
+        mockOpendir([dirent('good'), dirent('_')]);
+        const items = await box.listItems();
+        assert.deepStrictEqual(
+          items.map((i) => i.name),
+          ['good'],
+        );
       });
 
       it('should return an empty array when the container does not exist', async function () {


### PR DESCRIPTION
If an item name has no alphanumeric characters, `slugify()` returns an empty string and `path.join(container, '')` resolves to the container directory itself. So `createItem('---')` gives you an item whose `id` is the strongbox root, not a file inside it. Read and write then hit the wrong path.

The same thing shows up when listing. A file named `_` in the container gets picked up by `listItems()`, slugifies to nothing, and comes back as an item pointing at the container again.

This rejects those names in `createItem()` and skips un-slugifiable basenames when walking the directory. `slugify()` itself is unchanged so other callers like `suffix: ''` are not affected.

Two tests added, both failing on master:

- `createItem('---')` (and `@#$`, whitespace, empty string) throws instead of returning an item at the container path
- `listItems()` with a `good` file and a `_` file returns only `good`
