### PR TITLE
feat: backport diff from master

### DIFF
--- a/packages/appium/docs/en/blog/.authors.yml
+++ b/packages/appium/docs/en/blog/.authors.yml
@@ -17,3 +17,8 @@ authors:
     avatar: 'https://avatars.githubusercontent.com/u/4045041?v=4'
     slug: 'sai'
     url: 'https://saikrishna.tech'
+  mykola:
+    name: 'Mykola Mokhnach'
+    description: 'Appium Core Maintainer'
+    avatar: https://avatars.githubusercontent.com/u/7767781?v=4
+    slug: 'mykola'

--- a/packages/appium/docs/en/blog/posts/announcing-watchos-simulator-support.md
+++ b/packages/appium/docs/en/blog/posts/announcing-watchos-simulator-support.md
@@ -1,0 +1,38 @@
+---
+authors:
+  - mykola
+date: 2026-09-01
+---
+
+# Announcing watchOS Simulator Support in the XCUITest Driver
+
+We’re excited to announce that the XCUITest driver now supports automation of watchOS apps — a
+platform that’s been on Appium’s requested list for a long time.
+
+<!-- more -->
+
+In order to automate watchOS, you'll need the following:
+
+* XCUITest driver version 12.6.0 or later (WebDriverAgent 16.5.0 or later)
+* Xcode 15.4 or later
+* watchOS 10 or later
+
+Important to note: ^^the driver currently only works with simulators — real devices are not
+compatible.^^
+
+The good news: automating a watchOS app looks just like automating any other iOS/iPadOS app. The
+standard use-cases of finding and clicking on elements, retrieving the page source, using the
+Appium Inspector — all work as usual. The one exception here is standard W3C gesture/touch actions
+(tap/swipe via the Actions API), which are not supported.
+
+On top of that, a few watchOS-specific extensions are available:
+
+- `mobile: pressButton` — press the Digital Crown or Action button
+- `mobile: rotateDigitalCrown` — rotate the Digital Crown (since driver version 12.7.0)
+- `mobile: performHandGesture` — perform double-tap or wrist flick hand gestures (since driver
+  version 12.7.0)
+
+For full setup instructions, capabilities, and limitations, check out the
+[watchOS guide](https://appium.github.io/appium-xcuitest-driver/latest/guides/watchos/).
+
+Happy testing!

--- a/packages/appium/docs/ja/blog/.authors.yml
+++ b/packages/appium/docs/ja/blog/.authors.yml
@@ -17,3 +17,8 @@ authors:
     avatar: 'https://avatars.githubusercontent.com/u/4045041?v=4'
     slug: 'sai'
     url: 'https://saikrishna.tech'
+  mykola:
+    name: 'Mykola Mokhnach'
+    description: 'Appium Core Maintainer'
+    avatar: https://avatars.githubusercontent.com/u/7767781?v=4
+    slug: 'mykola'

--- a/packages/appium/docs/ja/blog/posts/announcing-watchos-simulator-support.md
+++ b/packages/appium/docs/ja/blog/posts/announcing-watchos-simulator-support.md
@@ -1,0 +1,38 @@
+---
+authors:
+  - mykola
+date: 2026-09-01
+---
+
+# Announcing watchOS Simulator Support in the XCUITest Driver
+
+We’re excited to announce that the XCUITest driver now supports automation of watchOS apps — a
+platform that’s been on Appium’s requested list for a long time.
+
+<!-- more -->
+
+In order to automate watchOS, you'll need the following:
+
+- XCUITest driver version 12.6.0 or later (WebDriverAgent 16.5.0 or later)
+- Xcode 15.4 or later
+- watchOS 10 or later
+
+Important to note: ^^the driver currently only works with simulators — real devices are not
+compatible.^^
+
+The good news: automating a watchOS app looks just like automating any other iOS/iPadOS app. The
+standard use-cases of finding and clicking on elements, retrieving the page source, using the
+Appium Inspector — all work as usual. The one exception here is standard W3C gesture/touch actions
+(tap/swipe via the Actions API), which are not supported.
+
+On top of that, a few watchOS-specific extensions are available:
+
+- `mobile: pressButton` — press the Digital Crown or Action button
+- `mobile: rotateDigitalCrown` — rotate the Digital Crown (since driver version 12.7.0)
+- `mobile: performHandGesture` — perform double-tap or wrist flick hand gestures (since driver
+  version 12.7.0)
+
+For full setup instructions, capabilities, and limitations, check out the
+[watchOS guide](https://appium.github.io/appium-xcuitest-driver/latest/guides/watchos/).
+
+Happy testing!

--- a/packages/appium/docs/zh/blog/.authors.yml
+++ b/packages/appium/docs/zh/blog/.authors.yml
@@ -17,3 +17,8 @@ authors:
     avatar: 'https://avatars.githubusercontent.com/u/4045041?v=4'
     slug: 'sai'
     url: 'https://saikrishna.tech'
+  mykola:
+    name: 'Mykola Mokhnach'
+    description: 'Appium Core Maintainer'
+    avatar: https://avatars.githubusercontent.com/u/7767781?v=4
+    slug: 'mykola'

--- a/packages/appium/docs/zh/blog/posts/announcing-watchos-simulator-support.md
+++ b/packages/appium/docs/zh/blog/posts/announcing-watchos-simulator-support.md
@@ -1,0 +1,38 @@
+---
+authors:
+  - mykola
+date: 2026-09-01
+---
+
+# Announcing watchOS Simulator Support in the XCUITest Driver
+
+We’re excited to announce that the XCUITest driver now supports automation of watchOS apps — a
+platform that’s been on Appium’s requested list for a long time.
+
+<!-- more -->
+
+In order to automate watchOS, you'll need the following:
+
+- XCUITest driver version 12.6.0 or later (WebDriverAgent 16.5.0 or later)
+- Xcode 15.4 or later
+- watchOS 10 or later
+
+Important to note: ^^the driver currently only works with simulators — real devices are not
+compatible.^^
+
+The good news: automating a watchOS app looks just like automating any other iOS/iPadOS app. The
+standard use-cases of finding and clicking on elements, retrieving the page source, using the
+Appium Inspector — all work as usual. The one exception here is standard W3C gesture/touch actions
+(tap/swipe via the Actions API), which are not supported.
+
+On top of that, a few watchOS-specific extensions are available:
+
+- `mobile: pressButton` — press the Digital Crown or Action button
+- `mobile: rotateDigitalCrown` — rotate the Digital Crown (since driver version 12.7.0)
+- `mobile: performHandGesture` — perform double-tap or wrist flick hand gestures (since driver
+  version 12.7.0)
+
+For full setup instructions, capabilities, and limitations, check out the
+[watchOS guide](https://appium.github.io/appium-xcuitest-driver/latest/guides/watchos/).
+
+Happy testing!

--- a/packages/appium/lib/insecure-features.ts
+++ b/packages/appium/lib/insecure-features.ts
@@ -48,6 +48,9 @@ export function configureGlobalFeatures(this: AppiumDriver) {
  * @param driverName
  */
 export function configureDriverFeatures(this: AppiumDriver, driver: ExternalDriver, driverName: string) {
+  // the docs tell users to scope a feature with the driver's automationName, which is also what
+  // the driver itself compares against in `isFeatureEnabled`
+  const automationName = this.driverConfig?.installedExtensions?.[driverName]?.automationName;
   if (this.relaxedSecurityEnabled) {
     this.log.info(
       `Enabling relaxed security for this session as per the server configuration. ` +
@@ -55,13 +58,13 @@ export function configureDriverFeatures(this: AppiumDriver, driver: ExternalDriv
     );
     driver.relaxedSecurityEnabled = true;
   }
-  const allowedDriverFeatures = filterInsecureFeatures(this.allowInsecure, driverName);
+  const allowedDriverFeatures = filterInsecureFeatures(this.allowInsecure, driverName, automationName);
   if (!util.isEmpty(allowedDriverFeatures)) {
     this.log.info('Explicitly enabling insecure features for this session ' + 'as per the server configuration:');
     allowedDriverFeatures.forEach((a) => this.log.info(`    ${a}`));
     driver.allowInsecure = allowedDriverFeatures;
   }
-  const deniedDriverFeatures = filterInsecureFeatures(this.denyInsecure, driverName);
+  const deniedDriverFeatures = filterInsecureFeatures(this.denyInsecure, driverName, automationName);
   if (util.isEmpty(deniedDriverFeatures)) {
     return;
   }
@@ -97,20 +100,29 @@ function validateFeatures(features: string[]): string[] {
 
 /**
  * Filters the list of insecure features to only those that are
- * applicable to the given driver name.
+ * applicable to the given driver.
  * Assumes that all feature names have already been validated
+ *
+ * The prefix may be the driver's install name or its automationName, which is the one the
+ * security guide documents. Both are compared case-insensitively, like the prefix check
+ * `isFeatureEnabled` does on the driver side.
  *
  * @param features
  * @param driverName
+ * @param automationName
  */
-function filterInsecureFeatures(features: string[], driverName: string = ALL_DRIVERS_MATCH): string[] {
+function filterInsecureFeatures(features: string[], driverName?: string, automationName?: string): string[] {
+  const acceptedPrefixes = new Set(
+    [ALL_DRIVERS_MATCH, driverName, automationName]
+      .filter((name): name is string => Boolean(name))
+      .map((name) => name.toLowerCase()),
+  );
   const filterFn = (fullName: string) => {
     const separatorPos = fullName.indexOf(FEATURE_NAME_SEPARATOR);
     if (separatorPos <= 0) {
       return false;
     }
-    const automationName = fullName.substring(0, separatorPos);
-    return [driverName, ALL_DRIVERS_MATCH].includes(automationName);
+    return acceptedPrefixes.has(fullName.substring(0, separatorPos).toLowerCase());
   };
   return features.filter(filterFn);
 }

--- a/packages/appium/lib/schema/cli-transformers.ts
+++ b/packages/appium/lib/schema/cli-transformers.ts
@@ -1,4 +1,4 @@
-import {existsSync, readFileSync} from 'node:fs';
+import {readFileSync, statSync} from 'node:fs';
 
 import {ArgumentTypeError} from 'argparse';
 
@@ -28,7 +28,7 @@ export const transformers = {
     let csv = csvOrPath;
     let loadedFromFile = false;
     // Value could be a single CSV token or a filepath; attempt file first.
-    if (existsSync(csvOrPath)) {
+    if (isRegularFile(csvOrPath)) {
       try {
         csv = readFileSync(csvOrPath, 'utf8');
       } catch (err) {
@@ -52,7 +52,7 @@ export const transformers = {
   json: (jsonOrPath: string): Record<string, any> => {
     let json = jsonOrPath;
     let loadedFromFile = false;
-    if (existsSync(jsonOrPath)) {
+    if (isRegularFile(jsonOrPath)) {
       try {
         // Intentionally sync: argparse type hooks are synchronous.
         json = readFileSync(jsonOrPath, 'utf8');
@@ -79,6 +79,21 @@ export interface AppiumJSONSchemaKeywords {
   appiumCliIgnored?: boolean;
   appiumCliTransformer?: AppiumCliTransformerName;
   appiumDeprecated?: boolean;
+}
+
+/**
+ * Whether `filepath` is an existing regular file.
+ *
+ * Directories are not files: `--allow-insecure adb_shell` names a feature, not the `./adb_shell`
+ * folder. Any other stat failure means "not a file" too, since these values are usually not paths
+ * at all (a long JSON blob fails with ENAMETOOLONG, not ENOENT).
+ */
+function isRegularFile(filepath: string): boolean {
+  try {
+    return statSync(filepath).isFile();
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/packages/appium/test/unit/appiumdriver.spec.ts
+++ b/packages/appium/test/unit/appiumdriver.spec.ts
@@ -343,7 +343,10 @@ describe('AppiumDriver', function () {
     describe('configureDriverFeatures', function () {
       let appium: InstanceType<typeof AppiumModule.AppiumDriver>;
 
-      async function getDriverInstance(appiumArgs: any): Promise<FakeDriver> {
+      async function getDriverInstance(
+        appiumArgs: any,
+        {driverName = 'fake', automationName = 'Fake'} = {},
+      ): Promise<FakeDriver> {
         appium = new AppiumDriver(appiumArgs);
         appium.configureGlobalFeatures();
         const fakeDriver = new FakeDriver();
@@ -354,10 +357,11 @@ describe('AppiumDriver', function () {
 
         // stub does not satisfy DriverConfig typing
         (appium as any).driverConfig = {
+          installedExtensions: {[driverName]: {automationName}},
           findMatchingDriver: sandbox.stub().returns({
             driver: mockedDriverReturnerClass,
             version: '1.2.3',
-            driverName: 'fake',
+            driverName,
           }),
         };
 
@@ -394,6 +398,25 @@ describe('AppiumDriver', function () {
       it(`should apply driver-scope insecure features only if the driver name matches`, async function () {
         fakeDriver = await getDriverInstance({allowInsecure: ['fake:foo', 'real:bar']});
         assert.deepStrictEqual(fakeDriver.allowInsecure, ['fake:foo']);
+      });
+
+      it(`should apply driver-scope features when the prefix is the automationName`, async function () {
+        // the docs tell users to prefix with the automationName, which does not have to be
+        // the name the driver is installed under
+        fakeDriver = await getDriverInstance(
+          {allowInsecure: ['MyAutomation:foo', 'real:bar']},
+          {driverName: 'my-driver', automationName: 'MyAutomation'},
+        );
+        assert.deepStrictEqual(fakeDriver.allowInsecure, ['MyAutomation:foo']);
+      });
+
+      it(`should match the feature prefix case-insensitively`, async function () {
+        fakeDriver = await getDriverInstance({
+          allowInsecure: ['FAKE:foo'],
+          denyInsecure: ['Fake:bar'],
+        });
+        assert.deepStrictEqual(fakeDriver.allowInsecure, ['FAKE:foo']);
+        assert.deepStrictEqual(fakeDriver.denyInsecure, ['Fake:bar']);
       });
     });
     describe('getAppiumSessions', function () {

--- a/packages/appium/test/unit/parser.spec.ts
+++ b/packages/appium/test/unit/parser.spec.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import {mkdirSync, mkdtempSync, rmSync} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import {describe, it, beforeEach, before, after} from 'node:test';
 
 import fakeDriverSchema from '@appium/fake-driver/build/lib/fake-driver-schema.js';
@@ -97,6 +100,13 @@ describe('parser', function () {
         assert.deepStrictEqual(args.defaultCapabilities, defaultCapabilities);
       });
 
+      it('should parse default capabilities which are longer than the max filename length', function () {
+        // a value this long fails stat() with ENAMETOOLONG instead of ENOENT on posix systems
+        const defaultCapabilities = {'appium:app': 'a'.repeat(300)};
+        const args = p.parseArgs(['--default-capabilities', JSON.stringify(defaultCapabilities)]);
+        assert.deepStrictEqual(args.defaultCapabilities, defaultCapabilities);
+      });
+
       it('should parse default capabilities correctly from a file', function () {
         const defaultCapabilities = {a: 'b'};
         const args = p.parseArgs(['--default-capabilities', CAPS_FIXTURE]);
@@ -143,6 +153,19 @@ describe('parser', function () {
         const parsed = p.parseArgs(['--allow-insecure', ALLOW_FIXTURE, '--deny-insecure', DENY_FIXTURE]);
         assert.deepStrictEqual(parsed.allowInsecure, ['*:feature1', '*:feature2', '*:feature3']);
         assert.deepStrictEqual(parsed.denyInsecure, ['*:nofeature1', '*:nofeature2', '*:nofeature3']);
+      });
+
+      it('should treat --allow-insecure as a feature name even if a directory with that name exists', function () {
+        const tmpDir = mkdtempSync(path.join(os.tmpdir(), 'appium-allow-insecure-'));
+        mkdirSync(path.join(tmpDir, 'adb_shell'));
+        const prevCwd = process.cwd();
+        try {
+          process.chdir(tmpDir);
+          assert.deepStrictEqual(p.parseArgs(['--allow-insecure', 'adb_shell']).allowInsecure, ['adb_shell']);
+        } finally {
+          process.chdir(prevCwd);
+          rmSync(tmpDir, {recursive: true, force: true});
+        }
       });
 
       it('should allow a string for --use-drivers', function () {

--- a/packages/appium/test/unit/schema/cli-transformers.spec.ts
+++ b/packages/appium/test/unit/schema/cli-transformers.spec.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {after, before, describe, it} from 'node:test';
+
+import {transformers} from '../../../lib/schema/cli-transformers';
+
+describe('cli-transformers', function () {
+  let tmpDir: string;
+  let prevCwd: string;
+
+  before(function () {
+    prevCwd = process.cwd();
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), 'appium-cli-transformers-'));
+    process.chdir(tmpDir);
+  });
+
+  after(function () {
+    process.chdir(prevCwd);
+    rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  describe('csv', function () {
+    it('should parse a comma-delimited string', function () {
+      assert.deepStrictEqual(transformers.csv('adb_shell,get_server_logs'), ['adb_shell', 'get_server_logs']);
+    });
+
+    it('should treat a directory as a literal value instead of reading it', function () {
+      mkdirSync(path.join(tmpDir, 'adb_shell'));
+      assert.deepStrictEqual(transformers.csv('adb_shell'), ['adb_shell']);
+    });
+
+    it('should still load a CSV file when the path is a regular file', function () {
+      const file = path.join(tmpDir, 'features.csv');
+      writeFileSync(file, 'adb_shell\nget_server_logs\n', 'utf8');
+      assert.deepStrictEqual(transformers.csv(file), ['adb_shell', 'get_server_logs']);
+    });
+  });
+
+  describe('json', function () {
+    it('should parse a JSON string', function () {
+      assert.deepStrictEqual(transformers.json('{"foo":1}'), {foo: 1});
+    });
+
+    it('should parse a JSON string longer than the max filename length', function () {
+      // a value this long fails stat() with ENAMETOOLONG instead of ENOENT on posix systems
+      const caps = {'appium:app': 'a'.repeat(300)};
+      assert.deepStrictEqual(transformers.json(JSON.stringify(caps)), caps);
+    });
+
+    it('should treat a directory as a literal value instead of reading it', function () {
+      mkdirSync(path.join(tmpDir, 'caps'));
+      assert.throws(() => transformers.json('caps'), /must be a valid JSON/i);
+    });
+
+    it('should still load a JSON file when the path is a regular file', function () {
+      const file = path.join(tmpDir, 'caps.json');
+      writeFileSync(file, '{"foo":1}', 'utf8');
+      assert.deepStrictEqual(transformers.json(file), {foo: 1});
+    });
+  });
+});

--- a/packages/appium/test/unit/schema/cli-transformers.spec.ts
+++ b/packages/appium/test/unit/schema/cli-transformers.spec.ts
@@ -4,7 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {after, before, describe, it} from 'node:test';
 
-import {transformers} from '../../../lib/schema/cli-transformers';
+import {transformers} from '../../../lib/schema/cli-transformers.js';
 
 describe('cli-transformers', function () {
   let tmpDir: string;

--- a/packages/base-driver/lib/basedriver/commands/timeout.ts
+++ b/packages/base-driver/lib/basedriver/commands/timeout.ts
@@ -184,7 +184,7 @@ export async function implicitWaitForCondition<C extends Constraints>(
 export function parseTimeoutArgument<C extends Constraints>(this: BaseDriver<C>, ms: number | string): number {
   const duration = parseInt(String(ms), 10);
   if (Number.isNaN(duration) || duration < MIN_TIMEOUT) {
-    throw new errors.UnknownError(`Invalid timeout value '${ms}'`);
+    throw new errors.InvalidArgumentError(`Invalid timeout value '${ms}'`);
   }
   return duration;
 }

--- a/packages/base-driver/test/unit/basedriver/commands/bidi.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/commands/bidi.spec.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import {beforeEach, describe, it} from 'node:test';
+
+import type {InitialOpts} from '@appium/types';
+
+import {BaseDriver} from '../../../../lib/index.js';
+
+describe('bidi commands -', function () {
+  let driver: BaseDriver<any, any, any, any, any, any>;
+
+  beforeEach(function () {
+    driver = new BaseDriver({} as InitialOpts);
+  });
+
+  describe('bidiUnsubscribe', function () {
+    it('should not throw when the event was never subscribed', async function () {
+      await driver.bidiUnsubscribe(['log.entryAdded'], ['']);
+      assert.deepStrictEqual(driver.bidiEventSubs, {});
+    });
+
+    it('should still unsubscribe a matching event when the list also has an unknown one', async function () {
+      await driver.bidiSubscribe(['log.entryAdded'], ['']);
+      await driver.bidiUnsubscribe(['log.entryAdded', 'browsingContext.domContentLoaded'], ['']);
+      assert.deepStrictEqual(driver.bidiEventSubs, {});
+    });
+  });
+});

--- a/packages/base-driver/test/unit/basedriver/commands/bidi.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/commands/bidi.spec.ts
@@ -6,7 +6,7 @@ import type {InitialOpts} from '@appium/types';
 import {BaseDriver} from '../../../../lib/index.js';
 
 describe('bidi commands -', function () {
-  let driver: BaseDriver<any, any, any, any, any, any>;
+  let driver: BaseDriver<any, any, any, any, any>;
 
   beforeEach(function () {
     driver = new BaseDriver({} as InitialOpts);

--- a/packages/base-driver/test/unit/basedriver/timeout.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/timeout.spec.ts
@@ -4,7 +4,7 @@ import {after, afterEach, before, beforeEach, describe, it} from 'node:test';
 import type {InitialOpts} from '@appium/types';
 import {createSandbox} from 'sinon';
 
-import {BaseDriver} from '../../../lib/index.js';
+import {BaseDriver, errors} from '../../../lib/index.js';
 
 describe('timeout', function () {
   let driver: BaseDriver<any, any, any, any, any>;
@@ -27,6 +27,10 @@ describe('timeout', function () {
 
   describe('timeouts', function () {
     describe('errors', function () {
+      it('should reject an invalid timeout with InvalidArgumentError', function () {
+        assert.throws(() => driver.parseTimeoutArgument('abc'), errors.InvalidArgumentError);
+        assert.throws(() => driver.parseTimeoutArgument(-1), errors.InvalidArgumentError);
+      });
       it('should throw an error if something random is sent', async function () {
         await assert.rejects(driver.timeouts('random timeout', 'howdy'));
       });

--- a/packages/images-plugin/package.json
+++ b/packages/images-plugin/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "test": "npm run test:unit",
     "test:smoke": "node ./build/lib/index.js",
-    "test:unit": "node --test --experimental-test-module-mocks --enable-source-maps --test-timeout=5000 \"./build/test/unit/**/*.spec.js\"",
+    "test:unit": "node --test --experimental-test-module-mocks --enable-source-maps --test-timeout=10000 \"./build/test/unit/**/*.spec.js\"",
     "test:e2e": "node --test --enable-source-maps --test-force-exit --test-concurrency=1 --test-timeout=20000 \"./build/test/e2e/**/*.spec.js\""
   },
   "dependencies": {

--- a/packages/images-plugin/test/unit/finder.spec.ts
+++ b/packages/images-plugin/test/unit/finder.spec.ts
@@ -175,7 +175,9 @@ describe('finding elements by image', function () {
       assert.deepStrictEqual(await f.findByImage(template, d as any, {multiple: true}), []);
     });
     it('should respect implicit wait', async function () {
-      (d as any).setImplicitWait(10);
+      // the wait budget must exceed the 500ms poll interval, otherwise whether the retry happens
+      // at all depends on how quickly the first attempt returns
+      (d as any).setImplicitWait(2000);
       compareStub.resetHistory();
       compareStub.returns({rect, score});
       compareStub.onFirstCall().throws(new Error('Cannot find any occurrences'));

--- a/packages/storage-plugin/lib/storage.ts
+++ b/packages/storage-plugin/lib/storage.ts
@@ -5,6 +5,7 @@ import type Stream from 'node:stream';
 
 import {fs, timing, util} from '@appium/support';
 import type {AppiumLogger} from '@appium/types';
+import {errors} from 'appium/driver.js';
 import AsyncLock from 'async-lock';
 import {asyncmap} from 'asyncbox';
 import type WebSocket from 'ws';
@@ -218,7 +219,7 @@ export class Storage {
   }
 }
 
-export class StorageArgumentError extends Error {}
+export class StorageArgumentError extends errors.InvalidArgumentError {}
 
 /**
  * Validates storage item options and returns the same object when valid.

--- a/packages/storage-plugin/test/unit/plugin.spec.ts
+++ b/packages/storage-plugin/test/unit/plugin.spec.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import type {AppiumServer} from '@appium/types';
+import type {Express, Request, Response} from 'express';
+
+import {StoragePlugin} from '../../lib/plugin.js';
+
+interface CapturedResponse {
+  status: number;
+  body: any;
+}
+
+/**
+ * Registers the plugin routes against a stub app and returns a function which invokes the
+ * handler bound to `routePath` with the given request body.
+ */
+async function routeCaller(routePath: string): Promise<(body: unknown) => Promise<CapturedResponse>> {
+  const routes: Record<string, (req: Request, res: Response) => Promise<void>> = {};
+  const register = (path: string, handler: (req: Request, res: Response) => Promise<void>) => {
+    routes[path] = handler;
+  };
+  const app = {post: register, get: register} as unknown as Express;
+  // the request under test is rejected before the websocket setup runs, so this stub is never used
+  await StoragePlugin.updateServer(app, {} as unknown as AppiumServer);
+  const handler = routes[routePath];
+  assert.ok(handler, `No handler was registered for ${routePath}`);
+
+  return async function callRoute(body: unknown): Promise<CapturedResponse> {
+    const captured: CapturedResponse = {status: 0, body: undefined};
+    const res = {
+      set: () => res,
+      status: (code: number) => {
+        captured.status = code;
+        return res;
+      },
+      send: (payload: any) => {
+        captured.body = payload;
+        return res;
+      },
+    } as unknown as Response;
+    await handler({body} as Request, res);
+    return captured;
+  };
+}
+
+describe('StoragePlugin routes', function () {
+  it('should reject an invalid add name as an invalid argument', async function () {
+    const callRoute = await routeCaller('/appium/storage/add');
+    const {status, body} = await callRoute({
+      name: 'foo/bar',
+      sha1: 'ccc963411b2621335657963322890305ebe96186',
+    });
+    assert.strictEqual(status, 400);
+    assert.strictEqual(body.value.error, 'invalid argument');
+  });
+});

--- a/packages/storage-plugin/test/unit/storage.spec.ts
+++ b/packages/storage-plugin/test/unit/storage.spec.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {after, afterEach, before, beforeEach, describe, it} from 'node:test';
 
 import {fs, logger, tempDir} from '@appium/support';
+import {errors, getResponseForW3CError} from 'appium/driver.js';
 
 import {Storage, StorageArgumentError, validateStorageItemName} from '../../lib/storage.js';
 
@@ -138,6 +139,18 @@ describe('storage', function () {
           return true;
         },
       );
+    });
+
+    it('should be reported as a W3C invalid argument', function () {
+      try {
+        validateStorageItemName('foo/bar');
+        assert.fail('expected validateStorageItemName to throw');
+      } catch (err) {
+        assert.ok(err instanceof errors.InvalidArgumentError);
+        const [status, body] = getResponseForW3CError(err);
+        assert.strictEqual(status, 400);
+        assert.strictEqual(body.value.error, 'invalid argument');
+      }
     });
   });
 

--- a/packages/strongbox/lib/index.ts
+++ b/packages/strongbox/lib/index.ts
@@ -223,6 +223,10 @@ export class Strongbox<Options extends StrongboxOpts = StrongboxOpts> implements
       encoding = encodingOrCtor;
       encodingOrCtor = this.defaultItemCtor;
     }
+    if (!slugify(name)) {
+      // the slug is the filename; an empty one would resolve to the container directory itself
+      throw new TypeError(`Item name '${name}' must contain at least one alphanumeric character`);
+    }
     const item = new (encodingOrCtor ?? (this.defaultItemCtor as ItemCtor<T>))(name, this, encoding);
     if (this.getLiveItem(item.id)) {
       throw new ReferenceError(`Item with id "${item.id}" already exists`);
@@ -388,7 +392,8 @@ export class Strongbox<Options extends StrongboxOpts = StrongboxOpts> implements
       throw e;
     }
     for await (const ent of dir) {
-      if (ent.isFile()) {
+      // a basename with no alphanumerics has no slug, so it cannot belong to an item
+      if (ent.isFile() && slugify(ent.name)) {
         yield ent.name;
       }
     }

--- a/packages/strongbox/test/unit/strongbox.spec.ts
+++ b/packages/strongbox/test/unit/strongbox.spec.ts
@@ -193,6 +193,17 @@ describe('Strongbox', function () {
           assert.strictEqual(item.encoding, 'base64');
         });
       });
+
+      describe('when the name has no alphanumeric characters', function () {
+        it('should reject instead of pointing the item at the container', async function () {
+          for (const name of ['---', '@#$', ' ', '']) {
+            await assert.rejects(box.createItem(name), {
+              name: 'TypeError',
+              message: `Item name '${name}' must contain at least one alphanumeric character`,
+            });
+          }
+        });
+      });
     });
 
     describe('clearAll()', function () {
@@ -281,6 +292,15 @@ describe('Strongbox', function () {
           ['zebra', 'alpha'],
         );
         assert.strictEqual(MockFs.opendir.calledWith(box.container), true);
+      });
+
+      it('should skip files whose name has no alphanumeric characters', async function () {
+        mockOpendir([dirent('good'), dirent('_')]);
+        const items = await box.listItems();
+        assert.deepStrictEqual(
+          items.map((i) => i.name),
+          ['good'],
+        );
       });
 
       it('should return an empty array when the container does not exist', async function () {


### PR DESCRIPTION
## Summary

Compared `appium4` against upstream `appium/appium` master (31 commits ahead) and cherry-picked the fixes that still apply and aren't already covered by appium4's refactors. Dependency bumps, lockfile regenerations, and docs-translation commits were left out as routine, branch-independent noise.

## Backported

- fix(base-driver): reject invalid timeout with `InvalidArgumentError` (#22679)
- fix(appium): do not treat a directory as a CLI argument file (#22709)
- fix(strongbox): reject item names that slugify to an empty path (#22717)
- fix(appium): match insecure feature prefixes by automationName, case-insensitively (#22710)
- fix(storage-plugin): map `StorageArgumentError` to `InvalidArgumentError` (#22734)
- test(images-plugin): give the flaky implicit-wait unit test room to retry (#22743)
- fix: add missing `.js` extension in a cherry-picked test import, required by appium4's NodeNext module resolution

## Not backported (already covered or inapplicable)

- fix(base-driver): skip unknown events in `session.unsubscribe` (#22671) — appium4's mixin-removal refactor already contains this fix
- test(base-driver): fix invalid import (#22729) — the bug it fixes (self-referencing package import) doesn't exist in appium4's version of the file
- 18 `chore(deps)`/lockfile-regeneration commits and 3 docs-translation commits — each branch manages these independently
