### PR TITLE
refactor(base-driver)!: remove deprecated multi-argument createSession overload

### DIFF
--- a/packages/appium/docs/en/developing/build-drivers.md
+++ b/packages/appium/docs/en/developing/build-drivers.md
@@ -229,13 +229,6 @@ async createSession(w3cCaps) {
 }
 ```
 
-!!! warning "Deprecated"
-
-    Older drivers may still define `createSession` with up to three parameters, e.g.
-    `createSession(jwpCaps, reqCaps, w3cCaps)`. This shape is a holdover from the retired JSON Wire
-    Protocol, which required desired and required caps as the first two arguments; only the first
-    W3C-shaped argument was ever used. New drivers should use the single-argument form shown above.
-
 You'll want to make sure to call `super.createSession` in order to get the session ID as well as
 the processed capabilities (note that capabilities are also set on `this.caps`; modifying `caps`
 locally here would have no effect other than changing what the user sees in the create session

--- a/packages/appium/docs/en/reference/api/webdriver.md
+++ b/packages/appium/docs/en/reference/api/webdriver.md
@@ -25,18 +25,11 @@ POST /session
 
 Creates a new WebDriver session.
 
-Appium implements a modified version of this endpoint for historical reasons. While the W3C
-endpoint only accepts 1 parameter, Appium's implementation allows up to 3 parameters, as this was
-required by the legacy JSON Wire Protocol (JSONWP). Since Appium 2, the JSONWP format is no longer
-supported, and any of the 3 parameters can be used to specify the W3C capabilities.
-
 #### Parameters
 
 |Name|Description|Type|
 |--|--|--|
-|`w3cCapabilities1?`|Capabilities of the new session|`W3CDriverCaps`|
-|`w3cCapabilities2?`|Another location for the new session capabilities (legacy)|`W3CDriverCaps`|
-|`w3cCapabilities?`|Another location for the new session capabilities (legacy)|`W3CDriverCaps`|
+|`capabilities?`|Capabilities of the new session|`W3CDriverCaps`|
 
 #### Response
 

--- a/packages/appium/lib/appium.ts
+++ b/packages/appium/lib/appium.ts
@@ -75,19 +75,6 @@ type SessionHandlerCreateResult = SessionHandlerResult<
 
 type SessionHandlerDeleteResult = SessionHandlerResult<void>;
 
-/**
- * Tuple shape of the deprecated multi-argument overload of {@link AppiumDriver.createSession}.
- * Shared between that overload's declaration and its implementation signature so the parameter
- * list only needs to be written out once.
- *
- * @deprecated Use the single-argument overload of {@link AppiumDriver.createSession} instead.
- */
-type LegacyCreateSessionArgs = [
-  w3cCapabilities1: W3CAppiumDriverCaps,
-  w3cCapabilities2?: W3CAppiumDriverCaps,
-  w3cCapabilities3?: W3CAppiumDriverCaps,
-];
-
 /** @internal Not part of {@link ExternalDriver}; used only when wiring session IPC. */
 type IpcAssignable = {
   assignIpc?: (ipc: IAppiumIpc) => Promise<void>;
@@ -279,23 +266,15 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
    * Creates a session: picks an inner driver from caps, runs plugin hooks, and returns a protocol
    * envelope with either `[sessionId, caps, protocol]` or an error.
    *
-   * @param w3cCapabilities - the new session capabilities in W3C format
+   * @param rawW3cCapabilities - the new session capabilities in W3C format
    */
-  async createSession(w3cCapabilities: W3CAppiumDriverCaps): Promise<SessionHandlerCreateResult>;
-  /**
-   * @deprecated Legacy call sites may pass the same W3C caps in up to three positions. These
-   * positions are intended to carry the same value; if they differ, which one wins is
-   * unspecified. Use the single-argument overload of {@linkcode createSession} instead.
-   */
-  async createSession(...legacyArgs: LegacyCreateSessionArgs): Promise<SessionHandlerCreateResult>;
-  async createSession(...legacyArgs: LegacyCreateSessionArgs): Promise<SessionHandlerCreateResult> {
-    const [w3cCapabilities1, w3cCapabilities2, w3cCapabilities3] = legacyArgs;
+  async createSession(rawW3cCapabilities: W3CAppiumDriverCaps): Promise<SessionHandlerCreateResult> {
     const defaultCapabilities = structuredClone(this.args.defaultCapabilities);
     const defaultSettings = pullSettings((defaultCapabilities ?? {}) as StringRecord);
-    const w3cCapabilities = structuredClone([w3cCapabilities3, w3cCapabilities2, w3cCapabilities1].find(isW3cCaps));
-    if (!w3cCapabilities) {
+    if (!isW3cCaps(rawW3cCapabilities)) {
       throw makeNonW3cCapsError();
     }
+    const w3cCapabilities = structuredClone(rawW3cCapabilities);
     const w3cSettings = {
       ...defaultSettings,
       ...pullSettings(w3cCapabilities.alwaysMatch ?? {}),
@@ -358,11 +337,10 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
       driverInstance.serverPort = this.args.port;
       driverInstance.serverPath = this.args.basePath;
 
-      [innerSessionId, dCaps] = (await driverInstance.createSession(
-        processedW3CCapabilities as never,
-        processedW3CCapabilities,
-        processedW3CCapabilities,
-      )) as [string, DriverCaps<AppiumDriverConstraints> & {webSocketUrl?: string | boolean}];
+      [innerSessionId, dCaps] = (await driverInstance.createSession(processedW3CCapabilities as never)) as [
+        string,
+        DriverCaps<AppiumDriverConstraints> & {webSocketUrl?: string | boolean},
+      ];
       this.sessions[innerSessionId] = driverInstance;
       // create an IPC channel for the driver and all plugins on this session
       this.sessionIpcs[innerSessionId] = new AppiumIpc({

--- a/packages/appium/test/unit/appiumdriver.spec.ts
+++ b/packages/appium/test/unit/appiumdriver.spec.ts
@@ -185,7 +185,7 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withExactArgs(W3C_CAPS, W3C_CAPS, W3C_CAPS)
+          .withExactArgs(W3C_CAPS)
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS as NSCapabilities<Constraints>)]);
         await appium.createSession(W3C_CAPS);
         mockFakeDriver.verify();
@@ -200,9 +200,9 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withArgs(allCaps, allCaps, allCaps)
+          .withArgs(allCaps)
           .returns([SESSION_ID, removeAppiumPrefixes(allCaps.alwaysMatch as NSCapabilities<Constraints>)]);
-        await appium.createSession(W3C_CAPS, W3C_CAPS, W3C_CAPS);
+        await appium.createSession(W3C_CAPS);
         mockFakeDriver.verify();
       });
       it(`should call inner driver's createSession with desired and default capabilities without overriding caps`, async function () {
@@ -213,9 +213,9 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withArgs(W3C_CAPS, W3C_CAPS, W3C_CAPS)
+          .withArgs(W3C_CAPS)
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS as NSCapabilities<Constraints>)]);
-        await appium.createSession(W3C_CAPS, W3C_CAPS, W3C_CAPS);
+        await appium.createSession(W3C_CAPS);
         mockFakeDriver.verify();
       });
       it('should kill all other sessions if sessionOverride is on', async function () {
@@ -241,9 +241,9 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withExactArgs(W3C_CAPS, W3C_CAPS, W3C_CAPS)
+          .withExactArgs(W3C_CAPS)
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS as NSCapabilities<Constraints>)]);
-        await appium.createSession(W3C_CAPS, W3C_CAPS, W3C_CAPS);
+        await appium.createSession(W3C_CAPS);
 
         sessions = await appium.getAppiumSessions();
         assert.strictEqual(sessions.length, 1);
@@ -257,9 +257,9 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withArgs(W3C_CAPS, W3C_CAPS, W3C_CAPS)
+          .withArgs(W3C_CAPS)
           .returns([SESSION_ID, BASE_CAPS]);
-        await appium.createSession(W3C_CAPS, W3C_CAPS, W3C_CAPS);
+        await appium.createSession(W3C_CAPS);
         mockFakeDriver.verify();
       });
       it('should call "createSession" with W3C capabilities argument with additional provided parameters', async function () {
@@ -280,10 +280,10 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withArgs(expectedCaps, expectedCaps, expectedCaps)
+          .withArgs(expectedCaps)
           .returns([SESSION_ID, insertAppiumPrefixes(BASE_CAPS as Capabilities<Constraints>)]);
 
-        await appium.createSession(w3cCaps, w3cCaps, w3cCaps);
+        await appium.createSession(w3cCaps);
         mockFakeDriver.verify();
       });
 
@@ -291,7 +291,7 @@ describe('AppiumDriver', function () {
         class ArgsDriver extends BaseDriver<Constraints> {}
         const args = {driver: {fake: {randomArg: 1234}}};
         [appium, mockFakeDriver] = getDriverAndFakeDriver(args, ArgsDriver as typeof FakeDriver);
-        const {value} = await appium.createSession(W3C_CAPS, W3C_CAPS, W3C_CAPS);
+        const {value} = await appium.createSession(W3C_CAPS);
         try {
           assert.deepStrictEqual(fakeDriver.cliArgs, {randomArg: 1234});
         } finally {
@@ -310,7 +310,7 @@ describe('AppiumDriver', function () {
       });
       it('should remove the session if it is found', async function () {
         appium.configureGlobalFeatures();
-        const [sessionId] = (await appium.createSession(null as any, null as any, W3C_CAPS)).value!;
+        const [sessionId] = (await appium.createSession(W3C_CAPS)).value!;
         let sessions = await appium.getAppiumSessions();
         assert.strictEqual(sessions.length, 1);
         await appium.deleteSession(sessionId);
@@ -318,7 +318,7 @@ describe('AppiumDriver', function () {
         assert.strictEqual(sessions.length, 0);
       });
       it("should call inner driver's deleteSession method", async function () {
-        const [sessionId] = (await appium.createSession(null as any, null as any, W3C_CAPS)).value!;
+        const [sessionId] = (await appium.createSession(W3C_CAPS)).value!;
         mockFakeDriver.expects('deleteSession').once().withExactArgs(sessionId).returns(undefined);
         await appium.deleteSession(sessionId);
         mockFakeDriver.verify();
@@ -351,9 +351,9 @@ describe('AppiumDriver', function () {
         mockFakeDriver
           .expects('createSession')
           .once()
-          .withExactArgs(undefined, null, W3C_CAPS)
+          .withExactArgs(W3C_CAPS)
           .returns([SESSION_ID, removeAppiumPrefixes(W3C_PREFIXED_CAPS as NSCapabilities<Constraints>)]);
-        await appium.createSession(undefined as any, null as any, W3C_CAPS);
+        await appium.createSession(W3C_CAPS);
 
         return fakeDriver;
       }
@@ -413,12 +413,12 @@ describe('AppiumDriver', function () {
           .expects('createSession')
           .once()
           .returns(['fake-session-id-1', removeAppiumPrefixes(caps1.alwaysMatch as NSCapabilities<Constraints>)]);
-        const [session1Id, session1Caps] = (await appium.createSession(null as any, null as any, caps1 as any)).value!;
+        const [session1Id, session1Caps] = (await appium.createSession(caps1 as any)).value!;
         mockFakeDriver
           .expects('createSession')
           .once()
           .returns(['fake-session-id-2', removeAppiumPrefixes(caps2.alwaysMatch as NSCapabilities<Constraints>)]);
-        const [session2Id, session2Caps] = (await appium.createSession(null as any, null as any, caps2 as any)).value!;
+        const [session2Id, session2Caps] = (await appium.createSession(caps2 as any)).value!;
 
         sessions = await appium.getAppiumSessions();
         assert.ok(Array.isArray(sessions));
@@ -456,7 +456,7 @@ describe('AppiumDriver', function () {
       });
 
       it('should remove session if inner driver unexpectedly exits with an error', async function () {
-        const [sessionId] = (await appium.createSession(null as any, null as any, structuredClone(W3C_CAPS))).value!;
+        const [sessionId] = (await appium.createSession(structuredClone(W3C_CAPS))).value!;
         assert.ok(Object.keys(appium.sessions).includes(sessionId));
         appium.sessions[sessionId].eventEmitter.emit('onUnexpectedShutdown', new Error('Oops'));
         // let event loop spin so rejection is handled
@@ -464,7 +464,7 @@ describe('AppiumDriver', function () {
         assert.ok(!Object.keys(appium.sessions).includes(sessionId));
       });
       it('should remove session if inner driver unexpectedly exits with no error', async function () {
-        const [sessionId] = (await appium.createSession(null as any, null as any, structuredClone(W3C_CAPS))).value!;
+        const [sessionId] = (await appium.createSession(structuredClone(W3C_CAPS))).value!;
         assert.ok(Object.keys(appium.sessions).includes(sessionId));
         appium.sessions[sessionId].eventEmitter.emit('onUnexpectedShutdown');
         // let event loop spin so rejection is handled

--- a/packages/appium/test/unit/appiumdriver.spec.ts
+++ b/packages/appium/test/unit/appiumdriver.spec.ts
@@ -254,11 +254,7 @@ describe('AppiumDriver', function () {
         mockFakeDriver.verify();
       });
       it('should call "createSession" with W3C capabilities argument, if provided', async function () {
-        mockFakeDriver
-          .expects('createSession')
-          .once()
-          .withArgs(W3C_CAPS)
-          .returns([SESSION_ID, BASE_CAPS]);
+        mockFakeDriver.expects('createSession').once().withArgs(W3C_CAPS).returns([SESSION_ID, BASE_CAPS]);
         await appium.createSession(W3C_CAPS);
         mockFakeDriver.verify();
       });

--- a/packages/base-driver/lib/basedriver/driver.ts
+++ b/packages/base-driver/lib/basedriver/driver.ts
@@ -10,7 +10,6 @@ import {
   type Driver,
   type DriverCaps,
   type InitialOpts,
-  type LegacyCreateSessionArgs,
   type ServerArgs,
   type SessionCapabilities,
   type StringRecord,
@@ -278,23 +277,14 @@ export class BaseDriver<
    *
    * @param w3cCapabilities - the new session capabilities in W3C format
    */
-  async createSession(w3cCapabilities: W3CDriverCaps<C>): Promise<CreateResult>;
-  /**
-   * @deprecated Historically the first three arguments were reserved for JSONWP capabilities.
-   * Appium 2 dropped support for that protocol; these positions are now intended to carry the
-   * same W3C capabilities value, and if they differ, which one wins is unspecified. Use the
-   * single-argument overload of {@linkcode createSession} instead.
-   */
-  async createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult>;
-  async createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult> {
-    const [w3cCapabilities1, w3cCapabilities2, w3cCapabilities] = legacyArgs;
+  async createSession(w3cCapabilities: W3CDriverCaps<C>): Promise<CreateResult> {
     if (this.sessionId !== null) {
       throw new errors.SessionNotCreatedError('Cannot create a new session while one is in progress');
     }
 
     this.log.debug();
 
-    const originalCaps = structuredClone([w3cCapabilities, w3cCapabilities1, w3cCapabilities2].find(isW3cCaps));
+    const originalCaps = isW3cCaps(w3cCapabilities) ? structuredClone(w3cCapabilities) : undefined;
     if (!originalCaps) {
       throw new errors.SessionNotCreatedError(
         'Appium only supports W3C-style capability objects. ' +

--- a/packages/base-driver/lib/protocol/routes/w3c.ts
+++ b/packages/base-driver/lib/protocol/routes/w3c.ts
@@ -10,11 +10,7 @@ export const W3C_ROUTES = {
     POST: {
       command: 'createSession',
       payloadParams: {
-        // Deliberately sent 3 times: this array is spread directly into any plugin hooking
-        // 'createSession' (see AppiumDriver#wrapCommandWithPlugins), so changing its shape here
-        // would be a wire-level breaking change for third-party plugins, not just drivers. Keep
-        // this in sync with the deprecated multi-argument overload of `createSession`.
-        optional: ['capabilities', 'capabilities', 'capabilities'],
+        optional: ['capabilities'],
       },
     },
   },

--- a/packages/base-driver/test/e2e/protocol/fake-driver.ts
+++ b/packages/base-driver/test/e2e/protocol/fake-driver.ts
@@ -32,9 +32,7 @@ class FakeDriver extends BaseDriver<Constraints> {
     return this;
   }
 
-  async createSession(
-    w3cCapabilities: W3CDriverCaps<Constraints>,
-  ): Promise<DefaultCreateSessionResult<Constraints>> {
+  async createSession(w3cCapabilities: W3CDriverCaps<Constraints>): Promise<DefaultCreateSessionResult<Constraints>> {
     if (!isW3cCaps(w3cCapabilities)) {
       throw new errors.SessionNotCreatedError('No capabilities provided');
     }

--- a/packages/base-driver/test/e2e/protocol/fake-driver.ts
+++ b/packages/base-driver/test/e2e/protocol/fake-driver.ts
@@ -33,12 +33,9 @@ class FakeDriver extends BaseDriver<Constraints> {
   }
 
   async createSession(
-    desiredCapabilities: W3CDriverCaps<Constraints>,
-    requiredCapabilities?: W3CDriverCaps<Constraints>,
-    capabilities?: W3CDriverCaps<Constraints>,
+    w3cCapabilities: W3CDriverCaps<Constraints>,
   ): Promise<DefaultCreateSessionResult<Constraints>> {
-    const w3cCapabilities = [desiredCapabilities, requiredCapabilities, capabilities].find(isW3cCaps);
-    if (!w3cCapabilities) {
+    if (!isW3cCaps(w3cCapabilities)) {
       throw new errors.SessionNotCreatedError('No capabilities provided');
     }
     this.sessionId = `fakeSession_${util.uuidV4()}`;

--- a/packages/base-driver/test/unit/protocol/routes.spec.ts
+++ b/packages/base-driver/test/unit/protocol/routes.spec.ts
@@ -41,7 +41,7 @@ describe('Routes', function () {
       }
       const hash = shasum.digest('hex').substring(0, 8);
       // Update this value again only when an intentional route/command/param change is made.
-      assert.strictEqual(hash, '2675d7f2');
+      assert.strictEqual(hash, '6039eb66');
     });
   });
 

--- a/packages/fake-driver/lib/driver.ts
+++ b/packages/fake-driver/lib/driver.ts
@@ -192,15 +192,8 @@ export class FakeDriver<Thing extends IpcData = null> extends BaseDriver<FakeDri
    * Create session and load fake app XML from caps.app.
    * Starts clock event emitter if caps.runClock is true.
    */
-  override async createSession(
-    w3cCapabilities1: W3CFakeDriverCaps,
-    w3cCapabilities2?: W3CFakeDriverCaps,
-    w3cCapabilities3?: W3CFakeDriverCaps,
-  ): Promise<[string, FakeDriverCaps]> {
-    const [sessionId, caps] = (await super.createSession(w3cCapabilities1, w3cCapabilities2, w3cCapabilities3)) as [
-      string,
-      FakeDriverCaps,
-    ];
+  override async createSession(w3cCapabilities: W3CFakeDriverCaps): Promise<[string, FakeDriverCaps]> {
+    const [sessionId, caps] = (await super.createSession(w3cCapabilities)) as [string, FakeDriverCaps];
     this.caps = caps;
     await this.appModel.loadApp(caps.app);
     if (this.caps.runClock) {

--- a/packages/fake-driver/test/unit/driver.spec.ts
+++ b/packages/fake-driver/test/unit/driver.spec.ts
@@ -126,12 +126,12 @@ describe('FakeDriver unit suite', function () {
     await assert.rejects(d.executeCommand('getStatus'), /shut down/);
     await sleep(500);
 
-    await d.executeCommand('createSession', null, null, structuredClone(w3cCaps));
+    await d.executeCommand('createSession', structuredClone(w3cCaps));
     await d.deleteSession();
   });
 
-  it('should distinguish between W3C and JSONWP session', async function () {
-    await d.executeCommand('createSession', null, null, {
+  it('should set the protocol to W3C on session creation', async function () {
+    await d.executeCommand('createSession', {
       alwaysMatch: {
         ...defaultCaps,
         platformName: 'Fake',
@@ -399,7 +399,7 @@ describe('FakeDriver unit suite', function () {
     beforeEach(async function () {
       beforeStartTime = Date.now();
       d.shouldValidateCaps = false;
-      await d.executeCommand('createSession', null, null, {
+      await d.executeCommand('createSession', {
         alwaysMatch: {...defaultCaps},
         firstMatch: [{}],
       });
@@ -514,10 +514,10 @@ describe('.isFeatureEnabled', function () {
 describe('FakeDriver', function () {
   it('should start a new session when another non-unique session is running', async function () {
     const d1 = new FakeDriver();
-    const [session1Id] = await d1.createSession(null as any, null as any, structuredClone(W3C_CAPS));
+    const [session1Id] = await d1.createSession(structuredClone(W3C_CAPS));
     assert.strictEqual(typeof session1Id, 'string');
     const d2 = new FakeDriver();
-    const [session2Id] = await d2.createSession(null as any, null as any, structuredClone(W3C_CAPS));
+    const [session2Id] = await d2.createSession(structuredClone(W3C_CAPS));
     assert.strictEqual(typeof session2Id, 'string');
     assert.notStrictEqual(session1Id, session2Id);
     await d1.deleteSession(session1Id);

--- a/packages/relaxed-caps-plugin/lib/plugin.ts
+++ b/packages/relaxed-caps-plugin/lib/plugin.ts
@@ -9,14 +9,10 @@ const HAS_VENDOR_PREFIX_RE = /^.+:/;
 export class RelaxedCapsPlugin extends BasePlugin {
   async createSession(
     next: () => Promise<unknown>,
-    driver: {createSession: (...args: unknown[]) => Promise<unknown>},
-    caps1: W3CCapsLike | null,
-    caps2?: W3CCapsLike | null,
-    caps3?: W3CCapsLike | null,
-    ...restArgs: unknown[]
+    driver: {createSession: (caps: W3CCapsLike) => Promise<unknown>},
+    caps: W3CCapsLike,
   ): Promise<unknown> {
-    const patchedCaps = [caps1, caps2, caps3].map((c) => (isPlainObject(c) ? this.fixCapsIfW3C(c) : c));
-    return await driver.createSession(...patchedCaps, ...restArgs);
+    return await driver.createSession(isPlainObject(caps) ? this.fixCapsIfW3C(caps) : caps);
   }
 
   private fixCapsIfW3C<T>(caps: T): T {

--- a/packages/relaxed-caps-plugin/test/unit/plugin.spec.ts
+++ b/packages/relaxed-caps-plugin/test/unit/plugin.spec.ts
@@ -89,17 +89,8 @@ describe('relaxed caps plugin', function () {
       const mock = sandbox.mock(driver);
       const w3c = {firstMatch: [MIXED_CAPS]};
       const w3cAdjusted = {firstMatch: [ADJUSTED_CAPS]};
-      mock.expects('createSession').once().withExactArgs(null, null, w3cAdjusted);
-      await rcp.createSession(next, driver, null, null, w3c);
-      mock.verify();
-    });
-
-    it('should work with any argument', async function () {
-      const mock = sandbox.mock(driver);
-      const w3c = {firstMatch: [MIXED_CAPS]};
-      const w3cAdjusted = {firstMatch: [ADJUSTED_CAPS]};
-      mock.expects('createSession').once().withExactArgs(w3cAdjusted, w3cAdjusted, null);
-      await rcp.createSession(next, driver, w3c, w3c, null);
+      mock.expects('createSession').once().withExactArgs(w3cAdjusted);
+      await rcp.createSession(next, driver, w3c);
       mock.verify();
     });
 
@@ -109,8 +100,8 @@ describe('relaxed caps plugin', function () {
       const w3cAdjusted = {
         firstMatch: [ADJUSTED_CAPS, STD_CAPS, ADJUSTED_CAPS],
       };
-      mock.expects('createSession').once().withExactArgs(null, {}, w3cAdjusted);
-      await rcp.createSession(next, driver, null, {}, w3c);
+      mock.expects('createSession').once().withExactArgs(w3cAdjusted);
+      await rcp.createSession(next, driver, w3c);
       mock.verify();
     });
 
@@ -118,8 +109,8 @@ describe('relaxed caps plugin', function () {
       const mock = sandbox.mock(driver);
       const w3c = {alwaysMatch: MIXED_CAPS};
       const w3cAdjusted = {alwaysMatch: ADJUSTED_CAPS};
-      mock.expects('createSession').once().withExactArgs(null, null, w3cAdjusted);
-      await rcp.createSession(next, driver, null, null, w3c);
+      mock.expects('createSession').once().withExactArgs(w3cAdjusted);
+      await rcp.createSession(next, driver, w3c);
       mock.verify();
     });
 
@@ -130,8 +121,8 @@ describe('relaxed caps plugin', function () {
         alwaysMatch: ADJUSTED_CAPS,
         firstMatch: [ADJUSTED_CAPS],
       };
-      mock.expects('createSession').once().withExactArgs(null, null, w3cAdjusted);
-      await rcp.createSession(next, driver, null, null, w3c);
+      mock.expects('createSession').once().withExactArgs(w3cAdjusted);
+      await rcp.createSession(next, driver, w3c);
       mock.verify();
     });
   });

--- a/packages/types/lib/capabilities.ts
+++ b/packages/types/lib/capabilities.ts
@@ -118,11 +118,11 @@ export type NSCapabilities<C extends Constraints, NS extends string = W3C_APPIUM
  * @example
  * ```ts
  * class MyDriver extends BaseDriver<MyDriverConstraints> {
- *   async createSession (w3ccaps: W3CDriverCaps<MyDriverConstraints>, ...args: any[]) {
+ *   async createSession (w3ccaps: W3CDriverCaps<MyDriverConstraints>) {
  *     const [
  *       sessionId: string,
  *       caps: DriverCaps<MyDriverConstraints>
- *     ] = await super.createSession(w3ccaps, ...args);
+ *     ] = await super.createSession(w3ccaps);
  *     // ...
  *   }
  * }
@@ -143,7 +143,7 @@ export type DriverCaps<C extends Constraints = Constraints> = BaseCapabilities &
  * @example
  * ```ts
  * class MyDriver extends BaseDriver<MyDriverConstraints> {
- *   async createSession (w3ccaps: W3CDriverCaps<MyDriverConstraints>, ...args: any[]) {
+ *   async createSession (w3ccaps: W3CDriverCaps<MyDriverConstraints>) {
  *     // ...
  *   }
  * }

--- a/packages/types/lib/commands/basedriver.ts
+++ b/packages/types/lib/commands/basedriver.ts
@@ -319,20 +319,6 @@ export interface ISettingsCommands<T extends object = object> {
 }
 
 /**
- * Tuple shape of the deprecated multi-argument overload of {@linkcode ISessionHandler.createSession}.
- * Shared with {@linkcode BaseDriver.createSession}'s implementation so the parameter list only
- * needs to be written out once.
- *
- * @deprecated Use the single-argument overload of {@linkcode ISessionHandler.createSession}
- * instead.
- */
-export type LegacyCreateSessionArgs<C extends Constraints> = [
-  w3cCaps1: W3CDriverCaps<C>,
-  w3cCaps2?: W3CDriverCaps<C>,
-  w3cCaps3?: W3CDriverCaps<C>,
-];
-
-/**
  * An interface which creates and deletes sessions.
  */
 export interface ISessionHandler<
@@ -348,16 +334,6 @@ export interface ISessionHandler<
    * @returns The capabilities object representing the created session
    */
   createSession(w3cCapabilities: W3CDriverCaps<C>): Promise<CreateResult>;
-  /**
-   * @deprecated Historically this method accepted the same W3C capabilities object in up to three
-   * positions to support the retired JSONWP protocol. These positions are intended to carry the
-   * same value; if they differ, which one wins is unspecified. Use the single-argument overload
-   * of {@linkcode createSession} instead.
-   *
-   * @param legacyArgs - see {@linkcode LegacyCreateSessionArgs}
-   * @returns The capabilities object representing the created session
-   */
-  createSession(...legacyArgs: LegacyCreateSessionArgs<C>): Promise<CreateResult>;
 
   /**
    * Stop an automation session


### PR DESCRIPTION
Removes the deprecated multi-argument overload of `createSession`, keeping only the single
`w3cCapabilities` argument.

Historically `createSession` accepted the same W3C capabilities object in up to three positions
(`createSession(jwpCaps, reqCaps, w3cCaps)`), a holdover from the retired JSON Wire Protocol where
the first two positions carried desired/required capabilities. Appium 2 dropped JSONWP support, and
since then all three positions have only ever carried the same W3C-shaped value, so the extra
positions serve no purpose.

BREAKING CHANGE: `ISessionHandler.createSession` (`@appium/types`) and `LegacyCreateSessionArgs` — overload and type deleted, single-argument signature only.
BREAKING CHANGE: `BaseDriver.createSession` and `AppiumDriver.createSession` — collapsed to the single-argument mplementation; capability validation now checks the one argument directly instead of scanning three positions for the first W3C-shaped value.
BREAKING CHANGE: `FakeDriver.createSession` (and the base-driver e2e test double) — overrides updated to match.
BREAKING CHANGE: `RelaxedCapsPlugin.createSession` — this plugin existed specifically to normalize capabilities across the (now-gone) three positions; its hook is simplified to a single `caps` argument.
BREAKING CHANGE: `POST /session` wire route (`w3c.ts`) — `payloadParams.optional` no longer sends `capabilities` three times into the command args.
BREAKING CHANGE: Docs (`build-drivers.md`, `webdriver.md`) and JSDoc examples updated to drop references to the deprecated multi-argument shape.

Tests updated accordingly (`appiumdriver.spec.ts`, `fake-driver` unit tests, `relaxed-caps-plugin`
unit tests, and the `base-driver` route-shape checksum test, whose hash intentionally changed since
the wire route's `payloadParams` shape changed).
