### PR TITLE
feat(types): check execute method params against the command signature

### DIFF
--- a/packages/appium/docs/en/developing/build-drivers.md
+++ b/packages/appium/docs/en/developing/build-drivers.md
@@ -714,6 +714,12 @@ A couple notes about this system:
    mode!
 1. The `executeMethod` helper will reject with an error if a script name doesn't match one of the
    script names defined as a command in `executeMethodMap`, or if there are missing parameters.
+1. If your driver is written in TypeScript, declare the map `as const satisfies
+   ExecuteMethodMap<MyDriver>` (with `ExecuteMethodMap` imported from `@appium/types`). The
+   compiler then checks that each `command` names a method of your driver, and that the
+   `required`/`optional` params are consistent with that method's signature: the method must not
+   require a parameter which is listed as `optional` (or not listed at all), and must accept all
+   of the listed parameters.
 
 One of the nice things about the Execute Method strategy is that methods implemented in this way
 will be available via the classic or BiDi interfaces (since they will result in the same Appium

--- a/packages/types/lib/command-maps.ts
+++ b/packages/types/lib/command-maps.ts
@@ -1,4 +1,4 @@
-import type {ConditionalPick, MultidimensionalReadonlyArray} from 'type-fest';
+import type {ConditionalPick, IsAny, IsNever, MultidimensionalReadonlyArray} from 'type-fest';
 
 import type {Driver, DriverCommand} from './driver.js';
 import type {Plugin, PluginCommand} from './plugin.js';
@@ -129,18 +129,145 @@ export interface BaseExecuteMethodDef {
 }
 
 /**
- * A definition of an execute method in a {@linkcode Driver}.
+ * The elements of `P` preceding its first optional or rest element, i.e. the parameters a method
+ * accepting `P` requires.
  */
-export interface DriverExecuteMethodDef<T extends Driver> extends BaseExecuteMethodDef {
-  command: keyof ConditionalPick<T, DriverCommand>;
-}
+type RequiredParams<P extends readonly unknown[]> = P extends readonly [infer H, ...infer T]
+  ? [H, ...RequiredParams<T>]
+  : [];
+
+/**
+ * Tuple of `string`s with the same length as `T`.
+ */
+type StringTupleLike<T extends readonly unknown[]> = {[K in keyof T]: string};
+
+/**
+ * Tuple of `any`s with the same length as `T`.
+ */
+type AnyTupleLike<T extends readonly unknown[]> = {[K in keyof T]: any};
+
+/**
+ * The shape of `params` declaring the given required and optional param names.
+ *
+ * Non-tuple (`string[]`) values are also accepted, since their length cannot be checked; this is
+ * the case for maps not declared `as const`.
+ */
+type ExecuteMethodParamsShape<R extends string[], O extends string[]> = (R extends []
+  ? {required?: readonly [] | string[]}
+  : {required: Readonly<R> | string[]}) &
+  (O extends [] ? {optional?: readonly [] | string[]} : {optional: Readonly<O> | string[]});
+
+/**
+ * Union of `params` shapes with exactly `R` required params and any number of optional params up
+ * to the length of `Budget`.
+ */
+type ExecuteMethodParamsWithRequired<R extends string[], Budget extends unknown[], O extends string[] = []> =
+  | ExecuteMethodParamsShape<R, O>
+  | (Budget extends [unknown, ...infer BudgetTail]
+      ? ExecuteMethodParamsWithRequired<R, BudgetTail, [...O, string]>
+      : never);
+
+/**
+ * Union of `params` shapes with at least `R` required params, where the total number of params
+ * does not exceed the length of `R` plus the length of `Budget`.
+ */
+type ExecuteMethodParamsWithin<R extends string[], Budget extends unknown[]> =
+  | ExecuteMethodParamsWithRequired<R, Budget>
+  | (Budget extends [unknown, ...infer BudgetTail] ? ExecuteMethodParamsWithin<[...R, string], BudgetTail> : never);
+
+/**
+ * The shape of `params` for a method with a rest parameter: at least `R` required params, and any
+ * number of further required and optional params.
+ */
+type ExecuteMethodParamsShapeWithRest<R extends string[]> = (R extends []
+  ? {required?: readonly string[]}
+  : {required: Readonly<[...R, ...string[]]> | string[]}) & {optional?: readonly string[]};
+
+/**
+ * Union of all `params` shapes whose `required`/`optional` param counts are compatible with a
+ * method accepting `P`: at runtime, the values of the `required` params are passed first (in
+ * order), followed by the values of the `optional` params (in order, `undefined` if not provided).
+ * So the method must accept at least as many required parameters as there are `required` params,
+ * must not require any of the `optional` ones, and must accept all of them.
+ */
+type ExecuteMethodParamsFor<P extends readonly unknown[]> = number extends Required<P>['length']
+  ? ExecuteMethodParamsShapeWithRest<StringTupleLike<RequiredParams<P>>>
+  : Required<P> extends readonly [...AnyTupleLike<RequiredParams<P>>, ...infer Optional]
+    ? ExecuteMethodParamsWithin<StringTupleLike<RequiredParams<P>>, Optional>
+    : never;
+
+/**
+ * The `params` property of an execute method definition for a method accepting `P`. It is
+ * mandatory if the method has required parameters, since omitting it means the method is invoked
+ * without any arguments.
+ */
+type ExecuteMethodParamsProp<P extends readonly unknown[]> =
+  RequiredParams<P> extends [] ? {params?: ExecuteMethodParamsFor<P>} : {params: ExecuteMethodParamsFor<P>};
+
+/**
+ * An execute method definition which cannot be cross-checked against a method signature.
+ */
+type LooseExecuteMethodDef = BaseExecuteMethodDef & {command: string};
+
+/**
+ * Parameters of a {@linkcode DriverCommand}.
+ */
+type DriverCommandParams<F> = F extends (...args: infer P) => any ? P : never;
+
+/**
+ * Parameters of a {@linkcode PluginCommand}, i.e. those following `next` and `driver`.
+ */
+type PluginCommandParams<F> = F extends (next: any, driver: any, ...args: infer P) => any ? P : never;
+
+/**
+ * Union of execute method definitions for the given command methods (`Commands`), one per
+ * command, whose `params` are cross-checked against the signature of the command they map to.
+ * See {@linkcode ExecuteMethodParamsFor}.
+ */
+type CheckedExecuteMethodDef<Commands, Kind extends 'driver' | 'plugin'> =
+  IsNever<Commands> extends true
+    ? LooseExecuteMethodDef
+    : IsNever<keyof Commands> extends true
+      ? LooseExecuteMethodDef
+      : {
+          [K in keyof Commands]: Omit<BaseExecuteMethodDef, 'params'> & {command: K} & ExecuteMethodParamsProp<
+              Kind extends 'driver' ? DriverCommandParams<Commands[K]> : PluginCommandParams<Commands[K]>
+            >;
+        }[keyof Commands];
+
+/**
+ * A definition of an execute method in a {@linkcode Driver}.
+ *
+ * The `command` must name a {@linkcode DriverCommand} of `T`, and the number of `required` and
+ * `optional` params must be compatible with that method's signature: the method must accept
+ * (at least) the `required` params, and must not require any of the `optional` ones.
+ *
+ * @example
+ * ```ts
+ * class MyDriver extends BaseDriver {
+ *   static executeMethodMap = {
+ *     'my: foo': {command: 'doFoo', params: {required: ['a', 'b'], optional: ['c']}},
+ *   } as const satisfies ExecuteMethodMap<MyDriver>;
+ *
+ *   // required params come first, in order, then optional params
+ *   async doFoo(a: string, b: string, c?: string) {}
+ *   // this would be an error, since `c` is optional in the map but required here:
+ *   // async doFoo(a: string, b: string, c: string) {}
+ * }
+ * ```
+ */
+export type DriverExecuteMethodDef<T extends Driver> =
+  IsAny<T> extends true ? LooseExecuteMethodDef : CheckedExecuteMethodDef<ConditionalPick<T, DriverCommand>, 'driver'>;
 
 /**
  * A definition of an execute method in a {@linkcode Plugin}.
+ *
+ * The `command` must name a {@linkcode PluginCommand} of `T`, and the number of `required` and
+ * `optional` params must be compatible with that method's signature (ignoring its leading `next`
+ * and `driver` parameters). See {@linkcode DriverExecuteMethodDef} for details.
  */
-export interface PluginExecuteMethodDef<T extends Plugin> extends BaseExecuteMethodDef {
-  command: keyof ConditionalPick<T, PluginCommand>;
-}
+export type PluginExecuteMethodDef<T extends Plugin> =
+  IsAny<T> extends true ? LooseExecuteMethodDef : CheckedExecuteMethodDef<ConditionalPick<T, PluginCommand>, 'plugin'>;
 
 /**
  * Definition of an execute method (which overloads the behavior of the `execute` command) in a {@linkcode Driver} or {@linkcode Plugin}.

--- a/packages/types/test-d/command-maps.test.ts
+++ b/packages/types/test-d/command-maps.test.ts
@@ -1,0 +1,116 @@
+import {expectAssignable, expectNotAssignable} from 'tsd';
+
+import type {
+  Driver,
+  DriverExecuteMethodDef,
+  ExecuteMethodMap,
+  ExternalDriver,
+  NextPluginCallback,
+  Plugin,
+  PluginExecuteMethodDef,
+} from '../lib/index.js';
+
+/**
+ * A driver with execute methods of various arities. Only the members relevant to the checks
+ * below are declared; the rest are stubbed via the intersection with `Driver`.
+ */
+type TestDriver = Driver & {
+  noArgs(): Promise<void>;
+  oneRequired(a: string): Promise<void>;
+  twoRequiredOneOptional(a: string, b: number, c?: boolean): Promise<void>;
+  allOptional(a?: string, b?: number): Promise<void>;
+  restArgs(a: string, ...rest: unknown[]): Promise<void>;
+  untyped(...args: any[]): Promise<void>;
+  notACommand: string;
+};
+
+type TestDef = DriverExecuteMethodDef<TestDriver>;
+
+// matching params
+expectAssignable<TestDef>({command: 'noArgs'} as const);
+expectAssignable<TestDef>({command: 'noArgs', params: {}} as const);
+expectAssignable<TestDef>({command: 'noArgs', params: {required: [], optional: []}} as const);
+expectAssignable<TestDef>({command: 'oneRequired', params: {required: ['a']}} as const);
+expectAssignable<TestDef>({
+  command: 'twoRequiredOneOptional',
+  params: {required: ['a', 'b'], optional: ['c']},
+} as const);
+// an optional method parameter may be mapped to a required param
+expectAssignable<TestDef>({command: 'twoRequiredOneOptional', params: {required: ['a', 'b', 'c']}} as const);
+// ...or omitted entirely
+expectAssignable<TestDef>({command: 'twoRequiredOneOptional', params: {required: ['a', 'b']}} as const);
+expectAssignable<TestDef>({command: 'allOptional'} as const);
+expectAssignable<TestDef>({command: 'allOptional', params: {optional: ['a', 'b']}} as const);
+expectAssignable<TestDef>({command: 'allOptional', params: {required: ['a'], optional: ['b']}} as const);
+expectAssignable<TestDef>({command: 'restArgs', params: {required: ['a', 'b', 'c'], optional: ['d', 'e']}} as const);
+expectAssignable<TestDef>({command: 'untyped', params: {optional: ['a', 'b', 'c', 'd']}} as const);
+expectAssignable<TestDef>({command: 'oneRequired', params: {required: ['a']}, deprecated: true, info: 'x'} as const);
+
+// too few required params
+expectNotAssignable<TestDef>({command: 'oneRequired'} as const);
+expectNotAssignable<TestDef>({command: 'oneRequired', params: {optional: ['a']}} as const);
+expectNotAssignable<TestDef>({
+  command: 'twoRequiredOneOptional',
+  params: {required: ['a'], optional: ['b', 'c']},
+} as const);
+// too many params
+expectNotAssignable<TestDef>({command: 'noArgs', params: {required: ['a']}} as const);
+expectNotAssignable<TestDef>({command: 'noArgs', params: {optional: ['a']}} as const);
+expectNotAssignable<TestDef>({command: 'oneRequired', params: {required: ['a', 'b']}} as const);
+expectNotAssignable<TestDef>({
+  command: 'twoRequiredOneOptional',
+  params: {required: ['a', 'b'], optional: ['c', 'd']},
+} as const);
+expectNotAssignable<TestDef>({command: 'allOptional', params: {optional: ['a', 'b', 'c']}} as const);
+// rest params still require the leading required ones
+expectNotAssignable<TestDef>({command: 'restArgs', params: {optional: ['a']}} as const);
+// unknown or non-command members
+expectNotAssignable<TestDef>({command: 'doesNotExist'} as const);
+expectNotAssignable<TestDef>({command: 'notACommand'} as const);
+
+// maps which are not declared `as const` cannot be checked, but are still accepted
+expectAssignable<TestDef>({command: 'oneRequired', params: {required: ['a', 'b']}});
+expectAssignable<TestDef>({command: 'noArgs', params: {optional: ['a']}});
+
+// whole maps
+expectAssignable<ExecuteMethodMap<TestDriver>>({
+  'test: noArgs': {command: 'noArgs'},
+  'test: twoRequiredOneOptional': {
+    command: 'twoRequiredOneOptional',
+    params: {required: ['a', 'b'], optional: ['c']},
+  },
+} as const);
+expectNotAssignable<ExecuteMethodMap<TestDriver>>({
+  'test: noArgs': {command: 'noArgs'},
+  'test: twoRequiredOneOptional': {
+    command: 'twoRequiredOneOptional',
+    params: {required: ['a'], optional: ['b', 'c']},
+  },
+} as const);
+
+// `any` drivers accept any command and params
+expectAssignable<ExecuteMethodMap<any>>({
+  'test: whatever': {command: 'whatever', params: {required: ['a'], optional: ['b']}},
+} as const);
+expectAssignable<DriverExecuteMethodDef<ExternalDriver>>({command: 'getPageSource'} as const);
+
+// plugins: `next` and `driver` are not counted
+type TestPlugin = Plugin & {
+  noArgs(next: NextPluginCallback, driver: ExternalDriver): Promise<void>;
+  oneRequiredOneOptional(next: NextPluginCallback, driver: ExternalDriver, a: string, b?: number): Promise<void>;
+};
+type TestPluginDef = PluginExecuteMethodDef<TestPlugin>;
+
+expectAssignable<TestPluginDef>({command: 'noArgs'} as const);
+expectAssignable<TestPluginDef>({
+  command: 'oneRequiredOneOptional',
+  params: {required: ['a'], optional: ['b']},
+} as const);
+expectAssignable<TestPluginDef>({command: 'oneRequiredOneOptional', params: {required: ['a', 'b']}} as const);
+expectNotAssignable<TestPluginDef>({command: 'noArgs', params: {required: ['a']}} as const);
+expectNotAssignable<TestPluginDef>({command: 'oneRequiredOneOptional', params: {optional: ['a', 'b']}} as const);
+expectNotAssignable<TestPluginDef>({command: 'oneRequiredOneOptional', params: {required: ['a', 'b', 'c']}} as const);
+expectNotAssignable<TestPluginDef>({command: 'handle'} as const);
+expectAssignable<ExecuteMethodMap<TestPlugin>>({
+  'test: one': {command: 'oneRequiredOneOptional', params: {required: ['a'], optional: ['b']}},
+} as const);


### PR DESCRIPTION
Closes #18455

## Proposed changes

`ExecuteMethodMap<T>` now checks `params` against the signature of the method named by `command`. With a map declared `as const satisfies ExecuteMethodMap<MyDriver>`, the compiler rejects:

- a method parameter that is required but listed as `optional` in the map (or not listed at all)
- more `required` + `optional` params than the method accepts

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://appium.io/docs/en/latest/contributing/)
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules