### PR TITLE
fix(storage-plugin): map StorageArgumentError to InvalidArgumentError

### DIFF
--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -116,14 +116,8 @@ STORAGE_HANDLERS.listStorageItems = async function listStorageItems(): Promise<S
 };
 
 STORAGE_HANDLERS.deleteStorageItem = async function deleteStorageItem(req: Request): Promise<boolean> {
-  let name: string;
-  try {
-    name = parseRequestArgs(req, ['name']).name;
-    validateStorageItemName(name);
-  } catch (e) {
-    log.error(`Failed to parse the request body for deleting a storage item: ${(e as Error).message}`);
-    return false;
-  }
+  const name = parseRequestArgs(req, ['name']).name;
+  validateStorageItemName(name);
   return await executeStorageMethod(async (storage: Storage) => await storage.delete(name));
 };
 

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -116,8 +116,14 @@ STORAGE_HANDLERS.listStorageItems = async function listStorageItems(): Promise<S
 };
 
 STORAGE_HANDLERS.deleteStorageItem = async function deleteStorageItem(req: Request): Promise<boolean> {
-  const name = parseRequestArgs(req, ['name']).name;
-  validateStorageItemName(name);
+  let name: string;
+  try {
+    name = parseRequestArgs(req, ['name']).name;
+    validateStorageItemName(name);
+  } catch (e) {
+    log.error(`Failed to parse the request body for deleting a storage item: ${(e as Error).message}`);
+    return false;
+  }
   return await executeStorageMethod(async (storage: Storage) => await storage.delete(name));
 };
 

--- a/packages/storage-plugin/lib/storage.ts
+++ b/packages/storage-plugin/lib/storage.ts
@@ -5,6 +5,7 @@ import type Stream from 'node:stream';
 
 import {fs, timing, util} from '@appium/support';
 import type {AppiumLogger} from '@appium/types';
+import {errors} from 'appium/driver.js';
 import AsyncLock from 'async-lock';
 import {asyncmap} from 'asyncbox';
 import type {Path} from 'path-scurry';
@@ -218,7 +219,7 @@ export class Storage {
   }
 }
 
-export class StorageArgumentError extends Error {}
+export class StorageArgumentError extends errors.InvalidArgumentError {}
 
 /**
  * Validates storage item options and returns the same object when valid.

--- a/packages/storage-plugin/test/unit/plugin.spec.ts
+++ b/packages/storage-plugin/test/unit/plugin.spec.ts
@@ -21,7 +21,7 @@ async function routeCaller(routePath: string): Promise<(body: unknown) => Promis
     routes[path] = handler;
   };
   const app = {post: register, get: register} as unknown as Express;
-  // every request below is rejected before the websocket setup runs, so this never gets touched
+  // the request under test is rejected before the websocket setup runs, so this stub is never used
   await StoragePlugin.updateServer(app, {} as unknown as AppiumServer);
   const handler = routes[routePath];
   assert.ok(handler, `No handler was registered for ${routePath}`);
@@ -45,38 +45,13 @@ async function routeCaller(routePath: string): Promise<(body: unknown) => Promis
 }
 
 describe('StoragePlugin routes', function () {
-  describe('delete', function () {
-    it('should reject a name which is not a valid file name', async function () {
-      const callRoute = await routeCaller('/appium/storage/delete');
-      const {status, body} = await callRoute({name: 'foo/bar'});
-      assert.strictEqual(status, 400);
-      assert.strictEqual(body.value.error, 'invalid argument');
+  it('should reject an invalid add name as an invalid argument', async function () {
+    const callRoute = await routeCaller('/appium/storage/add');
+    const {status, body} = await callRoute({
+      name: 'foo/bar',
+      sha1: 'ccc963411b2621335657963322890305ebe96186',
     });
-
-    it('should reject a request body without a name', async function () {
-      const callRoute = await routeCaller('/appium/storage/delete');
-      const {status, body} = await callRoute({});
-      assert.strictEqual(status, 400);
-      assert.strictEqual(body.value.error, 'invalid argument');
-    });
-
-    it('should still report a valid name which is not in the storage', async function () {
-      const callRoute = await routeCaller('/appium/storage/delete');
-      const {status, body} = await callRoute({name: 'missing.txt'});
-      assert.strictEqual(status, 200);
-      assert.strictEqual(body.value, false);
-    });
-  });
-
-  describe('add', function () {
-    it('should reject a name which is not a valid file name', async function () {
-      const callRoute = await routeCaller('/appium/storage/add');
-      const {status, body} = await callRoute({
-        name: 'foo/bar',
-        sha1: 'ccc963411b2621335657963322890305ebe96186',
-      });
-      assert.strictEqual(status, 400);
-      assert.strictEqual(body.value.error, 'invalid argument');
-    });
+    assert.strictEqual(status, 400);
+    assert.strictEqual(body.value.error, 'invalid argument');
   });
 });

--- a/packages/storage-plugin/test/unit/plugin.spec.ts
+++ b/packages/storage-plugin/test/unit/plugin.spec.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import type {AppiumServer} from '@appium/types';
+import type {Express, Request, Response} from 'express';
+
+import {StoragePlugin} from '../../lib/plugin.js';
+
+interface CapturedResponse {
+  status: number;
+  body: any;
+}
+
+/**
+ * Registers the plugin routes against a stub app and returns a function which invokes the
+ * handler bound to `routePath` with the given request body.
+ */
+async function routeCaller(routePath: string): Promise<(body: unknown) => Promise<CapturedResponse>> {
+  const routes: Record<string, (req: Request, res: Response) => Promise<void>> = {};
+  const register = (path: string, handler: (req: Request, res: Response) => Promise<void>) => {
+    routes[path] = handler;
+  };
+  const app = {post: register, get: register} as unknown as Express;
+  // every request below is rejected before the websocket setup runs, so this never gets touched
+  await StoragePlugin.updateServer(app, {} as unknown as AppiumServer);
+  const handler = routes[routePath];
+  assert.ok(handler, `No handler was registered for ${routePath}`);
+
+  return async function callRoute(body: unknown): Promise<CapturedResponse> {
+    const captured: CapturedResponse = {status: 0, body: undefined};
+    const res = {
+      set: () => res,
+      status: (code: number) => {
+        captured.status = code;
+        return res;
+      },
+      send: (payload: any) => {
+        captured.body = payload;
+        return res;
+      },
+    } as unknown as Response;
+    await handler({body} as Request, res);
+    return captured;
+  };
+}
+
+describe('StoragePlugin routes', function () {
+  describe('delete', function () {
+    it('should reject a name which is not a valid file name', async function () {
+      const callRoute = await routeCaller('/appium/storage/delete');
+      const {status, body} = await callRoute({name: 'foo/bar'});
+      assert.strictEqual(status, 400);
+      assert.strictEqual(body.value.error, 'invalid argument');
+    });
+
+    it('should reject a request body without a name', async function () {
+      const callRoute = await routeCaller('/appium/storage/delete');
+      const {status, body} = await callRoute({});
+      assert.strictEqual(status, 400);
+      assert.strictEqual(body.value.error, 'invalid argument');
+    });
+
+    it('should still report a valid name which is not in the storage', async function () {
+      const callRoute = await routeCaller('/appium/storage/delete');
+      const {status, body} = await callRoute({name: 'missing.txt'});
+      assert.strictEqual(status, 200);
+      assert.strictEqual(body.value, false);
+    });
+  });
+
+  describe('add', function () {
+    it('should reject a name which is not a valid file name', async function () {
+      const callRoute = await routeCaller('/appium/storage/add');
+      const {status, body} = await callRoute({
+        name: 'foo/bar',
+        sha1: 'ccc963411b2621335657963322890305ebe96186',
+      });
+      assert.strictEqual(status, 400);
+      assert.strictEqual(body.value.error, 'invalid argument');
+    });
+  });
+});

--- a/packages/storage-plugin/test/unit/storage.spec.ts
+++ b/packages/storage-plugin/test/unit/storage.spec.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {after, afterEach, before, beforeEach, describe, it} from 'node:test';
 
 import {fs, logger, tempDir} from '@appium/support';
+import {errors, getResponseForW3CError} from 'appium/driver.js';
 
 import {Storage, StorageArgumentError, validateStorageItemName} from '../../lib/storage.js';
 
@@ -138,6 +139,18 @@ describe('storage', function () {
           return true;
         },
       );
+    });
+
+    it('should be reported as a W3C invalid argument', function () {
+      try {
+        validateStorageItemName('foo/bar');
+        assert.fail('expected validateStorageItemName to throw');
+      } catch (err) {
+        assert.ok(err instanceof errors.InvalidArgumentError);
+        const [status, body] = getResponseForW3CError(err);
+        assert.strictEqual(status, 400);
+        assert.strictEqual(body.value.error, 'invalid argument');
+      }
     });
   });
 


### PR DESCRIPTION
`StorageArgumentError` is a plain `Error`, so `add` with a name that cannot be a file, or a sha1 of the wrong length, comes back as `500 unknown error`. The same happens on the upload web socket status event when the hashes do not match.

This makes `StorageArgumentError` extend `InvalidArgumentError`, so `getResponseForW3CError` maps those cases to `400 invalid argument`. Delete is unchanged: a name that is missing, unusable, or simply not in the storage still returns `false`.

## Tests

- [x] `add` with `foo/bar` returns `400 invalid argument`
- [x] `validateStorageItemName` maps through `getResponseForW3CError` to `400`
- [x] both cases fail on master with `500` / a plain `Error`
- [x] `npm run test:unit` in packages/storage-plugin, 11 pass
- [x] lint clean
