### PR TITLE
fix(support)!: route non-error CLI console output to stdout

### DIFF
--- a/packages/appium/lib/bootstrap/appium-initializer.ts
+++ b/packages/appium/lib/bootstrap/appium-initializer.ts
@@ -1,4 +1,4 @@
-import {util} from '@appium/support';
+import {console as supportConsole, util} from '@appium/support';
 import type {DriverOpts} from '@appium/types';
 import type {
   Args,
@@ -77,6 +77,8 @@ export class AppiumInitializer {
     }
 
     if (isSetupCommandArgs(preConfigArgs)) {
+      driverConfig.printValidationSummary(logger);
+      pluginConfig.printValidationSummary(logger);
       await runSetupCommand(preConfigArgs, driverConfig, pluginConfig);
       return {} as InitResult<Cmd>;
     }
@@ -135,6 +137,8 @@ export class AppiumInitializer {
 
     if (preConfigArgs.showConfig) {
       showConfig(getNonDefaultServerArgs(preConfigArgs as Args), configResult, defaults, serverArgs);
+      driverConfig.printValidationSummary(logger);
+      pluginConfig.printValidationSummary(logger);
       return {} as InitResult<Cmd>;
     }
 
@@ -144,10 +148,15 @@ export class AppiumInitializer {
         pluginConfig,
         appiumHome,
       });
+      driverConfig.printValidationSummary(logger);
+      pluginConfig.printValidationSummary(logger);
       return {} as InitResult<Cmd>;
     }
 
     await logsinkInit(serverArgs);
+    // Deferred from loadExtensions() so these render through the now-active (Winston-backed) logger.
+    driverConfig.printValidationSummary(logger);
+    pluginConfig.printValidationSummary(logger);
     await this.applyLogFilters(serverArgs);
 
     if (!serverArgs.noPermsCheck) {
@@ -201,7 +210,10 @@ export class AppiumInitializer {
     if (isDriverCommandArgs(preConfigArgs) || isPluginCommandArgs(preConfigArgs)) {
       const cmd = isDriverCommandArgs(preConfigArgs) ? preConfigArgs.driverCommand : preConfigArgs.pluginCommand;
       if (cmd === 'install') {
-        await injectAppiumSymlinks(driverConfig, pluginConfig, logger);
+        // Match the same command's own console so a non-fatal symlink error never lands on
+        // STDOUT under `--json` (unlike the raw npmlog logger, which isn't JSON-mode-aware).
+        const symlinkLog = new supportConsole.CliConsole({jsonMode: Boolean(preConfigArgs.json)});
+        await injectAppiumSymlinks(driverConfig, pluginConfig, symlinkLog);
       }
     }
   }

--- a/packages/appium/lib/bootstrap/appium-initializer.ts
+++ b/packages/appium/lib/bootstrap/appium-initializer.ts
@@ -77,8 +77,7 @@ export class AppiumInitializer {
     }
 
     if (isSetupCommandArgs(preConfigArgs)) {
-      driverConfig.printValidationSummary(logger);
-      pluginConfig.printValidationSummary(logger);
+      this.printValidationSummaries(driverConfig, pluginConfig);
       await runSetupCommand(preConfigArgs, driverConfig, pluginConfig);
       return {} as InitResult<Cmd>;
     }
@@ -137,8 +136,7 @@ export class AppiumInitializer {
 
     if (preConfigArgs.showConfig) {
       showConfig(getNonDefaultServerArgs(preConfigArgs as Args), configResult, defaults, serverArgs);
-      driverConfig.printValidationSummary(logger);
-      pluginConfig.printValidationSummary(logger);
+      this.printValidationSummaries(driverConfig, pluginConfig);
       return {} as InitResult<Cmd>;
     }
 
@@ -148,15 +146,13 @@ export class AppiumInitializer {
         pluginConfig,
         appiumHome,
       });
-      driverConfig.printValidationSummary(logger);
-      pluginConfig.printValidationSummary(logger);
+      this.printValidationSummaries(driverConfig, pluginConfig);
       return {} as InitResult<Cmd>;
     }
 
     await logsinkInit(serverArgs);
     // Deferred from loadExtensions() so these render through the now-active (Winston-backed) logger.
-    driverConfig.printValidationSummary(logger);
-    pluginConfig.printValidationSummary(logger);
+    this.printValidationSummaries(driverConfig, pluginConfig);
     await this.applyLogFilters(serverArgs);
 
     if (!serverArgs.noPermsCheck) {
@@ -174,6 +170,15 @@ export class AppiumInitializer {
       pluginConfig,
       appiumHome,
     } as InitResult<Cmd>;
+  }
+
+  /** Renders each config's pending `loadExtensions()`-time validation summary via the raw logger. */
+  private printValidationSummaries(
+    driverConfig: ExtensionConfigs['driverConfig'],
+    pluginConfig: ExtensionConfigs['pluginConfig'],
+  ): void {
+    driverConfig.printValidationSummary(logger);
+    pluginConfig.printValidationSummary(logger);
   }
 
   private async applyLogFilters(serverArgs: ParsedArgs<CliCommandServer>): Promise<void> {

--- a/packages/appium/lib/cli/extension-command.ts
+++ b/packages/appium/lib/cli/extension-command.ts
@@ -4,7 +4,7 @@ import {pathToFileURL} from 'node:url';
 import {inspect} from 'node:util';
 
 import {console, fs, system, util} from '@appium/support';
-import type {AppiumLogger, ExtensionType, IDoctorCheck} from '@appium/types';
+import type {ExtensionType, IDoctorCheck} from '@appium/types';
 import type {
   ExtInstallReceipt as AppiumExtInstallReceipt,
   ExtManifest as AppiumExtManifest,
@@ -161,6 +161,9 @@ type GetInstallationReceiptOpts<ExtType extends ExtensionType = ExtensionType> =
 
 type InstalledExtensionLike = {installType?: InstallType; installPath?: string};
 
+/** Minimal logger shape accepted where callers must control whether output can hit `STDOUT`. */
+type InfoSink = {info(message?: string, ...args: any[]): void};
+
 class NotUpdatableError extends Error {}
 
 class NoUpdatesAvailableError extends Error {}
@@ -191,6 +194,15 @@ export abstract class ExtensionCliCommand<ExtType extends ExtensionType = Extens
     this.config = config;
     this.log = new console.CliConsole({jsonMode: json});
     this.isJsonOutput = Boolean(json);
+  }
+
+  /**
+   * Renders the config's pending manifest-validation summary (from the `loadExtensions()` call at
+   * CLI startup) through this command's own JSON-mode-aware console, so it's suppressed under
+   * `--json` just like any other non-JSON output.
+   */
+  printPendingValidationSummary(): void {
+    this.config.printValidationSummary(this.log);
   }
 
   /**
@@ -1153,13 +1165,14 @@ export abstract class ExtensionCliCommand<ExtType extends ExtensionType = Extens
  *
  * @param driverConfig - active driver extension config
  * @param pluginConfig - active plugin extension config
- * @param logger - logger instance used for non-fatal symlink errors
+ * @param logger - sink for non-fatal symlink errors; pass a JSON-mode-aware `CliConsole` so this
+ * never writes to `STDOUT` under `--json`
  * @returns resolves when symlink injection has completed for all extensions
  */
 export async function injectAppiumSymlinks(
   driverConfig: ExtensionConfig<any>,
   pluginConfig: ExtensionConfig<any>,
-  logger: AppiumLogger,
+  logger: InfoSink,
 ): Promise<void> {
   const isNpmInstalledExtension = (
     details: InstalledExtensionLike,
@@ -1226,7 +1239,7 @@ async function getRemoteExtensionVersionReq(pkgName: string, pkgVer?: string): P
  *
  * @param dstFolder The destination folder where the symlink should be created
  */
-async function injectAppiumSymlink(dstFolder: string, logger: AppiumLogger): Promise<void> {
+async function injectAppiumSymlink(dstFolder: string, logger: InfoSink): Promise<void> {
   try {
     const symlinkPath = path.join(dstFolder, path.basename(appiumPackageRoot));
     if ((await fs.exists(dstFolder)) && !(await fs.exists(symlinkPath))) {

--- a/packages/appium/lib/cli/extension.ts
+++ b/packages/appium/lib/cli/extension.ts
@@ -45,6 +45,7 @@ export async function runExtensionCommand<Cmd extends CliExtensionCommand, SubCm
   }
   const CommandClass = commandClasses[type] as ExtCommand<Cmd>;
   const cmd = new CommandClass({config, json} as any);
+  cmd.printPendingValidationSummary();
   try {
     jsonResult = (await cmd.execute(args)) as Record<string, unknown>;
   } catch (err) {

--- a/packages/appium/lib/extension/extension-config.ts
+++ b/packages/appium/lib/extension/extension-config.ts
@@ -33,14 +33,41 @@ export type ExtManifestWithSchema<E extends ExtensionType> = ExtManifest<E> & {
 export type ExtensionConfigMutationOpts = {write?: boolean};
 
 /**
+ * Results of the most recent {@linkcode ExtensionConfig.validate} call, not yet rendered anywhere.
+ * `validate()` only computes this; call {@linkcode ExtensionConfig.printValidationSummary} to display it,
+ * so the caller can pick a sink appropriate to its own output context (e.g. a JSON-mode-aware CLI
+ * console, or the server's Winston-backed logger).
+ */
+interface ExtensionValidationSummary {
+  /** Number of extensions considered; used only for pluralizing the summary's lead-in line. */
+  checkedCount: number;
+  errorSummaries: string[];
+  warningSummaries: string[];
+}
+
+/** Minimal logger shape needed to render a {@linkcode ExtensionValidationSummary}. */
+export type ValidationSummarySink = {
+  warn(message?: string, ...args: any[]): void;
+  error(message?: string, ...args: any[]): void;
+};
+
+const EMPTY_VALIDATION_SUMMARY: ExtensionValidationSummary = {
+  checkedCount: 0,
+  errorSummaries: [],
+  warningSummaries: [],
+};
+
+/**
  * Shared configuration and validation for installed Appium extensions (drivers or plugins).
  * Subclasses fix the extension kind; do not instantiate this class directly.
  */
 export abstract class ExtensionConfig<ExtType extends ExtensionType> {
   readonly extensionType: ExtType;
   readonly manifest: Manifest;
-  installedExtensions: ExtRecord<ExtType>;
-  #listDataCache: ExtensionList<ExtType> | undefined;
+  readonly installedExtensions: ExtRecord<ExtType>;
+  /** Populated by {@linkcode ExtensionConfig.validate}; see {@linkcode ExtensionValidationSummary}. */
+  private validationSummary: ExtensionValidationSummary = EMPTY_VALIDATION_SUMMARY;
+  private listDataCache: ExtensionList<ExtType> | undefined;
 
   protected constructor(extensionType: ExtType, manifest: Manifest) {
     this.extensionType = extensionType;
@@ -326,8 +353,8 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
   }
 
   /**
-   * Validates all entries in `exts`, logs summaries, and removes keys that have blocking errors.
-   * Intended for subclasses’ `validate` implementation.
+   * Validates all entries in `exts`, records a summary (see {@linkcode ExtensionConfig.printValidationSummary}),
+   * and removes keys that have blocking errors. Intended for subclasses’ `validate` implementation.
    */
   protected async _validate(exts: ExtRecord<ExtType>): Promise<ExtRecord<ExtType>> {
     const errorMap = new Map<string, ExtManifestProblem[]>();
@@ -346,47 +373,61 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
     }
 
     const {errorSummaries, warningSummaries} = this.getValidationResultSummaries(errorMap, warningMap);
+    this.validationSummary = {checkedCount: errorMap.size, errorSummaries, warningSummaries};
+    return exts;
+  }
+
+  /**
+   * Renders the summary from the most recent {@linkcode ExtensionConfig.validate} call via `sink`,
+   * then clears it so a later call doesn't re-print the same summary. Errors take precedence:
+   * warnings are only shown when there were no errors. No-op if there's nothing to report.
+   *
+   * @param sink - Where to write the summary; e.g. a JSON-mode-aware CLI console for extension
+   * subcommands, or the server's own (by then Winston-backed) logger once it has taken over.
+   */
+  printValidationSummary(sink: ValidationSummarySink): void {
+    const {checkedCount, errorSummaries, warningSummaries} = this.validationSummary;
+    this.validationSummary = EMPTY_VALIDATION_SUMMARY;
 
     if (!util.isEmpty(errorSummaries)) {
-      log.error(
+      sink.error(
         `Appium encountered ${util.pluralize(
           'error',
-          errorMap.size,
+          checkedCount,
           true,
         )} while validating ${this.extensionType}s found in manifest ${this.manifestPath}`,
       );
       for (const summary of errorSummaries) {
-        log.error(summary);
+        sink.error(summary);
       }
     } else if (!util.isEmpty(warningSummaries)) {
       // only display warnings if there are no errors!
-      log.warn(
+      sink.warn(
         `Appium encountered ${util.pluralize(
           'warning',
-          warningMap.size,
+          checkedCount,
           true,
         )} while validating ${this.extensionType}s found in manifest ${this.manifestPath}`,
       );
       for (const summary of warningSummaries) {
-        log.warn(summary);
+        sink.warn(summary);
       }
     }
-    return exts;
   }
 
   /**
    * Fetches `appium driver|plugin list`-style data via the CLI command class; result is cached.
    */
   protected async getListData(): Promise<ExtensionList<ExtType>> {
-    if (this.#listDataCache) {
-      return this.#listDataCache;
+    if (this.listDataCache) {
+      return this.listDataCache;
     }
     // Import here to avoid circular dependency with cli/extension
     const {commandClasses} = await import('../cli/extension.js');
     const CommandClass = (commandClasses as StringRecord)[this.extensionType];
     const cmd = new CommandClass({config: this, json: true}) as ExtensionCliCommand<ExtType>;
     const listData = await cmd.list({showInstalled: true, showUpdates: true});
-    this.#listDataCache = listData;
+    this.listDataCache = listData;
     return listData;
   }
 

--- a/packages/appium/lib/logsink.ts
+++ b/packages/appium/lib/logsink.ts
@@ -111,8 +111,9 @@ export async function init(args: ParsedArgs): Promise<void> {
       }
     }
   });
-  // Only Winston produces output; avoid duplicate lines from the logger's default stream
+  // Only Winston produces output; avoid duplicate lines from the logger's default streams
   globalLog.stream = null;
+  globalLog.errorStream = null;
 }
 
 /**

--- a/packages/appium/test/e2e/cli-driver.e2e.spec.ts
+++ b/packages/appium/test/e2e/cli-driver.e2e.spec.ts
@@ -82,9 +82,9 @@ describe('Driver CLI', {timeout: 90000}, function () {
 
   describe(LIST, function () {
     it('should list available drivers', async function () {
-      const {stderr} = await runAppiumRaw(appiumHome, [DRIVER_TYPE, LIST], {});
+      const {stdout} = await runAppiumRaw(appiumHome, [DRIVER_TYPE, LIST], {});
       for (const d of Object.keys(KNOWN_DRIVERS)) {
-        assert.match(stderr, new RegExp(`${d}.+[not installed]`));
+        assert.match(stdout, new RegExp(`${d}.+[not installed]`));
       }
     });
 
@@ -135,8 +135,8 @@ describe('Driver CLI', {timeout: 90000}, function () {
         util.compareVersions(String(updateVersion), '>', penultimateFakeDriverVersionAsOfRightNow),
         true,
       );
-      const {stderr} = await runAppiumRaw(appiumHome, [DRIVER_TYPE, LIST, '--updates'], {});
-      assert.match(stderr, new RegExp(`fake.+[${updateVersion} available]`));
+      const {stdout} = await runAppiumRaw(appiumHome, [DRIVER_TYPE, LIST, '--updates'], {});
+      assert.match(stdout, new RegExp(`fake.+[${updateVersion} available]`));
     });
 
     describe('if a driver is not published to npm', function () {
@@ -296,9 +296,9 @@ describe('Driver CLI', {timeout: 90000}, function () {
           [DRIVER_TYPE, INSTALL, '--source', 'local', TEST_DRIVER_INVALID_PEERS_DIR],
           {},
         );
-        if ('stderr' in ret) {
-          assert.match(ret.stderr, /may be incompatible with the current version of Appium/i);
-          assert.match(ret.stderr, /successfully installed/i);
+        if ('stdout' in ret) {
+          assert.match(ret.stdout, /may be incompatible with the current version of Appium/i);
+          assert.match(ret.stdout, /successfully installed/i);
         }
       });
     });
@@ -306,9 +306,9 @@ describe('Driver CLI', {timeout: 90000}, function () {
     describe('when peer dependencies are valid', function () {
       it('should not display a warning', async function () {
         const ret = await runAppiumRaw(appiumHome, [DRIVER_TYPE, INSTALL, '--source', 'local', TEST_DRIVER_DIR], {});
-        if ('stderr' in ret) {
-          assert.doesNotMatch(ret.stderr, /may be incompatible with the current version of Appium/i);
-          assert.match(ret.stderr, /successfully installed/i);
+        if ('stdout' in ret) {
+          assert.doesNotMatch(ret.stdout, /may be incompatible with the current version of Appium/i);
+          assert.match(ret.stdout, /successfully installed/i);
         }
       });
     });

--- a/packages/appium/test/unit/cli/cli.spec.ts
+++ b/packages/appium/test/unit/cli/cli.spec.ts
@@ -23,7 +23,7 @@ describe('DriverCommand', function () {
     Manifest.getInstance.cache = new Map();
     sandbox.stub(fs, 'exists').resolves(false);
     config = (await loadExtensions(appiumHome)).driverConfig;
-    config.installedExtensions = {
+    Object.assign(config.installedExtensions, {
       [driver]: {
         version: '1.0.0',
         pkgName,
@@ -34,7 +34,7 @@ describe('DriverCommand', function () {
         installSpec: pkgName,
         installPath: '',
       },
-    };
+    });
     dc = new DriverCommand({config, json: true});
   });
 

--- a/packages/appium/test/unit/extension/extension-config.spec.ts
+++ b/packages/appium/test/unit/extension/extension-config.spec.ts
@@ -4,8 +4,6 @@ import os from 'node:os';
 import path from 'node:path';
 import {describe, it, beforeEach, afterEach, before, after, mock} from 'node:test';
 
-import type {SinonStub} from 'sinon';
-
 import {DRIVER_TYPE} from '../../../lib/constants.js';
 import {APPIUM_VER} from '../../../lib/helpers/build.js';
 import {FAKE_DRIVER_DIR, PROJECT_ROOT} from '../../helpers.js';
@@ -295,28 +293,12 @@ describe('ExtensionConfig', function () {
     });
 
     describe('_validate()', function () {
-      // `extension-config.ts` calls `log` from `lib/logger.ts`, which creates its singleton
-      // via `@appium/support`'s `getLogger()` at module-load time. `lib/logger.js` gets loaded
-      // (unmocked) transitively via this file's own static `test/helpers.js` import, well
-      // before `applyExtensionMocks()` ever runs, so mocking `@appium/support` can't reach it.
-      // `log` is a plain mutable object though (not a frozen ES module namespace), so stub its
-      // methods directly instead.
-      let logWarnStub: SinonStub;
-      let logErrorStub: SinonStub;
-
-      // Stubbed once: `log` is a persistent singleton (not recreated per test), and sinon
-      // throws if the same method is stubbed twice without restoring in between. History is
-      // cleared every test via `resetMockDefaults`'s `sandbox.resetHistory()`.
-      before(async function () {
-        const {log} = await import('../../../lib/logger.js');
-        logWarnStub = mocks.sandbox.stub(log, 'warn');
-        logErrorStub = mocks.sandbox.stub(log, 'error');
-      });
-
-      after(function () {
-        logWarnStub.restore();
-        logErrorStub.restore();
-      });
+      // `_validate()` no longer prints directly (see `printValidationSummary()`): it only
+      // records a summary, so callers can render it via whatever sink fits their own output
+      // context (a JSON-mode-aware CLI console, the server's Winston-backed logger, etc.).
+      function createSink() {
+        return {warn: mocks.sandbox.stub(), error: mocks.sandbox.stub()};
+      }
 
       describe('when there is a single warning', function () {
         beforeEach(function () {
@@ -324,10 +306,12 @@ describe('ExtensionConfig', function () {
           mocks.sandbox.stub(config, 'getWarnings').resolves([{err: 'some warning', val: 'whatever'}]);
         });
 
-        it('should display a warning count of 1', async function () {
+        it('should record and print a warning count of 1', async function () {
           await config._validate({foo: {}});
+          const sink = createSink();
+          config.printValidationSummary(sink);
           assert.strictEqual(
-            logWarnStub.calledWith(
+            sink.warn.calledWith(
               'Appium encountered 1 warning while validating drivers found in manifest /some/path/extensions.yaml',
             ),
             true,
@@ -341,14 +325,35 @@ describe('ExtensionConfig', function () {
           mocks.sandbox.stub(config, 'getWarnings').resolves([]);
         });
 
-        it('should display an error count of 1', async function () {
+        it('should record and print an error count of 1', async function () {
           await config._validate({foo: {}});
+          const sink = createSink();
+          config.printValidationSummary(sink);
           assert.strictEqual(
-            logErrorStub.calledWith(
+            sink.error.calledWith(
               'Appium encountered 1 error while validating drivers found in manifest /some/path/extensions.yaml',
             ),
             true,
           );
+        });
+      });
+
+      describe('printValidationSummary()', function () {
+        it('does nothing when there is nothing to report', function () {
+          const sink = createSink();
+          config.printValidationSummary(sink);
+          assert.strictEqual(sink.warn.called, false);
+          assert.strictEqual(sink.error.called, false);
+        });
+
+        it('clears the summary so it is not printed twice', async function () {
+          mocks.sandbox.stub(config, 'getProblems').resolves([]);
+          mocks.sandbox.stub(config, 'getWarnings').resolves([{err: 'some warning', val: 'whatever'}]);
+          await config._validate({foo: {}});
+          config.printValidationSummary(createSink());
+          const sink = createSink();
+          config.printValidationSummary(sink);
+          assert.strictEqual(sink.warn.called, false);
         });
       });
     });

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -39,45 +39,35 @@ interface ArgumentFormatResult {
 }
 
 export class Log extends EventEmitter implements Logger {
-  level: LogLevel | string;
-  prefixStyle: StyleObject;
-  headingStyle: StyleObject;
-  heading: string;
-  stream: Writable | null; // Defaults to process.stderr; set to null when using custom output (e.g. Winston)
+  level: LogLevel | string = 'info';
+  prefixStyle: StyleObject = {fg: 'magenta'};
+  headingStyle: StyleObject = {fg: 'white', bg: 'black'};
+  heading = '';
+  stream: Writable | null = process.stdout; // Output for levels below `stderrLevel`. Set to null when using custom output (e.g. Winston)
+  errorStream: Writable | null = process.stderr; // Output for levels at/above `stderrLevel`. Set to null when using custom output (e.g. Winston)
+  stderrLevel: LogLevel | string = 'error'; // Minimum severity (inclusive) routed to `errorStream` instead of `stream`
 
-  private _asyncStorage: AsyncLocalStorage<Record<string, any>>;
+  private _asyncStorage: AsyncLocalStorage<Record<string, any>> = new AsyncLocalStorage();
   private _colorEnabled?: boolean;
-  private _buffer: MessageObject[];
-  private _style: Record<LogLevel | string, StyleObject | undefined>;
-  private _levels: Record<LogLevel | string, number>;
-  private _disp: Record<LogLevel | string, number | string>;
-  private _id: number;
-  private _paused: boolean;
-  private _secureValuesPreprocessor: SecureValuesPreprocessor;
+  private _buffer: MessageObject[] = [];
+  private _style: Record<LogLevel | string, StyleObject | undefined> = Object.fromEntries(
+    DEFAULT_LOG_LEVELS.map(([level, , style]) => [level, style]),
+  );
+  private _levels: Record<LogLevel | string, number> = Object.fromEntries(
+    DEFAULT_LOG_LEVELS.map(([level, index]) => [level, index]),
+  );
+  private _disp: Record<LogLevel | string, number | string> = Object.fromEntries(
+    DEFAULT_LOG_LEVELS.map(([level, , , disp]) => [level, disp ?? level]),
+  );
+  private _id = 0;
+  private _paused = false;
+  private _secureValuesPreprocessor: SecureValuesPreprocessor = new SecureValuesPreprocessor();
 
-  private _history: LRUCache<number, MessageObject>;
-  private _maxRecordSize: number;
+  private _history: LRUCache<number, MessageObject> = new LRUCache({max: DEFAULT_HISTORY_SIZE});
+  private _maxRecordSize: number = DEFAULT_HISTORY_SIZE;
 
   constructor() {
     super();
-
-    this.level = 'info';
-    this._buffer = [];
-    this._maxRecordSize = DEFAULT_HISTORY_SIZE;
-    this._history = new LRUCache({max: this.maxRecordSize});
-    this.stream = process.stderr;
-    this.heading = '';
-    this.prefixStyle = {fg: 'magenta'};
-    this.headingStyle = {fg: 'white', bg: 'black'};
-    this._id = 0;
-    this._paused = false;
-    this._asyncStorage = new AsyncLocalStorage();
-    this._secureValuesPreprocessor = new SecureValuesPreprocessor();
-
-    this._style = {};
-    this._levels = {};
-    this._disp = {};
-    this.initDefaultLevels();
 
     // allow 'error' prefix
     this.on('error', () => {});
@@ -271,9 +261,15 @@ export class Log extends EventEmitter implements Logger {
     };
   }
 
-  private useColor(): boolean {
+  private useColor(stream: Writable | null): boolean {
     // by default, decide based on tty-ness.
-    return this._colorEnabled ?? Boolean(this.stream && 'isTTY' in this.stream && this.stream.isTTY);
+    return this._colorEnabled ?? Boolean(stream && 'isTTY' in stream && stream.isTTY);
+  }
+
+  /** The stream a message at the given (already-resolved) severity should be written to. */
+  private streamFor(severity: number): Writable | null {
+    const threshold = this._levels[this.stderrLevel];
+    return threshold !== undefined && severity >= threshold ? this.errorStream : this.stream;
   }
 
   private emitLog(m: MessageObject): void {
@@ -293,33 +289,38 @@ export class Log extends EventEmitter implements Logger {
       return;
     }
 
+    const stream = this.streamFor(l);
+    if (!stream) {
+      return;
+    }
+
     // If 'disp' is null or undefined, use the lvl as a default
     // Allows: '', 0 as valid disp
     const disp = this._disp[m.level];
     for (const line of m.message.split(/\r?\n/)) {
       const heading = this.heading;
       if (heading) {
-        this.write(heading, this.headingStyle);
-        this.write(' ');
+        this.write(stream, heading, this.headingStyle);
+        this.write(stream, ' ');
       }
-      this.write(String(disp), this._style[m.level]);
+      this.write(stream, String(disp), this._style[m.level]);
       const p = m.prefix || '';
       if (p) {
-        this.write(' ');
+        this.write(stream, ' ');
       }
 
-      this.write(p, this.prefixStyle);
-      this.write(` ${line}\n`);
+      this.write(stream, p, this.prefixStyle);
+      this.write(stream, ` ${line}\n`);
     }
   }
 
-  private _format(msg: string, style: StyleObject = {}): string | undefined {
-    if (!this.stream) {
+  private _format(stream: Writable | null, msg: string, style: StyleObject = {}): string | undefined {
+    if (!stream) {
       return;
     }
 
     let output = '';
-    if (this.useColor()) {
+    if (this.useColor(stream)) {
       const settings: string[] = [];
       if (style.fg) {
         settings.push(style.fg);
@@ -344,28 +345,20 @@ export class Log extends EventEmitter implements Logger {
       }
     }
     output += msg;
-    if (this.useColor()) {
+    if (this.useColor(stream)) {
       output += ansiColor('reset');
     }
     return output;
   }
 
-  private write(msg: string, style: StyleObject = {}): void {
-    if (!this.stream) {
+  private write(stream: Writable | null, msg: string, style: StyleObject = {}): void {
+    if (!stream) {
       return;
     }
 
-    const formatted = this._format(msg, style);
+    const formatted = this._format(stream, msg, style);
     if (formatted !== undefined) {
-      this.stream.write(formatted);
-    }
-  }
-
-  private initDefaultLevels(): void {
-    for (const [level, index, style, disp] of DEFAULT_LOG_LEVELS) {
-      this._levels[level] = index;
-      this._style[level] = style;
-      this._disp[level] = disp ?? level;
+      stream.write(formatted);
     }
   }
 

--- a/packages/logger/lib/log.ts
+++ b/packages/logger/lib/log.ts
@@ -43,7 +43,12 @@ export class Log extends EventEmitter implements Logger {
   prefixStyle: StyleObject = {fg: 'magenta'};
   headingStyle: StyleObject = {fg: 'white', bg: 'black'};
   heading = '';
-  stream: Writable | null = process.stdout; // Output for levels below `stderrLevel`. Set to null when using custom output (e.g. Winston)
+  // `stream` and `errorStream` both default to STDERR. This class is used directly (unwrapped) by
+  // code that may run during a `--json` CLI command, where a stray STDOUT write corrupts the JSON
+  // payload; call sites that need the STDOUT/STDERR split render through a JSON-mode-aware sink
+  // instead (e.g. `ExtensionConfig.printValidationSummary`) rather than relying on this default.
+  // The server path nulls both streams out once Winston takes over, in logsink.ts.
+  stream: Writable | null = process.stderr; // Output for levels below `stderrLevel`. Set to null when using custom output (e.g. Winston)
   errorStream: Writable | null = process.stderr; // Output for levels at/above `stderrLevel`. Set to null when using custom output (e.g. Winston)
   stderrLevel: LogLevel | string = 'error'; // Minimum severity (inclusive) routed to `errorStream` instead of `stream`
 

--- a/packages/logger/lib/types.ts
+++ b/packages/logger/lib/types.ts
@@ -3,15 +3,37 @@ import type {EventEmitter} from 'node:events';
 import type {Writable} from 'node:stream';
 
 export interface Logger extends EventEmitter {
+  /** Minimum severity that gets written out; messages below this level are dropped. @default 'info' */
   level: string;
+  /** The most recent log messages, newest first, capped at {@linkcode Logger.maxRecordSize}. */
   record: MessageObject[];
+  /** Maximum number of messages kept in {@linkcode Logger.record}. Shrinking it evicts the oldest entries. */
   maxRecordSize: number;
+  /** Style applied to the level tag's prefix segment (e.g. a request/session id) written before each message. */
   prefixStyle: StyleObject;
+  /** Style applied to {@linkcode Logger.heading}. */
   headingStyle: StyleObject;
+  /** Optional text written before the level tag on every line. Empty disables it. @default '' */
   heading: string;
-  stream: Writable | null; // Output for levels below `stderrLevel`; defaults to process.stdout. Set to null when using custom output (e.g. Winston)
-  errorStream: Writable | null; // Output for levels at/above `stderrLevel`; defaults to process.stderr. Set to null when using custom output (e.g. Winston)
-  stderrLevel: string; // Minimum severity (inclusive) routed to `errorStream` instead of `stream`; defaults to 'error'
+  /**
+   * Output destination for messages below {@linkcode Logger.stderrLevel}.
+   * Set to `null` to drop them (e.g. once a custom sink like Winston takes over).
+   * @default process.stderr
+   */
+  stream: Writable | null;
+  /**
+   * Output destination for messages at/above {@linkcode Logger.stderrLevel}.
+   * Set to `null` to drop them (e.g. once a custom sink like Winston takes over).
+   * @default process.stderr
+   */
+  errorStream: Writable | null;
+  /**
+   * Minimum severity (inclusive) routed to {@linkcode Logger.errorStream} instead of {@linkcode Logger.stream}.
+   * Comparison is by the level's numeric severity (see {@linkcode Logger.addLevel}), so a custom level more
+   * severe than this threshold is routed to `errorStream` too, without needing to name it explicitly.
+   * @default 'error'
+   */
+  stderrLevel: string;
 
   /**
    * Creates a log message
@@ -38,20 +60,44 @@ export interface Logger extends EventEmitter {
   error(prefix: string, message: any, ...args: any[]): void;
   silent(prefix: string, message: any, ...args: any[]): void;
 
+  /**
+   * Loads secure-value replacement rules used to redact sensitive data from log messages.
+   * Replaces any previously loaded rules.
+   * @param rulesJsonPath Path (or paths) to a rules JSON file, or the rules themselves
+   */
   loadSecureValuesPreprocessingRules(
     rulesJsonPath: string | string[] | LogFiltersConfig,
   ): Promise<PreprocessingRulesLoadResult>;
 
+  /** Forces ANSI color output on, regardless of the output stream's TTY-ness. */
   enableColor(): void;
+  /** Forces ANSI color output off, regardless of the output stream's TTY-ness. */
   disableColor(): void;
 
+  /** Buffers subsequent messages instead of writing them, until {@linkcode Logger.resume} is called. */
   pause(): void;
+  /** Stops buffering and flushes any messages queued since {@linkcode Logger.pause}, in order. */
   resume(): void;
 
+  /**
+   * Registers a custom level and, if not already present, a same-named logging method
+   * (e.g. `addLevel('custom', level)` enables `log.custom(prefix, message)`).
+   * @param level Level name
+   * @param n Numeric severity used both for level-gating and for the `stderrLevel` comparison
+   * @param style Optional display style for the level tag
+   * @param disp Optional level tag text; defaults to `level`
+   */
   addLevel(level: string, n: number, style?: StyleObject, disp?: string): void;
 
+  /**
+   * Merges (or replaces) values into the logger's `AsyncLocalStorage`-backed context for the
+   * current asynchronous call chain, e.g. to attach a request/session id to subsequent log lines.
+   * @param contextInfo Key-value pairs to store
+   * @param replace If `true`, replaces the existing context instead of merging into it
+   */
   updateAsyncStorage(contextInfo: Record<string, any>, replace: boolean): void;
 
+  /** The `AsyncLocalStorage` backing {@linkcode Logger.updateAsyncStorage}. */
   get asyncStorage(): AsyncLocalStorage<Record<string, any>>;
 
   // Allows for custom log levels
@@ -60,6 +106,7 @@ export interface Logger extends EventEmitter {
   [key: string]: any;
 }
 
+/** Built-in severities, from least to most severe (`silent` never produces output). */
 export type LogLevel =
   | 'silly'
   | 'verbose'
@@ -72,20 +119,28 @@ export type LogLevel =
   | 'error'
   | 'silent';
 
+/** ANSI display style for a level tag or heading. */
 export interface StyleObject {
+  /** Foreground color name (e.g. `'red'`). */
   fg?: string;
+  /** Background color name (e.g. `'black'`). */
   bg?: string;
   bold?: boolean;
   inverse?: boolean;
   underline?: boolean;
+  /** Emit a terminal bell character alongside the styled text. */
   bell?: boolean;
 }
 
+/** A single formatted log entry, as emitted on the `'log'`/`'log.<level>'`/`'<prefix>'` events and stored in {@linkcode Logger.record}. */
 export interface MessageObject {
+  /** Monotonically increasing id, unique per {@linkcode Logger} instance. */
   id: number;
+  /** `Date.now()` at the time the message was logged. */
   timestamp: number;
   level: string;
   prefix: string;
+  /** The fully formatted message text (after `util.format()` and secure-value redaction). */
   message: string;
 }
 

--- a/packages/logger/lib/types.ts
+++ b/packages/logger/lib/types.ts
@@ -9,7 +9,9 @@ export interface Logger extends EventEmitter {
   prefixStyle: StyleObject;
   headingStyle: StyleObject;
   heading: string;
-  stream: Writable | null; // Defaults to process.stderr; set to null when using custom output (e.g. Winston)
+  stream: Writable | null; // Output for levels below `stderrLevel`; defaults to process.stdout. Set to null when using custom output (e.g. Winston)
+  errorStream: Writable | null; // Output for levels at/above `stderrLevel`; defaults to process.stderr. Set to null when using custom output (e.g. Winston)
+  stderrLevel: string; // Minimum severity (inclusive) routed to `errorStream` instead of `stream`; defaults to 'error'
 
   /**
    * Creates a log message

--- a/packages/logger/test/unit/basic.spec.ts
+++ b/packages/logger/test/unit/basic.spec.ts
@@ -107,6 +107,7 @@ describe('basic', function () {
         end: () => {},
       }) as typeof s;
       log.stream = s as any;
+      log.errorStream = s as any;
       log.heading = 'npm';
     });
 
@@ -174,12 +175,12 @@ describe('basic', function () {
   describe('utils', function () {
     it('enableColor', function () {
       log.enableColor();
-      assert.ok((log as any)._format('x', {fg: 'red'}).includes('\u001b'));
+      assert.ok((log as any)._format(log.stream, 'x', {fg: 'red'}).includes('\u001b'));
     });
 
     it('disableColor', function () {
       log.disableColor();
-      assert.strictEqual((log as any)._format('x', {fg: 'red'}), 'x');
+      assert.strictEqual((log as any)._format(log.stream, 'x', {fg: 'red'}), 'x');
     });
 
     it('_buffer while paused', function () {
@@ -260,8 +261,7 @@ describe('basic', function () {
     });
 
     it('write with no stream', function () {
-      log.stream = null as any;
-      (log as any).write('message');
+      (log as any).write(null, 'message');
     });
   });
 
@@ -281,32 +281,31 @@ describe('basic', function () {
     });
 
     it('with nonexistent stream', function () {
-      log.stream = null as any;
-      assert.strictEqual((log as any)._format('message'), undefined);
+      assert.strictEqual((log as any)._format(null, 'message'), undefined);
     });
     it('fg', function () {
       log.enableColor();
-      const o = (log as any)._format('test message', {bg: 'blue'});
+      const o = (log as any)._format(log.stream, 'test message', {bg: 'blue'});
       assert.ok(o.includes('\u001b[44mtest message\u001b[0m'));
     });
     it('bg', function () {
       log.enableColor();
-      const o = (log as any)._format('test message', {bg: 'white'});
+      const o = (log as any)._format(log.stream, 'test message', {bg: 'white'});
       assert.ok(o.includes('\u001b[47mtest message\u001b[0m'));
     });
     it('bold', function () {
       log.enableColor();
-      const o = (log as any)._format('test message', {bold: true});
+      const o = (log as any)._format(log.stream, 'test message', {bold: true});
       assert.ok(o.includes('\u001b[1mtest message\u001b[0m'));
     });
     it('underline', function () {
       log.enableColor();
-      const o = (log as any)._format('test message', {underline: true});
+      const o = (log as any)._format(log.stream, 'test message', {underline: true});
       assert.ok(o.includes('\u001b[4mtest message\u001b[0m'));
     });
     it('inverse', function () {
       log.enableColor();
-      const o = (log as any)._format('test message', {inverse: true});
+      const o = (log as any)._format(log.stream, 'test message', {inverse: true});
       assert.ok(o.includes('\u001b[7mtest message\u001b[0m'));
     });
   });

--- a/packages/logger/test/unit/basic.spec.ts
+++ b/packages/logger/test/unit/basic.spec.ts
@@ -264,8 +264,8 @@ describe('basic', function () {
       (log as any).write(null, 'message');
     });
 
-    it('defaults stream to stdout, errorStream to stderr, and stderrLevel to error', function () {
-      assert.strictEqual(log.stream, process.stdout);
+    it('defaults stream and errorStream to stderr, and stderrLevel to error', function () {
+      assert.strictEqual(log.stream, process.stderr);
       assert.strictEqual(log.errorStream, process.stderr);
       assert.strictEqual(log.stderrLevel, 'error');
     });

--- a/packages/logger/test/unit/basic.spec.ts
+++ b/packages/logger/test/unit/basic.spec.ts
@@ -263,6 +263,85 @@ describe('basic', function () {
     it('write with no stream', function () {
       (log as any).write(null, 'message');
     });
+
+    it('defaults stream to stdout, errorStream to stderr, and stderrLevel to error', function () {
+      assert.strictEqual(log.stream, process.stdout);
+      assert.strictEqual(log.errorStream, process.stderr);
+      assert.strictEqual(log.stderrLevel, 'error');
+    });
+
+    describe('routing by severity', function () {
+      function createFakeStream() {
+        const chunks: string[] = [];
+        const stream = Object.assign(new Stream(), {
+          write: (m: string) => {
+            chunks.push(m);
+            return true;
+          },
+          writable: true,
+          isTTY: false,
+          end: () => {},
+        });
+        return {stream, chunks};
+      }
+
+      let out: ReturnType<typeof createFakeStream>;
+      let err: ReturnType<typeof createFakeStream>;
+
+      beforeEach(function () {
+        out = createFakeStream();
+        err = createFakeStream();
+        log.stream = out.stream as any;
+        log.errorStream = err.stream as any;
+        log.level = 'silly';
+      });
+
+      it('routes levels below stderrLevel to stream only', function () {
+        log.info('t', 'info message');
+        log.warn('t', 'warn message');
+        assert.deepStrictEqual(err.chunks, []);
+        assert.ok(out.chunks.join('').includes('info message'));
+        assert.ok(out.chunks.join('').includes('warn message'));
+      });
+
+      it('routes the error level to errorStream only', function () {
+        log.error('t', 'error message');
+        assert.deepStrictEqual(out.chunks, []);
+        assert.ok(err.chunks.join('').includes('error message'));
+      });
+
+      it('routes a custom level with a higher severity than error to errorStream', function () {
+        log.addLevel('fatal', 6000, {fg: 'red'}, 'FATAL');
+        (log as any).fatal('t', 'fatal message');
+        assert.deepStrictEqual(out.chunks, []);
+        assert.ok(err.chunks.join('').includes('fatal message'));
+      });
+
+      it('respects a reconfigured stderrLevel threshold', function () {
+        log.stderrLevel = 'warn';
+        log.info('t', 'info message');
+        log.warn('t', 'warn message');
+        assert.ok(out.chunks.join('').includes('info message'));
+        assert.ok(err.chunks.join('').includes('warn message'));
+        assert.ok(!out.chunks.join('').includes('warn message'));
+      });
+
+      it('drops error output when errorStream is null without affecting stream', function () {
+        log.errorStream = null;
+        log.info('t', 'info message');
+        log.error('t', 'error message');
+        assert.strictEqual(err.chunks.length, 0);
+        assert.ok(out.chunks.join('').includes('info message'));
+      });
+
+      it('drops non-error output when stream is null without affecting errorStream', function () {
+        log.stream = null;
+        log.info('t', 'info message');
+        log.error('t', 'error message');
+        assert.strictEqual(out.chunks.length, 0);
+        assert.ok(err.chunks.join('').includes('error message'));
+      });
+    });
   });
 
   describe('emitLog', function () {

--- a/packages/logger/test/unit/display.spec.ts
+++ b/packages/logger/test/unit/display.spec.ts
@@ -13,7 +13,7 @@ describe('display', function () {
     beforeEach(function () {
       actual = '';
       log = new Log();
-      (log as any).write = (msg: string) => {
+      (log as any).write = (_stream: unknown, msg: string) => {
         actual += msg;
       };
     });

--- a/packages/support/lib/console.ts
+++ b/packages/support/lib/console.ts
@@ -78,8 +78,8 @@ function isUnicodeSupported(): boolean {
 
 const UNICODE = isUnicodeSupported();
 
-/** Returns whether stderr should use ANSI color by default. */
-function stderrSupportsColor(stream: {isTTY?: boolean} = process.stderr): boolean {
+/** Returns whether the given stream should use ANSI color by default. */
+function streamSupportsColor(stream: {isTTY?: boolean}): boolean {
   const {env} = process;
   if (env.NO_COLOR !== undefined || env.NODE_DISABLE_COLORS !== undefined) {
     return false;
@@ -111,7 +111,7 @@ export interface ConsoleOpts {
   jsonMode?: boolean;
   /** If _falsy_, do not use fancy symbols. */
   useSymbols?: boolean;
-  /** If _falsy_, do not use color output. If _truthy_, forces color output. By default, checks `NO_COLOR`, `FORCE_COLOR`, `TERM`, and stderr TTY. Ignored if `useSymbols` is `false`. */
+  /** If _falsy_, do not use color output. If _truthy_, forces color output. By default, checks `NO_COLOR`, `FORCE_COLOR`, `TERM`, and stdout TTY. Ignored if `useSymbols` is `false`. */
   useColor?: boolean;
 }
 
@@ -133,8 +133,8 @@ class NullWritable extends Writable {
  * A particular console/logging class for Appium's CLI.
  *
  * - By default, uses some fancy symbols
- * - Writes to `STDERR`, generally.
- * - In "JSON mode", `STDERR` is squelched. Use {@linkcode CliConsole.json} to write the JSON.
+ * - Writes to `STDOUT`, except for {@linkcode CliConsole#error}, which writes to `STDERR`.
+ * - In "JSON mode", regular output is squelched. Use {@linkcode CliConsole.json} to write the JSON to `STDOUT`.
  *
  * DO NOT extend this to do anything other than what it already does. Download a library or something.
  */
@@ -147,14 +147,18 @@ export class CliConsole {
   };
 
   readonly #console: InstanceType<typeof NodeConsole>;
+  readonly #jsonConsole: InstanceType<typeof NodeConsole>;
   readonly #useSymbols: boolean;
   readonly #useColor: boolean;
 
   constructor(opts: ConsoleOpts = {}) {
     const {jsonMode = false, useSymbols = true, useColor} = opts;
-    this.#console = new NodeConsole(process.stdout, jsonMode ? new NullWritable() : process.stderr);
+    const nullStream = new NullWritable();
+    this.#console = new NodeConsole(jsonMode ? nullStream : process.stdout, jsonMode ? nullStream : process.stderr);
+    // json() must always reach real STDOUT, even in JSON mode where #console is squelched.
+    this.#jsonConsole = new NodeConsole(process.stdout, nullStream);
     this.#useSymbols = Boolean(useSymbols);
-    this.#useColor = Boolean(useColor ?? stderrSupportsColor(process.stderr));
+    this.#useColor = Boolean(useColor ?? streamSupportsColor(process.stdout));
   }
 
   /**
@@ -180,17 +184,17 @@ export class CliConsole {
    * You probably don't want to call this more than once before exiting (since that will output invalid JSON).
    */
   json(value: JsonValue): void {
-    this.#console.log(JSON.stringify(value));
+    this.#jsonConsole.log(JSON.stringify(value));
   }
 
-  /** General logging function. */
+  /** General logging function. Writes to `STDOUT`. */
   log(message?: string, ...args: unknown[]): void {
-    this.#console.error(message, ...args);
+    this.#console.log(message, ...args);
   }
 
   /** A "success" message */
   ok(message?: string, ...args: unknown[]): void {
-    this.#console.error(this.decorate(message, 'success'), ...args);
+    this.log(this.decorate(message, 'success'), ...args);
   }
 
   /** Alias for {@linkcode CliConsole.log} */
@@ -213,9 +217,9 @@ export class CliConsole {
     this.log(this.decorate(message, 'warning'), ...args);
   }
 
-  /** An "error" message */
+  /** An "error" message. Writes to `STDERR`. */
   error(message?: string, ...args: unknown[]): void {
-    this.log(this.decorate(message, 'error'), ...args);
+    this.#console.error(this.decorate(message, 'error'), ...args);
   }
 }
 

--- a/packages/support/lib/console.ts
+++ b/packages/support/lib/console.ts
@@ -146,19 +146,19 @@ export class CliConsole {
     error: 'red',
   };
 
-  readonly #console: InstanceType<typeof NodeConsole>;
-  readonly #jsonConsole: InstanceType<typeof NodeConsole>;
-  readonly #useSymbols: boolean;
-  readonly #useColor: boolean;
+  private readonly console: InstanceType<typeof NodeConsole>;
+  private readonly jsonConsole: InstanceType<typeof NodeConsole>;
+  private readonly useSymbols: boolean;
+  private readonly useColor: boolean;
 
   constructor(opts: ConsoleOpts = {}) {
     const {jsonMode = false, useSymbols = true, useColor} = opts;
     const nullStream = new NullWritable();
-    this.#console = new NodeConsole(jsonMode ? nullStream : process.stdout, jsonMode ? nullStream : process.stderr);
-    // json() must always reach real STDOUT, even in JSON mode where #console is squelched.
-    this.#jsonConsole = new NodeConsole(process.stdout, nullStream);
-    this.#useSymbols = Boolean(useSymbols);
-    this.#useColor = Boolean(useColor ?? streamSupportsColor(process.stdout));
+    this.console = new NodeConsole(jsonMode ? nullStream : process.stdout, jsonMode ? nullStream : process.stderr);
+    // json() must always reach real STDOUT, even in JSON mode where `console` is squelched.
+    this.jsonConsole = new NodeConsole(process.stdout, nullStream);
+    this.useSymbols = Boolean(useSymbols);
+    this.useColor = Boolean(useColor ?? streamSupportsColor(process.stdout));
   }
 
   /**
@@ -167,12 +167,12 @@ export class CliConsole {
    * Returns `undefined` if `msg` is `undefined`.
    */
   decorate(msg: string | undefined, symbol?: SymbolKey): string | undefined {
-    if (typeof msg !== 'string' || typeof symbol !== 'string' || !this.#useSymbols) {
+    if (typeof msg !== 'string' || typeof symbol !== 'string' || !this.useSymbols) {
       return msg;
     }
 
     let newMsg = `${logSymbols[symbol]} ${msg}`;
-    if (this.#useColor) {
+    if (this.useColor) {
       newMsg = styleText(CliConsole.symbolToColor[symbol], newMsg);
     }
     return newMsg;
@@ -184,12 +184,12 @@ export class CliConsole {
    * You probably don't want to call this more than once before exiting (since that will output invalid JSON).
    */
   json(value: JsonValue): void {
-    this.#jsonConsole.log(JSON.stringify(value));
+    this.jsonConsole.log(JSON.stringify(value));
   }
 
   /** General logging function. Writes to `STDOUT`. */
   log(message?: string, ...args: unknown[]): void {
-    this.#console.log(message, ...args);
+    this.console.log(message, ...args);
   }
 
   /** A "success" message */
@@ -204,7 +204,7 @@ export class CliConsole {
 
   /** Wraps {@link console.dir} */
   dump(item: unknown, opts?: InspectOptions): void {
-    this.#console.dir(item, opts);
+    this.console.dir(item, opts);
   }
 
   /** An "info" message */
@@ -219,7 +219,7 @@ export class CliConsole {
 
   /** An "error" message. Writes to `STDERR`. */
   error(message?: string, ...args: unknown[]): void {
-    this.#console.error(this.decorate(message, 'error'), ...args);
+    this.console.error(this.decorate(message, 'error'), ...args);
   }
 }
 

--- a/packages/support/test/unit/console.spec.ts
+++ b/packages/support/test/unit/console.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import {afterEach, describe, it} from 'node:test';
+import {afterEach, describe, it, type TestContext} from 'node:test';
 
 import * as consoleModule from '../../lib/console.js';
 
@@ -93,6 +93,73 @@ describe('console', function () {
         info: 'cyan',
         warning: 'yellow',
         error: 'red',
+      });
+    });
+
+    describe('stream routing', function () {
+      function captureWrites(t: TestContext) {
+        const stdout: string[] = [];
+        const stderr: string[] = [];
+        t.mock.method(process.stdout, 'write', (chunk: string) => {
+          stdout.push(String(chunk));
+          return true;
+        });
+        t.mock.method(process.stderr, 'write', (chunk: string) => {
+          stderr.push(String(chunk));
+          return true;
+        });
+        return {stdout, stderr};
+      }
+
+      it('writes log/ok/debug/info/warn to STDOUT only', function (t) {
+        const {stdout, stderr} = captureWrites(t);
+        const cli = new CliConsole({useSymbols: false});
+        cli.log('a');
+        cli.ok('b');
+        cli.debug('c');
+        cli.info('d');
+        cli.warn('e');
+        assert.deepStrictEqual(stderr, []);
+        assert.strictEqual(stdout.join(''), 'a\nb\nc\nd\ne\n');
+      });
+
+      it('writes error to STDERR only', function (t) {
+        const {stdout, stderr} = captureWrites(t);
+        const cli = new CliConsole({useSymbols: false});
+        cli.error('boom');
+        assert.deepStrictEqual(stdout, []);
+        assert.strictEqual(stderr.join(''), 'boom\n');
+      });
+
+      it('writes json() to STDOUT only', function (t) {
+        const {stdout, stderr} = captureWrites(t);
+        const cli = new CliConsole();
+        cli.json({a: 1});
+        assert.deepStrictEqual(stderr, []);
+        assert.strictEqual(stdout.join(''), `${JSON.stringify({a: 1})}\n`);
+      });
+
+      describe('in JSON mode', function () {
+        it('still writes json() to real STDOUT', function (t) {
+          const {stdout, stderr} = captureWrites(t);
+          const cli = new CliConsole({jsonMode: true});
+          cli.json({a: 1});
+          assert.deepStrictEqual(stderr, []);
+          assert.strictEqual(stdout.join(''), `${JSON.stringify({a: 1})}\n`);
+        });
+
+        it('squelches log/info/warn/ok/debug/error output', function (t) {
+          const {stdout, stderr} = captureWrites(t);
+          const cli = new CliConsole({jsonMode: true, useSymbols: false});
+          cli.log('a');
+          cli.info('b');
+          cli.warn('c');
+          cli.ok('d');
+          cli.debug('e');
+          cli.error('f');
+          assert.deepStrictEqual(stdout, []);
+          assert.deepStrictEqual(stderr, []);
+        });
       });
     });
   });


### PR DESCRIPTION
## Summary

Part of the Appium 4 logging cleanup tracked in #22051: "Change CLI logging to output non-error logs to stdout (currently everything goes to stderr)".

`CliConsole` (`@appium/support`'s `console`, used by `appium driver`/`plugin` install/list/update/etc., `appium doctor`, and other CLI-only output) wrote **every** message level — `log`, `ok`, `info`, `warn`, and `error` — to `STDERR`. Only `json()` output went to `STDOUT`.

This PR splits the two channels the way most CLI tools do:
- `log()`, `ok()`, `debug()`, `info()`, `warn()`, and `json()` → **STDOUT**
- `error()` → **STDERR**

`jsonMode` behavior is preserved: non-JSON output is still fully squelched, and `json()` is guaranteed to land on real `STDOUT` even in that mode (now via a dedicated internal stream instead of relying on the old accidental routing).

Color-support auto-detection (`useColor`) now defaults off of `stdout`'s TTY-ness instead of `stderr`'s, since stdout is now the primary output channel.

Note: the server's Winston-based log sink (`packages/appium/lib/logsink.ts`) already split `error` to stderr and everything else to stdout via `stderrLevels: ['error']`, so this PR only needed to touch the CLI console path.

BREAKING CHANGE: Any script or tool that consumes Appium CLI output (`driver`/`plugin` list/install/update, `doctor`, etc.) and relies on the previous stream layout will need to be updated. Previously, non-JSON human-readable output (info/success/warning messages) was written to `STDERR`, with `STDOUT` reserved almost exclusively for `--json` output. Now that output goes to `STDOUT`, and only actual errors go to `STDERR`.
BREAKING CHANGE: Scripts that discarded `STDOUT` (`1>/dev/null`) to suppress "chatter" while relying on `STDERR` for status text will now see that text on `STDOUT` instead.
BREAKING CHANGE: Scripts that captured `STDERR` to detect/log informational or success messages will no longer see them there — only genuine errors will appear on `STDERR`. `--json` output and error behavior are unaffected: `--json` continues to write clean JSON to `STDOUT` only, and errors continue to go to `STDERR`.
BREAKING CHANGE: **`@appium/logger`'s `Log` class changes its default output stream** from `STDERR` to `STDOUT` for all levels except `error`, and adds an `errorStream`/`stderrLevel` pair of properties. Any code that set `.stream` on a `Log` instance expecting it to capture *all* levels (including `error`) will now need to also set `.errorStream` to the same target.


