### PR TITLE
refactor(base-driver)!: remove deprecated getSession command

### DIFF
--- a/packages/appium/docs/en/guides/event-timing.md
+++ b/packages/appium/docs/en/guides/event-timing.md
@@ -6,14 +6,12 @@ title: Retrieving Event Timings
 ---
 
 Appium comes with the ability to retrieve timing information about startup
-information and command length. This is an advanced feature that is controlled
-by the use of the `appium:eventTimings` capability (set it to `true` to log event
-timings).
+information and command length. This is an advanced feature; event and
+command timings are collected automatically for the duration of a session.
 
-With this capability turned on, the `POST /session/:id/appium/events` response (i.e., 
-the response to `driver.logs.events` or similar, depending on client) will be 
-decorated with an `events` property. This is the structure of that `events`
-property:
+The `POST /session/:id/appium/events` response (i.e., the response to
+`driver.logs.events` or similar, depending on client) has the following
+structure:
 
 ```
 {

--- a/packages/appium/docs/en/reference/api/jsonwp.md
+++ b/packages/appium/docs/en/reference/api/jsonwp.md
@@ -10,29 +10,6 @@ title: JSON Wire Protocol
 The following is a list of legacy [JSON Wire Protocol (JSONWP)](https://www.selenium.dev/documentation/legacy/json_wire_protocol/)
 endpoints supported in Appium.
 
-### getSession
-
-```
-GET /session/:sessionId
-```
-
-> JSONWP documentation: [/session/:sessionId](https://www.selenium.dev/documentation/legacy/json_wire_protocol/#sessionsessionid)
-
-Retrieves the capabilities of the current session.
-
-Appium implements a modified version of this endpoint. If the `appium:eventTimings` capability is
-set to `true`, the returned result will additionally include the `events` key, whose value contains
-the event history and timings.
-
-!!! warning "Deprecated"
-
-    For retrieving capabilities, please use [`getAppiumSessionCapabilities`](./appium.md#getappiumsessioncapabilities).<br />
-    For retrieving event history, please use [`getLogEvents`](./appium.md#getlogevents).
-
-#### Response
-
-`Capabilities` - an object containing the session capabilities, and the event history (if applicable)
-
 ### availableIMEEngines
 
 ```

--- a/packages/appium/docs/en/reference/session/caps.md
+++ b/packages/appium/docs/en/reference/session/caps.md
@@ -32,7 +32,6 @@ default value.
 | <div style="width:19em">Capability</div> | Description | Type | Default |
 |--|--|--|--|
 | `webSocketUrl` | Toggle support of the WebDriver BiDi protocol | `boolean` ||
-| `appium:eventTimings` (deprecated) | Toggle collection of [Event Timings](../../guides/event-timing.md). This capability is deprecated - please use the [`getLogEvents`](../api/appium.md#getlogevents) endpoint instead. | `boolean` ||
 | `appium:newCommandTimeout` | Number of seconds the Appium server should wait for clients to send commands before stopping the session. A value of `0` disables the timeout. | `number` | `60` |
 | `appium:printPageSourceOnFindFailure` | Toggle retrieval of the the page source and its printing to the Appium log, whenever a request to find an element fails | `boolean` ||
 

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -13,7 +13,6 @@ import {
   type LegacyCreateSessionArgs,
   type ServerArgs,
   type SessionCapabilities,
-  type SingularSessionData,
   type StringRecord,
   type W3CDriverCaps,
 } from '@appium/types';
@@ -57,10 +56,9 @@ export class BaseDriver<
   Settings extends StringRecord = StringRecord,
   CreateResult = DefaultCreateSessionResult<C>,
   DeleteResult = DefaultDeleteSessionResult,
-  SessionData extends StringRecord = StringRecord,
 >
   extends DriverCore<C, Settings>
-  implements Driver<C, CArgs, Settings, CreateResult, DeleteResult, SessionData>
+  implements Driver<C, CArgs, Settings, CreateResult, DeleteResult>
 {
   cliArgs: CArgs & ServerArgs;
   caps: DriverCaps<C>;
@@ -367,18 +365,6 @@ export class BaseDriver<
     this.log.info(`Session created with session id: ${this.sessionId}`);
 
     return [this.sessionId, caps] as CreateResult;
-  }
-
-  /**
-   * Returns capabilities for the session and event history (if applicable)
-   * @deprecated Use {@linkcode getAppiumSessionCapabilities} instead for getting the capabilities.
-   * Use {@linkcode EventCommands.getLogEvents} instead to get the event history.
-   */
-  async getSession() {
-    return (this.caps.eventTimings ? {...this.caps, events: this.eventHistory} : this.caps) as SingularSessionData<
-      C,
-      SessionData
-    >;
   }
 
   /**

--- a/packages/base-driver/lib/protocol/routes/w3c.ts
+++ b/packages/base-driver/lib/protocol/routes/w3c.ts
@@ -19,8 +19,6 @@ export const W3C_ROUTES = {
     },
   },
   '/session/:sessionId': {
-    // TODO: JSONWP route, remove in the future
-    GET: {command: 'getSession', deprecated: true},
     DELETE: {command: 'deleteSession'},
   },
   '/status': {

--- a/packages/base-driver/test/e2e/protocol/fake-driver.ts
+++ b/packages/base-driver/test/e2e/protocol/fake-driver.ts
@@ -4,8 +4,6 @@ import type {
   DefaultCreateSessionResult,
   InitialOpts,
   RouteMatcher,
-  SingularSessionData,
-  StringRecord,
   W3CDriverCaps,
 } from '@appium/types';
 
@@ -86,10 +84,6 @@ class FakeDriver extends BaseDriver<Constraints> {
 
   async refresh(): Promise<void> {
     throw new Error('Too Fresh!');
-  }
-
-  async getSession(): Promise<SingularSessionData<Constraints, StringRecord>> {
-    throw new errors.NoSuchDriverError();
   }
 
   async click(elementId: string, sessionId: string): Promise<unknown[]> {

--- a/packages/base-driver/test/e2e/protocol/fake-driver.ts
+++ b/packages/base-driver/test/e2e/protocol/fake-driver.ts
@@ -1,11 +1,5 @@
 import {util} from '@appium/support';
-import type {
-  Constraints,
-  DefaultCreateSessionResult,
-  InitialOpts,
-  RouteMatcher,
-  W3CDriverCaps,
-} from '@appium/types';
+import type {Constraints, DefaultCreateSessionResult, InitialOpts, RouteMatcher, W3CDriverCaps} from '@appium/types';
 
 import {PROTOCOLS} from '../../../lib/constants.js';
 import {BaseDriver, errors, isW3cCaps} from '../../../lib/index.js';

--- a/packages/base-driver/test/unit/basedriver/capability.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/capability.spec.ts
@@ -14,7 +14,7 @@ import {BaseDriver, errors} from '../../../lib/index.js';
 type TestW3CCaps = W3CCapabilities<Constraints>;
 
 describe('Desired Capabilities', function () {
-  let d: BaseDriver<any, any, any, any, any, any>;
+  let d: BaseDriver<any, any, any, any, any>;
   let sandbox: sinon.SinonSandbox;
   let logWarnSpy: sinon.SinonSpy;
   let deprecatedStub: sinon.SinonStub;

--- a/packages/base-driver/test/unit/basedriver/commands/find.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/commands/find.spec.ts
@@ -8,7 +8,7 @@ import {BaseDriver, errors} from '../../../../lib/index.js';
 const PAGE_SOURCE = '<hierarchy />';
 
 describe('find commands -', function () {
-  let driver: BaseDriver<any, any, any, any, any, any>;
+  let driver: BaseDriver<any, any, any, any, any>;
 
   beforeEach(function () {
     driver = new BaseDriver({} as InitialOpts);

--- a/packages/base-driver/test/unit/basedriver/commands/log.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/commands/log.spec.ts
@@ -21,7 +21,7 @@ const SUPPORTED_LOG_TYPES = {
 
 describe('log commands -', function () {
   let sandbox: sinon.SinonSandbox;
-  let driver: BaseDriver<any, any, any, any, any, any>;
+  let driver: BaseDriver<any, any, any, any, any>;
 
   beforeEach(function () {
     sandbox = createSandbox();

--- a/packages/base-driver/test/unit/basedriver/timeout.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/timeout.spec.ts
@@ -7,7 +7,7 @@ import {createSandbox} from 'sinon';
 import {BaseDriver} from '../../../lib/index.js';
 
 describe('timeout', function () {
-  let driver: BaseDriver<any, any, any, any, any, any>;
+  let driver: BaseDriver<any, any, any, any, any>;
   let implicitWaitSpy: sinon.SinonSpy;
   let sandbox: sinon.SinonSandbox;
 
@@ -77,8 +77,8 @@ describe('timeout', function () {
       assert.strictEqual(driver.implicitWaitMs, 42);
     });
     describe('with managed driver', function () {
-      let managedDriver1: BaseDriver<any, any, any, any, any, any>;
-      let managedDriver2: BaseDriver<any, any, any, any, any, any>;
+      let managedDriver1: BaseDriver<any, any, any, any, any>;
+      let managedDriver2: BaseDriver<any, any, any, any, any>;
       before(function () {
         managedDriver1 = new BaseDriver({} as InitialOpts);
         managedDriver2 = new BaseDriver({} as InitialOpts);
@@ -103,8 +103,8 @@ describe('timeout', function () {
       assert.strictEqual(driver.newCommandTimeoutMs, 42);
     });
     describe('with managed driver', function () {
-      let managedDriver1: BaseDriver<any, any, any, any, any, any>;
-      let managedDriver2: BaseDriver<any, any, any, any, any, any>;
+      let managedDriver1: BaseDriver<any, any, any, any, any>;
+      let managedDriver2: BaseDriver<any, any, any, any, any>;
       before(function () {
         managedDriver1 = new BaseDriver({} as InitialOpts);
         managedDriver2 = new BaseDriver({} as InitialOpts);

--- a/packages/base-driver/test/unit/protocol/routes.spec.ts
+++ b/packages/base-driver/test/unit/protocol/routes.spec.ts
@@ -41,7 +41,7 @@ describe('Routes', function () {
       }
       const hash = shasum.digest('hex').substring(0, 8);
       // Update this value again only when an intentional route/command/param change is made.
-      assert.strictEqual(hash, '8b461b1a');
+      assert.strictEqual(hash, '2675d7f2');
     });
   });
 

--- a/packages/fake-driver/test/e2e/driver.e2e.spec.ts
+++ b/packages/fake-driver/test/e2e/driver.e2e.spec.ts
@@ -3,13 +3,7 @@ import {Agent} from 'node:http';
 import {describe, it, before, after, type TestContext, beforeEach, afterEach} from 'node:test';
 
 import {createAppiumURL, getTestPort} from '@appium/driver-test-support';
-import type {
-  AppiumServer,
-  BaseNSCapabilities,
-  Capabilities,
-  Constraints,
-  W3CCapabilities,
-} from '@appium/types';
+import type {AppiumServer, BaseNSCapabilities, Capabilities, Constraints, W3CCapabilities} from '@appium/types';
 import {DeviceSettings, routeConfiguringFunction, server} from 'appium/driver.js';
 import {sleep} from 'asyncbox';
 import axios from 'axios';

--- a/packages/fake-driver/test/e2e/driver.e2e.spec.ts
+++ b/packages/fake-driver/test/e2e/driver.e2e.spec.ts
@@ -8,7 +8,6 @@ import type {
   BaseNSCapabilities,
   Capabilities,
   Constraints,
-  SingularSessionData,
   W3CCapabilities,
 } from '@appium/types';
 import {DeviceSettings, routeConfiguringFunction, server} from 'appium/driver.js';
@@ -53,7 +52,6 @@ interface SessionHelpers<CommandData = unknown, ResponseData = any> {
   ) => Promise<ResponseData>;
   startSession: (data: NewSessionData, config?: RawAxiosRequestConfig) => Promise<NewSessionResponse>;
   endSession: (sessionId: string) => Promise<AxiosResponse<{value: {error?: string} | null}, {validateStatus: null}>>;
-  getSession: (sessionId: string) => Promise<SingularSessionData>;
 }
 
 describe(`FakeDriver E2E`, function () {
@@ -61,7 +59,6 @@ describe(`FakeDriver E2E`, function () {
   let d: FakeDriver;
   let newSessionURL: string;
   let startSession: SessionHelpers['startSession'];
-  let getSession: SessionHelpers['getSession'];
   let endSession: SessionHelpers['endSession'];
   let getCommand: SessionHelpers['getCommand'];
   let postCommand: SessionHelpers['postCommand'];
@@ -80,7 +77,6 @@ describe(`FakeDriver E2E`, function () {
     });
     const helpers = createSessionHelpers(port, address);
     startSession = helpers.startSession;
-    getSession = helpers.getSession;
     endSession = helpers.endSession;
     getCommand = helpers.getCommand;
     postCommand = helpers.postCommand;
@@ -224,7 +220,7 @@ describe(`FakeDriver E2E`, function () {
         value: 'foo',
       });
       await sleep(400);
-      const value = await getSession(sessionId);
+      const value = await getCommand(sessionId, 'appium/capabilities');
       assert.strictEqual(value.error, 'invalid session id');
       assert.strictEqual(d.sessionId, null);
       const resp = (await endSession(newSession.sessionId)).data.value;
@@ -252,8 +248,8 @@ describe(`FakeDriver E2E`, function () {
         value: 'foo',
       });
       await sleep(400);
-      const value = await getSession(d.sessionId!);
-      assert.strictEqual(value.platformName, defaultCaps.platformName);
+      const value = await getCommand(d.sessionId!, 'appium/capabilities');
+      assert.strictEqual(value.capabilities.platformName, defaultCaps.platformName);
       const resp = (await endSession(newSession.sessionId)).data.value;
       assert.strictEqual(resp, null);
 
@@ -269,7 +265,7 @@ describe(`FakeDriver E2E`, function () {
         value: 'foo',
       });
       await sleep(400);
-      const value = await getSession(sessionId!);
+      const value = await getCommand(sessionId!, 'appium/capabilities');
       assert.strictEqual((value as any).error, 'invalid session id');
       assert.strictEqual(d.sessionId, null);
       const resp = (await endSession(newSession.sessionId)).data.value as {error?: string};
@@ -329,51 +325,6 @@ describe(`FakeDriver E2E`, function () {
       const value = await reqPromise;
       assert.ok((value as any).message.includes('Crashytimes'));
       await shutdownEventPromise;
-    });
-  });
-
-  describe('event timings', function () {
-    let session: NewSessionResponse | undefined;
-    let res: SingularSessionData;
-
-    describe('when not provided the eventTimings cap', function () {
-      before(async function () {
-        session = await startSession({capabilities: {alwaysMatch: defaultCaps}});
-        res = await getSession(session.sessionId);
-      });
-
-      after(async function () {
-        if (session) {
-          await endSession(session.sessionId);
-        }
-      });
-
-      it('should not respond with events', function () {
-        assert.strictEqual(res.events, undefined);
-      });
-    });
-
-    describe('when provided the eventTimings cap', function () {
-      before(async function () {
-        session = await startSession({
-          capabilities: {alwaysMatch: {...defaultCaps, 'appium:eventTimings': true}},
-        });
-        res = await getSession(session.sessionId);
-      });
-
-      after(async function () {
-        if (session) {
-          await endSession(session.sessionId);
-        }
-      });
-
-      it('should add a newSessionRequested event', function () {
-        assert.strictEqual(typeof res.events?.newSessionRequested?.[0], 'number');
-      });
-
-      it('should add a newSessionStarted event', function () {
-        assert.strictEqual(typeof res.events?.newSessionRequested?.[0], 'number');
-      });
     });
   });
 });
@@ -490,12 +441,5 @@ function createSessionHelpers<CommandData = unknown, ResponseData = any>(
       await axios.delete(createSessionURL(sessionId), {
         validateStatus: null,
       }),
-    getSession: async (sessionId) => {
-      const response = await axios({
-        url: createSessionURL(sessionId),
-        validateStatus: null,
-      });
-      return response.data?.value;
-    },
   };
 }

--- a/packages/fake-driver/test/unit/driver.spec.ts
+++ b/packages/fake-driver/test/unit/driver.spec.ts
@@ -64,9 +64,9 @@ describe('FakeDriver unit suite', function () {
     assert.notDeepStrictEqual(sessionId1, sessionId2);
   });
 
-  it('should get the current session', async function () {
+  it('should get the current session capabilities', async function () {
     const [, caps] = await d.createSession(w3cCaps);
-    assert.strictEqual(caps, await d.getSession());
+    assert.deepStrictEqual((await d.getAppiumSessionCapabilities()).capabilities, caps);
   });
 
   it('should fulfill an unexpected driver quit promise', async function () {
@@ -103,7 +103,7 @@ describe('FakeDriver unit suite', function () {
     });
     void d.startUnexpectedShutdown(new Error('We crashed'));
     await p;
-    await assert.rejects(d.executeCommand('getSession'), /shut down/);
+    await assert.rejects(d.executeCommand('getStatus'), /shut down/);
   });
 
   it('should allow new commands after done shutting down', async function () {
@@ -123,7 +123,7 @@ describe('FakeDriver unit suite', function () {
     void d.startUnexpectedShutdown(new Error('We crashed'));
     await p;
 
-    await assert.rejects(d.executeCommand('getSession'), /shut down/);
+    await assert.rejects(d.executeCommand('getStatus'), /shut down/);
     await sleep(500);
 
     await d.executeCommand('createSession', null, null, structuredClone(w3cCaps));
@@ -452,18 +452,6 @@ describe('FakeDriver unit suite', function () {
       assert.strictEqual(d.eventHistory.bar.length, 2);
       assert.strictEqual(typeof d.eventHistory.bar[1], 'number');
       assert.strictEqual(d.eventHistory.bar[1] >= d.eventHistory.bar[0], true);
-    });
-    describe('getSession decoration', function () {
-      it('should decorate getSession response if opt-in cap is provided', async function () {
-        let res = await d.getSession();
-        assert.ok(!res.events);
-
-        (d.caps as Record<string, unknown>).eventTimings = true;
-        res = await d.getSession();
-        assert.ok(res.events);
-        assert.ok(res.events?.newSessionRequested);
-        assert.strictEqual(typeof res.events?.newSessionRequested[0], 'number');
-      });
     });
   });
 });

--- a/packages/types/lib/commands/basedriver.ts
+++ b/packages/types/lib/commands/basedriver.ts
@@ -339,7 +339,6 @@ export interface ISessionHandler<
   C extends Constraints = Constraints,
   CreateResult = DefaultCreateSessionResult<C>,
   DeleteResult = DefaultDeleteSessionResult,
-  SessionData extends StringRecord = StringRecord,
 > {
   /**
    * Start a new automation session
@@ -369,13 +368,6 @@ export interface ISessionHandler<
   deleteSession(sessionId?: string): Promise<DeleteResult | void>;
 
   /**
-   * Get the data for the current session
-   *
-   * @returns A session data object
-   */
-  getSession(): Promise<SingularSessionData<C, SessionData>>;
-
-  /**
    * Get the capabilities of the current session
    *
    * @returns A session capabilities object
@@ -392,21 +384,6 @@ export type DefaultCreateSessionResult<C extends Constraints> = [sessionId: stri
  * @see {@linkcode ISessionHandler}
  */
 export type DefaultDeleteSessionResult = void;
-
-/**
- * Data returned by {@linkcode ISessionHandler.getSession}.
- *
- * @typeParam C - The driver's capability constraints
- * @typeParam T - Any extra data the driver stuffs in here
- * @privateRemarks The content of this object looks implementation-specific and in practice is not well-defined.  It's _possible_ to fully type this in the future.
- */
-export type SingularSessionData<
-  C extends Constraints = Constraints,
-  T extends StringRecord = StringRecord,
-> = DriverCaps<C> & {
-  events?: EventHistory;
-  error?: string;
-} & T;
 
 /**
  * Data returned by `AppiumDriver.getAppiumSessions`
@@ -437,7 +414,6 @@ export type IImplementedCommands<
   Settings extends StringRecord = StringRecord,
   CreateResult = DefaultCreateSessionResult<C>,
   DeleteResult = DefaultDeleteSessionResult,
-  SessionData extends StringRecord = StringRecord,
 > = IBidiCommands &
   ILogCommands &
   IFindCommands &
@@ -445,4 +421,4 @@ export type IImplementedCommands<
   ITimeoutCommands &
   IEventCommands &
   IExecuteCommands &
-  ISessionHandler<C, CreateResult, DeleteResult, SessionData>;
+  ISessionHandler<C, CreateResult, DeleteResult>;

--- a/packages/types/lib/constraints.ts
+++ b/packages/types/lib/constraints.ts
@@ -61,9 +61,6 @@ export const BASE_DESIRED_CAP_CONSTRAINTS = {
   locale: {
     isString: true,
   },
-  eventTimings: {
-    isBoolean: true,
-  },
   printPageSourceOnFindFailure: {
     isBoolean: true,
   },

--- a/packages/types/lib/driver.ts
+++ b/packages/types/lib/driver.ts
@@ -138,9 +138,8 @@ export interface Driver<
   Settings extends StringRecord = StringRecord,
   CreateResult = DefaultCreateSessionResult<C>,
   DeleteResult = DefaultDeleteSessionResult,
-  SessionData extends StringRecord = StringRecord,
 >
-  extends IImplementedCommands<C, Settings, CreateResult, DeleteResult, SessionData>, Core<C, Settings> {
+  extends IImplementedCommands<C, Settings, CreateResult, DeleteResult>, Core<C, Settings> {
   /**
    * The set of command line arguments set for this driver.
    *
@@ -287,10 +286,9 @@ export interface ExternalDriver<
   Settings extends StringRecord = StringRecord,
   CreateResult = DefaultCreateSessionResult<C>,
   DeleteResult = DefaultDeleteSessionResult,
-  SessionData extends StringRecord = StringRecord,
 >
   extends
-    Driver<C, CArgs, Settings, CreateResult, DeleteResult, SessionData>,
+    Driver<C, CArgs, Settings, CreateResult, DeleteResult>,
     IWDClassicCommands,
     IAppiumCommands,
     IJSONWPCommands,


### PR DESCRIPTION
BREAKING CHANGE: BaseDriver.getSession, ISessionHandler.getSession, and the GET /session/:sessionId JSONWP route are gone. Use getAppiumSessionCapabilities to retrieve session capabilities and EventCommands.getLogEvents to retrieve event history instead.
BREAKING CHANGE: The appium:eventTimings capability is removed; it only ever controlled whether getSession's response was decorated with event history, which getLogEvents already exposes unconditionally.
