### PR TITLE
feat(appium)!: replace --allow-cors flag with --allow-insecure=*:cors

### DIFF
--- a/packages/appium/docs/en/reference/cli/insecure-features.md
+++ b/packages/appium/docs/en/reference/cli/insecure-features.md
@@ -14,6 +14,7 @@ they can only be enabled using the wildcard (`*`) prefix:
 | Feature Name      | Description                                                                   |
 |-------------------|-------------------------------------------------------------------------------|
 |`session_discovery`|Allows retrieving the list of active server sessions via `GET /appium/sessions`|
+|`cors`             |Allows web browser connections to the server from any host                    |
 
 
 Of course, Appium drivers and plugins are free to define additional insecure features of their own.

--- a/packages/appium/docs/en/reference/cli/server.md
+++ b/packages/appium/docs/en/reference/cli/server.md
@@ -27,7 +27,6 @@ appium
 |<div style="width:15em">Argument</div>|Description|Type|<div style="width:7em">Default</div>|
 |--|--|--|--|
 |`--address`, `-a`|IPv4/IPv6 address to listen on|string|`0.0.0.0`|
-|`--allow-cors`|Allow web browser connections from any host|boolean|`false`|
 |`--allow-insecure`|List of [insecure features](../../guides/security.md) that should be allowed in this server's sessions. Individual features can be overridden by `--deny-insecure`. Has no effect in combination with `--relaxed-security`.|array<string>|`[]`|
 |`--allow-unknown-args`|Do not exit if unrecognized command-line arguments are passed to the server; ignore them instead. Useful when the Appium CLI is wrapped by external tooling that appends extra flags.|boolean|`false`|
 |`--base-path`, `-pa`|Base path to use as the prefix for all webdriver routes running on the server|string|`""`|

--- a/packages/appium/lib/bootstrap/appium-main-runner.ts
+++ b/packages/appium/lib/bootstrap/appium-main-runner.ts
@@ -76,7 +76,7 @@ export class AppiumMainRunner {
       return undefined as Cmd extends CliCommandServer ? AppiumServer : void;
     }
 
-    this.warnIfCorsEnabled(parsedArgs);
+    this.warnIfCorsEnabled(serverOpts);
     appiumDriver.server = server;
 
     this.attachSignalHandlers(appiumDriver, server);
@@ -108,8 +108,8 @@ export class AppiumMainRunner {
     }
   }
 
-  private warnIfCorsEnabled(parsedArgs: ServerInitData['parsedArgs']): void {
-    if (parsedArgs.allowCors) {
+  private warnIfCorsEnabled(serverOpts: ServerOpts): void {
+    if (serverOpts.allowCors) {
       logger.warn(
         'You have enabled CORS requests from any host. Be careful not ' +
           'to visit sites which could maliciously try to start Appium ' +

--- a/packages/appium/lib/bootstrap/main-helpers.ts
+++ b/packages/appium/lib/bootstrap/main-helpers.ts
@@ -13,7 +13,7 @@ import type {Args, CliCommandServer, ParsedArgs} from 'appium/types/index.js';
 import {WebSocketServer} from 'ws';
 
 import type {AppiumDriver} from '../appium.js';
-import {BIDI_BASE_PATH, LONG_STACKTRACE_LIMIT} from '../constants.js';
+import {BIDI_BASE_PATH, CORS_FEATURE, LONG_STACKTRACE_LIMIT} from '../constants.js';
 import type {DriverNameMap, PluginNameMap} from '../extension/index.js';
 import {APPIUM_VER, getBuildInfo, getGitRev, updateBuildInfo} from '../helpers/build.js';
 import {fetchInterfaces, isBroadcastIp, V4_BROADCAST_IP} from '../helpers/network.js';
@@ -173,7 +173,7 @@ export function buildServerOpts(
     routeConfiguringFunction,
     port: parsedArgs.port,
     hostname: parsedArgs.address,
-    allowCors: parsedArgs.allowCors,
+    allowCors: appiumDriver.isFeatureEnabled(CORS_FEATURE),
     basePath: parsedArgs.basePath,
     serverUpdaters: getServerUpdaters(driverClasses, pluginClasses),
     extraMethodMap: getExtraMethodMap(driverClasses, pluginClasses),

--- a/packages/appium/lib/constants.ts
+++ b/packages/appium/lib/constants.ts
@@ -115,3 +115,8 @@ export const BIDI_EVENT_NAME = 'bidiEvent';
  * The name of the insecure feature that allows retrieving the list of active server sessions
  */
 export const SESSION_DISCOVERY_FEATURE = 'session_discovery';
+
+/**
+ * The name of the insecure feature that allows CORS requests from any host
+ */
+export const CORS_FEATURE = 'cors';

--- a/packages/appium/sample-code/appium.config.sample.js
+++ b/packages/appium/sample-code/appium.config.sample.js
@@ -1,7 +1,6 @@
 module.exports = {
   server: {
     address: '127.0.0.1',
-    'allow-cors': true,
     'allow-insecure': ['*:foo', '*:bar'],
     'base-path': '/',
     'callback-address': '127.0.0.1',

--- a/packages/appium/sample-code/appium.config.sample.json
+++ b/packages/appium/sample-code/appium.config.sample.json
@@ -1,7 +1,6 @@
 {
   "server": {
     "address": "127.0.0.1",
-    "allow-cors": true,
     "allow-insecure": ["*:foo", "*:bar"],
     "base-path": "/",
     "callback-address": "127.0.0.1",

--- a/packages/appium/sample-code/appium.config.sample.yaml
+++ b/packages/appium/sample-code/appium.config.sample.yaml
@@ -1,6 +1,5 @@
 server:
   address: 127.0.0.1
-  allow-cors: true
   allow-insecure:
     - foo
     - bar

--- a/packages/appium/test/e2e/config-file.e2e.spec.ts
+++ b/packages/appium/test/e2e/config-file.e2e.spec.ts
@@ -38,7 +38,6 @@ describe('config file behavior', function () {
           config: {
             server: {
               address: '0.0.0.0',
-              allowCors: false,
               allowInsecure: [],
               basePath: '/',
               callbackAddress: '0.0.0.0',
@@ -130,7 +129,6 @@ describe('config file behavior', function () {
             appiumHome: 'foo',
             server: {
               address: '0.0.0.0',
-              allowCors: 1,
               allowInsecure: {},
               basePath: '/',
               callbackAddress: '0.0.0.0',
@@ -158,7 +156,7 @@ describe('config file behavior', function () {
             },
           });
           assert.strictEqual(result.filepath, BAD_FILEPATH);
-          assert.strictEqual(result.errors?.length, 7);
+          assert.strictEqual(result.errors?.length, 6);
           assert.ok(
             result.errors?.some((error) =>
               util.isEqual(error, {

--- a/packages/appium/test/fixtures/config/appium-config-bad.json
+++ b/packages/appium/test/fixtures/config/appium-config-bad.json
@@ -2,7 +2,6 @@
   "appium-home": "foo",
   "server": {
     "address": "0.0.0.0",
-    "allow-cors": 1,
     "allow-insecure": {},
     "base-path": "/",
     "callback-address": "0.0.0.0",

--- a/packages/appium/test/fixtures/config/appium-config-good-normalized.json
+++ b/packages/appium/test/fixtures/config/appium-config-good-normalized.json
@@ -1,7 +1,6 @@
 {
   "server": {
     "address": "0.0.0.0",
-    "allow-cors": false,
     "allow-insecure": [],
     "base-path": "/",
     "callback-address": "0.0.0.0",

--- a/packages/appium/test/fixtures/config/appium-config-good.json
+++ b/packages/appium/test/fixtures/config/appium-config-good.json
@@ -1,7 +1,6 @@
 {
   "server": {
     "address": "0.0.0.0",
-    "allow-cors": false,
     "allow-insecure": [],
     "base-path": "/",
     "callback-address": "0.0.0.0",

--- a/packages/appium/test/fixtures/config/appium-config-good.ts
+++ b/packages/appium/test/fixtures/config/appium-config-good.ts
@@ -1,7 +1,6 @@
 export default {
   server: {
     address: '0.0.0.0',
-    'allow-cors': false,
     'allow-insecure': [] as string[],
     'base-path': '/',
     'callback-address': '0.0.0.0',

--- a/packages/appium/test/fixtures/config/appium-config-good.yaml
+++ b/packages/appium/test/fixtures/config/appium-config-good.yaml
@@ -1,7 +1,6 @@
 server:
   address: '0.0.0.0'
   port: 31337
-  allow-cors: false
   allow-insecure: []
   base-path: /
   callback-address: '0.0.0.0'

--- a/packages/appium/test/fixtures/config/appium-config-invalid.json
+++ b/packages/appium/test/fixtures/config/appium-config-invalid.json
@@ -2,7 +2,6 @@
   "server": {
     "address": "0.0.0.0",
     "port": 31337,
-    "allow-cors": false,
     "allow-insecure": [],
     "base-path": "/",
     "callback-address": "0.0.0.0",

--- a/packages/appium/test/fixtures/default-args.ts
+++ b/packages/appium/test/fixtures/default-args.ts
@@ -1,6 +1,5 @@
 export default {
   address: '0.0.0.0',
-  allowCors: false,
   allowInsecure: [] as string[],
   allowUnknownArgs: false,
   basePath: '',

--- a/packages/appium/test/fixtures/flattened-schema.ts
+++ b/packages/appium/test/fixtures/flattened-schema.ts
@@ -24,25 +24,6 @@ export default [
   },
   {
     argSpec: {
-      arg: 'allow-cors',
-      defaultValue: false,
-      dest: 'allowCors',
-      extName: undefined,
-      extType: undefined,
-      name: 'allow-cors',
-      rawDest: 'allowCors',
-      ref: 'appium.json#/properties/server/properties/allow-cors',
-    },
-    schema: {
-      default: false,
-      description:
-        'Whether the Appium server should allow web browser connections from any host',
-      title: 'allow-cors config',
-      type: 'boolean',
-    },
-  },
-  {
-    argSpec: {
       arg: 'allow-insecure',
       defaultValue: [],
       dest: 'allowInsecure',

--- a/packages/appium/test/unit/appiumdriver.spec.ts
+++ b/packages/appium/test/unit/appiumdriver.spec.ts
@@ -10,7 +10,7 @@ import type {SinonMock, SinonSandbox, SinonStubbedMember} from 'sinon';
 import {createSandbox, stub} from 'sinon';
 
 import type * as AppiumModule from '../../lib/appium.js';
-import {PLUGIN_TYPE, SESSION_DISCOVERY_FEATURE} from '../../lib/constants.js';
+import {CORS_FEATURE, PLUGIN_TYPE, SESSION_DISCOVERY_FEATURE} from '../../lib/constants.js';
 import * as buildInfoModule from '../../lib/helpers/build.js';
 import {insertAppiumPrefixes, removeAppiumPrefixes} from '../../lib/helpers/capability.js';
 import {finalizeSchema, registerSchema, resetSchema} from '../../lib/schema/schema.js';
@@ -168,6 +168,22 @@ describe('AppiumDriver', function () {
         } as any);
         assert.strictEqual(appium.allowInsecure.length, 0);
         assert.strictEqual(appium.relaxedSecurityEnabled, true);
+      });
+      it('should not enable cors by default', function () {
+        createDriver({} as any);
+        assert.strictEqual(appium.isFeatureEnabled(CORS_FEATURE), false);
+      });
+      it('should enable cors via allow-insecure=*:cors', function () {
+        createDriver({allowInsecure: [`*:${CORS_FEATURE}`]} as any);
+        assert.strictEqual(appium.isFeatureEnabled(CORS_FEATURE), true);
+      });
+      it('should enable cors via relaxed security', function () {
+        createDriver({relaxedSecurityEnabled: true} as any);
+        assert.strictEqual(appium.isFeatureEnabled(CORS_FEATURE), true);
+      });
+      it('should deny cors via deny-insecure=*:cors even with relaxed security', function () {
+        createDriver({relaxedSecurityEnabled: true, denyInsecure: [`*:${CORS_FEATURE}`]} as any);
+        assert.strictEqual(appium.isFeatureEnabled(CORS_FEATURE), false);
       });
     });
     describe('createSession', function () {

--- a/packages/appium/test/unit/bootstrap/startup-config.spec.ts
+++ b/packages/appium/test/unit/bootstrap/startup-config.spec.ts
@@ -41,7 +41,7 @@ describe('bootstrap/startup-config', function () {
             },
           },
           {port: 1234},
-          {allowCors: false},
+          {sessionOverride: false},
         );
         assert.strictEqual(log.calledWith('Appium Configuration\n'), true);
       });
@@ -95,9 +95,9 @@ describe('bootstrap/startup-config', function () {
       });
 
       it('should catch a non-default argument', function () {
-        args.allowCors = true;
+        args.sessionOverride = true;
         const nonDefaultArgs = getNonDefaultServerArgs(args);
-        assert.deepStrictEqual(nonDefaultArgs, {allowCors: true});
+        assert.deepStrictEqual(nonDefaultArgs, {sessionOverride: true});
       });
 
       describe('when arg is an array', function () {

--- a/packages/appium/test/unit/utils/object.spec.ts
+++ b/packages/appium/test/unit/utils/object.spec.ts
@@ -124,14 +124,14 @@ describe('utils/object', function () {
         properties: {
           server: {
             properties: {
-              'allow-cors': {appiumCliDest: 'allowCors'},
+              'allow-insecure': {appiumCliDest: 'allowInsecure'},
               log: {appiumCliDest: 'logFile'},
             },
           },
         },
       };
       assert.strictEqual(getPath(schema, 'properties.server.properties.log.appiumCliDest'), 'logFile');
-      assert.strictEqual(getPath(schema, 'properties.server.properties.allow-cors.appiumCliDest'), 'allowCors');
+      assert.strictEqual(getPath(schema, 'properties.server.properties.allow-insecure.appiumCliDest'), 'allowInsecure');
     });
   });
 

--- a/packages/schema/lib/appium-config-schema.ts
+++ b/packages/schema/lib/appium-config-schema.ts
@@ -38,12 +38,6 @@ export const AppiumConfigJsonSchema = {
             },
           ],
         },
-        'allow-cors': {
-          description: 'Whether the Appium server should allow web browser connections from any host',
-          title: 'allow-cors config',
-          type: 'boolean',
-          default: false,
-        },
         'allow-insecure': {
           appiumCliTransformer: 'csv',
           default: [],

--- a/packages/schema/lib/appium-config.schema.json
+++ b/packages/schema/lib/appium-config.schema.json
@@ -32,12 +32,6 @@
             }
           ]
         },
-        "allow-cors": {
-          "description": "Whether the Appium server should allow web browser connections from any host",
-          "title": "allow-cors config",
-          "type": "boolean",
-          "default": false
-        },
         "allow-insecure": {
           "appiumCliTransformer": "csv",
           "default": [],

--- a/packages/types/lib/appium-config.ts
+++ b/packages/types/lib/appium-config.ts
@@ -10,10 +10,6 @@
  */
 export type AddressConfig = string;
 /**
- * Whether the Appium server should allow web browser connections from any host
- */
-export type AllowCorsConfig = boolean;
-/**
  * Set which insecure features are allowed to run in this server's sessions. Features are defined on a driver level; see documentation for more details. Note that features defined via "deny-insecure" will be disabled, even if also listed here. If string, a path to a text file containing policy or a comma-delimited list.
  */
 export type AllowInsecureConfig = string[];
@@ -199,7 +195,6 @@ export interface AppiumConfiguration {
  */
 export interface ServerConfig {
   address?: AddressConfig;
-  "allow-cors"?: AllowCorsConfig;
   "allow-insecure"?: AllowInsecureConfig;
   "allow-unknown-args"?: AllowUnknownArgsConfig;
   "base-path"?: BasePathConfig;


### PR DESCRIPTION
CORS is now gated through the existing insecure-feature mechanism (allow-insecure/deny-insecure/relaxed-security) instead of a dedicated flag, consistent with how other server-level features like session_discovery work.

BREAKING CHANGE: The --allow-cors CLI flag and allow-cors config file property have been removed. Use --allow-insecure=*:cors (or --relaxed-security, optionally overridden with --deny-insecure=*:cors) instead.
