### PR TITLE
feat(appium): validate extension manifests and extensions.yaml via ajv

### DIFF
--- a/packages/appium/lib/bootstrap/config-file.ts
+++ b/packages/appium/lib/bootstrap/config-file.ts
@@ -1,10 +1,10 @@
 import {util} from '@appium/support';
 import type {AppiumConfig, NormalizedAppiumConfig} from '@appium/types';
 import type {IOutputError} from '@sidvind/better-ajv-errors';
-import type {ErrorObject, SchemaObject} from 'ajv';
 import {lilconfig, type LilconfigResult, type LoaderSync} from 'lilconfig';
 import * as yaml from 'yaml';
 
+import type {ErrorObject, SchemaObject} from '../schema/ajv.js';
 import {formatErrors} from '../schema/format-errors.js';
 import {getSchema, validate} from '../schema/schema.js';
 import {camelCase, getPath, mapKeys, mapValues} from '../utils/index.js';

--- a/packages/appium/lib/cli/args.ts
+++ b/packages/appium/lib/cli/args.ts
@@ -1,7 +1,6 @@
 import {util} from '@appium/support';
 import type {ExtensionType} from '@appium/types';
 import type {CliExtensionSubcommand} from 'appium/types/index.js';
-import type {ArgumentOptions} from 'argparse';
 
 import {
   DRIVER_TYPE,
@@ -13,12 +12,10 @@ import {
   EXT_SUBCOMMAND_UPDATE,
   PLUGIN_TYPE,
 } from '../constants.js';
-import {INSTALL_TYPES} from '../extension/extension-config.js';
-import {toParserArgs} from '../schema/cli-args.js';
+import {INSTALL_TYPES} from '../extension/manifest/index.js';
+import {toParserArgs, type ArgumentDefinitions} from '../schema/cli-args.js';
 const DRIVER_EXAMPLE = 'xcuitest';
 const PLUGIN_EXAMPLE = 'images';
-
-export type ArgumentDefinitions = Map<[name: string] | [name: string, alias: string], ArgumentOptions>;
 
 /**
  * This is necessary because we pass the array into `argparse`. `argparse` is bad and mutates things. We don't want that.

--- a/packages/appium/lib/cli/args.ts
+++ b/packages/appium/lib/cli/args.ts
@@ -13,7 +13,8 @@ import {
   PLUGIN_TYPE,
 } from '../constants.js';
 import {INSTALL_TYPES} from '../extension/manifest/index.js';
-import {toParserArgs, type ArgumentDefinitions} from '../schema/cli-args.js';
+import {toParserArgs} from '../schema/cli-args.js';
+import type {ArgumentDefinitions} from '../schema/cli-args.js';
 const DRIVER_EXAMPLE = 'xcuitest';
 const PLUGIN_EXAMPLE = 'images';
 

--- a/packages/appium/lib/cli/extension-command.ts
+++ b/packages/appium/lib/cli/extension-command.ts
@@ -26,7 +26,7 @@ import {
   INSTALL_TYPE_GITHUB,
   INSTALL_TYPE_LOCAL,
   INSTALL_TYPE_NPM,
-} from '../extension/extension-config.js';
+} from '../extension/manifest/index.js';
 import {appiumPackageRoot, compact, hasAppiumDependency, npm, npmPackage, packageDidChange} from '../utils/index.js';
 import {RingBuffer, spinWith} from './utils.js';
 

--- a/packages/appium/lib/cli/parser.ts
+++ b/packages/appium/lib/cli/parser.ts
@@ -18,10 +18,10 @@ import {
   SETUP_SUBCOMMAND,
 } from '../constants.js';
 import {APPIUM_VER} from '../helpers/build.js';
+import type {ArgumentDefinitions} from '../schema/index.js';
 import {finalizeSchema, getAllArgSpecs, getArgSpec, hasArgSpec} from '../schema/index.js';
 import {setPath} from '../utils/index.js';
 import {getExtensionArgs, getServerArgs} from './args.js';
-import type {ArgumentDefinitions} from './args.js';
 import {
   DEFAULT_PLUGINS,
   determinePlatformName,

--- a/packages/appium/lib/extension/driver-config.ts
+++ b/packages/appium/lib/extension/driver-config.ts
@@ -1,12 +1,11 @@
-import {util} from '@appium/support';
 import type {DriverClass, DriverType, StringRecord} from '@appium/types';
 import type {ExtManifest, ExtName, ExtRecord} from 'appium/types/index.js';
 
 import {DRIVER_TYPE} from '../constants.js';
 import {log} from '../logger.js';
-import type {ExtManifestProblem} from './extension-config.js';
 import {ExtensionConfig} from './extension-config.js';
-import type {Manifest} from './manifest.js';
+import {manifestValidator} from './manifest/index.js';
+import type {ExtManifestProblem, Manifest} from './manifest/index.js';
 
 export type MatchedDriver = {
   driver: DriverClass;
@@ -87,45 +86,20 @@ export class DriverConfig extends ExtensionConfig<DriverType> {
 
   protected override getConfigProblems(extManifest: ExtManifest<DriverType>, extName: string): ExtManifestProblem[] {
     void extName;
-    const problems: ExtManifestProblem[] = [];
-    const {platformNames, automationName} = extManifest;
+    const problems = manifestValidator.getDriverManifestProblems(extManifest);
+    // `?.`, not destructuring: a corrupted entry may be null/non-object (already reported above).
+    const automationName = (extManifest as unknown as Record<string, unknown> | null | undefined)?.automationName;
 
-    if (!Array.isArray(platformNames)) {
-      problems.push({
-        err: 'Missing or incorrect supported platformNames list.',
-        val: platformNames,
-      });
-    } else if (util.isEmpty(platformNames)) {
-      problems.push({
-        err: 'Empty platformNames list.',
-        val: platformNames,
-      });
-    } else {
-      for (const pName of platformNames) {
-        if (typeof pName !== 'string') {
-          problems.push({
-            err: 'Incorrectly formatted platformName.',
-            val: pName,
-          });
-        }
+    // Only track actual strings — `undefined` would make every automationName-less entry a "duplicate".
+    if (typeof automationName === 'string') {
+      if (this.knownAutomationNames.has(automationName)) {
+        problems.push({
+          err: 'Multiple drivers claim support for the same automationName',
+          val: automationName,
+        });
       }
+      this.knownAutomationNames.add(automationName);
     }
-
-    if (typeof automationName !== 'string') {
-      problems.push({
-        err: 'Missing or incorrect automationName',
-        val: automationName,
-      });
-    }
-
-    if (this.knownAutomationNames.has(automationName as string)) {
-      problems.push({
-        err: 'Multiple drivers claim support for the same automationName',
-        val: automationName,
-      });
-    }
-
-    this.knownAutomationNames.add(automationName as string);
 
     return problems;
   }

--- a/packages/appium/lib/extension/extension-config.ts
+++ b/packages/appium/lib/extension/extension-config.ts
@@ -4,8 +4,7 @@ import {pathToFileURL} from 'node:url';
 
 import {fs, system, util} from '@appium/support';
 import type {ExtensionType, StringRecord} from '@appium/types';
-import type {SchemaObject} from 'ajv';
-import type {ExtClass, ExtManifest, ExtName, ExtRecord, InstallType} from 'appium/types/index.js';
+import type {ExtClass, ExtManifest, ExtName, ExtRecord} from 'appium/types/index.js';
 import {satisfies} from 'semver';
 
 import type {
@@ -16,51 +15,16 @@ import type {
 } from '../cli/extension-command.js';
 import {APPIUM_VER} from '../helpers/build.js';
 import {log} from '../logger.js';
+import type {SchemaObject} from '../schema/ajv.js';
 import {ALLOWED_SCHEMA_EXTENSIONS, isAllowedSchemaFileExtension, registerSchema} from '../schema/schema.js';
 import {capitalize, resolveFrom} from '../utils/index.js';
-import type {Manifest} from './manifest.js';
+import {INSTALL_TYPES, manifestValidator} from './manifest/index.js';
+import type {ExtManifestProblem, Manifest} from './manifest/index.js';
 
 const DEFAULT_ENTRY_POINT = 'index.js';
 // Counter for `APPIUM_RELOAD_EXTENSIONS` cache-busting; `Date.now()` alone can collide when two
 // reloads happen within the same millisecond, which would serve the stale cached module.
 let reloadCounter = 0;
-/**
- * "npm" install type
- * Used when extension was installed by npm package name
- * @remarks _All_ extensions are installed _by_ `npm`, but only this one means the package name was
- * used to specify it
- */
-export const INSTALL_TYPE_NPM = 'npm';
-/**
- * "local" install type
- * Used when extension was installed from a local path
- */
-export const INSTALL_TYPE_LOCAL = 'local';
-/**
- * "github" install type
- * Used when extension was installed via GitHub URL
- */
-export const INSTALL_TYPE_GITHUB = 'github';
-/**
- * "git" install type
- * Used when extensions was installed via Git URL
- */
-export const INSTALL_TYPE_GIT = 'git';
-/**
- * "dev" install type
- * Used when automatically detected as a working copy
- */
-export const INSTALL_TYPE_DEV = 'dev';
-
-export const INSTALL_TYPES = new Set<InstallType>([
-  INSTALL_TYPE_GIT,
-  INSTALL_TYPE_GITHUB,
-  INSTALL_TYPE_LOCAL,
-  INSTALL_TYPE_NPM,
-  INSTALL_TYPE_DEV,
-]);
-
-export type ExtManifestProblem = {err: string; val: unknown};
 
 export type ExtManifestWithSchema<E extends ExtensionType> = ExtManifest<E> & {
   schema: NonNullable<ExtManifest<E>['schema']>;
@@ -542,31 +506,7 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
   /** Blocking issues for required manifest fields shared by all extensions (version, package name, main class). */
   protected getGenericConfigProblems(extManifest: ExtManifest<ExtType>, extName: string): ExtManifestProblem[] {
     void extName;
-    const {version, pkgName, mainClass} = extManifest;
-    const problems: ExtManifestProblem[] = [];
-
-    if (typeof version !== 'string') {
-      problems.push({
-        err: `Invalid or missing \`version\` field in my \`package.json\` and/or \`extensions.yaml\` (must be a string)`,
-        val: version,
-      });
-    }
-
-    if (typeof pkgName !== 'string') {
-      problems.push({
-        err: `Invalid or missing \`name\` field in my \`package.json\` and/or \`extensions.yaml\` (must be a string)`,
-        val: pkgName,
-      });
-    }
-
-    if (typeof mainClass !== 'string') {
-      problems.push({
-        err: `Invalid or missing \`appium.mainClass\` field in my \`package.json\` and/or \`mainClass\` field in \`extensions.yaml\` (must be a string)`,
-        val: mainClass,
-      });
-    }
-
-    return problems;
+    return manifestValidator.getCommonManifestProblems(extManifest);
   }
 
   /** Driver- or plugin-specific blocking validation; override in subclasses when needed. */

--- a/packages/appium/lib/extension/index.ts
+++ b/packages/appium/lib/extension/index.ts
@@ -7,7 +7,7 @@ import {USE_ALL_PLUGINS} from '../constants.js';
 import {log} from '../logger.js';
 import {zip} from '../utils/index.js';
 import {DriverConfig} from './driver-config.js';
-import {Manifest} from './manifest.js';
+import {Manifest} from './manifest/index.js';
 import {PluginConfig} from './plugin-config.js';
 
 export type ExtensionConfigs = {

--- a/packages/appium/lib/extension/manifest/index.ts
+++ b/packages/appium/lib/extension/manifest/index.ts
@@ -1,0 +1,11 @@
+export {Manifest} from './manifest.js';
+export {
+  INSTALL_TYPE_DEV,
+  INSTALL_TYPE_GIT,
+  INSTALL_TYPE_GITHUB,
+  INSTALL_TYPE_LOCAL,
+  INSTALL_TYPE_NPM,
+  INSTALL_TYPES,
+} from './install-types.js';
+export type {EnvelopeValidationResult, ExtManifestProblem} from './validator.js';
+export {manifestValidator} from './validator.js';

--- a/packages/appium/lib/extension/manifest/install-types.ts
+++ b/packages/appium/lib/extension/manifest/install-types.ts
@@ -1,0 +1,37 @@
+import type {InstallType} from 'appium/types/index.js';
+
+/**
+ * "npm" install type
+ * Used when extension was installed by npm package name
+ * @remarks _All_ extensions are installed _by_ `npm`, but only this one means the package name was
+ * used to specify it
+ */
+export const INSTALL_TYPE_NPM = 'npm';
+/**
+ * "local" install type
+ * Used when extension was installed from a local path
+ */
+export const INSTALL_TYPE_LOCAL = 'local';
+/**
+ * "github" install type
+ * Used when extension was installed via GitHub URL
+ */
+export const INSTALL_TYPE_GITHUB = 'github';
+/**
+ * "git" install type
+ * Used when extensions was installed via Git URL
+ */
+export const INSTALL_TYPE_GIT = 'git';
+/**
+ * "dev" install type
+ * Used when automatically detected as a working copy
+ */
+export const INSTALL_TYPE_DEV = 'dev';
+
+export const INSTALL_TYPES = new Set<InstallType>([
+  INSTALL_TYPE_GIT,
+  INSTALL_TYPE_GITHUB,
+  INSTALL_TYPE_LOCAL,
+  INSTALL_TYPE_NPM,
+  INSTALL_TYPE_DEV,
+]);

--- a/packages/appium/lib/extension/manifest/manifest.ts
+++ b/packages/appium/lib/extension/manifest/manifest.ts
@@ -5,14 +5,16 @@ import type {DriverType, ExtensionType, PluginType} from '@appium/types';
 import type {ExtManifest, ExtPackageJson, ExtRecord, InternalMetadata, ManifestData} from 'appium/types/index.js';
 import * as YAML from 'yaml';
 
-import {CURRENT_SCHEMA_REV, DRIVER_TYPE, PLUGIN_TYPE} from '../constants.js';
+import {CURRENT_SCHEMA_REV, DRIVER_TYPE, PLUGIN_TYPE} from '../../constants.js';
+import {log} from '../../logger.js';
 import {
   hasAppiumDependency as checkHasAppiumDependency,
   packageDidChange,
   resolveManifestPath,
-} from '../utils/index.js';
-import {INSTALL_TYPE_DEV, INSTALL_TYPE_NPM} from './extension-config.js';
-import {migrate} from './manifest-migrations.js';
+} from '../../utils/index.js';
+import {INSTALL_TYPE_DEV, INSTALL_TYPE_NPM} from './install-types.js';
+import {migrate} from './migrations.js';
+import {manifestValidator} from './validator.js';
 
 const CONFIG_DATA_DRIVER_KEY = `${DRIVER_TYPE}s` as const;
 const CONFIG_DATA_PLUGIN_KEY = `${PLUGIN_TYPE}s` as const;
@@ -123,6 +125,18 @@ export class Manifest {
               `cache file (${manifestPathResolved}). It may be invalid YAML. Specific error: ${err.message}`,
             {cause: err},
           );
+        }
+      }
+
+      if (!shouldWrite) {
+        const {valid, errors} = manifestValidator.validateManifestEnvelope(data);
+        if (!valid) {
+          log.warn(
+            `Appium had trouble validating the extension installation cache file (${manifestPathResolved}); ` +
+              `it will be reset. Specific error(s): ${manifestValidator.describeValidationErrors(errors)}`,
+          );
+          data = structuredClone(INITIAL_MANIFEST_DATA) as ManifestData;
+          shouldWrite = true;
         }
       }
 

--- a/packages/appium/lib/extension/manifest/migrations.ts
+++ b/packages/appium/lib/extension/manifest/migrations.ts
@@ -1,7 +1,7 @@
 import type {ManifestDataVersions} from 'appium/types/index.js';
 
-import {CURRENT_SCHEMA_REV, DRIVER_TYPE, PLUGIN_TYPE} from '../constants.js';
-import {log} from '../logger.js';
+import {CURRENT_SCHEMA_REV, DRIVER_TYPE, PLUGIN_TYPE} from '../../constants.js';
+import {log} from '../../logger.js';
 import type {Manifest} from './manifest.js';
 
 const SCHEMA_REV_3 = 3;

--- a/packages/appium/lib/extension/manifest/schema.ts
+++ b/packages/appium/lib/extension/manifest/schema.ts
@@ -1,0 +1,42 @@
+import type {SchemaObject} from '../../schema/ajv.js';
+
+/**
+ * Shallow shape of the parsed `extensions.yaml` document. Deliberately permissive about the
+ * shape of individual `drivers`/`plugins` entries (see {@link commonExtManifestProblemsSchema}
+ * and {@link driverExtManifestProblemsSchema}) so that old-but-valid manifest revisions are
+ * never rejected here; that's `Manifest.read()`'s job before per-extension validation runs.
+ */
+export const manifestEnvelopeSchema: SchemaObject = {
+  type: 'object',
+  required: ['drivers', 'plugins'],
+  properties: {
+    drivers: {type: 'object'},
+    plugins: {type: 'object'},
+    schemaRev: {type: 'integer'},
+  },
+};
+
+/** Fields required of every extension manifest entry, regardless of driver/plugin kind. */
+export const commonExtManifestProblemsSchema: SchemaObject = {
+  type: 'object',
+  required: ['version', 'pkgName', 'mainClass'],
+  properties: {
+    version: {type: 'string'},
+    pkgName: {type: 'string'},
+    mainClass: {type: 'string'},
+  },
+};
+
+/** Additional fields required of driver manifest entries. */
+export const driverExtManifestProblemsSchema: SchemaObject = {
+  type: 'object',
+  required: ['automationName', 'platformNames'],
+  properties: {
+    automationName: {type: 'string'},
+    platformNames: {
+      type: 'array',
+      minItems: 1,
+      items: {type: 'string'},
+    },
+  },
+};

--- a/packages/appium/lib/extension/manifest/validator.ts
+++ b/packages/appium/lib/extension/manifest/validator.ts
@@ -1,0 +1,156 @@
+import {Ajv, type ErrorObject, type ValidateFunction} from '../../schema/ajv.js';
+import {commonExtManifestProblemsSchema, driverExtManifestProblemsSchema, manifestEnvelopeSchema} from './schema.js';
+
+export interface EnvelopeValidationResult {
+  valid: boolean;
+  errors: ErrorObject[];
+}
+
+export type ExtManifestProblem = {err: string; val: unknown};
+
+function topLevelProp(error: ErrorObject): string | undefined {
+  if (error.keyword === 'required') {
+    return error.params.missingProperty as string;
+  }
+  return error.instancePath.split('/').filter(Boolean)[0];
+}
+
+/** Whether `errors` includes a failure of the root value itself (e.g. a string/array/null instead of an object). */
+function hasRootTypeError(errors: ErrorObject[]): boolean {
+  return errors.some((error) => error.instancePath === '' && error.keyword === 'type');
+}
+
+/** Validates parsed `extensions.yaml` and individual extension manifest entries via a dedicated Ajv instance. */
+class ManifestValidator {
+  private readonly validateEnvelope: ValidateFunction;
+  private readonly validateCommonProblems: ValidateFunction;
+  private readonly validateDriverProblems: ValidateFunction;
+
+  constructor() {
+    // Dedicated instance: manifest validation runs before `AppiumSchema` (lib/schema/schema.ts) is
+    // finalized, so that singleton can't be reused here. No `format` keyword, so no ajv-formats.
+    const ajv = new Ajv({allErrors: true});
+    this.validateEnvelope = ajv.compile(manifestEnvelopeSchema);
+    this.validateCommonProblems = ajv.compile(commonExtManifestProblemsSchema);
+    this.validateDriverProblems = ajv.compile(driverExtManifestProblemsSchema);
+  }
+
+  /**
+   * Validates the top-level shape of a parsed `extensions.yaml` document (before migration).
+   *
+   * @param data - Result of `YAML.parse()` on the manifest file contents
+   */
+  validateManifestEnvelope(data: unknown): EnvelopeValidationResult {
+    const valid = Boolean(this.validateEnvelope(data));
+    return {valid, errors: valid ? [] : [...(this.validateEnvelope.errors ?? [])]};
+  }
+
+  /** Human-readable summary of ajv errors, tolerating `message` being unset (it's optional on `ErrorObject`). */
+  describeValidationErrors(errors: ErrorObject[]): string {
+    return errors
+      .map((error) => error.message ?? `${error.keyword} error at "${error.instancePath || '/'}"`)
+      .join('; ');
+  }
+
+  /**
+   * Blocking issues for manifest fields shared by all extensions (version, package name, main class).
+   *
+   * @param extManifest - Manifest entry for one extension
+   */
+  getCommonManifestProblems(extManifest: unknown): ExtManifestProblem[] {
+    // Stored in a variable: branching on the call directly narrows the negative branch to `never`.
+    const valid: boolean = this.validateCommonProblems(extManifest);
+    if (valid) {
+      return [];
+    }
+
+    const errors = this.validateCommonProblems.errors ?? [];
+    // A root type error means every field is missing; topLevelProp() can't attribute it to one.
+    const props = hasRootTypeError(errors)
+      ? new Set(['version', 'pkgName', 'mainClass'])
+      : new Set(errors.map(topLevelProp));
+
+    // Cast once (extManifest may be non-object/null/undefined), then read safely via `?.`.
+    const manifest = extManifest as Record<string, unknown> | null | undefined;
+    const problems: ExtManifestProblem[] = [];
+
+    if (props.has('version')) {
+      problems.push({
+        err: 'Invalid or missing `version` field in my `package.json` and/or `extensions.yaml` (must be a string)',
+        val: manifest?.version,
+      });
+    }
+    if (props.has('pkgName')) {
+      problems.push({
+        err: 'Invalid or missing `name` field in my `package.json` and/or `extensions.yaml` (must be a string)',
+        val: manifest?.pkgName,
+      });
+    }
+    if (props.has('mainClass')) {
+      problems.push({
+        err: 'Invalid or missing `appium.mainClass` field in my `package.json` and/or `mainClass` field in `extensions.yaml` (must be a string)',
+        val: manifest?.mainClass,
+      });
+    }
+
+    return problems;
+  }
+
+  /**
+   * Blocking issues for driver-specific manifest fields (automationName, platformNames).
+   * Does not include the cross-driver duplicate-`automationName` check, which needs state
+   * spanning multiple extensions and lives in {@link DriverConfig.getConfigProblems} instead.
+   *
+   * @param extManifest - Manifest entry for one driver
+   */
+  getDriverManifestProblems(extManifest: unknown): ExtManifestProblem[] {
+    // See the comment in `getCommonManifestProblems` about not narrowing on the call directly.
+    const valid: boolean = this.validateDriverProblems(extManifest);
+    if (valid) {
+      return [];
+    }
+
+    const errors = this.validateDriverProblems.errors ?? [];
+    // See the comment in `getCommonManifestProblems` about casting once and reading via `?.`.
+    const manifest = extManifest as Record<string, unknown> | null | undefined;
+
+    // A root type error means both fields are missing; no per-property error to attribute either to.
+    if (hasRootTypeError(errors)) {
+      return [
+        {err: 'Missing or incorrect supported platformNames list.', val: manifest?.platformNames},
+        {err: 'Missing or incorrect automationName', val: manifest?.automationName},
+      ];
+    }
+
+    const problems: ExtManifestProblem[] = [];
+    const platformNamesErrors = errors.filter((error) => topLevelProp(error) === 'platformNames');
+    const automationNameErrors = errors.filter((error) => topLevelProp(error) === 'automationName');
+    const platformNames = manifest?.platformNames;
+
+    const isMissingOrWrongType = platformNamesErrors.some(
+      (error) => error.keyword === 'required' || (error.keyword === 'type' && error.instancePath === '/platformNames'),
+    );
+    const isEmpty = platformNamesErrors.some((error) => error.keyword === 'minItems');
+
+    if (isMissingOrWrongType) {
+      problems.push({err: 'Missing or incorrect supported platformNames list.', val: platformNames});
+    } else if (isEmpty) {
+      problems.push({err: 'Empty platformNames list.', val: platformNames});
+    } else {
+      for (const error of platformNamesErrors) {
+        if (error.keyword === 'type') {
+          const index = Number(error.instancePath.split('/')[2]);
+          problems.push({err: 'Incorrectly formatted platformName.', val: (platformNames as unknown[])[index]});
+        }
+      }
+    }
+
+    if (automationNameErrors.length) {
+      problems.push({err: 'Missing or incorrect automationName', val: manifest?.automationName});
+    }
+
+    return problems;
+  }
+}
+
+export const manifestValidator = new ManifestValidator();

--- a/packages/appium/lib/extension/manifest/validator.ts
+++ b/packages/appium/lib/extension/manifest/validator.ts
@@ -1,4 +1,5 @@
-import {Ajv, type ErrorObject, type ValidateFunction} from '../../schema/ajv.js';
+import {Ajv} from '../../schema/ajv.js';
+import type {ErrorObject, ValidateFunction} from '../../schema/ajv.js';
 import {commonExtManifestProblemsSchema, driverExtManifestProblemsSchema, manifestEnvelopeSchema} from './schema.js';
 
 export interface EnvelopeValidationResult {

--- a/packages/appium/lib/extension/manifest/validator.ts
+++ b/packages/appium/lib/extension/manifest/validator.ts
@@ -9,6 +9,13 @@ export interface EnvelopeValidationResult {
 
 export type ExtManifestProblem = {err: string; val: unknown};
 
+/**
+ * Top-level manifest field an ajv error is about. For `required` errors, ajv reports the missing
+ * field in `params.missingProperty` (since `instancePath` points at the object that's missing it,
+ * not the field itself); for every other keyword, `instancePath` points at the offending field
+ * directly, so its first segment is the field name (ignoring any array index after it, e.g. the
+ * `0` in `/platformNames/0`).
+ */
 function topLevelProp(error: ErrorObject): string | undefined {
   if (error.keyword === 'required') {
     return error.params.missingProperty as string;
@@ -20,6 +27,9 @@ function topLevelProp(error: ErrorObject): string | undefined {
 function hasRootTypeError(errors: ErrorObject[]): boolean {
   return errors.some((error) => error.instancePath === '' && error.keyword === 'type');
 }
+
+const MISSING_PLATFORM_NAMES_ERR = 'Missing or incorrect supported platformNames list.';
+const MISSING_AUTOMATION_NAME_ERR = 'Missing or incorrect automationName';
 
 /** Validates parsed `extensions.yaml` and individual extension manifest entries via a dedicated Ajv instance. */
 class ManifestValidator {
@@ -114,19 +124,20 @@ class ManifestValidator {
     const errors = this.validateDriverProblems.errors ?? [];
     // See the comment in `getCommonManifestProblems` about casting once and reading via `?.`.
     const manifest = extManifest as Record<string, unknown> | null | undefined;
+    const platformNames = manifest?.platformNames;
+    const automationName = manifest?.automationName;
 
     // A root type error means both fields are missing; no per-property error to attribute either to.
     if (hasRootTypeError(errors)) {
       return [
-        {err: 'Missing or incorrect supported platformNames list.', val: manifest?.platformNames},
-        {err: 'Missing or incorrect automationName', val: manifest?.automationName},
+        {err: MISSING_PLATFORM_NAMES_ERR, val: platformNames},
+        {err: MISSING_AUTOMATION_NAME_ERR, val: automationName},
       ];
     }
 
     const problems: ExtManifestProblem[] = [];
     const platformNamesErrors = errors.filter((error) => topLevelProp(error) === 'platformNames');
     const automationNameErrors = errors.filter((error) => topLevelProp(error) === 'automationName');
-    const platformNames = manifest?.platformNames;
 
     const isMissingOrWrongType = platformNamesErrors.some(
       (error) => error.keyword === 'required' || (error.keyword === 'type' && error.instancePath === '/platformNames'),
@@ -134,7 +145,7 @@ class ManifestValidator {
     const isEmpty = platformNamesErrors.some((error) => error.keyword === 'minItems');
 
     if (isMissingOrWrongType) {
-      problems.push({err: 'Missing or incorrect supported platformNames list.', val: platformNames});
+      problems.push({err: MISSING_PLATFORM_NAMES_ERR, val: platformNames});
     } else if (isEmpty) {
       problems.push({err: 'Empty platformNames list.', val: platformNames});
     } else {
@@ -147,7 +158,7 @@ class ManifestValidator {
     }
 
     if (automationNameErrors.length) {
-      problems.push({err: 'Missing or incorrect automationName', val: manifest?.automationName});
+      problems.push({err: MISSING_AUTOMATION_NAME_ERR, val: automationName});
     }
 
     return problems;

--- a/packages/appium/lib/extension/plugin-config.ts
+++ b/packages/appium/lib/extension/plugin-config.ts
@@ -5,7 +5,7 @@ import type {ExtManifest, ExtName, ExtRecord} from 'appium/types/index.js';
 import {PLUGIN_TYPE} from '../constants.js';
 import {log} from '../logger.js';
 import {ExtensionConfig} from './extension-config.js';
-import type {Manifest} from './manifest.js';
+import type {Manifest} from './manifest/index.js';
 
 export class PluginConfig extends ExtensionConfig<PluginType> {
   private static readonly _instances = new WeakMap<Manifest, PluginConfig>();

--- a/packages/appium/lib/schema/ajv.ts
+++ b/packages/appium/lib/schema/ajv.ts
@@ -1,0 +1,16 @@
+import AjvImport from 'ajv';
+import addFormatsImport from 'ajv-formats';
+
+export type {ErrorObject, KeywordDefinition, SchemaObject, ValidateFunction} from 'ajv';
+
+// `ajv`/`ajv-formats` are CJS with no ESM types; nodenext types their default imports as the
+// whole module namespace, so re-derive the real constructor/function types via indexed access
+// and cast the values to match.
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+export type AjvCtor = (typeof import('ajv'))['default'];
+export type AjvInstance = InstanceType<AjvCtor>;
+export const Ajv = AjvImport as unknown as AjvCtor;
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+type AddFormatsFn = (typeof import('ajv-formats'))['default'];
+export const addFormats = addFormatsImport as unknown as AddFormatsFn;

--- a/packages/appium/lib/schema/cli-args.ts
+++ b/packages/appium/lib/schema/cli-args.ts
@@ -2,13 +2,18 @@ import {util} from '@appium/support';
 import {type ArgumentOptions, ArgumentTypeError} from 'argparse';
 import type {JSONSchema7, JSONSchema7TypeName} from 'json-schema';
 
-import type {ArgumentDefinitions} from '../cli/args.js';
 import {kebabCase} from '../utils/index.js';
 import type {ArgSpec} from './arg-spec.js';
-import {parseCsvLine, transformers} from './cli-transformers.js';
+import {
+  parseCsvLine,
+  transformers,
+  type AppiumCliTransformerName,
+  type AppiumJSONSchemaKeywords,
+} from './cli-transformers.js';
 import {formatErrors} from './format-errors.js';
-import type {AppiumCliTransformerName, AppiumJSONSchemaKeywords} from './keywords.js';
 import {flattenSchema, validate} from './schema.js';
+
+export type ArgumentDefinitions = Map<[name: string] | [name: string, alias: string], ArgumentOptions>;
 
 type AppiumJSONSchema = AppiumJSONSchemaKeywords & JSONSchema7;
 type ArgDef = [[string] | [string, string], ArgumentOptions];

--- a/packages/appium/lib/schema/cli-transformers.ts
+++ b/packages/appium/lib/schema/cli-transformers.ts
@@ -70,6 +70,17 @@ export const transformers = {
   },
 } as const;
 
+export type AppiumCliTransformerName = keyof typeof transformers;
+
+export interface AppiumJSONSchemaKeywords {
+  appiumCliDest?: string;
+  appiumCliDescription?: string;
+  appiumCliAliases?: string[];
+  appiumCliIgnored?: boolean;
+  appiumCliTransformer?: AppiumCliTransformerName;
+  appiumDeprecated?: boolean;
+}
+
 /**
  * Split a file by newline then calls {@link parseCsvLine} on each line.
  */

--- a/packages/appium/lib/schema/format-errors.ts
+++ b/packages/appium/lib/schema/format-errors.ts
@@ -1,7 +1,7 @@
 import type {NormalizedAppiumConfig} from '@appium/types';
 import betterAjvErrorsImport, {type IOutputError} from '@sidvind/better-ajv-errors';
-import type {ErrorObject} from 'ajv';
 
+import type {ErrorObject} from './ajv.js';
 import {getSchema} from './schema.js';
 
 // `@sidvind/better-ajv-errors` has no `"type"` field in its own package.json, so TS's

--- a/packages/appium/lib/schema/index.ts
+++ b/packages/appium/lib/schema/index.ts
@@ -1,4 +1,32 @@
-export * from './cli-args.js';
-export * from './cli-args-guards.js';
-export * from './format-errors.js';
-export * from './schema.js';
+export type {ArgumentDefinitions} from './cli-args.js';
+export {toParserArgs} from './cli-args.js';
+export {
+  isDriverCommandArgs,
+  isExtensionCommandArgs,
+  isPluginCommandArgs,
+  isServerCommandArgs,
+  isSetupCommandArgs,
+} from './cli-args-guards.js';
+export type {FormatConfigErrorsOptions, RawJson} from './format-errors.js';
+export {formatErrors} from './format-errors.js';
+export {
+  ALLOWED_SCHEMA_EXTENSIONS,
+  finalizeSchema,
+  flattenSchema,
+  getAllArgSpecs,
+  getArgSpec,
+  getDefaultsForExtension,
+  getDefaultsForSchema,
+  getSchema,
+  hasArgSpec,
+  isAllowedSchemaFileExtension,
+  isFinalized,
+  registerSchema,
+  resetSchema,
+  RoachHotelMap,
+  SchemaFinalizationError,
+  SchemaNameConflictError,
+  SchemaUnknownSchemaError,
+  SchemaUnsupportedSchemaError,
+  validate,
+} from './schema.js';

--- a/packages/appium/lib/schema/keywords.ts
+++ b/packages/appium/lib/schema/keywords.ts
@@ -1,17 +1,5 @@
-import type {KeywordDefinition} from 'ajv';
-
-import {transformers} from './cli-transformers.js';
-
-export type AppiumCliTransformerName = keyof typeof transformers;
-
-export interface AppiumJSONSchemaKeywords {
-  appiumCliDest?: string;
-  appiumCliDescription?: string;
-  appiumCliAliases?: string[];
-  appiumCliIgnored?: boolean;
-  appiumCliTransformer?: AppiumCliTransformerName;
-  appiumDeprecated?: boolean;
-}
+import type {KeywordDefinition} from './ajv.js';
+import {transformers, type AppiumCliTransformerName} from './cli-transformers.js';
 
 /**
  * Collection of keyword definitions to add to the singleton `Ajv` instance.

--- a/packages/appium/lib/schema/keywords.ts
+++ b/packages/appium/lib/schema/keywords.ts
@@ -1,5 +1,6 @@
 import type {KeywordDefinition} from './ajv.js';
-import {transformers, type AppiumCliTransformerName} from './cli-transformers.js';
+import {transformers} from './cli-transformers.js';
+import type {AppiumCliTransformerName} from './cli-transformers.js';
 
 /**
  * Collection of keyword definitions to add to the singleton `Ajv` instance.

--- a/packages/appium/lib/schema/schema.ts
+++ b/packages/appium/lib/schema/schema.ts
@@ -3,24 +3,12 @@ import path from 'node:path';
 import {AppiumConfigJsonSchema} from '@appium/schema';
 import {util} from '@appium/support';
 import type {ExtensionType} from '@appium/types';
-import AjvImport, {type ErrorObject, type SchemaObject, type ValidateFunction} from 'ajv';
-import addFormatsImport from 'ajv-formats';
 
 import {DRIVER_TYPE, PLUGIN_TYPE} from '../constants.js';
 import {bindAll, kebabCase, omitKeys, setPath} from '../utils/index.js';
+import {addFormats, Ajv, type AjvInstance, type ErrorObject, type SchemaObject, type ValidateFunction} from './ajv.js';
 import {APPIUM_CONFIG_SCHEMA_ID, ArgSpec, SERVER_PROP_NAME} from './arg-spec.js';
 import {keywords} from './keywords.js';
-
-// `ajv` and `ajv-formats` are plain CJS with no ESM-specific typings; nodenext types
-// their default imports as the whole module namespace rather than the actual default
-// export, so re-derive the real types via indexed access and cast the values to match.
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-type AjvCtor = (typeof import('ajv'))['default'];
-type AjvInstance = InstanceType<AjvCtor>;
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
-type AddFormatsFn = (typeof import('ajv-formats'))['default'];
-const Ajv = AjvImport as unknown as AjvCtor;
-const addFormats = addFormatsImport as unknown as AddFormatsFn;
 
 type StrictSchemaObject = SchemaObject & {additionalProperties: false};
 type FlattenedSchema = {schema: SchemaObject; argSpec: ArgSpec}[];

--- a/packages/appium/lib/schema/schema.ts
+++ b/packages/appium/lib/schema/schema.ts
@@ -6,7 +6,8 @@ import type {ExtensionType} from '@appium/types';
 
 import {DRIVER_TYPE, PLUGIN_TYPE} from '../constants.js';
 import {bindAll, kebabCase, omitKeys, setPath} from '../utils/index.js';
-import {addFormats, Ajv, type AjvInstance, type ErrorObject, type SchemaObject, type ValidateFunction} from './ajv.js';
+import {addFormats, Ajv} from './ajv.js';
+import type {AjvInstance, ErrorObject, SchemaObject, ValidateFunction} from './ajv.js';
 import {APPIUM_CONFIG_SCHEMA_ID, ArgSpec, SERVER_PROP_NAME} from './arg-spec.js';
 import {keywords} from './keywords.js';
 

--- a/packages/appium/test/e2e/driver.e2e.spec.ts
+++ b/packages/appium/test/e2e/driver.e2e.spec.ts
@@ -15,8 +15,8 @@ import {remote as wdio} from 'webdriverio';
 
 import {runExtensionCommand} from '../../lib/cli/extension.js';
 import {DRIVER_TYPE} from '../../lib/constants.js';
-import {INSTALL_TYPE_LOCAL} from '../../lib/extension/extension-config.js';
 import {loadExtensions} from '../../lib/extension/index.js';
+import {INSTALL_TYPE_LOCAL} from '../../lib/extension/manifest/index.js';
 import {removeAppiumPrefixes} from '../../lib/helpers/capability.js';
 import {main as appiumServer} from '../../lib/main.js';
 import {FAKE_DRIVER_DIR, getTestPort, TEST_FAKE_APP, TEST_HOST, W3C_PREFIXED_CAPS} from '../helpers.js';

--- a/packages/appium/test/e2e/plugin.e2e.spec.ts
+++ b/packages/appium/test/e2e/plugin.e2e.spec.ts
@@ -11,8 +11,8 @@ import {remote as wdio} from 'webdriverio';
 
 import {runExtensionCommand} from '../../lib/cli/extension.js';
 import {DRIVER_TYPE, PLUGIN_TYPE} from '../../lib/constants.js';
-import {INSTALL_TYPE_LOCAL} from '../../lib/extension/extension-config.js';
 import {loadExtensions} from '../../lib/extension/index.js';
+import {INSTALL_TYPE_LOCAL} from '../../lib/extension/manifest/index.js';
 import {main as appiumServer} from '../../lib/main.js';
 import {resetSchema} from '../../lib/schema/index.js';
 import {FAKE_DRIVER_DIR, FAKE_PLUGIN_DIR, getTestPort, TEST_HOST, W3C_PREFIXED_CAPS} from '../helpers.js';

--- a/packages/appium/test/unit/cli/cli.spec.ts
+++ b/packages/appium/test/unit/cli/cli.spec.ts
@@ -6,7 +6,7 @@ import {createSandbox} from 'sinon';
 
 import DriverCommand from '../../../lib/cli/driver-command.js';
 import {loadExtensions} from '../../../lib/extension/index.js';
-import {Manifest} from '../../../lib/extension/manifest.js';
+import {Manifest} from '../../../lib/extension/manifest/manifest.js';
 import {npm} from '../../../lib/utils/index.js';
 
 describe('DriverCommand', function () {

--- a/packages/appium/test/unit/extension/driver-config.spec.ts
+++ b/packages/appium/test/unit/extension/driver-config.spec.ts
@@ -5,7 +5,7 @@ import {describe, it, beforeEach, before, after, mock} from 'node:test';
 import type {DriverType, ExtensionType} from '@appium/types';
 import type {ExtManifest} from 'appium/types/index.js';
 
-import type {Manifest} from '../../../lib/extension/manifest.js';
+import type {Manifest} from '../../../lib/extension/manifest/manifest.js';
 import type {resetSchema as ResetSchemaFn} from '../../../lib/schema/index.js';
 import {assertArrayIncludesDeep, resolveFixture} from '../../helpers.js';
 import {applyExtensionMocks, initMocks, resetMockDefaults} from './mocks.js';
@@ -17,7 +17,7 @@ import type {InitMocksResult} from './mocks.js';
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 type DriverConfig = ReturnType<(typeof import('../../../lib/extension/driver-config.js'))['DriverConfig']['create']>;
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-type ManifestClass = (typeof import('../../../lib/extension/manifest.js'))['Manifest'];
+type ManifestClass = (typeof import('../../../lib/extension/manifest/manifest.js'))['Manifest'];
 
 type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType> & {
   schema: NonNullable<ExtManifest<ExtType>['schema']>;
@@ -55,7 +55,7 @@ describe('DriverConfig', function () {
     yamlFixture = await fs.readFile(resolveFixture('manifest', 'v3.yaml'), 'utf8');
     mocks = initMocks();
     applyExtensionMocks(mocks);
-    ({Manifest} = await import('../../../lib/extension/manifest.js'));
+    ({Manifest} = await import('../../../lib/extension/manifest/manifest.js'));
     ({resetSchema} = await import('../../../lib/schema/index.js'));
   });
 
@@ -139,8 +139,11 @@ describe('DriverConfig', function () {
       });
 
       describe('when provided no arguments', function () {
-        it('should throw', function () {
-          assert.throws(() => driverConfig.getConfigProblems());
+        it('should not throw, and should return a problem for both platformNames and automationName', function () {
+          assert.deepStrictEqual(driverConfig.getConfigProblems(), [
+            {err: 'Missing or incorrect supported platformNames list.', val: undefined},
+            {err: 'Missing or incorrect automationName', val: undefined},
+          ]);
         });
       });
 
@@ -199,6 +202,40 @@ describe('DriverConfig', function () {
               val: 'foo',
             });
           });
+        });
+
+        describe('when two unrelated entries both lack `automationName`', function () {
+          it('should not flag them as duplicates of each other', function () {
+            driverConfig.getConfigProblems({platformNames: ['a']});
+            const problems = driverConfig.getConfigProblems({platformNames: ['b']});
+            assert.ok(
+              !problems.some(
+                (problem: any) => problem.err === 'Multiple drivers claim support for the same automationName',
+              ),
+            );
+          });
+        });
+      });
+
+      describe('when the extension data is not an object at all (e.g. a corrupted manifest entry)', function () {
+        it('should return a problem for both platformNames and automationName', function () {
+          assert.deepStrictEqual(driverConfig.getConfigProblems('garbage'), [
+            {err: 'Missing or incorrect supported platformNames list.', val: undefined},
+            {err: 'Missing or incorrect automationName', val: undefined},
+          ]);
+        });
+      });
+
+      describe('when the extension data is `null` (e.g. an empty YAML value for a manifest entry)', function () {
+        it('should not throw', function () {
+          assert.doesNotThrow(() => driverConfig.getConfigProblems(null));
+        });
+
+        it('should return a problem for both platformNames and automationName', function () {
+          assert.deepStrictEqual(driverConfig.getConfigProblems(null), [
+            {err: 'Missing or incorrect supported platformNames list.', val: undefined},
+            {err: 'Missing or incorrect automationName', val: undefined},
+          ]);
         });
       });
     });

--- a/packages/appium/test/unit/extension/extension-command.spec.ts
+++ b/packages/appium/test/unit/extension/extension-command.spec.ts
@@ -17,7 +17,7 @@ import type {
   injectAppiumSymlinks as injectAppiumSymlinksStatic,
 } from '../../../lib/cli/extension-command.js';
 import {DriverConfig} from '../../../lib/extension/driver-config.js';
-import {Manifest} from '../../../lib/extension/manifest.js';
+import {Manifest} from '../../../lib/extension/manifest/manifest.js';
 import {appiumPackageRoot} from '../../../lib/utils/index.js';
 import {FAKE_DRIVER_DIR} from '../../helpers.js';
 

--- a/packages/appium/test/unit/extension/extension-config.spec.ts
+++ b/packages/appium/test/unit/extension/extension-config.spec.ts
@@ -43,7 +43,7 @@ describe('ExtensionConfig', function () {
     ({ExtensionConfig, resolveEsmEntryPoint} = await import(
       `../../../lib/extension/extension-config.js?t=${importCounter++}`
     ));
-    ({Manifest} = await import(`../../../lib/extension/manifest.js?t=${importCounter++}`));
+    ({Manifest} = await import(`../../../lib/extension/manifest/manifest.js?t=${importCounter++}`));
   });
 
   afterEach(function () {
@@ -139,6 +139,25 @@ describe('ExtensionConfig', function () {
 
         it('should return a problem', function () {
           assert.deepStrictEqual(config.getGenericConfigProblems(extData, extData.pkgName), [
+            {
+              err: 'Invalid or missing `appium.mainClass` field in my `package.json` and/or `mainClass` field in `extensions.yaml` (must be a string)',
+              val: undefined,
+            },
+          ]);
+        });
+      });
+
+      describe('when the extension data is not an object at all (e.g. a corrupted manifest entry)', function () {
+        it('should return a problem for every required field', function () {
+          assert.deepStrictEqual(config.getGenericConfigProblems('garbage' as any, 'derp'), [
+            {
+              err: 'Invalid or missing `version` field in my `package.json` and/or `extensions.yaml` (must be a string)',
+              val: undefined,
+            },
+            {
+              err: 'Invalid or missing `name` field in my `package.json` and/or `extensions.yaml` (must be a string)',
+              val: undefined,
+            },
             {
               err: 'Invalid or missing `appium.mainClass` field in my `package.json` and/or `mainClass` field in `extensions.yaml` (must be a string)',
               val: undefined,

--- a/packages/appium/test/unit/extension/manifest-migrations.spec.ts
+++ b/packages/appium/test/unit/extension/manifest-migrations.spec.ts
@@ -4,8 +4,8 @@ import {describe, it} from 'node:test';
 import type {ExtManifest} from 'appium/types/index.js';
 
 import {DRIVER_TYPE} from '../../../lib/constants.js';
-import {migrate} from '../../../lib/extension/manifest-migrations.js';
-import {Manifest} from '../../../lib/extension/manifest.js';
+import {Manifest} from '../../../lib/extension/manifest/manifest.js';
+import {migrate} from '../../../lib/extension/manifest/migrations.js';
 
 describe('manifest-migrations', function () {
   describe('when no installPath property present in manifest', function () {

--- a/packages/appium/test/unit/extension/manifest.spec.ts
+++ b/packages/appium/test/unit/extension/manifest.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import {promises as fs} from 'node:fs';
-import {describe, it, beforeEach, before, after, mock} from 'node:test';
+import {describe, it, beforeEach, afterEach, before, after, mock} from 'node:test';
 
 import type {DriverType, PluginType} from '@appium/types';
 import type {ExtManifest, ExtPackageJson, ManifestData} from 'appium/types/index.js';
@@ -29,7 +29,7 @@ describe('Manifest', function () {
     MockAppiumSupport = mocks.MockAppiumSupport;
     migrateStub = mocks.sandbox.stub().resolves();
     applyExtensionMocks(mocks);
-    mock.module('../../../lib/extension/manifest-migrations.js', {
+    mock.module('../../../lib/extension/manifest/migrations.js', {
       namedExports: {migrate: migrateStub},
     });
   });
@@ -42,7 +42,7 @@ describe('Manifest', function () {
     resetMockDefaults(mocks);
     migrateStub.resolves();
     MockAppiumSupport.fs.readFile.resolves(yamlFixture);
-    ({Manifest} = await import(`../../../lib/extension/manifest.js?t=${importCounter++}`));
+    ({Manifest} = await import(`../../../lib/extension/manifest/manifest.js?t=${importCounter++}`));
   });
 
   describe('class method', function () {
@@ -143,6 +143,36 @@ describe('Manifest', function () {
             name: 'Error',
             message: /trouble loading the extension installation cache file/i,
           });
+        });
+      });
+
+      describe('when the file is valid YAML but does not match the manifest envelope shape', function () {
+        let logWarnStub: ReturnType<InitMocksResult['sandbox']['stub']>;
+
+        beforeEach(async function () {
+          MockAppiumSupport.fs.readFile.resolves('drivers: not-an-object\nplugins: {}\n');
+          const {log} = await import('../../../lib/logger.js');
+          logWarnStub = mocks.sandbox.stub(log, 'warn');
+        });
+
+        afterEach(function () {
+          logWarnStub.restore();
+        });
+
+        it('should not reject, and should reset to the initial manifest data', async function () {
+          const data = await manifest.read();
+          assert.deepStrictEqual(data.drivers, {});
+          assert.deepStrictEqual(data.plugins, {});
+        });
+
+        it('should log a warning', async function () {
+          await manifest.read();
+          assert.strictEqual(logWarnStub.calledOnce, true);
+        });
+
+        it('should write the reset data back to disk', async function () {
+          await manifest.read();
+          assert.strictEqual(MockAppiumSupport.fs.writeFile.calledOnce, true);
         });
       });
 

--- a/packages/appium/test/unit/extension/mocks.ts
+++ b/packages/appium/test/unit/extension/mocks.ts
@@ -178,31 +178,20 @@ export function resetMockDefaults(mocks: InitMocksResult): void {
 }
 
 /**
- * Mocks `@appium/support` and `lib/utils/index.js` for the module-under-test, using the mocks
- * from {@link initMocks}. Call once from a suite's `before()` hook — `before()` only gets a
- * `SuiteContext`, which has no `.mock`, so this uses the standalone `mock` export instead of
- * `t.mock`. That tracker isn't scoped to one test and doesn't auto-restore, so pair this with
- * `after(() => mock.reset())` in the same file to avoid leaking the mock into other spec files
- * (all spec files share one process/module registry under `node --test`). Call from a spec
- * file in `test/unit/extension/` (the relative specifiers below are resolved from this file's
- * own location, which is the same directory).
+ * Mocks `@appium/support` and the `lib/utils/index.js` barrel (not `npm.js`/`is-package-changed.js`
+ * directly — a barrel re-export is a live binding resolved at the barrel's own link time, so
+ * mocking a leaf file doesn't retroactively change an already-linked barrel), using the mocks
+ * from {@link initMocks}.
  *
- * Mocks `lib/utils/index.js` (the barrel) rather than `npm.js`/`is-package-changed.js`
- * directly: `extension-config.ts` et al. import `resolveFrom`/`npm` through that barrel, and a
- * barrel's re-export is a live binding resolved at the barrel's own link time — mocking the
- * leaf file doesn't retroactively change a barrel that's already linked.
+ * Call once from a suite's `before()` (which has no `t.mock`, hence the standalone `mock` export)
+ * in a spec file under `test/unit/extension/`, and pair with `after(() => mock.reset())` — the
+ * tracker doesn't auto-restore and spec files share one module registry under `node --test`.
  *
- * IMPORTANT — this only works if the file that directly imports the mocked module (e.g.
- * `extension-config.js`, which imports `resolveFrom`/`@appium/support`) has never itself been
- * linked before `mock.module()` runs. It is fine if `@appium/support`/`utils/index.js`
- * themselves were already loaded elsewhere (e.g. transitively via `test/helpers.ts`) — Node
- * still redirects any *new* linking of a consumer to the mocked registry entry. What breaks it
- * is a *static* top-level import in the spec file that itself statically imports the direct
- * consumer (e.g. `import {Manifest} from '.../manifest.js'`, since `manifest.ts` directly
- * imports `extension-config.js`) — that import resolves before this file's own `before()` hook
- * runs, permanently binding the consumer to the real, unmocked dependencies. When a spec file
- * needs such a module, import it dynamically inside `before()`, after calling this function,
- * rather than as a static top-level import.
+ * Only works if the module that directly imports the mocked dependency (e.g. `extension-config.js`)
+ * hasn't been linked yet. A *static* top-level import of such a consumer in the spec file (e.g.
+ * `Manifest` from `manifest/manifest.js`, which imports `extension-config.js`) resolves before
+ * this function's `before()` hook runs and permanently binds it to the real dependencies —
+ * import it dynamically inside `before()`, after calling this function, instead.
  */
 export function applyExtensionMocks(mocks: InitMocksResult): void {
   // `default` is destructured out: on Node 22, passing a `default` key through

--- a/packages/appium/test/unit/extension/plugin-config.spec.ts
+++ b/packages/appium/test/unit/extension/plugin-config.spec.ts
@@ -5,7 +5,7 @@ import {describe, it, beforeEach, before, after, mock} from 'node:test';
 import type {ExtensionType, PluginType} from '@appium/types';
 import type {ExtManifest} from 'appium/types/index.js';
 
-import type {Manifest} from '../../../lib/extension/manifest.js';
+import type {Manifest} from '../../../lib/extension/manifest/manifest.js';
 import type {PluginConfig as PluginConfigInstance} from '../../../lib/extension/plugin-config.js';
 import type {resetSchema as ResetSchemaFn} from '../../../lib/schema/index.js';
 import {assertArrayIncludesDeep, resolveFixture} from '../../helpers.js';
@@ -19,7 +19,7 @@ type ExtManifestWithSchema<ExtType extends ExtensionType> = ExtManifest<ExtType>
 // `applyExtensionMocks` in mocks.ts), so their constructor types can't come from a normal value
 // import; indexed access into the module's namespace type is the only way to spell them.
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-type ManifestClass = (typeof import('../../../lib/extension/manifest.js'))['Manifest'];
+type ManifestClass = (typeof import('../../../lib/extension/manifest/manifest.js'))['Manifest'];
 
 interface PluginConfigConstructor {
   new (...args: never[]): PluginConfigInstance;
@@ -44,7 +44,7 @@ describe('PluginConfig', function () {
     yamlFixture = await fs.readFile(resolveFixture('manifest', 'v3.yaml'), 'utf8');
     mocks = initMocks();
     applyExtensionMocks(mocks);
-    ({Manifest} = await import('../../../lib/extension/manifest.js'));
+    ({Manifest} = await import('../../../lib/extension/manifest/manifest.js'));
     ({resetSchema} = await import('../../../lib/schema/index.js'));
   });
 

--- a/packages/appium/test/unit/parser.spec.ts
+++ b/packages/appium/test/unit/parser.spec.ts
@@ -6,7 +6,7 @@ import fakeDriverSchema from '@appium/fake-driver/build/lib/fake-driver-schema.j
 import {readConfigFile} from '../../lib/bootstrap/config-file.js';
 import {ArgParser, getParser} from '../../lib/cli/parser.js';
 import {DRIVER_TYPE, PLUGIN_TYPE, SETUP_SUBCOMMAND} from '../../lib/constants.js';
-import {INSTALL_TYPES} from '../../lib/extension/extension-config.js';
+import {INSTALL_TYPES} from '../../lib/extension/manifest/index.js';
 import * as schema from '../../lib/schema/schema.js';
 import {resolveFixture} from '../helpers.js';
 


### PR DESCRIPTION
## Proposed changes

Progresses [#15916](https://github.com/appium/appium/issues/15916) ("handle more validation via ajv"), a long-standing epic proposing that Appium replace hand-rolled config/manifest validation with `ajv`/JSON Schema. Two of that issue's items were still unaddressed: validation of the `appium` field in an extension's `package.json`, and validation of the overall shape of `$APPIUM_HOME/extensions.yaml` (which today has none at all beyond catching YAML parse errors).

This PR:

- Adds `packages/appium/lib/extension/manifest-schema.ts` and `manifest-validator.ts`, which replace the hand-rolled `typeof`/`Array.isArray` checks in `ExtensionConfig.getGenericConfigProblems()` and `DriverConfig.getConfigProblems()` with `ajv` schema validation. User-facing problem messages are unchanged, so no behavior changes for existing valid/invalid manifests.
- Adds a shallow `ajv` envelope check for `extensions.yaml` itself, run in `Manifest.read()` right after parsing. A corrupted-but-syntactically-valid file (e.g. `drivers` not being an object) now resets to the initial empty manifest and logs a warning instead of silently loading bad data that crashes later downstream with confusing errors (e.g. `automationName.toLowerCase is not a function`).
- Keeps the stateful cross-driver duplicate-`automationName` check as plain code, since it depends on state across multiple extensions and can't be expressed as a single-object JSON schema.
- Extracts the `ajv` CJS/ESM interop type-cast (previously only in `lib/schema/schema.ts`) into a shared `lib/schema/ajv-ctor.ts`, since the new validator needs its own dedicated `Ajv` instance (manifest loading happens before the `AppiumSchema` singleton used for config-file/CLI validation is ever finalized).

## Further comments

The new envelope/manifest schemas are deliberately narrow — scoped to exactly what the existing hand-rolled checks covered (plus the new top-level envelope shape) — rather than a full `ManifestData` schema, so that old-but-valid manifest revisions (v2/v3, before `installPath`/`dev` install type existed) keep parsing without changes. A dedicated `Ajv` instance is used instead of reusing the `AppiumSchema` singleton from `lib/schema/schema.ts`, since manifest loading happens during `AppiumInitializer.init()` well before that singleton's `finalize()` is ever called.
