### PR TITLE
feat(docutils)!: set 'latest' as default canonical version

### DIFF
--- a/packages/docutils/base-mkdocs.yml
+++ b/packages/docutils/base-mkdocs.yml
@@ -35,6 +35,8 @@ markdown_extensions:
 plugins:
   git-revision-date-localized:
     type: timeago
+  mike:
+    canonical_version: 'latest'
   search: {}
 
 theme:


### PR DESCRIPTION
Applies #22641 for all sites built using docutils, not just the Appium documentation.

Reference: https://github.com/jimporter/mike#configuration

BREAKING CHANGE: new docs versions are now published with their canonical version set to 'latest'. This value can be changed in mkdocs.yml using the 'mike: canonical_version:' key. The previous behavior can be retained by setting the key value to null.