### PR TITLE
refactor(logger)!: remove default exports and dead logging APIs

### DIFF
--- a/packages/appium/lib/logsink.ts
+++ b/packages/appium/lib/logsink.ts
@@ -1,4 +1,4 @@
-import globalLog, {type MessageObject} from '@appium/logger';
+import {log as globalLog, type MessageObject} from '@appium/logger';
 import {fs, util} from '@appium/support';
 import type {ParsedArgs} from 'appium/types/index.js';
 import {LRUCache} from 'lru-cache';

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -11,7 +11,7 @@ npm install @appium/logger --save
 ## Basic Usage
 
 ```js
-import log from '@appium/logger';
+import {log} from '@appium/logger';
 
 // additional stuff ---------------------------+
 // message ----------+                         |

--- a/packages/logger/lib/index.ts
+++ b/packages/logger/lib/index.ts
@@ -1,6 +1,4 @@
 export {markSensitive} from './log.js';
 export type * from './types.js';
 
-import log from './log.js';
-export {log};
-export default log;
+export {GLOBAL_LOG as log} from './log.js';

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -45,15 +45,15 @@ export class Log extends EventEmitter implements Logger {
   heading: string;
   stream: Writable | null; // Defaults to process.stderr; set to null when using custom output (e.g. Winston)
 
-  _asyncStorage: AsyncLocalStorage<Record<string, any>>;
-  _colorEnabled?: boolean;
-  _buffer: MessageObject[];
-  _style: Record<LogLevel | string, StyleObject | undefined>;
-  _levels: Record<LogLevel | string, number>;
-  _disp: Record<LogLevel | string, number | string>;
-  _id: number;
-  _paused: boolean;
-  _secureValuesPreprocessor: SecureValuesPreprocessor;
+  private _asyncStorage: AsyncLocalStorage<Record<string, any>>;
+  private _colorEnabled?: boolean;
+  private _buffer: MessageObject[];
+  private _style: Record<LogLevel | string, StyleObject | undefined>;
+  private _levels: Record<LogLevel | string, number>;
+  private _disp: Record<LogLevel | string, number | string>;
+  private _id: number;
+  private _paused: boolean;
+  private _secureValuesPreprocessor: SecureValuesPreprocessor;
 
   private _history: LRUCache<number, MessageObject>;
   private _maxRecordSize: number;
@@ -127,15 +127,6 @@ export class Log extends EventEmitter implements Logger {
 
   disableColor(): void {
     this._colorEnabled = false;
-  }
-
-  // this functionality has been deliberately disabled
-  enableUnicode(): void {}
-  disableUnicode(): void {}
-  enableProgress(): void {}
-  disableProgress(): void {}
-  progressEnabled(): boolean {
-    return false;
   }
 
   /**
@@ -305,7 +296,6 @@ export class Log extends EventEmitter implements Logger {
     // If 'disp' is null or undefined, use the lvl as a default
     // Allows: '', 0 as valid disp
     const disp = this._disp[m.level];
-    this.clearProgress();
     for (const line of m.message.split(/\r?\n/)) {
       const heading = this.heading;
       if (heading) {
@@ -321,7 +311,6 @@ export class Log extends EventEmitter implements Logger {
       this.write(p, this.prefixStyle);
       this.write(` ${line}\n`);
     }
-    this.showProgress();
   }
 
   private _format(msg: string, style: StyleObject = {}): string | undefined {
@@ -404,10 +393,6 @@ export class Log extends EventEmitter implements Logger {
 
     return result;
   }
-
-  // this functionality has been deliberately disabled
-  private clearProgress(): void {}
-  private showProgress(): void {}
 }
 
 /**
@@ -433,4 +418,3 @@ export const GLOBAL_LOG =
     g[GLOBAL_NPMLOG_KEY] = log;
     return log;
   })();
-export default GLOBAL_LOG;

--- a/packages/logger/lib/types.ts
+++ b/packages/logger/lib/types.ts
@@ -43,13 +43,6 @@ export interface Logger extends EventEmitter {
   enableColor(): void;
   disableColor(): void;
 
-  enableProgress(): void;
-  disableProgress(): void;
-  progressEnabled(): boolean;
-
-  enableUnicode(): void;
-  disableUnicode(): void;
-
   pause(): void;
   resume(): void;
 

--- a/packages/logger/test/unit/basic.spec.ts
+++ b/packages/logger/test/unit/basic.spec.ts
@@ -185,9 +185,9 @@ describe('basic', function () {
     it('_buffer while paused', function () {
       log.pause();
       log.log('verbose', 'test', 'test log');
-      assert.strictEqual(log._buffer.length, 1);
+      assert.strictEqual((log as any)._buffer.length, 1);
       log.resume();
-      assert.strictEqual(log._buffer.length, 0);
+      assert.strictEqual((log as any)._buffer.length, 0);
     });
   });
 

--- a/packages/support/lib/logging.ts
+++ b/packages/support/lib/logging.ts
@@ -1,4 +1,4 @@
-import globalLog, {type Logger, markSensitive as _markSensitive} from '@appium/logger';
+import {log as globalLog, type Logger, markSensitive as _markSensitive} from '@appium/logger';
 import type {AppiumLogger, AppiumLoggerContext, AppiumLoggerLevel, AppiumLoggerPrefix} from '@appium/types';
 
 export const LEVELS: readonly AppiumLoggerLevel[] = ['silly', 'verbose', 'debug', 'info', 'http', 'warn', 'error'];
@@ -39,9 +39,6 @@ export function getLogger(prefix: AppiumLoggerPrefix | null = null): AppiumLogge
     errorWithException(...args: any[]) {
       this.error(...args);
       return args[0] instanceof Error ? args[0] : new Error(args.join('\n'));
-    },
-    errorAndThrow(...args: any[]) {
-      throw this.errorWithException(...args);
     },
     updateAsyncContext(contextInfo: AppiumLoggerContext, replace = false) {
       this.unwrap().updateAsyncStorage?.(contextInfo, replace);
@@ -119,5 +116,3 @@ function getFinalPrefix(prefix: AppiumLoggerPrefix | null | undefined, shouldLog
   )}]`;
   return result ? `${formattedTimestamp} ${result}` : formattedTimestamp;
 }
-
-export default log;

--- a/packages/types/lib/logger.ts
+++ b/packages/types/lib/logger.ts
@@ -48,12 +48,6 @@ export interface AppiumLogger {
   silly(...args: any[]): void;
   http(...args: any[]): void;
   /**
-   * @deprecated Use {@link errorWithException} instead
-   * @param {...any} args
-   * @throws {Error}
-   */
-  errorAndThrow(...args: any[]): never;
-  /**
    * Logs given arguments at the error level and returns
    * the error object.
    *


### PR DESCRIPTION
Cleans up the @appium/logger package and its downstream consumers (@appium/support, @appium/types, appium):

- Removed the default exports from @appium/logger (log) and @appium/support's internal logging.ts module — use the named log export instead.
- Removed the deprecated AppiumLogger#errorAndThrow method (superseded by errorWithException).
- Removed the long-disabled, no-op progress/unicode API (enableProgress, disableProgress, progressEnabled, enableUnicode, disableUnicode) from the Logger interface and implementation, along with the internal clearProgress/showProgress stubs that backed them.
- Made several internal Log fields private, since nothing outside the class read or wrote them.

BREAKING CHANGE: @appium/logger and @appium/support no longer export a default log — import the named log export instead.
BREAKING CHANGE: AppiumLogger#errorAndThrow has been removed; use errorWithException instead.
BREAKING CHANGE: Logger#enableProgress, disableProgress, progressEnabled, enableUnicode, disableUnicode have been removed; they were already permanently disabled no-ops.