### PR TITLE
fix(types): declare express and ws as direct dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19061,7 +19061,6 @@
         "@appium/support": "7.2.7",
         "@appium/types": "1.7.0",
         "@types/express": "5.0.6",
-        "@types/ws": "8.18.1",
         "async-lock": "1.4.1",
         "asyncbox": "6.4.2",
         "axios": "1.19.0",
@@ -19073,8 +19072,7 @@
         "method-override": "3.0.0",
         "morgan": "1.11.0",
         "path-to-regexp": "8.4.2",
-        "type-fest": "5.8.0",
-        "ws": "8.21.3"
+        "type-fest": "5.8.0"
       },
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
@@ -19996,9 +19994,7 @@
         "@appium/schema": "1.3.0",
         "@types/express": "5.0.6",
         "@types/ws": "8.18.1",
-        "express": "5.2.1",
-        "type-fest": "5.8.0",
-        "ws": "8.21.3"
+        "type-fest": "5.8.0"
       },
       "devDependencies": {
         "@appium/logger": "2.0.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5012,7 +5012,6 @@
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -5021,7 +5020,6 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.35",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5054,7 +5052,6 @@
       "version": "5.0.6",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
       "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -5066,7 +5063,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
       "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -5089,7 +5085,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsftp": {
@@ -5191,12 +5186,10 @@
     },
     "node_modules/@types/qs": {
       "version": "6.9.7",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -5210,7 +5203,6 @@
       "version": "0.17.4",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
       "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -5221,7 +5213,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/serve-favicon": {
@@ -5237,7 +5228,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -19070,6 +19060,8 @@
       "dependencies": {
         "@appium/support": "7.2.7",
         "@appium/types": "1.7.0",
+        "@types/express": "5.0.6",
+        "@types/ws": "8.18.1",
         "async-lock": "1.4.1",
         "asyncbox": "6.4.2",
         "axios": "1.19.0",
@@ -19081,7 +19073,8 @@
         "method-override": "3.0.0",
         "morgan": "1.11.0",
         "path-to-regexp": "8.4.2",
-        "type-fest": "5.8.0"
+        "type-fest": "5.8.0",
+        "ws": "8.21.3"
       },
       "engines": {
         "node": "^22.22.2 || ^24.15.0 || >=26.0.0",
@@ -20001,7 +19994,11 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@appium/schema": "1.3.0",
-        "type-fest": "5.8.0"
+        "@types/express": "5.0.6",
+        "@types/ws": "8.18.1",
+        "express": "5.2.1",
+        "type-fest": "5.8.0",
+        "ws": "8.21.3"
       },
       "devDependencies": {
         "@appium/logger": "2.0.11",

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -56,7 +56,6 @@
     "@appium/support": "7.2.7",
     "@appium/types": "1.7.0",
     "@types/express": "5.0.6",
-    "@types/ws": "8.18.1",
     "async-lock": "1.4.1",
     "asyncbox": "6.4.2",
     "axios": "1.19.0",
@@ -68,8 +67,7 @@
     "method-override": "3.0.0",
     "morgan": "1.11.0",
     "path-to-regexp": "8.4.2",
-    "type-fest": "5.8.0",
-    "ws": "8.21.3"
+    "type-fest": "5.8.0"
   },
   "tsd": {
     "compilerOptions": {

--- a/packages/base-driver/package.json
+++ b/packages/base-driver/package.json
@@ -55,6 +55,8 @@
   "dependencies": {
     "@appium/support": "7.2.7",
     "@appium/types": "1.7.0",
+    "@types/express": "5.0.6",
+    "@types/ws": "8.18.1",
     "async-lock": "1.4.1",
     "asyncbox": "6.4.2",
     "axios": "1.19.0",
@@ -66,7 +68,8 @@
     "method-override": "3.0.0",
     "morgan": "1.11.0",
     "path-to-regexp": "8.4.2",
-    "type-fest": "5.8.0"
+    "type-fest": "5.8.0",
+    "ws": "8.21.3"
   },
   "tsd": {
     "compilerOptions": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -52,9 +52,7 @@
     "@appium/schema": "1.3.0",
     "@types/express": "5.0.6",
     "@types/ws": "8.18.1",
-    "express": "5.2.1",
-    "type-fest": "5.8.0",
-    "ws": "8.21.3"
+    "type-fest": "5.8.0"
   },
   "devDependencies": {
     "@appium/logger": "2.0.11",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -50,7 +50,11 @@
   },
   "dependencies": {
     "@appium/schema": "1.3.0",
-    "type-fest": "5.8.0"
+    "@types/express": "5.0.6",
+    "@types/ws": "8.18.1",
+    "express": "5.2.1",
+    "type-fest": "5.8.0",
+    "ws": "8.21.3"
   },
   "devDependencies": {
     "@appium/logger": "2.0.11",


### PR DESCRIPTION
@appium/types publicly exports AppiumServer, AppiumServerExtension and UpdateServerCallback which reference Express/Router and ws.Server types, but express/ws (and their @types packages) were only present as root-level devDependencies. Consumers installing @appium/types or @appium/base-driver standalone couldn't resolve these types.
