### PR TITLE
fix: address code review cleanups (plist, env memoize, test reuse)

### DIFF
--- a/packages/appium/lib/utils/env.ts
+++ b/packages/appium/lib/utils/env.ts
@@ -74,7 +74,7 @@ export const findAppiumDependencyPackage = util.memoize(async function findAppiu
  * Read a `package.json` in dir `cwd`. If none is found, resolves with `undefined`.
  * @returns Parsed package data, or `undefined` when `package.json` is missing in `cwd`
  */
-const readPackageInDir = util.memoize(async function _readPackageInDir(
+export const readPackageInDir = util.memoize(async function _readPackageInDir(
   cwd: string,
 ): Promise<NormalizedPackageJson | undefined> {
   try {

--- a/packages/appium/lib/utils/env.ts
+++ b/packages/appium/lib/utils/env.ts
@@ -74,7 +74,9 @@ export const findAppiumDependencyPackage = util.memoize(async function findAppiu
  * Read a `package.json` in dir `cwd`. If none is found, resolves with `undefined`.
  * @returns Parsed package data, or `undefined` when `package.json` is missing in `cwd`
  */
-async function readPackageInDir(cwd: string): Promise<NormalizedPackageJson | undefined> {
+const readPackageInDir = util.memoize(async function _readPackageInDir(
+  cwd: string,
+): Promise<NormalizedPackageJson | undefined> {
   try {
     return await readPackage({cwd, normalize: true});
   } catch (err) {
@@ -83,7 +85,7 @@ async function readPackageInDir(cwd: string): Promise<NormalizedPackageJson | un
     }
     throw err;
   }
-}
+});
 
 function isMissingPackageJsonError(err: unknown): boolean {
   return err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';

--- a/packages/appium/test/e2e/env.e2e.spec.ts
+++ b/packages/appium/test/e2e/env.e2e.spec.ts
@@ -7,6 +7,7 @@ import {fs, node, tempDir} from '@appium/support';
 import {
   DEFAULT_APPIUM_HOME,
   findAppiumDependencyPackage,
+  readPackageInDir,
   resolveAppiumHome,
   resolveManifestPath,
 } from '../../lib/utils/env.js';
@@ -29,6 +30,7 @@ describe('environment', function () {
     resolveManifestPath.cache = new Map();
     resolveAppiumHome.cache = new Map();
     findAppiumDependencyPackage.cache = new Map();
+    readPackageInDir.cache = new Map();
 
     oldEnvAppiumHome = process.env.APPIUM_HOME;
     delete process.env.APPIUM_HOME;

--- a/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
+++ b/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import {after, afterEach, before, beforeEach, describe, it} from 'node:test';
 import {fileURLToPath} from 'node:url';
 
+import {httpGet, httpPost} from '@appium/driver-test-support';
 import {pluginE2EHarness} from '@appium/plugin-test-support';
 import {fs, node, tempDir} from '@appium/support';
 import {exec} from 'teen_process';
@@ -27,26 +28,6 @@ const WDIO_OPTS: WebdriverIOConfig = {
   connectionRetryCount: 0,
   capabilities: TEST_CAPS,
 };
-
-async function getJson(url: string): Promise<any> {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`Request failed with status code ${response.status}`);
-  }
-  return response.json();
-}
-
-async function postJson(url: string, data?: unknown): Promise<any> {
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: typeof data === 'undefined' ? undefined : {'content-type': 'application/json'},
-    body: typeof data === 'undefined' ? undefined : JSON.stringify(data),
-  });
-  if (!response.ok) {
-    throw new Error(`Request failed with status code ${response.status}`);
-  }
-  return response.json();
-}
 
 describe('StoragePlugin', function () {
   let driver: any;
@@ -79,11 +60,11 @@ describe('StoragePlugin', function () {
     const baseUrl = `http://${TEST_HOST}:${WDIO_OPTS.port}/appium/storage`;
     driver.addCommand(
       'addStorageItem',
-      async (name: string, sha1: string) => (await postJson(`${baseUrl}/add`, {name, sha1})).value,
+      async (name: string, sha1: string) => (await httpPost(`${baseUrl}/add`, {name, sha1})).data.value,
     );
-    driver.addCommand('listStorageItems', async () => (await getJson(`${baseUrl}/list`)).value);
-    driver.addCommand('resetStorageItems', async () => (await postJson(`${baseUrl}/reset`)).value);
-    driver.addCommand('deleteStorageItem', async (name: string) => (await postJson(`${baseUrl}/delete`, {name})).value);
+    driver.addCommand('listStorageItems', async () => (await httpGet(`${baseUrl}/list`)).data.value);
+    driver.addCommand('resetStorageItems', async () => (await httpPost(`${baseUrl}/reset`)).data.value);
+    driver.addCommand('deleteStorageItem', async (name: string) => (await httpPost(`${baseUrl}/delete`, {name})).data.value);
   });
 
   afterEach(async function () {
@@ -119,7 +100,7 @@ describe('StoragePlugin', function () {
 
   it('should still serve the deprecated /storage endpoints', async function () {
     const deprecatedBaseUrl = `http://${TEST_HOST}:${WDIO_OPTS.port}/storage`;
-    const data = await getJson(`${deprecatedBaseUrl}/list`);
+    const {data} = await httpGet(`${deprecatedBaseUrl}/list`);
     assert.strictEqual(data.value.length, 0);
   });
 

--- a/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
+++ b/packages/storage-plugin/test/e2e/storage.e2e.spec.ts
@@ -64,7 +64,10 @@ describe('StoragePlugin', function () {
     );
     driver.addCommand('listStorageItems', async () => (await httpGet(`${baseUrl}/list`)).data.value);
     driver.addCommand('resetStorageItems', async () => (await httpPost(`${baseUrl}/reset`)).data.value);
-    driver.addCommand('deleteStorageItem', async (name: string) => (await httpPost(`${baseUrl}/delete`, {name})).data.value);
+    driver.addCommand(
+      'deleteStorageItem',
+      async (name: string) => (await httpPost(`${baseUrl}/delete`, {name})).data.value,
+    );
   });
 
   afterEach(async function () {

--- a/packages/storage-plugin/tsconfig.json
+++ b/packages/storage-plugin/tsconfig.json
@@ -17,6 +17,7 @@
   "include": ["lib", "test"],
   "references": [
     {"path": "../base-plugin"},
+    {"path": "../driver-test-support"},
     {"path": "../logger"},
     {"path": "../support"},
     {"path": "../types"},

--- a/packages/support/lib/plist.ts
+++ b/packages/support/lib/plist.ts
@@ -173,10 +173,23 @@ function toBufferDeep(value: unknown): unknown {
     return Buffer.from(value.buffer, value.byteOffset, value.byteLength);
   }
   if (Array.isArray(value)) {
-    return value.map(toBufferDeep);
+    let changed = false;
+    const result = value.map((v) => {
+      const converted = toBufferDeep(v);
+      changed ||= converted !== v;
+      return converted;
+    });
+    return changed ? result : value;
   }
   if (value !== null && typeof value === 'object') {
-    return Object.fromEntries(Object.entries(value).map(([key, v]) => [key, toBufferDeep(v)]));
+    let changed = false;
+    const result: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(value)) {
+      const converted = toBufferDeep(v);
+      changed ||= converted !== v;
+      result[key] = converted;
+    }
+    return changed ? result : value;
   }
   return value;
 }


### PR DESCRIPTION
- plist.ts: toBufferDeep() now returns the original reference when no Uint8Array needs upgrading, avoiding a full tree rebuild on every parse.
- appium/utils/env.ts: restore the memoize() wrapper on readPackageInDir lost when this code moved from packages/support/lib/env.ts.
- storage-plugin e2e test: reuse httpGet/httpPost from @appium/driver-test-support instead of a local fetch-based reimplementation.
