### PR TITLE
refactor(base-plugin)!: remove deprecated legacy logger and default export

### DIFF
--- a/packages/appium/docs/en/developing/build-plugins.md
+++ b/packages/appium/docs/en/developing/build-plugins.md
@@ -257,7 +257,7 @@ throw new errors.NoSuchElementError();
 ### Log messages to the Appium log
 
 You can always use `console.log`, of course, but Appium provides a nice logger for you as
-`this.logger` (it has `.info`, `.debug`, `.log`, `.warn`, `.error` methods on it for differing log
+`this.log` (it has `.info`, `.debug`, `.warn`, `.error` methods on it for differing log
 levels). If you want to create an Appium logger outside of a plugin context (say in a script or
 helper file), you can always construct your own too:
 

--- a/packages/appium/plugin.d.ts
+++ b/packages/appium/plugin.d.ts
@@ -1,2 +1,1 @@
 export * from '@appium/base-plugin';
-export {default} from '@appium/base-plugin';

--- a/packages/appium/plugin.js
+++ b/packages/appium/plugin.js
@@ -8,4 +8,3 @@
  * import { BasePlugin } from 'appium/plugin.js';
  */
 export * from '@appium/base-plugin';
-export {default} from '@appium/base-plugin';

--- a/packages/base-plugin/lib/index.ts
+++ b/packages/base-plugin/lib/index.ts
@@ -1,7 +1,7 @@
 import {realpathSync} from 'node:fs';
 import {fileURLToPath} from 'node:url';
 
-export {BasePlugin, default} from './plugin.js';
+export {BasePlugin} from './plugin.js';
 
 // Handle smoke test flag. realpath() both sides so this still matches when invoked through a
 // bin symlink, since `import.meta.url` resolves symlinks but `process.argv[1]` does not.

--- a/packages/base-plugin/lib/plugin.ts
+++ b/packages/base-plugin/lib/plugin.ts
@@ -1,6 +1,6 @@
 import {ExtensionCore, generateDriverLogPrefix, validateExecuteMethodParams} from '@appium/base-driver';
+import {node} from '@appium/support';
 import type {
-  AppiumLogger,
   Constraints,
   Driver,
   ExecuteMethodMap,
@@ -24,13 +24,8 @@ export class BasePlugin extends ExtensionCore implements Plugin {
 
   static executeMethodMap: ExecuteMethodMap<BasePluginMapType> = {};
 
-  name: string;
-  cliArgs: Record<string, unknown>;
-
-  /**
-   * @deprecated Use this.log instead of this.logger
-   */
-  declare logger: AppiumLogger;
+  readonly name: string;
+  readonly cliArgs: Readonly<Record<string, unknown>>;
 
   constructor(name: string, cliArgs: Record<string, unknown> = {}, driverId: string | null = null) {
     super();
@@ -38,8 +33,7 @@ export class BasePlugin extends ExtensionCore implements Plugin {
       this.updateLogPrefix(`${generateDriverLogPrefix(this)} <${driverId}>`);
     }
     this.name = name;
-    this.cliArgs = cliArgs;
-    this.logger = this.log;
+    this.cliArgs = node.deepFreeze({...cliArgs});
   }
 
   /**
@@ -65,5 +59,3 @@ export class BasePlugin extends ExtensionCore implements Plugin {
     return await command.call(this, next, driver, ...args);
   }
 }
-
-export default BasePlugin;

--- a/packages/types/lib/plugin.ts
+++ b/packages/types/lib/plugin.ts
@@ -2,7 +2,6 @@ import type {AsyncReturnType} from 'type-fest';
 
 import type {BidiModuleMap, ExecuteMethodMap, MethodMap} from './command-maps.js';
 import type {DriverCommand, ExternalDriver} from './driver.js';
-import type {AppiumLogger} from './logger.js';
 import type {UpdateServerCallback} from './server.js';
 import type {Class, StringRecord} from './util.js';
 /**
@@ -68,13 +67,9 @@ export interface Plugin {
    */
   name: string;
   /**
-   * A logger with prefix identifying the plugin
-   */
-  logger: AppiumLogger;
-  /**
    * CLI args for this plugin (if any are accepted and provided).
    */
-  cliArgs: Record<string, any>;
+  cliArgs: Readonly<Record<string, any>>;
   /**
    * Listener for unexpected server shutdown, which allows a plugin to do cleanup or take custom actions.
    */


### PR DESCRIPTION
`this.logger` on plugins is removed in favor of `this.log`, and `@appium/base-plugin` no longer has a default export. `name` and `cliArgs` are now readonly, with `cliArgs` deep-frozen to prevent external mutation.

BREAKING CHANGE: `Plugin#logger` has been removed; use `Plugin#log` instead. 
BREAKING CHANGE: `@appium/base-plugin` no longer exports `BasePlugin` as the default export; use the named `BasePlugin` export.
