### PR TITLE
test(images-plugin): give the unit tests room to retry and finish on CI

### DIFF
--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "test": "npm run test:unit",
     "test:smoke": "node ./build/lib/index.js",
-    "test:unit": "node --test --experimental-test-module-mocks --enable-source-maps --test-timeout=5000 \"./build/test/unit/**/*.spec.js\"",
+    "test:unit": "node --test --experimental-test-module-mocks --enable-source-maps --test-timeout=10000 \"./build/test/unit/**/*.spec.js\"",
     "test:e2e": "node --test --enable-source-maps --test-force-exit --test-concurrency=1 --test-timeout=20000 \"./build/test/e2e/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/images-plugin/test/unit/finder.spec.ts
+++ b/packages/images-plugin/test/unit/finder.spec.ts
@@ -175,7 +175,9 @@ describe('finding elements by image', function () {
       assert.deepStrictEqual(await f.findByImage(template, d as any, {multiple: true}), []);
     });
     it('should respect implicit wait', async function () {
-      (d as any).setImplicitWait(10);
+      // the wait budget must exceed the 500ms poll interval, otherwise whether the retry happens
+      // at all depends on how quickly the first attempt returns
+      (d as any).setImplicitWait(2000);
       compareStub.resetHistory();
       compareStub.returns({rect, score});
       compareStub.onFirstCall().throws(new Error('Cannot find any occurrences'));


### PR DESCRIPTION
Two different `images-plugin` unit failures have been turning up on unrelated PRs. Neither reproduces locally, both only show up when the runner is loaded.

## The file timeout

From [this run](https://github.com/appium/appium/actions/runs/34032972209/job/101485847276):

```
not ok 3 - build/test/unit/plugin.spec.js
  duration_ms: 5001.258898
  failureType: 'testTimeoutFailure'
  error: 'test timed out after 5000ms'
# tests 78
# pass 77
# fail 0
```

Every assertion passed, TAP says `# fail 0`, and the job still exits 1. Node treats each file as a test of its own, so `--test-timeout=5000` applies to `plugin.spec.js` as a whole, and that file does real OpenCV work. It came in 1.2ms over the line.

`compareImages` already carries `{timeout: 6000}`, so someone hit this before, but a suite level override does not lift the file the suite lives in. The flag is the only lever, so this raises it to 10000, which is what `base-driver` and `fake-driver` already use.

## The implicit wait test

From [this run](https://github.com/appium/appium/actions/runs/34168034081/job/101882980711):

```
not ok 9 - should respect implicit wait
  location: '.../images-plugin/test/unit/finder.spec.ts:177:5'
  error: 'An element could not be located on the page using the given search parameters.'
  name: 'NoSuchElementError'
```

The test sets the implicit wait to 10ms, makes the first `compareImages` call throw, and expects the wait loop to retry and succeed. `implicitWaitForCondition` polls on a fixed interval:

```js
return await waitForCondition(wrappedCondFn, {
  waitMs: this.implicitWaitMs,
  intervalMs: 500,
  logger: this.log,
});
```

The budget is shorter than a single interval, so whether the retry happens at all comes down to how fast the first attempt returns. Locally that is about a millisecond, it fits inside 10ms, and the test passes. On the failing run the first attempt took 26ms, the budget was already spent, and `waitForCondition` gave up before the second call.

Raising the wait to 2000ms makes the retry part of the test instead of a race. It does not make the suite slower, since the passing path already slept the full 500ms interval to reach its retry.

## Tests

- [x] `npm run test:unit` in packages/images-plugin, 82 pass
- [x] `should respect implicit wait` still proves the retry (`compareStub.calledTwice`), 532ms
- [x] no production code touched
- [x] lint clean, the one warning in `lib/finder.ts` is pre-existing
