### PR TITLE
fix(appium): discover hoisted monorepo extensions from search root

### DIFF
--- a/packages/appium/docs/en/reference/cli/extensions.md
+++ b/packages/appium/docs/en/reference/cli/extensions.md
@@ -138,6 +138,7 @@ appium {driver|plugin} list
 |<div style="width:7em">Argument</div>|Description|Type|
 |--|--|--|
 |`--installed`|Only list all installed extensions|boolean|
+|`--ext-search-root`|Search the dependencies of this project directory for installed extensions|string|
 |`--json`|Return the result in JSON format|boolean|
 |`--updates`|List all extensions along with information on whether newer versions are available. Only supported for extensions installed via `npm`.|boolean|
 |`--verbose`|Show additional details for each extension|boolean|

--- a/packages/appium/docs/en/reference/cli/server.md
+++ b/packages/appium/docs/en/reference/cli/server.md
@@ -21,8 +21,9 @@ appium
 
 !!! note
 
-    All of these options can also be set via a [Configuration File](../../guides/config.md). Options
-    set on the command line will override any options found in a configuration file.
+    Except for `--ext-search-root`, all of these options can also be set via a
+    [Configuration File](../../guides/config.md). Options set on the command line will override any
+    options found in a configuration file.
 
 |<div style="width:15em">Argument</div>|Description|Type|<div style="width:7em">Default</div>|
 |--|--|--|--|
@@ -39,6 +40,7 @@ appium
 |`--deny-insecure`|List of [insecure features](../../guides/security.md) that should be disabled in this server's sessions. Since all insecure features are disabled by default, this argument has no effect without either `--allow-insecure` or `--relaxed-security`, and is applied after both.|array<string>|`[]`|
 |`--driver`|Driver-specific configuration. Keys should correspond to driver package names|object||
 |`--drivers-import-chunk-size`|Maximum number of drivers that can be imported in parallel on server startup|number|`3`|
+|`--ext-search-root`|Search the dependencies of this project directory for installed extensions|string||
 |`--keep-alive-timeout`, `-ka`|Timeout (in seconds) to use as both the keep-alive timeout and the connection timeout for all client requests. Disabled if set to `0`.|integer|`600`|
 |`--request-timeout`|Timeout (in seconds) for waiting to receive the entire HTTP request from the client. Disabled if set to `0`. Requests exceeding this timeout will be rejected with the code `HTTP 408`.|integer|`3600`|
 |`--local-timezone`|Use local timezone for log timestamps|boolean|`false`|

--- a/packages/appium/lib/bootstrap/appium-initializer.ts
+++ b/packages/appium/lib/bootstrap/appium-initializer.ts
@@ -12,7 +12,7 @@ import type {
 import {AppiumDriver, type AppiumDriverConstraints} from '../appium';
 import {runExtensionCommand} from '../cli/extension';
 import {injectAppiumSymlinks} from '../cli/extension-command';
-import {ArgParser, getParser} from '../cli/parser';
+import {ArgParser, getExtensionSearchRoot, getParser} from '../cli/parser';
 import {runSetupCommand} from '../cli/setup-command';
 import {SERVER_SUBCOMMAND} from '../constants';
 import {type ExtensionConfigs, loadExtensions} from '../extension';
@@ -57,7 +57,8 @@ export class AppiumInitializer {
 
     adjustNodePath();
 
-    const {driverConfig, pluginConfig} = await loadExtensions(appiumHome);
+    const extensionSearchRoot = args ? args.extSearchRoot : getExtensionSearchRoot();
+    const {driverConfig, pluginConfig} = await loadExtensions(appiumHome, extensionSearchRoot);
 
     const {preConfigArgs, throwInsteadOfExit} = await this.parsePreConfigArgs(args);
     this.throwInsteadOfExit = throwInsteadOfExit;

--- a/packages/appium/lib/cli/args.ts
+++ b/packages/appium/lib/cli/args.ts
@@ -82,6 +82,15 @@ function makeListArgs(type: ExtensionType): ArgumentDefinitions {
   return new Map([
     ...globalExtensionArgs,
     [
+      ['--ext-search-root'],
+      {
+        required: false,
+        type: 'str',
+        help: 'Search the dependencies of this project directory for installed extensions',
+        dest: 'extSearchRoot',
+      },
+    ],
+    [
       ['--installed'],
       {
         required: false,
@@ -250,6 +259,15 @@ function makeRunArgs(type: ExtensionType): ArgumentDefinitions {
  * These don't make sense in the context of a config file for obvious reasons.
  */
 const serverArgsDisallowedInConfig: ArgumentDefinitions = new Map([
+  [
+    ['--ext-search-root'],
+    {
+      dest: 'extSearchRoot',
+      type: 'str',
+      required: false,
+      help: 'Search the dependencies of this project directory for installed extensions',
+    },
+  ],
   [
     ['--shell'],
     {

--- a/packages/appium/lib/cli/args.ts
+++ b/packages/appium/lib/cli/args.ts
@@ -5,6 +5,7 @@ import type {ArgumentOptions} from 'argparse';
 
 import {
   DRIVER_TYPE,
+  EXT_SEARCH_ROOT_ARG,
   EXT_SUBCOMMAND_DOCTOR,
   EXT_SUBCOMMAND_INSTALL,
   EXT_SUBCOMMAND_LIST,
@@ -82,7 +83,7 @@ function makeListArgs(type: ExtensionType): ArgumentDefinitions {
   return new Map([
     ...globalExtensionArgs,
     [
-      ['--ext-search-root'],
+      [EXT_SEARCH_ROOT_ARG],
       {
         required: false,
         type: 'str',
@@ -260,7 +261,7 @@ function makeRunArgs(type: ExtensionType): ArgumentDefinitions {
  */
 const serverArgsDisallowedInConfig: ArgumentDefinitions = new Map([
   [
-    ['--ext-search-root'],
+    [EXT_SEARCH_ROOT_ARG],
     {
       dest: 'extSearchRoot',
       type: 'str',

--- a/packages/appium/lib/cli/parser.ts
+++ b/packages/appium/lib/cli/parser.ts
@@ -359,3 +359,38 @@ export async function getParser(debug = false): Promise<ArgParser> {
 
   return new ArgParser(debug);
 }
+
+/**
+ * Extracts `--ext-search-root` before extension schemas are loaded and the full CLI can be parsed.
+ */
+export function getExtensionSearchRoot(args: string[] = process.argv.slice(2)): string | undefined {
+  if ((args[0] === DRIVER_TYPE || args[0] === PLUGIN_TYPE) && args[1] !== EXT_SUBCOMMAND_LIST && args[1] !== 'ls') {
+    return undefined;
+  }
+  let result: string | undefined;
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    if (arg === '--') {
+      break;
+    }
+    if (arg.startsWith('--') && '--ext-search-root'.startsWith(arg)) {
+      const value = args[++index];
+      if (!value || value.startsWith('-')) {
+        throw new Error('[ERROR] argument --ext-search-root: expected one argument');
+      }
+      result = value;
+    } else if (arg.includes('=')) {
+      const separatorIndex = arg.indexOf('=');
+      const name = arg.slice(0, separatorIndex);
+      const value = arg.slice(separatorIndex + 1);
+      if (!name.startsWith('--') || !'--ext-search-root'.startsWith(name)) {
+        continue;
+      }
+      if (!value) {
+        throw new Error('[ERROR] argument --ext-search-root: expected one argument');
+      }
+      result = value;
+    }
+  }
+  return result;
+}

--- a/packages/appium/lib/cli/parser.ts
+++ b/packages/appium/lib/cli/parser.ts
@@ -7,9 +7,11 @@ import type {SubArgumentParserOptions, SubparsersAction} from 'argparse';
 
 import {
   DRIVER_TYPE,
+  EXT_SEARCH_ROOT_ARG,
   EXT_SUBCOMMAND_DOCTOR,
   EXT_SUBCOMMAND_INSTALL,
   EXT_SUBCOMMAND_LIST,
+  EXT_SUBCOMMAND_LIST_ALIASES,
   EXT_SUBCOMMAND_RUN,
   EXT_SUBCOMMAND_UNINSTALL,
   EXT_SUBCOMMAND_UPDATE,
@@ -203,7 +205,7 @@ export class ArgParser {
           command: EXT_SUBCOMMAND_LIST,
           args: extensionArgs[type].list,
           help: `List available and installed ${type}s`,
-          aliases: ['ls'],
+          aliases: [...EXT_SUBCOMMAND_LIST_ALIASES],
         },
         {
           command: EXT_SUBCOMMAND_INSTALL,
@@ -315,9 +317,9 @@ export class ArgParser {
       const [knownArgs, unknownArgs] = parsed;
       // XXX: you'd think that argparse, when given an alias for a subcommand,
       // would set this value to the original subcommand name, but it doesn't.
-      if (knownArgs?.driverCommand === 'ls') {
+      if (EXT_SUBCOMMAND_LIST_ALIASES.includes(knownArgs?.driverCommand)) {
         knownArgs.driverCommand = 'list';
-      } else if (knownArgs?.pluginCommand === 'ls') {
+      } else if (EXT_SUBCOMMAND_LIST_ALIASES.includes(knownArgs?.pluginCommand)) {
         knownArgs.pluginCommand = 'list';
       }
       if (unknownArgs?.length && (knownArgs.driverCommand === 'run' || knownArgs.pluginCommand === 'run')) {
@@ -364,7 +366,11 @@ export async function getParser(debug = false): Promise<ArgParser> {
  * Extracts `--ext-search-root` before extension schemas are loaded and the full CLI can be parsed.
  */
 export function getExtensionSearchRoot(args: string[] = process.argv.slice(2)): string | undefined {
-  if ((args[0] === DRIVER_TYPE || args[0] === PLUGIN_TYPE) && args[1] !== EXT_SUBCOMMAND_LIST && args[1] !== 'ls') {
+  const extensionType = args[0];
+  if (
+    (extensionType === DRIVER_TYPE || extensionType === PLUGIN_TYPE) &&
+    !extensionCommandSupportsArg(extensionType, args[1], EXT_SEARCH_ROOT_ARG)
+  ) {
     return undefined;
   }
   let result: string | undefined;
@@ -373,24 +379,34 @@ export function getExtensionSearchRoot(args: string[] = process.argv.slice(2)): 
     if (arg === '--') {
       break;
     }
-    if (arg.startsWith('--') && '--ext-search-root'.startsWith(arg)) {
+    if (arg.startsWith('--') && EXT_SEARCH_ROOT_ARG.startsWith(arg)) {
       const value = args[++index];
       if (!value || value.startsWith('-')) {
-        throw new Error('[ERROR] argument --ext-search-root: expected one argument');
+        throw new Error(`[ERROR] argument ${EXT_SEARCH_ROOT_ARG}: expected one argument`);
       }
       result = value;
     } else if (arg.includes('=')) {
       const separatorIndex = arg.indexOf('=');
       const name = arg.slice(0, separatorIndex);
       const value = arg.slice(separatorIndex + 1);
-      if (!name.startsWith('--') || !'--ext-search-root'.startsWith(name)) {
+      if (!name.startsWith('--') || !EXT_SEARCH_ROOT_ARG.startsWith(name)) {
         continue;
       }
       if (!value) {
-        throw new Error('[ERROR] argument --ext-search-root: expected one argument');
+        throw new Error(`[ERROR] argument ${EXT_SEARCH_ROOT_ARG}: expected one argument`);
       }
       result = value;
     }
   }
   return result;
+}
+
+function extensionCommandSupportsArg(
+  extensionType: DriverType | PluginType,
+  command: string | undefined,
+  arg: string,
+): boolean {
+  const normalizedCommand = EXT_SUBCOMMAND_LIST_ALIASES.includes(command as 'ls') ? EXT_SUBCOMMAND_LIST : command;
+  const definitions = getExtensionArgs()[extensionType][normalizedCommand as CliExtensionSubcommand];
+  return Boolean(definitions && [...definitions.keys()].some((names) => names.includes(arg)));
 }

--- a/packages/appium/lib/constants.ts
+++ b/packages/appium/lib/constants.ts
@@ -76,11 +76,14 @@ export const CACHE_DIR_RELATIVE_PATH = path.join('node_modules', '.cache', 'appi
 export const PKG_HASHFILE_RELATIVE_PATH = path.join(CACHE_DIR_RELATIVE_PATH, 'package.hash');
 
 export const EXT_SUBCOMMAND_LIST = 'list';
+export const EXT_SUBCOMMAND_LIST_ALIASES = ['ls'] as const;
 export const EXT_SUBCOMMAND_INSTALL = 'install';
 export const EXT_SUBCOMMAND_UNINSTALL = 'uninstall';
 export const EXT_SUBCOMMAND_UPDATE = 'update';
 export const EXT_SUBCOMMAND_RUN = 'run';
 export const EXT_SUBCOMMAND_DOCTOR = 'doctor';
+
+export const EXT_SEARCH_ROOT_ARG = '--ext-search-root';
 
 /**
  * Current revision of the manifest (`extensions.yaml`) schema

--- a/packages/appium/lib/extension/extension-config.ts
+++ b/packages/appium/lib/extension/extension-config.ts
@@ -16,7 +16,7 @@ import type {
 import {APPIUM_VER} from '../helpers/build';
 import {log} from '../logger';
 import {ALLOWED_SCHEMA_EXTENSIONS, isAllowedSchemaFileExtension, registerSchema} from '../schema/schema';
-import {capitalize, resolveFrom} from '../utils';
+import {capitalize} from '../utils';
 import type {Manifest} from './manifest';
 
 const DEFAULT_ENTRY_POINT = 'index.js';
@@ -118,7 +118,7 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
     }
     let moduleObject: any;
     if (typeof argSchemaPath === 'string') {
-      const schemaPath = await resolveFrom(appiumHome, path.join(pkgName, argSchemaPath));
+      const schemaPath = path.resolve(extManifest.installPath ?? appiumHome, argSchemaPath);
       moduleObject = require(schemaPath);
     } else {
       moduleObject = argSchemaPath;

--- a/packages/appium/lib/extension/extension-config.ts
+++ b/packages/appium/lib/extension/extension-config.ts
@@ -16,7 +16,7 @@ import type {
 import {APPIUM_VER} from '../helpers/build';
 import {log} from '../logger';
 import {ALLOWED_SCHEMA_EXTENSIONS, isAllowedSchemaFileExtension, registerSchema} from '../schema/schema';
-import {capitalize, resolveFrom} from '../utils';
+import {capitalize, resolveFrom, resolvePackageSubpathFrom} from '../utils';
 import type {Manifest} from './manifest';
 
 const DEFAULT_ENTRY_POINT = 'index.js';
@@ -118,11 +118,9 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
     }
     let moduleObject: any;
     if (typeof argSchemaPath === 'string') {
-      const fromDirectory = extManifest.installPath ?? appiumHome;
-      const moduleId = extManifest.installPath
-        ? path.resolve(extManifest.installPath, argSchemaPath)
-        : path.join(pkgName, argSchemaPath);
-      const schemaPath = await resolveFrom(fromDirectory, moduleId);
+      const schemaPath = extManifest.installPath
+        ? await resolvePackageSubpathFrom(extManifest.installPath, pkgName, argSchemaPath)
+        : await resolveFrom(appiumHome, path.posix.join(pkgName, argSchemaPath.replaceAll('\\', '/')));
       moduleObject = require(schemaPath);
     } else {
       moduleObject = argSchemaPath;

--- a/packages/appium/lib/extension/extension-config.ts
+++ b/packages/appium/lib/extension/extension-config.ts
@@ -16,7 +16,8 @@ import type {
 import {APPIUM_VER} from '../helpers/build';
 import {log} from '../logger';
 import {ALLOWED_SCHEMA_EXTENSIONS, isAllowedSchemaFileExtension, registerSchema} from '../schema/schema';
-import {capitalize, resolveFrom, resolvePackageSubpathFrom} from '../utils';
+import {capitalize, resolveFrom} from '../utils';
+import {resolvePackageSubpathFrom} from '../utils/resolve-from';
 import type {Manifest} from './manifest';
 
 const DEFAULT_ENTRY_POINT = 'index.js';

--- a/packages/appium/lib/extension/extension-config.ts
+++ b/packages/appium/lib/extension/extension-config.ts
@@ -16,7 +16,7 @@ import type {
 import {APPIUM_VER} from '../helpers/build';
 import {log} from '../logger';
 import {ALLOWED_SCHEMA_EXTENSIONS, isAllowedSchemaFileExtension, registerSchema} from '../schema/schema';
-import {capitalize} from '../utils';
+import {capitalize, resolveFrom} from '../utils';
 import type {Manifest} from './manifest';
 
 const DEFAULT_ENTRY_POINT = 'index.js';
@@ -118,7 +118,11 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
     }
     let moduleObject: any;
     if (typeof argSchemaPath === 'string') {
-      const schemaPath = path.resolve(extManifest.installPath ?? appiumHome, argSchemaPath);
+      const fromDirectory = extManifest.installPath ?? appiumHome;
+      const moduleId = extManifest.installPath
+        ? path.resolve(extManifest.installPath, argSchemaPath)
+        : path.join(pkgName, argSchemaPath);
+      const schemaPath = await resolveFrom(fromDirectory, moduleId);
       moduleObject = require(schemaPath);
     } else {
       moduleObject = argSchemaPath;

--- a/packages/appium/lib/extension/index.ts
+++ b/packages/appium/lib/extension/index.ts
@@ -27,8 +27,8 @@ export type DriverNameMap = Map<DriverClass, string>;
  *
  * If `appiumHome` is needed, use `resolveAppiumHome` from the `env` module in `@appium/support`.
  */
-export async function loadExtensions(appiumHome: string): Promise<ExtensionConfigs> {
-  const manifest = Manifest.getInstance(appiumHome);
+export async function loadExtensions(appiumHome: string, extensionSearchRoot?: string): Promise<ExtensionConfigs> {
+  const manifest = Manifest.getInstance(appiumHome, extensionSearchRoot);
   await manifest.read();
   const driverConfig = DriverConfig.getInstance(manifest) ?? DriverConfig.create(manifest);
   const pluginConfig = PluginConfig.getInstance(manifest) ?? PluginConfig.create(manifest);

--- a/packages/appium/lib/extension/index.ts
+++ b/packages/appium/lib/extension/index.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import {timing, util} from '@appium/support';
 import type {DriverClass, ExtensionType, PluginClass} from '@appium/types';
 import type {ExtClass} from 'appium/types';
@@ -26,9 +28,15 @@ export type DriverNameMap = Map<DriverClass, string>;
  * - Returns these instances
  *
  * If `appiumHome` is needed, use `resolveAppiumHome` from the `env` module in `@appium/support`.
+ *
+ * @param appiumHome - Appium home directory
+ * @param extensionSearchRoot - Optional project directory, normalized here before manifest lookup
  */
 export async function loadExtensions(appiumHome: string, extensionSearchRoot?: string): Promise<ExtensionConfigs> {
-  const manifest = Manifest.getInstance(appiumHome, extensionSearchRoot);
+  const manifest = Manifest.getInstance(
+    appiumHome,
+    extensionSearchRoot ? path.resolve(extensionSearchRoot) : undefined,
+  );
   await manifest.read();
   const driverConfig = DriverConfig.getInstance(manifest) ?? DriverConfig.create(manifest);
   const pluginConfig = PluginConfig.getInstance(manifest) ?? PluginConfig.create(manifest);

--- a/packages/appium/lib/extension/manifest.ts
+++ b/packages/appium/lib/extension/manifest.ts
@@ -6,7 +6,9 @@ import type {ExtManifest, ExtPackageJson, ExtRecord, InternalMetadata, ManifestD
 import * as YAML from 'yaml';
 
 import {CURRENT_SCHEMA_REV, DRIVER_TYPE, PLUGIN_TYPE} from '../constants';
+import {log} from '../logger';
 import {packageDidChange} from '../utils';
+import {resolveFrom} from '../utils/resolve-from';
 import {INSTALL_TYPE_DEV, INSTALL_TYPE_NPM} from './extension-config';
 import {migrate} from './manifest-migrations';
 
@@ -22,24 +24,33 @@ const INITIAL_MANIFEST_DATA: Readonly<ManifestData> = Object.freeze({
 /**
  * Handles reading & writing of extension config files.
  *
- * Only one instance of this class exists per value of `APPIUM_HOME`.
+ * Only one instance of this class exists per `APPIUM_HOME` and extension search root pair.
  */
 export class Manifest {
   /**
-   * Returns the memoized manifest for an `APPIUM_HOME` directory (one instance per home).
+   * Returns the memoized manifest for an `APPIUM_HOME` and extension search root pair.
    *
    * @param appiumHome - `APPIUM_HOME` path used as the cache key
+   * @param extensionSearchRoot - Optional project directory whose dependencies contain extensions
    */
-  static getInstance = util.memoize((appiumHome: string): Manifest => new Manifest(appiumHome));
+  static getInstance = util.memoize(
+    (appiumHome: string, extensionSearchRoot?: string): Manifest =>
+      new Manifest(appiumHome, extensionSearchRoot && path.resolve(extensionSearchRoot)),
+    (appiumHome, extensionSearchRoot) =>
+      JSON.stringify([appiumHome, extensionSearchRoot && path.resolve(extensionSearchRoot)]),
+  );
 
   #data!: ManifestData;
   readonly #appiumHome: string;
+  readonly #extensionSearchRoot: string | undefined;
+  #transientBaseData: ManifestData | undefined;
   #manifestPath: string | undefined = undefined;
   #writing: Promise<boolean> | undefined;
   #reading: Promise<void> | undefined;
 
-  private constructor(appiumHome: string) {
+  private constructor(appiumHome: string, extensionSearchRoot?: string) {
     this.#appiumHome = appiumHome;
+    this.#extensionSearchRoot = extensionSearchRoot;
     this.#data = structuredClone(INITIAL_MANIFEST_DATA) as ManifestData;
   }
 
@@ -103,6 +114,7 @@ export class Manifest {
     }
 
     this.#reading = (async () => {
+      this.#transientBaseData = undefined;
       let data: ManifestData;
       let shouldWrite = false;
       const manifestPathResolved = await this.#setManifestPath();
@@ -137,6 +149,11 @@ export class Manifest {
       if (shouldWrite) {
         await this.write();
       }
+      if (this.#extensionSearchRoot) {
+        const hasSearchRootAppiumDependency = await env.hasAppiumDependency(this.#extensionSearchRoot);
+        this.#transientBaseData = structuredClone(this.#data) as ManifestData;
+        await this.syncWithInstalledExtensions(hasSearchRootAppiumDependency, this.#extensionSearchRoot);
+      }
     })();
 
     try {
@@ -170,7 +187,7 @@ export class Manifest {
         );
       }
       try {
-        await fs.writeFile(manifestPathResolved, YAML.stringify(this.#data), 'utf8');
+        await fs.writeFile(manifestPathResolved, YAML.stringify(this.#getPersistableData()), 'utf8');
         return true;
       } catch (err: any) {
         throw new Error(
@@ -187,12 +204,13 @@ export class Manifest {
   }
 
   /**
-   * Scans `APPIUM_HOME` (root and `node_modules`) for Appium extension packages and merges them into the manifest.
+   * Finds Appium extension packages and merges them into the manifest.
    *
    * @param hasAppiumDependency - When true and the root `package.json` depends on Appium, matching extensions use the `"dev"` install type
+   * @param extensionSearchRoot - Optional project directory whose declared dependencies should be resolved instead of scanning `APPIUM_HOME/node_modules`
    * @returns `true` if any extension entries changed, `false` otherwise
    */
-  async syncWithInstalledExtensions(hasAppiumDependency = false): Promise<boolean> {
+  async syncWithInstalledExtensions(hasAppiumDependency = false, extensionSearchRoot?: string): Promise<boolean> {
     let didChange = false;
 
     const onMatch = async (filepath: string, devType = false): Promise<void> => {
@@ -210,12 +228,48 @@ export class Manifest {
 
     const queue: Promise<void>[] = [onMatch(path.join(this.#appiumHome, 'package.json'), true)];
 
-    const filepaths = await fs.glob('node_modules/{*,@*/*}/package.json', {
-      cwd: this.#appiumHome,
-      absolute: true,
-    });
-    for (const filepath of filepaths) {
-      queue.push(onMatch(filepath));
+    if (extensionSearchRoot) {
+      const searchRoot = path.resolve(extensionSearchRoot);
+      const packageJsonPath = path.join(searchRoot, 'package.json');
+      let pkg: unknown;
+      try {
+        pkg = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as unknown;
+      } catch (err) {
+        throw new Error(`Could not read extension search root package manifest at ${packageJsonPath}`, {cause: err});
+      }
+      if (!util.isPlainObject(pkg)) {
+        throw new TypeError(`Extension search root package manifest at ${packageJsonPath} must contain an object`);
+      }
+      const dependencyNames = new Set<string>();
+      for (const field of ['dependencies', 'devDependencies'] as const) {
+        const dependencies = pkg[field];
+        if (dependencies !== undefined && !util.isPlainObject(dependencies)) {
+          throw new TypeError(`The '${field}' field in ${packageJsonPath} must contain an object`);
+        }
+        for (const dependencyName of Object.keys(dependencies ?? {})) {
+          dependencyNames.add(dependencyName);
+        }
+      }
+      for (const dependencyName of dependencyNames) {
+        try {
+          const dependencyPackageJsonPath = await resolvePackageJson(searchRoot, dependencyName);
+          queue.push(onMatch(dependencyPackageJsonPath, true));
+        } catch (err) {
+          log.debug(
+            `Could not inspect declared dependency '${dependencyName}' from extension search root ${searchRoot}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }
+    } else {
+      const filepaths = await fs.glob('node_modules/{*,@*/*}/package.json', {
+        cwd: this.#appiumHome,
+        absolute: true,
+      });
+      for (const filepath of filepaths) {
+        queue.push(onMatch(filepath));
+      }
     }
 
     await Promise.all(queue);
@@ -335,6 +389,39 @@ export class Manifest {
     }
 
     return this.#manifestPath;
+  }
+
+  #getPersistableData(): ManifestData {
+    if (!this.#transientBaseData) {
+      return this.#data;
+    }
+    const data = structuredClone(this.#data) as ManifestData;
+    for (const type of [DRIVER_TYPE, PLUGIN_TYPE] as const) {
+      const key = `${type}s` as const;
+      for (const name of Object.keys(data[key])) {
+        if (!Object.hasOwn(this.#transientBaseData[key], name)) {
+          delete data[key][name];
+        }
+      }
+      for (const [name, manifest] of Object.entries(this.#transientBaseData[key])) {
+        if (!util.isEqual(data[key][name], manifest)) {
+          data[key][name] = manifest;
+        }
+      }
+    }
+    return data;
+  }
+}
+
+async function resolvePackageJson(searchRoot: string, dependencyName: string): Promise<string> {
+  try {
+    return await resolveFrom(searchRoot, `${dependencyName}/package.json`);
+  } catch (err) {
+    if (!(err instanceof Error && 'code' in err && err.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED')) {
+      throw err;
+    }
+    const entryPoint = await resolveFrom(searchRoot, dependencyName);
+    return path.join(fs.findRoot(path.dirname(entryPoint)), 'package.json');
   }
 }
 

--- a/packages/appium/lib/extension/manifest.ts
+++ b/packages/appium/lib/extension/manifest.ts
@@ -8,7 +8,7 @@ import * as YAML from 'yaml';
 import {CURRENT_SCHEMA_REV, DRIVER_TYPE, PLUGIN_TYPE} from '../constants';
 import {log} from '../logger';
 import {packageDidChange} from '../utils';
-import {resolveFrom} from '../utils/resolve-from';
+import {resolvePackageJsonFrom} from '../utils/resolve-from';
 import {INSTALL_TYPE_DEV, INSTALL_TYPE_NPM} from './extension-config';
 import {migrate} from './manifest-migrations';
 
@@ -31,13 +31,11 @@ export class Manifest {
    * Returns the memoized manifest for an `APPIUM_HOME` and extension search root pair.
    *
    * @param appiumHome - `APPIUM_HOME` path used as the cache key
-   * @param extensionSearchRoot - Optional project directory whose dependencies contain extensions
+   * @param extensionSearchRoot - Optional absolute project directory whose dependencies contain extensions
    */
   static getInstance = util.memoize(
-    (appiumHome: string, extensionSearchRoot?: string): Manifest =>
-      new Manifest(appiumHome, extensionSearchRoot && path.resolve(extensionSearchRoot)),
-    (appiumHome, extensionSearchRoot) =>
-      JSON.stringify([appiumHome, extensionSearchRoot && path.resolve(extensionSearchRoot)]),
+    (appiumHome: string, extensionSearchRoot?: string): Manifest => new Manifest(appiumHome, extensionSearchRoot),
+    (appiumHome, extensionSearchRoot) => JSON.stringify([appiumHome, extensionSearchRoot]),
   );
 
   #data!: ManifestData;
@@ -152,7 +150,7 @@ export class Manifest {
       if (this.#extensionSearchRoot) {
         const hasSearchRootAppiumDependency = await env.hasAppiumDependency(this.#extensionSearchRoot);
         this.#transientBaseData = structuredClone(this.#data) as ManifestData;
-        await this.syncWithInstalledExtensions(hasSearchRootAppiumDependency, this.#extensionSearchRoot);
+        await this.syncWithDeclaredExtensions(this.#extensionSearchRoot, hasSearchRootAppiumDependency);
       }
     })();
 
@@ -207,74 +205,38 @@ export class Manifest {
    * Finds Appium extension packages and merges them into the manifest.
    *
    * @param hasAppiumDependency - When true and the root `package.json` depends on Appium, matching extensions use the `"dev"` install type
-   * @param extensionSearchRoot - Optional project directory whose declared dependencies should be resolved instead of scanning `APPIUM_HOME/node_modules`
    * @returns `true` if any extension entries changed, `false` otherwise
    */
-  async syncWithInstalledExtensions(hasAppiumDependency = false, extensionSearchRoot?: string): Promise<boolean> {
-    let didChange = false;
+  async syncWithInstalledExtensions(hasAppiumDependency = false): Promise<boolean> {
+    const filepaths = await fs.glob('node_modules/{*,@*/*}/package.json', {
+      cwd: this.#appiumHome,
+      absolute: true,
+    });
+    const changes = await Promise.all([
+      this.#addExtensionFromPackagePath(
+        path.join(this.#appiumHome, 'package.json'),
+        hasAppiumDependency ? INSTALL_TYPE_DEV : INSTALL_TYPE_NPM,
+      ),
+      ...filepaths.map((filepath) => this.#addExtensionFromPackagePath(filepath, INSTALL_TYPE_NPM)),
+    ]);
+    return changes.some(Boolean);
+  }
 
-    const onMatch = async (filepath: string, devType = false): Promise<void> => {
-      try {
-        const pkg = JSON.parse(await fs.readFile(filepath, 'utf8')) as unknown;
-        if (isExtension(pkg)) {
-          const installType = devType && hasAppiumDependency ? INSTALL_TYPE_DEV : INSTALL_TYPE_NPM;
-          const changed = this.addExtensionFromPackage(pkg, filepath, installType);
-          didChange = didChange || changed;
-        }
-      } catch {
-        // ignore invalid package.json
-      }
-    };
-
-    const queue: Promise<void>[] = [onMatch(path.join(this.#appiumHome, 'package.json'), true)];
-
-    if (extensionSearchRoot) {
-      const searchRoot = path.resolve(extensionSearchRoot);
-      const packageJsonPath = path.join(searchRoot, 'package.json');
-      let pkg: unknown;
-      try {
-        pkg = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as unknown;
-      } catch (err) {
-        throw new Error(`Could not read extension search root package manifest at ${packageJsonPath}`, {cause: err});
-      }
-      if (!util.isPlainObject(pkg)) {
-        throw new TypeError(`Extension search root package manifest at ${packageJsonPath} must contain an object`);
-      }
-      const dependencyNames = new Set<string>();
-      for (const field of ['dependencies', 'devDependencies'] as const) {
-        const dependencies = pkg[field];
-        if (dependencies !== undefined && !util.isPlainObject(dependencies)) {
-          throw new TypeError(`The '${field}' field in ${packageJsonPath} must contain an object`);
-        }
-        for (const dependencyName of Object.keys(dependencies ?? {})) {
-          dependencyNames.add(dependencyName);
-        }
-      }
-      for (const dependencyName of dependencyNames) {
-        try {
-          const dependencyPackageJsonPath = await resolvePackageJson(searchRoot, dependencyName);
-          queue.push(onMatch(dependencyPackageJsonPath, true));
-        } catch (err) {
-          log.debug(
-            `Could not inspect declared dependency '${dependencyName}' from extension search root ${searchRoot}: ${
-              err instanceof Error ? err.message : String(err)
-            }`,
-          );
-        }
-      }
-    } else {
-      const filepaths = await fs.glob('node_modules/{*,@*/*}/package.json', {
-        cwd: this.#appiumHome,
-        absolute: true,
-      });
-      for (const filepath of filepaths) {
-        queue.push(onMatch(filepath));
-      }
-    }
-
-    await Promise.all(queue);
-
-    return didChange;
+  /**
+   * Resolves a project's declared dependencies and merges any Appium extensions into the manifest.
+   *
+   * @param searchRoot - Absolute project directory containing the dependency manifest
+   * @param hasAppiumDependency - When true, matching extensions use the `"dev"` install type
+   * @returns `true` if any extension entries changed, `false` otherwise
+   */
+  async syncWithDeclaredExtensions(searchRoot: string, hasAppiumDependency = false): Promise<boolean> {
+    const packageJsonPath = path.join(searchRoot, 'package.json');
+    const dependencyNames = await readDeclaredDependencyNames(packageJsonPath);
+    const installType = hasAppiumDependency ? INSTALL_TYPE_DEV : INSTALL_TYPE_NPM;
+    const changes = await Promise.all(
+      dependencyNames.map((dependencyName) => this.#addDeclaredExtension(searchRoot, dependencyName, installType)),
+    );
+    return changes.some(Boolean);
   }
 
   /**
@@ -411,18 +373,60 @@ export class Manifest {
     }
     return data;
   }
+
+  async #addExtensionFromPackagePath(
+    filepath: string,
+    installType: typeof INSTALL_TYPE_NPM | typeof INSTALL_TYPE_DEV,
+  ): Promise<boolean> {
+    try {
+      const pkg = JSON.parse(await fs.readFile(filepath, 'utf8')) as unknown;
+      return isExtension(pkg) ? this.addExtensionFromPackage(pkg, filepath, installType) : false;
+    } catch {
+      return false;
+    }
+  }
+
+  async #addDeclaredExtension(
+    searchRoot: string,
+    dependencyName: string,
+    installType: typeof INSTALL_TYPE_NPM | typeof INSTALL_TYPE_DEV,
+  ): Promise<boolean> {
+    try {
+      const dependencyPackageJsonPath = await resolvePackageJsonFrom(searchRoot, dependencyName);
+      return await this.#addExtensionFromPackagePath(dependencyPackageJsonPath, installType);
+    } catch (err) {
+      log.debug(
+        `Could not inspect declared dependency '${dependencyName}' from extension search root ${searchRoot}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return false;
+    }
+  }
 }
 
-async function resolvePackageJson(searchRoot: string, dependencyName: string): Promise<string> {
+async function readDeclaredDependencyNames(packageJsonPath: string): Promise<string[]> {
+  let pkg: unknown;
   try {
-    return await resolveFrom(searchRoot, path.join(dependencyName, 'package.json'));
+    pkg = JSON.parse(await fs.readFile(packageJsonPath, 'utf8')) as unknown;
   } catch (err) {
-    if (!(err instanceof Error && 'code' in err && err.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED')) {
-      throw err;
-    }
-    const entryPoint = await resolveFrom(searchRoot, dependencyName);
-    return path.join(fs.findRoot(path.dirname(entryPoint)), 'package.json');
+    throw new Error(`Could not read extension search root package manifest at ${packageJsonPath}`, {cause: err});
   }
+  if (!util.isPlainObject(pkg)) {
+    throw new TypeError(`Extension search root package manifest at ${packageJsonPath} must contain an object`);
+  }
+
+  const dependencyNames = new Set<string>();
+  for (const field of ['dependencies', 'devDependencies'] as const) {
+    const dependencies = pkg[field];
+    if (dependencies !== undefined && !util.isPlainObject(dependencies)) {
+      throw new TypeError(`The '${field}' field in ${packageJsonPath} must contain an object`);
+    }
+    for (const dependencyName of Object.keys(dependencies ?? {})) {
+      dependencyNames.add(dependencyName);
+    }
+  }
+  return [...dependencyNames];
 }
 
 function isExtension(value: unknown): value is ExtPackageJson<ExtensionType> {

--- a/packages/appium/lib/extension/manifest.ts
+++ b/packages/appium/lib/extension/manifest.ts
@@ -415,7 +415,7 @@ export class Manifest {
 
 async function resolvePackageJson(searchRoot: string, dependencyName: string): Promise<string> {
   try {
-    return await resolveFrom(searchRoot, `${dependencyName}/package.json`);
+    return await resolveFrom(searchRoot, path.join(dependencyName, 'package.json'));
   } catch (err) {
     if (!(err instanceof Error && 'code' in err && err.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED')) {
       throw err;

--- a/packages/appium/lib/extension/manifest.ts
+++ b/packages/appium/lib/extension/manifest.ts
@@ -417,7 +417,7 @@ async function readDeclaredDependencyNames(packageJsonPath: string): Promise<str
   }
 
   const dependencyNames = new Set<string>();
-  for (const field of ['dependencies', 'devDependencies'] as const) {
+  for (const field of ['dependencies', 'devDependencies', 'optionalDependencies'] as const) {
     const dependencies = pkg[field];
     if (dependencies !== undefined && !util.isPlainObject(dependencies)) {
       throw new TypeError(`The '${field}' field in ${packageJsonPath} must contain an object`);

--- a/packages/appium/lib/utils/index.ts
+++ b/packages/appium/lib/utils/index.ts
@@ -20,4 +20,4 @@ export {
 } from './object';
 export {packageDidChange} from './package-changed';
 export {appiumPackageRoot, npmPackage} from './package-json';
-export {resolveFrom} from './resolve-from';
+export {resolveFrom, resolvePackageJsonFrom, resolvePackageSubpathFrom} from './resolve-from';

--- a/packages/appium/lib/utils/resolve-from.ts
+++ b/packages/appium/lib/utils/resolve-from.ts
@@ -1,5 +1,5 @@
-import {realpath} from 'node:fs/promises';
-import Module from 'node:module';
+import {readFile, realpath} from 'node:fs/promises';
+import Module, {createRequire} from 'node:module';
 import path from 'node:path';
 
 /**
@@ -12,17 +12,7 @@ import path from 'node:path';
  * @throws `Error` if Node cannot resolve `moduleId` from `fromDirectory`
  */
 export async function resolveFrom(fromDirectory: string, moduleId: string): Promise<string> {
-  let resolvedFromDirectory: string;
-  try {
-    resolvedFromDirectory = await realpath(fromDirectory);
-  } catch (error) {
-    const err = error as NodeJS.ErrnoException;
-    if (err.code === 'ENOENT') {
-      resolvedFromDirectory = path.resolve(fromDirectory);
-    } else {
-      throw error;
-    }
-  }
+  const resolvedFromDirectory = await resolveDirectory(fromDirectory);
 
   const fromFile = path.join(resolvedFromDirectory, 'noop.js');
   const nodeModule = Module as typeof Module & {
@@ -34,4 +24,67 @@ export async function resolveFrom(fromDirectory: string, moduleId: string): Prom
     filename: fromFile,
     paths: nodeModule._nodeModulePaths(resolvedFromDirectory),
   });
+}
+
+/**
+ * Locates a dependency's package manifest using Node's module search paths without resolving an
+ * exported package entry point.
+ *
+ * @param fromDirectory - Directory whose dependency tree should be searched
+ * @param packageName - Declared dependency package name
+ * @returns Real path to the owning package's root `package.json`
+ */
+export async function resolvePackageJsonFrom(fromDirectory: string, packageName: string): Promise<string> {
+  const resolvedFromDirectory = await resolveDirectory(fromDirectory);
+  const resolver = createRequire(path.join(resolvedFromDirectory, 'noop.js'));
+  for (const nodeModulesPath of resolver.resolve.paths(packageName) ?? []) {
+    const candidate = path.join(nodeModulesPath, packageName, 'package.json');
+    try {
+      return await realpath(candidate);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+  }
+  throw Object.assign(new Error(`Cannot find package manifest for '${packageName}' from '${resolvedFromDirectory}'`), {
+    code: 'MODULE_NOT_FOUND',
+  });
+}
+
+/**
+ * Resolves a package subpath from a known package installation while honoring package exports.
+ * Packages without exports may be external links, so they fall back to a root-relative path.
+ *
+ * @param installPath - Absolute installed package root
+ * @param packageName - Package name from its manifest
+ * @param subpath - Package-relative path to resolve
+ * @returns Resolved subpath
+ */
+export async function resolvePackageSubpathFrom(
+  installPath: string,
+  packageName: string,
+  subpath: string,
+): Promise<string> {
+  const resolvedInstallPath = await resolveDirectory(installPath);
+  const packageJsonPath = path.join(resolvedInstallPath, 'package.json');
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+    exports?: unknown;
+  };
+  const moduleId = path.posix.join(packageName, subpath.replaceAll('\\', '/'));
+  if (Object.hasOwn(packageJson, 'exports')) {
+    return createRequire(packageJsonPath).resolve(moduleId);
+  }
+  return await realpath(path.resolve(resolvedInstallPath, subpath));
+}
+
+async function resolveDirectory(directory: string): Promise<string> {
+  try {
+    return await realpath(directory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return path.resolve(directory);
+    }
+    throw error;
+  }
 }

--- a/packages/appium/test/e2e/cli-driver.e2e.spec.ts
+++ b/packages/appium/test/e2e/cli-driver.e2e.spec.ts
@@ -104,6 +104,28 @@ describe('Driver CLI', {timeout: 90000}, function () {
       assert.deepStrictEqual(out, {});
     });
 
+    it('should find a driver hoisted above an explicit workspace search root', async function () {
+      await resetAppiumHome();
+      const monorepoRoot = await tempDir.openDir();
+      const searchRoot = path.join(monorepoRoot, 'packages', 'app');
+      const driverRoot = path.join(monorepoRoot, 'node_modules', '@appium', 'test-driver');
+      await fs.mkdirp(searchRoot);
+      await fs.mkdirp(driverRoot);
+      await fs.writeFile(
+        path.join(searchRoot, 'package.json'),
+        JSON.stringify({devDependencies: {'@appium/test-driver': '1.0.0'}}),
+      );
+      await fs.writeFile(
+        path.join(driverRoot, 'package.json'),
+        await fs.readFile(resolveFixture('test-driver/package.json')),
+      );
+
+      const result = await runList(['--installed', '--ext-search-root', searchRoot]);
+
+      assert.strictEqual(result.test.installed, true);
+      assert.strictEqual(result.test.pkgName, '@appium/test-driver');
+    });
+
     it('should show updates for installed drivers with --updates', async function (ctx: TestContext) {
       if (system.isWindows()) {
         return ctx.skip();

--- a/packages/appium/test/unit/extension/driver-config.spec.ts
+++ b/packages/appium/test/unit/extension/driver-config.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {promises as fs} from 'node:fs';
+import path from 'node:path';
 import {describe, it, beforeEach, afterEach, before} from 'node:test';
 
 import type {DriverType, ExtensionType} from '@appium/types';
@@ -11,7 +12,7 @@ import {Manifest} from '../../../lib/extension/manifest';
 import {resetSchema} from '../../../lib/schema';
 import {assertArrayIncludesDeep, resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, MockResolveFrom, Overrides} from './mocks';
+import type {MockAppiumSupport, Overrides} from './mocks';
 
 type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType> & {
   schema: NonNullable<ExtManifest<ExtType>['schema']>;
@@ -28,7 +29,6 @@ describe('DriverConfig', function () {
   let manifest: Manifest;
   let sandbox: SinonSandbox;
   let MockAppiumSupport: MockAppiumSupport;
-  let MockResolveFrom: MockResolveFrom;
   let DriverConfig: DriverConfigConstructor;
 
   before(async function () {
@@ -38,7 +38,7 @@ describe('DriverConfig', function () {
   beforeEach(function () {
     manifest = Manifest.getInstance('/somewhere/');
     let overrides: Overrides;
-    ({MockAppiumSupport, MockResolveFrom, overrides, sandbox} = initMocks());
+    ({MockAppiumSupport, overrides, sandbox} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({DriverConfig} = rewiremock.proxy(() => require('../../../lib/extension/driver-config'), overrides));
     resetSchema();
@@ -223,15 +223,12 @@ describe('DriverConfig', function () {
           });
 
           describe('when the property as a path is found', function () {
-            beforeEach(function () {
-              MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
-            });
-
             it('should return an empty array', async function () {
               const problems = await driverConfig.getSchemaProblems(
                 {
                   pkgName: 'whatever',
                   schema: 'driver-schema.js',
+                  installPath: path.dirname(resolveFixture('driver-schema.js')),
                 },
                 'foo',
               );
@@ -260,7 +257,7 @@ describe('DriverConfig', function () {
           installType: 'npm',
           installPath: '/somewhere',
         };
-        MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
+        extData.installPath = path.dirname(resolveFixture('driver-schema.js'));
         driverConfig = DriverConfig.create(manifest);
       });
 
@@ -283,10 +280,7 @@ describe('DriverConfig', function () {
 
       describe('when the extension schema has not yet been registered', function () {
         it('should resolve and load the extension schema file', async function () {
-          await driverConfig.readExtensionSchema(extName, extData);
-
-          // we don't have access to the schema registration cache directly, so this is as close as we can get.
-          assert.strictEqual(MockResolveFrom.calledOnce, true);
+          await assert.doesNotReject(driverConfig.readExtensionSchema(extName, extData));
         });
       });
     });

--- a/packages/appium/test/unit/extension/driver-config.spec.ts
+++ b/packages/appium/test/unit/extension/driver-config.spec.ts
@@ -12,7 +12,7 @@ import {Manifest} from '../../../lib/extension/manifest';
 import {resetSchema} from '../../../lib/schema';
 import {assertArrayIncludesDeep, resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, Overrides} from './mocks';
+import type {MockAppiumSupport, MockResolveFrom, Overrides} from './mocks';
 
 type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType> & {
   schema: NonNullable<ExtManifest<ExtType>['schema']>;
@@ -29,6 +29,7 @@ describe('DriverConfig', function () {
   let manifest: Manifest;
   let sandbox: SinonSandbox;
   let MockAppiumSupport: MockAppiumSupport;
+  let MockResolveFrom: MockResolveFrom;
   let DriverConfig: DriverConfigConstructor;
 
   before(async function () {
@@ -38,7 +39,7 @@ describe('DriverConfig', function () {
   beforeEach(function () {
     manifest = Manifest.getInstance('/somewhere/');
     let overrides: Overrides;
-    ({MockAppiumSupport, overrides, sandbox} = initMocks());
+    ({MockAppiumSupport, MockResolveFrom, overrides, sandbox} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({DriverConfig} = rewiremock.proxy(() => require('../../../lib/extension/driver-config'), overrides));
     resetSchema();
@@ -223,16 +224,23 @@ describe('DriverConfig', function () {
           });
 
           describe('when the property as a path is found', function () {
+            beforeEach(function () {
+              MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
+            });
+
             it('should return an empty array', async function () {
               const problems = await driverConfig.getSchemaProblems(
                 {
                   pkgName: 'whatever',
                   schema: 'driver-schema.js',
-                  installPath: path.dirname(resolveFixture('driver-schema.js')),
                 },
                 'foo',
               );
               assert.strictEqual(problems.length, 0);
+              assert.strictEqual(
+                MockResolveFrom.calledOnceWithExactly('/somewhere/', path.join('whatever', 'driver-schema.js')),
+                true,
+              );
             });
           });
         });
@@ -257,7 +265,7 @@ describe('DriverConfig', function () {
           installType: 'npm',
           installPath: '/somewhere',
         };
-        extData.installPath = path.dirname(resolveFixture('driver-schema.js'));
+        MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
         driverConfig = DriverConfig.create(manifest);
       });
 
@@ -280,7 +288,12 @@ describe('DriverConfig', function () {
 
       describe('when the extension schema has not yet been registered', function () {
         it('should resolve and load the extension schema file', async function () {
-          await assert.doesNotReject(driverConfig.readExtensionSchema(extName, extData));
+          await driverConfig.readExtensionSchema(extName, extData);
+
+          assert.strictEqual(
+            MockResolveFrom.calledOnceWithExactly('/somewhere', path.resolve('/somewhere', 'driver-schema.js')),
+            true,
+          );
         });
       });
     });

--- a/packages/appium/test/unit/extension/driver-config.spec.ts
+++ b/packages/appium/test/unit/extension/driver-config.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {promises as fs} from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import {describe, it, beforeEach, afterEach, before} from 'node:test';
 
@@ -10,9 +11,10 @@ import type {SinonSandbox} from 'sinon';
 import type {DriverConfig} from '../../../lib/extension/driver-config';
 import {Manifest} from '../../../lib/extension/manifest';
 import {resetSchema} from '../../../lib/schema';
+import {resolvePackageSubpathFrom} from '../../../lib/utils/resolve-from';
 import {assertArrayIncludesDeep, resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, MockResolveFrom, Overrides} from './mocks';
+import type {MockAppiumSupport, MockResolveFrom, MockResolvePackageSubpathFrom, Overrides} from './mocks';
 
 type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType> & {
   schema: NonNullable<ExtManifest<ExtType>['schema']>;
@@ -30,6 +32,7 @@ describe('DriverConfig', function () {
   let sandbox: SinonSandbox;
   let MockAppiumSupport: MockAppiumSupport;
   let MockResolveFrom: MockResolveFrom;
+  let MockResolvePackageSubpathFrom: MockResolvePackageSubpathFrom;
   let DriverConfig: DriverConfigConstructor;
 
   before(async function () {
@@ -39,7 +42,7 @@ describe('DriverConfig', function () {
   beforeEach(function () {
     manifest = Manifest.getInstance('/somewhere/');
     let overrides: Overrides;
-    ({MockAppiumSupport, MockResolveFrom, overrides, sandbox} = initMocks());
+    ({MockAppiumSupport, MockResolveFrom, MockResolvePackageSubpathFrom, overrides, sandbox} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({DriverConfig} = rewiremock.proxy(() => require('../../../lib/extension/driver-config'), overrides));
     resetSchema();
@@ -238,9 +241,37 @@ describe('DriverConfig', function () {
               );
               assert.strictEqual(problems.length, 0);
               assert.strictEqual(
-                MockResolveFrom.calledOnceWithExactly('/somewhere/', path.join('whatever', 'driver-schema.js')),
+                MockResolveFrom.calledOnceWithExactly('/somewhere/', path.posix.join('whatever', 'driver-schema.js')),
                 true,
               );
+            });
+
+            it('should honor an export-mapped schema from the installed package', async function () {
+              const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'appium-schema-exports-'));
+              const pkgName = 'exported-schema-driver';
+              const installPath = path.join(tempRoot, 'node_modules', pkgName);
+              try {
+                await fs.mkdir(path.join(installPath, 'build'), {recursive: true});
+                await fs.writeFile(
+                  path.join(installPath, 'package.json'),
+                  JSON.stringify({
+                    name: pkgName,
+                    version: '1.0.0',
+                    exports: {'./schema.json': './build/schema.json'},
+                  }),
+                );
+                await fs.writeFile(path.join(installPath, 'build', 'schema.json'), JSON.stringify({type: 'object'}));
+                MockResolvePackageSubpathFrom.callsFake(resolvePackageSubpathFrom);
+
+                const problems = await driverConfig.getSchemaProblems(
+                  {pkgName, schema: 'schema.json', installPath},
+                  'exported',
+                );
+
+                assert.deepStrictEqual(problems, []);
+              } finally {
+                await fs.rm(tempRoot, {recursive: true, force: true});
+              }
             });
           });
         });
@@ -291,7 +322,7 @@ describe('DriverConfig', function () {
           await driverConfig.readExtensionSchema(extName, extData);
 
           assert.strictEqual(
-            MockResolveFrom.calledOnceWithExactly('/somewhere', path.resolve('/somewhere', 'driver-schema.js')),
+            MockResolvePackageSubpathFrom.calledOnceWithExactly('/somewhere', 'some-pkg', 'driver-schema.js'),
             true,
           );
         });

--- a/packages/appium/test/unit/extension/driver-config.spec.ts
+++ b/packages/appium/test/unit/extension/driver-config.spec.ts
@@ -11,10 +11,9 @@ import type {SinonSandbox} from 'sinon';
 import type {DriverConfig} from '../../../lib/extension/driver-config';
 import {Manifest} from '../../../lib/extension/manifest';
 import {resetSchema} from '../../../lib/schema';
-import {resolvePackageSubpathFrom} from '../../../lib/utils/resolve-from';
 import {assertArrayIncludesDeep, resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, MockResolveFrom, MockResolvePackageSubpathFrom, Overrides} from './mocks';
+import type {MockAppiumSupport, MockResolveFrom, Overrides} from './mocks';
 
 type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType> & {
   schema: NonNullable<ExtManifest<ExtType>['schema']>;
@@ -32,7 +31,6 @@ describe('DriverConfig', function () {
   let sandbox: SinonSandbox;
   let MockAppiumSupport: MockAppiumSupport;
   let MockResolveFrom: MockResolveFrom;
-  let MockResolvePackageSubpathFrom: MockResolvePackageSubpathFrom;
   let DriverConfig: DriverConfigConstructor;
 
   before(async function () {
@@ -42,7 +40,7 @@ describe('DriverConfig', function () {
   beforeEach(function () {
     manifest = Manifest.getInstance('/somewhere/');
     let overrides: Overrides;
-    ({MockAppiumSupport, MockResolveFrom, MockResolvePackageSubpathFrom, overrides, sandbox} = initMocks());
+    ({MockAppiumSupport, MockResolveFrom, overrides, sandbox} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({DriverConfig} = rewiremock.proxy(() => require('../../../lib/extension/driver-config'), overrides));
     resetSchema();
@@ -261,7 +259,6 @@ describe('DriverConfig', function () {
                   }),
                 );
                 await fs.writeFile(path.join(installPath, 'build', 'schema.json'), JSON.stringify({type: 'object'}));
-                MockResolvePackageSubpathFrom.callsFake(resolvePackageSubpathFrom);
 
                 const problems = await driverConfig.getSchemaProblems(
                   {pkgName, schema: 'schema.json', installPath},
@@ -281,23 +278,39 @@ describe('DriverConfig', function () {
     describe('readExtensionSchema()', function () {
       let driverConfig: DriverConfig;
       let extData: ExtManifestWithSchema<DriverType>;
+      let tempRoot: string;
 
       const extName = 'stuff';
 
-      beforeEach(function () {
+      beforeEach(async function () {
+        tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'appium-driver-schema-'));
+        const installPath = path.join(tempRoot, 'node_modules', 'some-pkg');
+        await fs.mkdir(installPath, {recursive: true});
+        await fs.writeFile(
+          path.join(installPath, 'package.json'),
+          JSON.stringify({
+            name: 'some-pkg',
+            version: '1.0.0',
+            exports: {'./driver-schema.json': './driver-schema.json'},
+          }),
+        );
+        await fs.writeFile(path.join(installPath, 'driver-schema.json'), JSON.stringify({type: 'object'}));
         extData = {
           pkgName: 'some-pkg',
-          schema: 'driver-schema.js',
+          schema: 'driver-schema.json',
           automationName: 'foo',
           mainClass: 'Gargle',
           platformNames: ['barnyard'],
           version: '1.0.0',
           installSpec: 'some-pkg',
           installType: 'npm',
-          installPath: '/somewhere',
+          installPath,
         };
-        MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
         driverConfig = DriverConfig.create(manifest);
+      });
+
+      afterEach(async function () {
+        await fs.rm(tempRoot, {recursive: true, force: true});
       });
 
       describe('when the extension data is missing `schema`', function () {
@@ -318,13 +331,8 @@ describe('DriverConfig', function () {
       });
 
       describe('when the extension schema has not yet been registered', function () {
-        it('should resolve and load the extension schema file', async function () {
-          await driverConfig.readExtensionSchema(extName, extData);
-
-          assert.strictEqual(
-            MockResolvePackageSubpathFrom.calledOnceWithExactly('/somewhere', 'some-pkg', 'driver-schema.js'),
-            true,
-          );
+        it('should resolve and load the extension schema file from the installed package', async function () {
+          await assert.doesNotReject(driverConfig.readExtensionSchema(extName, extData));
         });
       });
     });

--- a/packages/appium/test/unit/extension/manifest.spec.ts
+++ b/packages/appium/test/unit/extension/manifest.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {promises as fs} from 'node:fs';
+import path from 'node:path';
 import {describe, it, beforeEach, afterEach, before} from 'node:test';
 
 import type {DriverType, PluginType} from '@appium/types';
@@ -10,13 +11,14 @@ import {DRIVER_TYPE, PLUGIN_TYPE} from '../../../lib/constants';
 import {APPIUM_VER} from '../../../lib/helpers/build';
 import {resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, MockPackageChanged} from './mocks';
+import type {MockAppiumSupport, MockPackageChanged, MockResolveFrom} from './mocks';
 
 describe('Manifest', function () {
   let sandbox: SinonSandbox;
   let yamlFixture: string;
   let MockPackageChanged: MockPackageChanged;
   let MockAppiumSupport: MockAppiumSupport;
+  let MockResolveFrom: MockResolveFrom;
   let Manifest: any;
 
   before(async function () {
@@ -25,7 +27,7 @@ describe('Manifest', function () {
 
   beforeEach(function () {
     let overrides: ReturnType<typeof initMocks>['overrides'];
-    ({MockPackageChanged, MockAppiumSupport, overrides, sandbox} = initMocks());
+    ({MockPackageChanged, MockAppiumSupport, MockResolveFrom, overrides, sandbox} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({Manifest} = rewiremock.proxy(() => require('../../../lib/extension/manifest'), {
       ...overrides,
@@ -54,6 +56,14 @@ describe('Manifest', function () {
           const firstInstance = Manifest.getInstance('/some/path');
           const secondInstance = Manifest.getInstance('/some/other/path');
           assert.notStrictEqual(firstInstance, secondInstance);
+        });
+
+        describe('when called with different extension search roots', function () {
+          it('should return different objects', function () {
+            const firstInstance = Manifest.getInstance('/some/path', '/workspace/packages/one');
+            const secondInstance = Manifest.getInstance('/some/path', '/workspace/packages/two');
+            assert.notStrictEqual(firstInstance, secondInstance);
+          });
         });
       });
     });
@@ -486,6 +496,118 @@ describe('Manifest', function () {
       it('should add a found extension', async function () {
         await manifest.syncWithInstalledExtensions();
         assert.ok(Object.hasOwn(manifest.getExtensionData(DRIVER_TYPE), 'myDriver'));
+      });
+
+      it('should resolve only dependencies declared by an explicit search root', async function () {
+        const searchRoot = path.resolve('/workspace/packages/app');
+        MockAppiumSupport.fs.readFile.callsFake(async (filepath: string) => {
+          if (filepath === path.join(searchRoot, 'package.json')) {
+            return JSON.stringify({devDependencies: {'appium-test-driver': '1.0.0', lodash: '1.0.0'}});
+          }
+          if (filepath.endsWith(path.join('appium-test-driver', 'package.json'))) {
+            return JSON.stringify({
+              name: 'appium-test-driver',
+              version: '1.0.0',
+              appium: {
+                automationName: 'Test',
+                mainClass: 'TestDriver',
+                platformNames: ['Test'],
+                driverName: 'test',
+              },
+            });
+          }
+          return JSON.stringify({name: 'lodash', version: '1.0.0'});
+        });
+
+        await manifest.syncWithInstalledExtensions(true, searchRoot);
+
+        assert.ok(Object.hasOwn(manifest.getExtensionData(DRIVER_TYPE), 'test'));
+        assert.strictEqual(MockAppiumSupport.fs.glob.called, false);
+        assert.strictEqual(MockResolveFrom.calledWith(searchRoot, 'appium-test-driver/package.json'), true);
+        assert.strictEqual(MockResolveFrom.calledWith(searchRoot, 'lodash/package.json'), true);
+      });
+
+      it('should reject an unreadable explicit search root', async function () {
+        const searchRoot = path.resolve('/workspace/packages/app');
+        MockAppiumSupport.fs.readFile.rejects(new Error('permission denied'));
+
+        await assert.rejects(
+          manifest.syncWithInstalledExtensions(false, searchRoot),
+          new RegExp(
+            `Could not read extension search root package manifest.*${path.basename(searchRoot)}.*package.json`,
+            'i',
+          ),
+        );
+      });
+
+      it('should reject malformed dependency data in an explicit search root', async function () {
+        const searchRoot = path.resolve('/workspace/packages/app');
+        MockAppiumSupport.fs.readFile.callsFake(async (filepath: string) =>
+          filepath === path.join(searchRoot, 'package.json') ? JSON.stringify({dependencies: []}) : '{}',
+        );
+
+        await assert.rejects(
+          manifest.syncWithInstalledExtensions(false, searchRoot),
+          /'dependencies' field.*must contain an object/i,
+        );
+      });
+
+      it('should find an extension whose package manifest is not exported', async function () {
+        const searchRoot = path.resolve('/workspace/packages/app');
+        const packageRoot = path.resolve('/workspace/node_modules/appium-driver');
+        const exportsError = Object.assign(new Error('Package subpath ./package.json is not defined by exports'), {
+          code: 'ERR_PACKAGE_PATH_NOT_EXPORTED',
+        });
+        MockAppiumSupport.fs.readFile.callsFake(async (filepath: string) =>
+          filepath === path.join(searchRoot, 'package.json')
+            ? JSON.stringify({dependencies: {'appium-driver': '1.0.0'}})
+            : JSON.stringify({
+                name: 'appium-driver',
+                version: '1.0.0',
+                appium: {
+                  automationName: 'Test',
+                  mainClass: 'TestDriver',
+                  platformNames: ['Test'],
+                  driverName: 'test',
+                },
+              }),
+        );
+        MockResolveFrom.withArgs(searchRoot, 'appium-driver/package.json').rejects(exportsError);
+        MockResolveFrom.withArgs(searchRoot, 'appium-driver').resolves(path.join(packageRoot, 'index.js'));
+        MockAppiumSupport.fs.findRoot.returns(packageRoot);
+
+        await manifest.syncWithInstalledExtensions(false, searchRoot);
+
+        assert.ok(Object.hasOwn(manifest.getExtensionData(DRIVER_TYPE), 'test'));
+      });
+
+      it('should not persist extensions discovered from an explicit search root', async function () {
+        const searchRoot = path.resolve('/workspace/packages/app');
+        const rootManifest = Manifest.getInstance('/some/path', searchRoot);
+        MockAppiumSupport.fs.readFile.callsFake(async (filepath: string) => {
+          if (filepath === '/some/path/extensions.yaml') {
+            return yamlFixture;
+          }
+          if (filepath === path.join(searchRoot, 'package.json')) {
+            return JSON.stringify({dependencies: {'appium-driver': '1.0.0'}});
+          }
+          return JSON.stringify({
+            name: 'appium-driver',
+            version: '1.0.0',
+            appium: {
+              automationName: 'Test',
+              mainClass: 'TestDriver',
+              platformNames: ['Test'],
+              driverName: 'test',
+            },
+          });
+        });
+
+        await rootManifest.read();
+        await rootManifest.write();
+
+        assert.ok(Object.hasOwn(rootManifest.getExtensionData(DRIVER_TYPE), 'test'));
+        assert.doesNotMatch(MockAppiumSupport.fs.writeFile.lastCall.args[1], /appium-driver/);
       });
 
       describe('when the underlying implementation emits "error"', function () {

--- a/packages/appium/test/unit/extension/manifest.spec.ts
+++ b/packages/appium/test/unit/extension/manifest.spec.ts
@@ -523,8 +523,11 @@ describe('Manifest', function () {
 
         assert.ok(Object.hasOwn(manifest.getExtensionData(DRIVER_TYPE), 'test'));
         assert.strictEqual(MockAppiumSupport.fs.glob.called, false);
-        assert.strictEqual(MockResolveFrom.calledWith(searchRoot, 'appium-test-driver/package.json'), true);
-        assert.strictEqual(MockResolveFrom.calledWith(searchRoot, 'lodash/package.json'), true);
+        assert.strictEqual(
+          MockResolveFrom.calledWith(searchRoot, path.join('appium-test-driver', 'package.json')),
+          true,
+        );
+        assert.strictEqual(MockResolveFrom.calledWith(searchRoot, path.join('lodash', 'package.json')), true);
       });
 
       it('should reject an unreadable explicit search root', async function () {
@@ -572,7 +575,7 @@ describe('Manifest', function () {
                 },
               }),
         );
-        MockResolveFrom.withArgs(searchRoot, 'appium-driver/package.json').rejects(exportsError);
+        MockResolveFrom.withArgs(searchRoot, path.join('appium-driver', 'package.json')).rejects(exportsError);
         MockResolveFrom.withArgs(searchRoot, 'appium-driver').resolves(path.join(packageRoot, 'index.js'));
         MockAppiumSupport.fs.findRoot.returns(packageRoot);
 

--- a/packages/appium/test/unit/extension/manifest.spec.ts
+++ b/packages/appium/test/unit/extension/manifest.spec.ts
@@ -502,7 +502,16 @@ describe('Manifest', function () {
         const searchRoot = path.resolve('/workspace/packages/app');
         MockAppiumSupport.fs.readFile.callsFake(async (filepath: string) => {
           if (filepath === path.join(searchRoot, 'package.json')) {
-            return JSON.stringify({devDependencies: {'appium-test-driver': '1.0.0', lodash: '1.0.0'}});
+            return JSON.stringify({
+              dependencies: {'appium-test-driver': '1.0.0'},
+              devDependencies: {'appium-test-driver': '1.0.0', lodash: '1.0.0'},
+              optionalDependencies: {
+                'appium-test-driver': '1.0.0',
+                'appium-optional-driver': '1.0.0',
+              },
+              peerDependencies: {'appium-peer-driver': '1.0.0'},
+              overrides: {'appium-override-driver': '1.0.0'},
+            });
           }
           if (filepath.endsWith(path.join('appium-test-driver', 'package.json'))) {
             return JSON.stringify({
@@ -516,15 +525,48 @@ describe('Manifest', function () {
               },
             });
           }
+          if (filepath.endsWith(path.join('appium-optional-driver', 'package.json'))) {
+            return JSON.stringify({
+              name: 'appium-optional-driver',
+              version: '1.0.0',
+              appium: {
+                automationName: 'Optional',
+                mainClass: 'OptionalDriver',
+                platformNames: ['Optional'],
+                driverName: 'optional',
+              },
+            });
+          }
           return JSON.stringify({name: 'lodash', version: '1.0.0'});
         });
 
         await manifest.syncWithDeclaredExtensions(searchRoot, true);
 
         assert.ok(Object.hasOwn(manifest.getExtensionData(DRIVER_TYPE), 'test'));
+        assert.ok(Object.hasOwn(manifest.getExtensionData(DRIVER_TYPE), 'optional'));
         assert.strictEqual(MockAppiumSupport.fs.glob.called, false);
         assert.strictEqual(MockResolvePackageJsonFrom.calledWith(searchRoot, 'appium-test-driver'), true);
+        assert.strictEqual(MockResolvePackageJsonFrom.withArgs(searchRoot, 'appium-test-driver').calledOnce, true);
         assert.strictEqual(MockResolvePackageJsonFrom.calledWith(searchRoot, 'lodash'), true);
+        assert.strictEqual(MockResolvePackageJsonFrom.calledWith(searchRoot, 'appium-optional-driver'), true);
+        assert.strictEqual(MockResolvePackageJsonFrom.calledWith(searchRoot, 'appium-peer-driver'), false);
+        assert.strictEqual(MockResolvePackageJsonFrom.calledWith(searchRoot, 'appium-override-driver'), false);
+      });
+
+      it('should ignore a missing optional dependency', async function () {
+        const searchRoot = path.resolve('/workspace/packages/app');
+        MockAppiumSupport.fs.readFile.callsFake(async (filepath: string) =>
+          filepath === path.join(searchRoot, 'package.json')
+            ? JSON.stringify({optionalDependencies: {'missing-driver': '1.0.0'}})
+            : '{}',
+        );
+        MockResolvePackageJsonFrom.withArgs(searchRoot, 'missing-driver').rejects(
+          Object.assign(new Error('Cannot find package'), {code: 'MODULE_NOT_FOUND'}),
+        );
+
+        await assert.doesNotReject(manifest.syncWithDeclaredExtensions(searchRoot));
+
+        assert.strictEqual(Object.hasOwn(manifest.getExtensionData(DRIVER_TYPE), 'missing-driver'), false);
       });
 
       it('should reject an unreadable explicit search root', async function () {
@@ -549,6 +591,18 @@ describe('Manifest', function () {
         await assert.rejects(
           manifest.syncWithDeclaredExtensions(searchRoot),
           /'dependencies' field.*must contain an object/i,
+        );
+      });
+
+      it('should reject malformed optional dependency data in an explicit search root', async function () {
+        const searchRoot = path.resolve('/workspace/packages/app');
+        MockAppiumSupport.fs.readFile.callsFake(async (filepath: string) =>
+          filepath === path.join(searchRoot, 'package.json') ? JSON.stringify({optionalDependencies: []}) : '{}',
+        );
+
+        await assert.rejects(
+          manifest.syncWithDeclaredExtensions(searchRoot),
+          /'optionalDependencies' field.*must contain an object/i,
         );
       });
 
@@ -588,7 +642,7 @@ describe('Manifest', function () {
           if (filepath === '/some/path/extensions.yaml') {
             return yamlFixture;
           }
-          if (filepath === '/some/path/package.json') {
+          if (filepath === path.join('/some/path', 'package.json')) {
             return JSON.stringify({name: 'appium-home', version: '1.0.0'});
           }
           if (filepath === path.join(searchRoot, 'package.json')) {

--- a/packages/appium/test/unit/extension/manifest.spec.ts
+++ b/packages/appium/test/unit/extension/manifest.spec.ts
@@ -11,14 +11,14 @@ import {DRIVER_TYPE, PLUGIN_TYPE} from '../../../lib/constants';
 import {APPIUM_VER} from '../../../lib/helpers/build';
 import {resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, MockPackageChanged, MockResolveFrom} from './mocks';
+import type {MockAppiumSupport, MockPackageChanged, MockResolvePackageJsonFrom} from './mocks';
 
 describe('Manifest', function () {
   let sandbox: SinonSandbox;
   let yamlFixture: string;
   let MockPackageChanged: MockPackageChanged;
   let MockAppiumSupport: MockAppiumSupport;
-  let MockResolveFrom: MockResolveFrom;
+  let MockResolvePackageJsonFrom: MockResolvePackageJsonFrom;
   let Manifest: any;
 
   before(async function () {
@@ -27,7 +27,7 @@ describe('Manifest', function () {
 
   beforeEach(function () {
     let overrides: ReturnType<typeof initMocks>['overrides'];
-    ({MockPackageChanged, MockAppiumSupport, MockResolveFrom, overrides, sandbox} = initMocks());
+    ({MockPackageChanged, MockAppiumSupport, MockResolvePackageJsonFrom, overrides, sandbox} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({Manifest} = rewiremock.proxy(() => require('../../../lib/extension/manifest'), {
       ...overrides,
@@ -519,15 +519,12 @@ describe('Manifest', function () {
           return JSON.stringify({name: 'lodash', version: '1.0.0'});
         });
 
-        await manifest.syncWithInstalledExtensions(true, searchRoot);
+        await manifest.syncWithDeclaredExtensions(searchRoot, true);
 
         assert.ok(Object.hasOwn(manifest.getExtensionData(DRIVER_TYPE), 'test'));
         assert.strictEqual(MockAppiumSupport.fs.glob.called, false);
-        assert.strictEqual(
-          MockResolveFrom.calledWith(searchRoot, path.join('appium-test-driver', 'package.json')),
-          true,
-        );
-        assert.strictEqual(MockResolveFrom.calledWith(searchRoot, path.join('lodash', 'package.json')), true);
+        assert.strictEqual(MockResolvePackageJsonFrom.calledWith(searchRoot, 'appium-test-driver'), true);
+        assert.strictEqual(MockResolvePackageJsonFrom.calledWith(searchRoot, 'lodash'), true);
       });
 
       it('should reject an unreadable explicit search root', async function () {
@@ -535,7 +532,7 @@ describe('Manifest', function () {
         MockAppiumSupport.fs.readFile.rejects(new Error('permission denied'));
 
         await assert.rejects(
-          manifest.syncWithInstalledExtensions(false, searchRoot),
+          manifest.syncWithDeclaredExtensions(searchRoot),
           new RegExp(
             `Could not read extension search root package manifest.*${path.basename(searchRoot)}.*package.json`,
             'i',
@@ -550,7 +547,7 @@ describe('Manifest', function () {
         );
 
         await assert.rejects(
-          manifest.syncWithInstalledExtensions(false, searchRoot),
+          manifest.syncWithDeclaredExtensions(searchRoot),
           /'dependencies' field.*must contain an object/i,
         );
       });
@@ -558,9 +555,6 @@ describe('Manifest', function () {
       it('should find an extension whose package manifest is not exported', async function () {
         const searchRoot = path.resolve('/workspace/packages/app');
         const packageRoot = path.resolve('/workspace/node_modules/appium-driver');
-        const exportsError = Object.assign(new Error('Package subpath ./package.json is not defined by exports'), {
-          code: 'ERR_PACKAGE_PATH_NOT_EXPORTED',
-        });
         MockAppiumSupport.fs.readFile.callsFake(async (filepath: string) =>
           filepath === path.join(searchRoot, 'package.json')
             ? JSON.stringify({dependencies: {'appium-driver': '1.0.0'}})
@@ -575,24 +569,42 @@ describe('Manifest', function () {
                 },
               }),
         );
-        MockResolveFrom.withArgs(searchRoot, path.join('appium-driver', 'package.json')).rejects(exportsError);
-        MockResolveFrom.withArgs(searchRoot, 'appium-driver').resolves(path.join(packageRoot, 'index.js'));
-        MockAppiumSupport.fs.findRoot.returns(packageRoot);
+        MockResolvePackageJsonFrom.withArgs(searchRoot, 'appium-driver').resolves(
+          path.join(packageRoot, 'package.json'),
+        );
 
-        await manifest.syncWithInstalledExtensions(false, searchRoot);
+        await manifest.syncWithDeclaredExtensions(searchRoot);
 
         assert.ok(Object.hasOwn(manifest.getExtensionData(DRIVER_TYPE), 'test'));
       });
 
       it('should not persist extensions discovered from an explicit search root', async function () {
         const searchRoot = path.resolve('/workspace/packages/app');
+        const standardDriverPath = path.resolve('/some/path/node_modules/appium-standard-driver/package.json');
         const rootManifest = Manifest.getInstance('/some/path', searchRoot);
+        MockAppiumSupport.env.hasAppiumDependency.resolves(true);
+        MockAppiumSupport.fs.glob.resolves([standardDriverPath]);
         MockAppiumSupport.fs.readFile.callsFake(async (filepath: string) => {
           if (filepath === '/some/path/extensions.yaml') {
             return yamlFixture;
           }
+          if (filepath === '/some/path/package.json') {
+            return JSON.stringify({name: 'appium-home', version: '1.0.0'});
+          }
           if (filepath === path.join(searchRoot, 'package.json')) {
             return JSON.stringify({dependencies: {'appium-driver': '1.0.0'}});
+          }
+          if (filepath === standardDriverPath) {
+            return JSON.stringify({
+              name: 'appium-standard-driver',
+              version: '1.0.0',
+              appium: {
+                automationName: 'Standard',
+                mainClass: 'StandardDriver',
+                platformNames: ['Standard'],
+                driverName: 'standard',
+              },
+            });
           }
           return JSON.stringify({
             name: 'appium-driver',
@@ -610,6 +622,9 @@ describe('Manifest', function () {
         await rootManifest.write();
 
         assert.ok(Object.hasOwn(rootManifest.getExtensionData(DRIVER_TYPE), 'test'));
+        assert.ok(Object.hasOwn(rootManifest.getExtensionData(DRIVER_TYPE), 'standard'));
+        assert.strictEqual(MockAppiumSupport.fs.glob.calledOnce, true);
+        assert.match(MockAppiumSupport.fs.writeFile.lastCall.args[1], /appium-standard-driver/);
         assert.doesNotMatch(MockAppiumSupport.fs.writeFile.lastCall.args[1], /appium-driver/);
       });
 

--- a/packages/appium/test/unit/extension/mocks.ts
+++ b/packages/appium/test/unit/extension/mocks.ts
@@ -15,6 +15,7 @@ export interface MockAppiumSupportFs {
   glob: SinonStub;
   mkdirp: SinonStub;
   exists: SinonStub;
+  findRoot: SinonStub;
 }
 
 export interface MockAppiumSupportEnv {
@@ -97,6 +98,7 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
       glob: sandbox.stub().resolves([]),
       mkdirp: sandbox.stub().resolves(),
       exists: sandbox.stub().resolves(true),
+      findRoot: sandbox.stub().callsFake((dir: string) => dir),
     },
     env: {
       resolveAppiumHome: sandbox.stub().resolves('/some/path'),

--- a/packages/appium/test/unit/extension/mocks.ts
+++ b/packages/appium/test/unit/extension/mocks.ts
@@ -8,6 +8,8 @@ import path from 'node:path';
 import {console as supportConsole, util as supportUtil} from '@appium/support';
 import {createSandbox, type SinonSandbox, type SinonStub} from 'sinon';
 
+import {resolvePackageSubpathFrom} from '../../../lib/utils/resolve-from';
+
 export interface MockAppiumSupportFs {
   readFile: SinonStub;
   writeFile: SinonStub;
@@ -71,13 +73,6 @@ export interface MockResolvePackageJsonFrom extends SinonStub<[cwd: string, pack
   (cwd: string, packageName: string): Promise<string>;
 }
 
-export interface MockResolvePackageSubpathFrom extends SinonStub<
-  [installPath: string, packageName: string, subpath: string],
-  Promise<string>
-> {
-  (installPath: string, packageName: string, subpath: string): Promise<string>;
-}
-
 export interface MockGlob extends SinonStub {
   (spec: string, opts: {cwd: string}, done: () => void): EventEmitter;
 }
@@ -87,7 +82,7 @@ export interface Overrides {
   '../../../lib/utils/resolve-from': {
     resolveFrom: MockResolveFrom;
     resolvePackageJsonFrom: MockResolvePackageJsonFrom;
-    resolvePackageSubpathFrom: MockResolvePackageSubpathFrom;
+    resolvePackageSubpathFrom: typeof resolvePackageSubpathFrom;
   };
   '../../../lib/utils/is-package-changed': MockPackageChanged;
   glob: MockGlob;
@@ -98,7 +93,6 @@ export interface InitMocksResult {
   MockPackageChanged: MockPackageChanged;
   MockResolveFrom: MockResolveFrom;
   MockResolvePackageJsonFrom: MockResolvePackageJsonFrom;
-  MockResolvePackageSubpathFrom: MockResolvePackageSubpathFrom;
   MockGlob: MockGlob;
   sandbox: SinonSandbox;
   overrides: Overrides;
@@ -167,9 +161,6 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
   const MockResolvePackageJsonFrom: MockResolvePackageJsonFrom = sandbox
     .stub<[cwd: string, packageName: string], Promise<string>>()
     .callsFake(async (cwd, packageName) => path.join(cwd, 'node_modules', packageName, 'package.json'));
-  const MockResolvePackageSubpathFrom: MockResolvePackageSubpathFrom = sandbox
-    .stub<[installPath: string, packageName: string, subpath: string], Promise<string>>()
-    .callsFake(async (installPath, _packageName, subpath) => path.join(installPath, subpath));
 
   const MockGlob = sandbox.stub().callsFake((spec: string, opts: {cwd: string}, done: () => void) => {
     const ee = new EventEmitter();
@@ -187,7 +178,7 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
     '../../../lib/utils/resolve-from': {
       resolveFrom: MockResolveFrom,
       resolvePackageJsonFrom: MockResolvePackageJsonFrom,
-      resolvePackageSubpathFrom: MockResolvePackageSubpathFrom,
+      resolvePackageSubpathFrom,
     },
     '../../../lib/utils/is-package-changed': MockPackageChanged,
     glob: MockGlob,
@@ -198,7 +189,6 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
     MockPackageChanged,
     MockResolveFrom,
     MockResolvePackageJsonFrom,
-    MockResolvePackageSubpathFrom,
     MockGlob,
     sandbox,
     overrides,

--- a/packages/appium/test/unit/extension/mocks.ts
+++ b/packages/appium/test/unit/extension/mocks.ts
@@ -67,13 +67,28 @@ export interface MockResolveFrom extends SinonStub<[cwd: string, id: string], Pr
   (cwd: string, id: string): Promise<string>;
 }
 
+export interface MockResolvePackageJsonFrom extends SinonStub<[cwd: string, packageName: string], Promise<string>> {
+  (cwd: string, packageName: string): Promise<string>;
+}
+
+export interface MockResolvePackageSubpathFrom extends SinonStub<
+  [installPath: string, packageName: string, subpath: string],
+  Promise<string>
+> {
+  (installPath: string, packageName: string, subpath: string): Promise<string>;
+}
+
 export interface MockGlob extends SinonStub {
   (spec: string, opts: {cwd: string}, done: () => void): EventEmitter;
 }
 
 export interface Overrides {
   '@appium/support': MockAppiumSupport;
-  '../../../lib/utils/resolve-from': {resolveFrom: MockResolveFrom};
+  '../../../lib/utils/resolve-from': {
+    resolveFrom: MockResolveFrom;
+    resolvePackageJsonFrom: MockResolvePackageJsonFrom;
+    resolvePackageSubpathFrom: MockResolvePackageSubpathFrom;
+  };
   '../../../lib/utils/is-package-changed': MockPackageChanged;
   glob: MockGlob;
 }
@@ -82,6 +97,8 @@ export interface InitMocksResult {
   MockAppiumSupport: MockAppiumSupport;
   MockPackageChanged: MockPackageChanged;
   MockResolveFrom: MockResolveFrom;
+  MockResolvePackageJsonFrom: MockResolvePackageJsonFrom;
+  MockResolvePackageSubpathFrom: MockResolvePackageSubpathFrom;
   MockGlob: MockGlob;
   sandbox: SinonSandbox;
   overrides: Overrides;
@@ -147,6 +164,12 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
   const MockResolveFrom: MockResolveFrom = sandbox
     .stub<[cwd: string, id: string], Promise<string>>()
     .callsFake(async (cwd, id) => path.join(cwd, id));
+  const MockResolvePackageJsonFrom: MockResolvePackageJsonFrom = sandbox
+    .stub<[cwd: string, packageName: string], Promise<string>>()
+    .callsFake(async (cwd, packageName) => path.join(cwd, 'node_modules', packageName, 'package.json'));
+  const MockResolvePackageSubpathFrom: MockResolvePackageSubpathFrom = sandbox
+    .stub<[installPath: string, packageName: string, subpath: string], Promise<string>>()
+    .callsFake(async (installPath, _packageName, subpath) => path.join(installPath, subpath));
 
   const MockGlob = sandbox.stub().callsFake((spec: string, opts: {cwd: string}, done: () => void) => {
     const ee = new EventEmitter();
@@ -161,7 +184,11 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
 
   const overrides: Overrides = {
     '@appium/support': MockAppiumSupport,
-    '../../../lib/utils/resolve-from': {resolveFrom: MockResolveFrom},
+    '../../../lib/utils/resolve-from': {
+      resolveFrom: MockResolveFrom,
+      resolvePackageJsonFrom: MockResolvePackageJsonFrom,
+      resolvePackageSubpathFrom: MockResolvePackageSubpathFrom,
+    },
     '../../../lib/utils/is-package-changed': MockPackageChanged,
     glob: MockGlob,
   };
@@ -170,6 +197,8 @@ export function initMocks(sandbox = createSandbox()): InitMocksResult {
     MockAppiumSupport,
     MockPackageChanged,
     MockResolveFrom,
+    MockResolvePackageJsonFrom,
+    MockResolvePackageSubpathFrom,
     MockGlob,
     sandbox,
     overrides,

--- a/packages/appium/test/unit/extension/plugin-config.spec.ts
+++ b/packages/appium/test/unit/extension/plugin-config.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {promises as fs} from 'node:fs';
+import path from 'node:path';
 import {describe, it, beforeEach, afterEach, before} from 'node:test';
 
 import type {ExtensionType, PluginType} from '@appium/types';
@@ -11,7 +12,7 @@ import type {PluginConfig as PluginConfigInstance} from '../../../lib/extension/
 import {resetSchema} from '../../../lib/schema';
 import {assertArrayIncludesDeep, resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, MockResolveFrom, Overrides} from './mocks';
+import type {MockAppiumSupport, Overrides} from './mocks';
 
 type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType> & {
   schema: NonNullable<ExtManifest<ExtType>['schema']>;
@@ -28,7 +29,6 @@ describe('PluginConfig', function () {
   let manifest: Manifest;
   let sandbox: SinonSandbox;
   let MockAppiumSupport: MockAppiumSupport;
-  let MockResolveFrom: MockResolveFrom;
   let PluginConfig: PluginConfigConstructor;
 
   before(async function () {
@@ -38,7 +38,7 @@ describe('PluginConfig', function () {
   beforeEach(function () {
     let overrides: Overrides;
     manifest = Manifest.getInstance('/somewhere/');
-    ({MockAppiumSupport, MockResolveFrom, sandbox, overrides} = initMocks());
+    ({MockAppiumSupport, sandbox, overrides} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({PluginConfig} = rewiremock.proxy(() => require('../../../lib/extension/plugin-config'), overrides));
     resetSchema();
@@ -190,15 +190,12 @@ describe('PluginConfig', function () {
           });
 
           describe('when the property as a path is found', function () {
-            beforeEach(function () {
-              MockResolveFrom.resolves(resolveFixture('plugin-schema'));
-            });
-
             it('should return an empty array', async function () {
               const problems = await pluginConfig.getSchemaProblems(
                 {
                   pkgName: '../fixtures',
                   schema: 'plugin-schema.js',
+                  installPath: path.dirname(resolveFixture('plugin-schema.js')),
                   mainClass: 'Yankovic',
                   version: '1.0.0',
                 },
@@ -269,8 +266,8 @@ describe('PluginConfig', function () {
           version: '0.0.0',
           installType: 'npm',
           installSpec: 'some-pkg',
+          installPath: path.dirname(resolveFixture('plugin-schema.js')),
         } as unknown as ExtManifestWithSchema<PluginType>;
-        MockResolveFrom.resolves(resolveFixture('plugin-schema.js'));
         pluginConfig = PluginConfig.create(manifest);
       });
 
@@ -295,7 +292,7 @@ describe('PluginConfig', function () {
         describe('when the schema differs (presumably a different extension)', function () {
           it('should throw', async function () {
             await pluginConfig.readExtensionSchema(extName, extData);
-            MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
+            extData.installPath = path.dirname(resolveFixture('driver-schema.js'));
             await assert.rejects(
               pluginConfig.readExtensionSchema(extName, extData),
               /conflicts with an existing schema/i,
@@ -306,8 +303,7 @@ describe('PluginConfig', function () {
 
       describe('when the extension schema has not yet been registered', function () {
         it('should resolve and load the extension schema file', async function () {
-          await pluginConfig.readExtensionSchema(extName, extData);
-          assert.strictEqual(MockResolveFrom.calledOnce, true);
+          await assert.doesNotReject(pluginConfig.readExtensionSchema(extName, extData));
         });
       });
     });

--- a/packages/appium/test/unit/extension/plugin-config.spec.ts
+++ b/packages/appium/test/unit/extension/plugin-config.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import {promises as fs} from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import {describe, it, beforeEach, afterEach, before} from 'node:test';
 
@@ -12,7 +13,7 @@ import type {PluginConfig as PluginConfigInstance} from '../../../lib/extension/
 import {resetSchema} from '../../../lib/schema';
 import {assertArrayIncludesDeep, resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, MockResolveFrom, MockResolvePackageSubpathFrom, Overrides} from './mocks';
+import type {MockAppiumSupport, MockResolveFrom, Overrides} from './mocks';
 
 type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType> & {
   schema: NonNullable<ExtManifest<ExtType>['schema']>;
@@ -30,7 +31,6 @@ describe('PluginConfig', function () {
   let sandbox: SinonSandbox;
   let MockAppiumSupport: MockAppiumSupport;
   let MockResolveFrom: MockResolveFrom;
-  let MockResolvePackageSubpathFrom: MockResolvePackageSubpathFrom;
   let PluginConfig: PluginConfigConstructor;
 
   before(async function () {
@@ -40,7 +40,7 @@ describe('PluginConfig', function () {
   beforeEach(function () {
     let overrides: Overrides;
     manifest = Manifest.getInstance('/somewhere/');
-    ({MockAppiumSupport, MockResolveFrom, MockResolvePackageSubpathFrom, sandbox, overrides} = initMocks());
+    ({MockAppiumSupport, MockResolveFrom, sandbox, overrides} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({PluginConfig} = rewiremock.proxy(() => require('../../../lib/extension/plugin-config'), overrides));
     resetSchema();
@@ -267,20 +267,44 @@ describe('PluginConfig', function () {
     describe('readExtensionSchema()', function () {
       let pluginConfig: any;
       let extData: ExtManifestWithSchema<PluginType>;
+      let tempRoot: string;
 
       const extName = 'stuff';
 
-      beforeEach(function () {
+      beforeEach(async function () {
+        tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'appium-plugin-schema-'));
+        const installPath = path.join(tempRoot, 'node_modules', 'some-pkg');
+        await fs.mkdir(installPath, {recursive: true});
+        await fs.writeFile(
+          path.join(installPath, 'package.json'),
+          JSON.stringify({
+            name: 'some-pkg',
+            version: '1.0.0',
+            exports: {
+              './plugin-schema.json': './plugin-schema.json',
+              './driver-schema.json': './driver-schema.json',
+            },
+          }),
+        );
+        await fs.writeFile(path.join(installPath, 'plugin-schema.json'), JSON.stringify({type: 'object'}));
+        await fs.writeFile(
+          path.join(installPath, 'driver-schema.json'),
+          JSON.stringify({type: 'object', properties: {driver: {type: 'string'}}}),
+        );
         extData = {
           pkgName: 'some-pkg',
-          schema: 'plugin-schema.js',
+          schema: 'plugin-schema.json',
           mainClass: 'SomeClass',
           version: '0.0.0',
           installType: 'npm',
           installSpec: 'some-pkg',
-        } as unknown as ExtManifestWithSchema<PluginType>;
-        MockResolveFrom.resolves(resolveFixture('plugin-schema.js'));
+          installPath,
+        };
         pluginConfig = PluginConfig.create(manifest);
+      });
+
+      afterEach(async function () {
+        await fs.rm(tempRoot, {recursive: true, force: true});
       });
 
       describe('when the extension data is missing `schema`', function () {
@@ -304,7 +328,7 @@ describe('PluginConfig', function () {
         describe('when the schema differs (presumably a different extension)', function () {
           it('should throw', async function () {
             await pluginConfig.readExtensionSchema(extName, extData);
-            MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
+            extData.schema = 'driver-schema.json';
             await assert.rejects(
               pluginConfig.readExtensionSchema(extName, extData),
               /conflicts with an existing schema/i,
@@ -314,19 +338,8 @@ describe('PluginConfig', function () {
       });
 
       describe('when the extension schema has not yet been registered', function () {
-        it('should resolve and load the extension schema file', async function () {
-          extData.installPath = '/workspace/node_modules/some-pkg';
-
-          await pluginConfig.readExtensionSchema(extName, extData);
-
-          assert.strictEqual(
-            MockResolvePackageSubpathFrom.calledOnceWithExactly(
-              '/workspace/node_modules/some-pkg',
-              'some-pkg',
-              'plugin-schema.js',
-            ),
-            true,
-          );
+        it('should resolve and load the extension schema file from the installed package', async function () {
+          await assert.doesNotReject(pluginConfig.readExtensionSchema(extName, extData));
         });
       });
     });

--- a/packages/appium/test/unit/extension/plugin-config.spec.ts
+++ b/packages/appium/test/unit/extension/plugin-config.spec.ts
@@ -12,7 +12,7 @@ import type {PluginConfig as PluginConfigInstance} from '../../../lib/extension/
 import {resetSchema} from '../../../lib/schema';
 import {assertArrayIncludesDeep, resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, Overrides} from './mocks';
+import type {MockAppiumSupport, MockResolveFrom, Overrides} from './mocks';
 
 type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType> & {
   schema: NonNullable<ExtManifest<ExtType>['schema']>;
@@ -29,6 +29,7 @@ describe('PluginConfig', function () {
   let manifest: Manifest;
   let sandbox: SinonSandbox;
   let MockAppiumSupport: MockAppiumSupport;
+  let MockResolveFrom: MockResolveFrom;
   let PluginConfig: PluginConfigConstructor;
 
   before(async function () {
@@ -38,7 +39,7 @@ describe('PluginConfig', function () {
   beforeEach(function () {
     let overrides: Overrides;
     manifest = Manifest.getInstance('/somewhere/');
-    ({MockAppiumSupport, sandbox, overrides} = initMocks());
+    ({MockAppiumSupport, MockResolveFrom, sandbox, overrides} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({PluginConfig} = rewiremock.proxy(() => require('../../../lib/extension/plugin-config'), overrides));
     resetSchema();
@@ -190,18 +191,25 @@ describe('PluginConfig', function () {
           });
 
           describe('when the property as a path is found', function () {
+            beforeEach(function () {
+              MockResolveFrom.resolves(resolveFixture('plugin-schema.js'));
+            });
+
             it('should return an empty array', async function () {
               const problems = await pluginConfig.getSchemaProblems(
                 {
                   pkgName: '../fixtures',
                   schema: 'plugin-schema.js',
-                  installPath: path.dirname(resolveFixture('plugin-schema.js')),
                   mainClass: 'Yankovic',
                   version: '1.0.0',
                 },
                 'foo',
               );
               assert.strictEqual(problems.length, 0);
+              assert.strictEqual(
+                MockResolveFrom.calledOnceWithExactly('/somewhere/', path.join('../fixtures', 'plugin-schema.js')),
+                true,
+              );
             });
           });
         });
@@ -266,8 +274,8 @@ describe('PluginConfig', function () {
           version: '0.0.0',
           installType: 'npm',
           installSpec: 'some-pkg',
-          installPath: path.dirname(resolveFixture('plugin-schema.js')),
         } as unknown as ExtManifestWithSchema<PluginType>;
+        MockResolveFrom.resolves(resolveFixture('plugin-schema.js'));
         pluginConfig = PluginConfig.create(manifest);
       });
 
@@ -292,7 +300,7 @@ describe('PluginConfig', function () {
         describe('when the schema differs (presumably a different extension)', function () {
           it('should throw', async function () {
             await pluginConfig.readExtensionSchema(extName, extData);
-            extData.installPath = path.dirname(resolveFixture('driver-schema.js'));
+            MockResolveFrom.resolves(resolveFixture('driver-schema.js'));
             await assert.rejects(
               pluginConfig.readExtensionSchema(extName, extData),
               /conflicts with an existing schema/i,
@@ -303,7 +311,17 @@ describe('PluginConfig', function () {
 
       describe('when the extension schema has not yet been registered', function () {
         it('should resolve and load the extension schema file', async function () {
-          await assert.doesNotReject(pluginConfig.readExtensionSchema(extName, extData));
+          extData.installPath = '/workspace/node_modules/some-pkg';
+
+          await pluginConfig.readExtensionSchema(extName, extData);
+
+          assert.strictEqual(
+            MockResolveFrom.calledOnceWithExactly(
+              '/workspace/node_modules/some-pkg',
+              path.resolve('/workspace/node_modules/some-pkg', 'plugin-schema.js'),
+            ),
+            true,
+          );
         });
       });
     });

--- a/packages/appium/test/unit/extension/plugin-config.spec.ts
+++ b/packages/appium/test/unit/extension/plugin-config.spec.ts
@@ -12,7 +12,7 @@ import type {PluginConfig as PluginConfigInstance} from '../../../lib/extension/
 import {resetSchema} from '../../../lib/schema';
 import {assertArrayIncludesDeep, resolveFixture, rewiremock} from '../../helpers';
 import {initMocks} from './mocks';
-import type {MockAppiumSupport, MockResolveFrom, Overrides} from './mocks';
+import type {MockAppiumSupport, MockResolveFrom, MockResolvePackageSubpathFrom, Overrides} from './mocks';
 
 type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType> & {
   schema: NonNullable<ExtManifest<ExtType>['schema']>;
@@ -30,6 +30,7 @@ describe('PluginConfig', function () {
   let sandbox: SinonSandbox;
   let MockAppiumSupport: MockAppiumSupport;
   let MockResolveFrom: MockResolveFrom;
+  let MockResolvePackageSubpathFrom: MockResolvePackageSubpathFrom;
   let PluginConfig: PluginConfigConstructor;
 
   before(async function () {
@@ -39,7 +40,7 @@ describe('PluginConfig', function () {
   beforeEach(function () {
     let overrides: Overrides;
     manifest = Manifest.getInstance('/somewhere/');
-    ({MockAppiumSupport, MockResolveFrom, sandbox, overrides} = initMocks());
+    ({MockAppiumSupport, MockResolveFrom, MockResolvePackageSubpathFrom, sandbox, overrides} = initMocks());
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
     ({PluginConfig} = rewiremock.proxy(() => require('../../../lib/extension/plugin-config'), overrides));
     resetSchema();
@@ -207,7 +208,10 @@ describe('PluginConfig', function () {
               );
               assert.strictEqual(problems.length, 0);
               assert.strictEqual(
-                MockResolveFrom.calledOnceWithExactly('/somewhere/', path.join('../fixtures', 'plugin-schema.js')),
+                MockResolveFrom.calledOnceWithExactly(
+                  '/somewhere/',
+                  path.posix.join('../fixtures', 'plugin-schema.js'),
+                ),
                 true,
               );
             });
@@ -316,9 +320,10 @@ describe('PluginConfig', function () {
           await pluginConfig.readExtensionSchema(extName, extData);
 
           assert.strictEqual(
-            MockResolveFrom.calledOnceWithExactly(
+            MockResolvePackageSubpathFrom.calledOnceWithExactly(
               '/workspace/node_modules/some-pkg',
-              path.resolve('/workspace/node_modules/some-pkg', 'plugin-schema.js'),
+              'some-pkg',
+              'plugin-schema.js',
             ),
             true,
           );

--- a/packages/appium/test/unit/parser.spec.ts
+++ b/packages/appium/test/unit/parser.spec.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import {describe, it, beforeEach, before, after} from 'node:test';
 
 import {readConfigFile} from '../../lib/bootstrap/config-file';
-import {ArgParser, getParser} from '../../lib/cli/parser';
+import {ArgParser, getExtensionSearchRoot, getParser} from '../../lib/cli/parser';
 import {DRIVER_TYPE, PLUGIN_TYPE, SETUP_SUBCOMMAND} from '../../lib/constants';
 import {INSTALL_TYPES} from '../../lib/extension/extension-config';
 import * as schema from '../../lib/schema/schema';
@@ -23,6 +23,34 @@ describe('parser', function () {
   describe('Main Parser', function () {
     beforeEach(async function () {
       p = await getParser(true);
+    });
+
+    describe('getExtensionSearchRoot()', function () {
+      it('should extract separate and equals-style values', function () {
+        assert.strictEqual(
+          getExtensionSearchRoot(['driver', 'list', '--ext-search-root', 'packages/app']),
+          'packages/app',
+        );
+        assert.strictEqual(getExtensionSearchRoot(['--ext-search-root=packages/app']), 'packages/app');
+      });
+
+      it('should reject a missing value', function () {
+        assert.throws(() => getExtensionSearchRoot(['driver', 'list', '--ext-search-root']), /expected one argument/);
+      });
+
+      it('should not inspect extension script arguments after --', function () {
+        assert.strictEqual(
+          getExtensionSearchRoot(['driver', 'run', 'fake', 'script', '--', '--ext-search-root', 'packages/app']),
+          undefined,
+        );
+      });
+
+      it('should not inspect extension script arguments without --', function () {
+        assert.strictEqual(
+          getExtensionSearchRoot(['driver', 'run', 'fake', 'script', '--ext-search-root', 'packages/app']),
+          undefined,
+        );
+      });
     });
 
     it('should accept only server and driver subcommands', function () {
@@ -139,6 +167,16 @@ describe('parser', function () {
         );
       });
 
+      it('should parse --ext-search-root', function () {
+        assert.strictEqual(p.parseArgs(['--ext-search-root', 'packages/app']).extSearchRoot, 'packages/app');
+      });
+
+      it('should bootstrap abbreviated long options consistently with argparse', function () {
+        assert.strictEqual(getExtensionSearchRoot(['--ext-search-r', 'packages/app']), 'packages/app');
+        assert.strictEqual(getExtensionSearchRoot(['--ext-search-r=packages/app']), 'packages/app');
+        assert.strictEqual(getExtensionSearchRoot(['--ext-search-r=packages/app=one']), 'packages/app=one');
+      });
+
       it('should parse --deny-insecure correctly', function () {
         assert.strictEqual((p.parseArgs([]) as {denyInsecure?: unknown}).denyInsecure, undefined);
         assert.deepStrictEqual(p.parseArgs(['--deny-insecure', '']).denyInsecure, []);
@@ -227,6 +265,13 @@ describe('parser', function () {
         ]);
 
         assert.deepStrictEqual(args.driver.fake, (config as any)?.driver?.fake);
+      });
+
+      it('should parse --ext-search-root', function () {
+        assert.strictEqual(
+          p.parseArgs([DRIVER_TYPE, 'list', '--ext-search-root', 'packages/app']).extSearchRoot,
+          'packages/app',
+        );
       });
 
       it('should not yet apply defaults', function () {

--- a/packages/appium/test/unit/parser.spec.ts
+++ b/packages/appium/test/unit/parser.spec.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import {describe, it, beforeEach, before, after} from 'node:test';
 
 import {readConfigFile} from '../../lib/bootstrap/config-file';
+import {getExtensionArgs} from '../../lib/cli/args';
 import {ArgParser, getExtensionSearchRoot, getParser} from '../../lib/cli/parser';
 import {DRIVER_TYPE, PLUGIN_TYPE, SETUP_SUBCOMMAND} from '../../lib/constants';
 import {INSTALL_TYPES} from '../../lib/extension/extension-config';
@@ -50,6 +51,24 @@ describe('parser', function () {
           getExtensionSearchRoot(['driver', 'run', 'fake', 'script', '--ext-search-root', 'packages/app']),
           undefined,
         );
+      });
+
+      it('should derive extension command support from its registered arguments', function () {
+        const extensionArgs = getExtensionArgs();
+        const searchRootDefinition = [...extensionArgs[DRIVER_TYPE].list].find(([names]) =>
+          names.includes('--ext-search-root'),
+        );
+        assert.ok(searchRootDefinition);
+        const [names, definition] = searchRootDefinition;
+        extensionArgs[DRIVER_TYPE].doctor.set(names, definition);
+        try {
+          assert.strictEqual(
+            getExtensionSearchRoot(['driver', 'doctor', '--ext-search-root', 'packages/app']),
+            'packages/app',
+          );
+        } finally {
+          extensionArgs[DRIVER_TYPE].doctor.delete(names);
+        }
       });
     });
 

--- a/packages/appium/test/unit/utils/resolve-from.spec.ts
+++ b/packages/appium/test/unit/utils/resolve-from.spec.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import {promises as fs} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {afterEach, beforeEach, describe, it} from 'node:test';
+
+import {resolvePackageJsonFrom, resolvePackageSubpathFrom} from '../../../lib/utils/resolve-from';
+
+describe('resolve-from', function () {
+  let root: string;
+  let searchRoot: string;
+
+  beforeEach(async function () {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'appium-resolve-from-'));
+    searchRoot = path.join(root, 'packages', 'app');
+    await fs.mkdir(searchRoot, {recursive: true});
+  });
+
+  afterEach(async function () {
+    await fs.rm(root, {recursive: true, force: true});
+  });
+
+  it('should honor package exports when resolving a schema from its install path', async function () {
+    const packageName = 'exported-schema-driver';
+    const packageRoot = await createPackage(packageName, {
+      exports: {'./schema.json': './build/schema.json'},
+    });
+    const schemaPath = path.join(packageRoot, 'build', 'schema.json');
+    await fs.mkdir(path.dirname(schemaPath), {recursive: true});
+    await fs.writeFile(schemaPath, JSON.stringify({type: 'object'}));
+
+    assert.strictEqual(
+      await resolvePackageSubpathFrom(packageRoot, packageName, 'schema.json'),
+      await fs.realpath(schemaPath),
+    );
+  });
+
+  it('should resolve a schema from an externally linked package without exports', async function () {
+    const packageName = 'linked-schema-driver';
+    const packageRoot = path.join(root, 'external', packageName);
+    const schemaPath = path.join(packageRoot, 'schema.json');
+    await fs.mkdir(packageRoot, {recursive: true});
+    await fs.writeFile(path.join(packageRoot, 'package.json'), JSON.stringify({name: packageName, version: '1.0.0'}));
+    await fs.writeFile(schemaPath, JSON.stringify({type: 'object'}));
+
+    assert.strictEqual(
+      await resolvePackageSubpathFrom(packageRoot, packageName, 'schema.json'),
+      await fs.realpath(schemaPath),
+    );
+  });
+
+  it('should reject a schema excluded by package exports', async function () {
+    const packageName = 'unexported-schema-driver';
+    const packageRoot = await createPackage(packageName, {
+      exports: {'.': './index.js'},
+    });
+    const schemaPath = path.join(packageRoot, 'schema.json');
+    await fs.writeFile(schemaPath, JSON.stringify({type: 'object'}));
+
+    await assert.rejects(
+      resolvePackageSubpathFrom(packageRoot, packageName, 'schema.json'),
+      (error: NodeJS.ErrnoException) => error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED',
+    );
+  });
+
+  it('should not resolve an exported schema from another copy of the package', async function () {
+    const packageName = 'duplicate-schema-driver';
+    const otherPackageRoot = await createPackage(packageName, {
+      exports: {'./schema.json': './other-schema.json'},
+    });
+    await fs.writeFile(path.join(otherPackageRoot, 'other-schema.json'), JSON.stringify({title: 'other'}));
+
+    const packageRoot = path.join(root, 'external', packageName);
+    const schemaPath = path.join(packageRoot, 'build', 'schema.json');
+    await fs.mkdir(path.dirname(schemaPath), {recursive: true});
+    await fs.writeFile(
+      path.join(packageRoot, 'package.json'),
+      JSON.stringify({
+        name: packageName,
+        version: '1.0.0',
+        exports: {'./schema.json': './build/schema.json'},
+      }),
+    );
+    await fs.writeFile(schemaPath, JSON.stringify({title: 'known'}));
+
+    assert.strictEqual(
+      await resolvePackageSubpathFrom(packageRoot, packageName, 'schema.json'),
+      await fs.realpath(schemaPath),
+    );
+  });
+
+  it('should find the package manifest when the root export is import-only', async function () {
+    const packageRoot = await createPackage('import-only-driver', {
+      type: 'module',
+      exports: {'.': {import: './index.js'}},
+      appium: {driverName: 'import-only'},
+    });
+    const packageJsonPath = await resolvePackageJsonFrom(searchRoot, 'import-only-driver');
+
+    assert.strictEqual(packageJsonPath, await fs.realpath(path.join(packageRoot, 'package.json')));
+    assert.strictEqual(JSON.parse(await fs.readFile(packageJsonPath, 'utf8')).appium.driverName, 'import-only');
+  });
+
+  it('should return the owning package manifest when an exported directory has its own package.json', async function () {
+    const packageRoot = await createPackage('nested-manifest-driver', {
+      exports: {'./build/index.js': './build/index.js'},
+      appium: {driverName: 'nested-manifest'},
+    });
+    await fs.mkdir(path.join(packageRoot, 'build'), {recursive: true});
+    await fs.writeFile(path.join(packageRoot, 'build', 'package.json'), JSON.stringify({type: 'commonjs'}));
+    await fs.writeFile(path.join(packageRoot, 'build', 'index.js'), 'module.exports = {};');
+
+    const packageJsonPath = await resolvePackageJsonFrom(searchRoot, 'nested-manifest-driver');
+
+    assert.strictEqual(packageJsonPath, await fs.realpath(path.join(packageRoot, 'package.json')));
+    assert.strictEqual(JSON.parse(await fs.readFile(packageJsonPath, 'utf8')).appium.driverName, 'nested-manifest');
+  });
+
+  async function createPackage(packageName: string, manifest: Record<string, unknown>): Promise<string> {
+    const packageRoot = path.join(root, 'node_modules', packageName);
+    await fs.mkdir(packageRoot, {recursive: true});
+    await fs.writeFile(
+      path.join(packageRoot, 'package.json'),
+      JSON.stringify({name: packageName, version: '1.0.0', ...manifest}),
+    );
+    return packageRoot;
+  }
+});

--- a/packages/appium/types/cli.ts
+++ b/packages/appium/types/cli.ts
@@ -72,6 +72,11 @@ export interface MoreArgs {
    * If true, open a REPL
    */
   shell?: boolean;
+
+  /**
+   * Directory containing the package.json whose dependencies should be searched for extensions.
+   */
+  extSearchRoot?: string;
 }
 
 /**


### PR DESCRIPTION
## Proposed changes

Add `--ext-search-root` to the Appium server and extension list commands so a workspace can explicitly identify the `package.json` whose declared dependencies contain Appium extensions. Dependencies are resolved using Node module resolution, allowing drivers and plugins hoisted to a monorepo root to be discovered without broadly globbing unrelated packages.

Search-root discoveries are transient and isolated from the persisted `APPIUM_HOME` manifest. The existing discovery behavior remains unchanged when the option is omitted.

Fixes #19819.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the Contributing Guide
- [ ] I have signed the CLA
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The repository dependency restore could not complete in the local Windows environment because the configured package proxy returned a 404 for a locked package and direct npm registry access repeatedly failed TLS negotiation. Formatting, non-type-aware linting, strict type-checking of every changed production file, diff checks, and substantive code review completed locally; CI should run the full unit and E2E suites in a clean dependency environment.