### PR TITLE
fix(base-driver): honor unquoted and RFC 5987 Content-Disposition filenames

### DIFF
--- a/packages/base-driver/lib/basedriver/helpers.ts
+++ b/packages/base-driver/lib/basedriver/helpers.ts
@@ -41,7 +41,10 @@ const APP_DOWNLOAD_TIMEOUT_MS = 120 * 1000;
 // RFC 5987: filename*=UTF-8''percent-encoded-name  (language tag is optional)
 const FILENAME_STAR_PATTERN = /(?:^|;)\s*filename\*\s*=\s*([^';\s]+)'[^']*'([^;]+)/i;
 const QUOTED_FILENAME_PATTERN = /(?:^|;)\s*filename\s*=\s*"((?:\\.|[^"\\])*)"/i;
+// unquoted token; stops at ';' so later parameters are not swallowed
 const UNQUOTED_FILENAME_PATTERN = /(?:^|;)\s*filename\s*=\s*([^;\s]+)/i;
+const SURROUNDING_QUOTES_PATTERN = /^["']|["']$/g;
+const ESCAPED_CHAR_PATTERN = /\\(.)/g;
 
 process.on('exit', () => {
   if (APPLICATIONS_CACHE.size === 0) {
@@ -498,7 +501,7 @@ export function filenameFromContentDisposition(header: string): string | undefin
   const encoded = FILENAME_STAR_PATTERN.exec(header);
   if (encoded?.[2]) {
     try {
-      const value = decodeURIComponent(encoded[2].trim().replace(/^["']|["']$/g, ''));
+      const value = decodeURIComponent(encoded[2].trim().replace(SURROUNDING_QUOTES_PATTERN, ''));
       if (value) {
         return value;
       }
@@ -511,7 +514,7 @@ export function filenameFromContentDisposition(header: string): string | undefin
   // token branch below, which would otherwise capture the quote characters themselves
   const quoted = QUOTED_FILENAME_PATTERN.exec(header);
   if (quoted) {
-    return quoted[1].replace(/\\(.)/g, '$1') || undefined;
+    return quoted[1].replace(ESCAPED_CHAR_PATTERN, '$1') || undefined;
   }
 
   const unquoted = UNQUOTED_FILENAME_PATTERN.exec(header);

--- a/packages/base-driver/lib/basedriver/helpers.ts
+++ b/packages/base-driver/lib/basedriver/helpers.ts
@@ -38,6 +38,10 @@ const APPLICATIONS_CACHE_GUARD = new AsyncLock();
 const SANITIZE_REPLACEMENT = '-';
 const DEFAULT_BASENAME = 'appium-app';
 const APP_DOWNLOAD_TIMEOUT_MS = 120 * 1000;
+// RFC 5987: filename*=UTF-8''percent-encoded-name  (language tag is optional)
+const FILENAME_STAR_PATTERN = /(?:^|;)\s*filename\*\s*=\s*([^';\s]+)'[^']*'([^;]+)/i;
+const QUOTED_FILENAME_PATTERN = /(?:^|;)\s*filename\s*=\s*"((?:\\.|[^"\\])*)"/i;
+const UNQUOTED_FILENAME_PATTERN = /(?:^|;)\s*filename\s*=\s*([^;\s]+)/i;
 
 process.on('exit', () => {
   if (APPLICATIONS_CACHE.size === 0) {
@@ -491,8 +495,7 @@ async function fetchApp(srcStream: Readable, dstPath: string): Promise<string> {
  * @internal
  */
 export function filenameFromContentDisposition(header: string): string | undefined {
-  // RFC 5987: filename*=UTF-8''percent-encoded-name  (language tag is optional)
-  const encoded = /(?:^|;)\s*filename\*\s*=\s*([^';\s]+)'[^']*'([^;]+)/i.exec(header);
+  const encoded = FILENAME_STAR_PATTERN.exec(header);
   if (encoded?.[2]) {
     try {
       const value = decodeURIComponent(encoded[2].trim().replace(/^["']|["']$/g, ''));
@@ -506,13 +509,12 @@ export function filenameFromContentDisposition(header: string): string | undefin
 
   // an empty quoted value is still the filename parameter, so it must not fall through to the
   // token branch below, which would otherwise capture the quote characters themselves
-  const quoted = /(?:^|;)\s*filename\s*=\s*"((?:\\.|[^"\\])*)"/i.exec(header);
+  const quoted = QUOTED_FILENAME_PATTERN.exec(header);
   if (quoted) {
     return quoted[1].replace(/\\(.)/g, '$1') || undefined;
   }
 
-  // unquoted token; stop at ';' so later parameters are not swallowed
-  const unquoted = /(?:^|;)\s*filename\s*=\s*([^;\s]+)/i.exec(header);
+  const unquoted = UNQUOTED_FILENAME_PATTERN.exec(header);
   if (unquoted?.[1]) {
     return unquoted[1];
   }

--- a/packages/base-driver/lib/basedriver/helpers.ts
+++ b/packages/base-driver/lib/basedriver/helpers.ts
@@ -485,6 +485,39 @@ async function fetchApp(srcStream: Readable, dstPath: string): Promise<string> {
   return dstPath;
 }
 
+/**
+ * Picks a download filename from a Content-Disposition header.
+ * Prefers RFC 5987 `filename*` over `filename`, and accepts both quoted and unquoted `filename`.
+ * @internal
+ */
+export function filenameFromContentDisposition(header: string): string | undefined {
+  // RFC 5987: filename*=UTF-8''percent-encoded-name  (language tag is optional)
+  const encoded = /(?:^|;)\s*filename\*\s*=\s*([^';\s]+)'[^']*'([^;]+)/i.exec(header);
+  if (encoded?.[2]) {
+    try {
+      const value = decodeURIComponent(encoded[2].trim().replace(/^["']|["']$/g, ''));
+      if (value) {
+        return value;
+      }
+    } catch {
+      // invalid percent-encoding; fall through to filename=
+    }
+  }
+
+  // an empty quoted value is still the filename parameter, so it must not fall through to the
+  // token branch below, which would otherwise capture the quote characters themselves
+  const quoted = /(?:^|;)\s*filename\s*=\s*"((?:\\.|[^"\\])*)"/i.exec(header);
+  if (quoted) {
+    return quoted[1].replace(/\\(.)/g, '$1') || undefined;
+  }
+
+  // unquoted token; stop at ';' so later parameters are not swallowed
+  const unquoted = /(?:^|;)\s*filename\s*=\s*([^;\s]+)/i.exec(header);
+  if (unquoted?.[1]) {
+    return unquoted[1];
+  }
+}
+
 function determineFilename(
   headers: AxiosResponseHeaders | RawAxiosRequestHeaders,
   pathname: string,
@@ -496,9 +529,9 @@ function determineFilename(
   const extname = path.extname(basename);
   if (headers['content-disposition'] && /^attachment/i.test(String(headers['content-disposition']))) {
     logger.debug(`Content-Disposition: ${headers['content-disposition']}`);
-    const match = /filename="([^"]+)/i.exec(String(headers['content-disposition']));
-    if (match) {
-      return fs.sanitizeName(match[1], {replacement: SANITIZE_REPLACEMENT});
+    const fromHeader = filenameFromContentDisposition(String(headers['content-disposition']));
+    if (fromHeader) {
+      return fs.sanitizeName(fromHeader, {replacement: SANITIZE_REPLACEMENT});
     }
   }
 

--- a/packages/base-driver/test/e2e/basedriver/helpers.e2e.spec.ts
+++ b/packages/base-driver/test/e2e/basedriver/helpers.e2e.spec.ts
@@ -66,7 +66,9 @@ describe('app download and configuration', function () {
           const serve = serveStatic(FIXTURE_ROOT, {
             index: false,
             setHeaders: (res, filePath) => {
-              res.setHeader('Content-Disposition', contentDisposition(filePath));
+              if (!res.getHeader('Content-Disposition')) {
+                res.setHeader('Content-Disposition', contentDisposition(filePath));
+              }
             },
           });
 
@@ -76,12 +78,14 @@ describe('app download and configuration', function () {
               res.end();
               return;
             }
-            // for testing zip file content types
-            const contentType = new URLSearchParams(new URL(req.url ?? '', 'http://localhost').search).get(
-              'content-type',
-            );
+            const params = new URLSearchParams(new URL(req.url ?? '', 'http://localhost').search);
+            const contentType = params.get('content-type');
             if (contentType !== null) {
               res.setHeader('content-type', contentType);
+            }
+            const disposition = params.get('disposition');
+            if (disposition !== null) {
+              res.setHeader('Content-Disposition', disposition);
             }
             serve(req, res, finalhandler(req, res));
           });
@@ -127,6 +131,20 @@ describe('app download and configuration', function () {
         it('should download an apk file', async function () {
           const newAppPath = await configureApp(`${serverUrl}/FakeAndroidApp.apk`, '.apk');
           assert.ok(newAppPath.includes('.apk'));
+          const contents = await fs.readFile(newAppPath, 'utf8');
+          assert.strictEqual(contents, 'this is not really an apk\n');
+        });
+        it('should use an unquoted Content-Disposition filename', async function () {
+          const disposition = encodeURIComponent('attachment; filename=from-header.apk');
+          const newAppPath = await configureApp(`${serverUrl}/FakeAndroidApp.apk?disposition=${disposition}`, '.apk');
+          assert.ok(newAppPath.includes('from-header.apk'));
+          const contents = await fs.readFile(newAppPath, 'utf8');
+          assert.strictEqual(contents, 'this is not really an apk\n');
+        });
+        it('should use an RFC 5987 filename* parameter', async function () {
+          const disposition = encodeURIComponent(`attachment; filename*=UTF-8''from-star.apk`);
+          const newAppPath = await configureApp(`${serverUrl}/FakeAndroidApp.apk?disposition=${disposition}`, '.apk');
+          assert.ok(newAppPath.includes('from-star.apk'));
           const contents = await fs.readFile(newAppPath, 'utf8');
           assert.strictEqual(contents, 'this is not really an apk\n');
         });

--- a/packages/base-driver/test/unit/basedriver/helpers.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/helpers.spec.ts
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import {describe, it} from 'node:test';
 
-import {duplicateKeys, isPackageOrBundle, parseCapsArray} from '../../../lib/basedriver/helpers';
+import {
+  duplicateKeys,
+  filenameFromContentDisposition,
+  isPackageOrBundle,
+  parseCapsArray,
+} from '../../../lib/basedriver/helpers';
 
 describe('helpers', function () {
   describe('#isPackageOrBundle', function () {
@@ -116,5 +121,64 @@ describe('parseCapsArray', function () {
   });
   it('should fail if an invalid JSON array is provided', function () {
     assert.throws(() => parseCapsArray(`['*']`));
+  });
+});
+
+describe('filenameFromContentDisposition', function () {
+  it('should read a quoted filename', function () {
+    assert.strictEqual(
+      filenameFromContentDisposition('attachment; filename="quoted-app.apk"'),
+      'quoted-app.apk',
+    );
+  });
+
+  it('should read an unquoted filename', function () {
+    assert.strictEqual(
+      filenameFromContentDisposition('attachment; filename=unquoted-app.apk'),
+      'unquoted-app.apk',
+    );
+  });
+
+  it('should prefer RFC 5987 filename* over filename', function () {
+    assert.strictEqual(
+      filenameFromContentDisposition(
+        `attachment; filename="wrong.apk"; filename*=UTF-8''from-star.apk`,
+      ),
+      'from-star.apk',
+    );
+  });
+
+  it('should decode a percent-encoded filename*', function () {
+    assert.strictEqual(
+      filenameFromContentDisposition(`attachment; filename*=UTF-8''My%20App.apk`),
+      'My App.apk',
+    );
+  });
+
+  it('should not let an unquoted token swallow later parameters', function () {
+    assert.strictEqual(
+      filenameFromContentDisposition('attachment; filename=app.apk; size=42'),
+      'app.apk',
+    );
+  });
+
+  it('should keep a quoted filename containing a semicolon', function () {
+    assert.strictEqual(filenameFromContentDisposition('attachment; filename="a;b.apk"'), 'a;b.apk');
+  });
+
+  it('should ignore a parameter which merely ends with filename', function () {
+    assert.strictEqual(filenameFromContentDisposition('attachment; x-filename=sneaky.apk'), undefined);
+  });
+
+  it('should return undefined for an empty quoted filename', function () {
+    assert.strictEqual(filenameFromContentDisposition('attachment; filename=""'), undefined);
+  });
+
+  it('should return undefined when filename* is not decodable', function () {
+    assert.strictEqual(filenameFromContentDisposition(`attachment; filename*=UTF-8''%E0%A4%A`), undefined);
+  });
+
+  it('should return undefined when the header has no filename', function () {
+    assert.strictEqual(filenameFromContentDisposition('attachment'), undefined);
   });
 });

--- a/packages/base-driver/test/unit/basedriver/helpers.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/helpers.spec.ts
@@ -126,40 +126,26 @@ describe('parseCapsArray', function () {
 
 describe('filenameFromContentDisposition', function () {
   it('should read a quoted filename', function () {
-    assert.strictEqual(
-      filenameFromContentDisposition('attachment; filename="quoted-app.apk"'),
-      'quoted-app.apk',
-    );
+    assert.strictEqual(filenameFromContentDisposition('attachment; filename="quoted-app.apk"'), 'quoted-app.apk');
   });
 
   it('should read an unquoted filename', function () {
-    assert.strictEqual(
-      filenameFromContentDisposition('attachment; filename=unquoted-app.apk'),
-      'unquoted-app.apk',
-    );
+    assert.strictEqual(filenameFromContentDisposition('attachment; filename=unquoted-app.apk'), 'unquoted-app.apk');
   });
 
   it('should prefer RFC 5987 filename* over filename', function () {
     assert.strictEqual(
-      filenameFromContentDisposition(
-        `attachment; filename="wrong.apk"; filename*=UTF-8''from-star.apk`,
-      ),
+      filenameFromContentDisposition(`attachment; filename="wrong.apk"; filename*=UTF-8''from-star.apk`),
       'from-star.apk',
     );
   });
 
   it('should decode a percent-encoded filename*', function () {
-    assert.strictEqual(
-      filenameFromContentDisposition(`attachment; filename*=UTF-8''My%20App.apk`),
-      'My App.apk',
-    );
+    assert.strictEqual(filenameFromContentDisposition(`attachment; filename*=UTF-8''My%20App.apk`), 'My App.apk');
   });
 
   it('should not let an unquoted token swallow later parameters', function () {
-    assert.strictEqual(
-      filenameFromContentDisposition('attachment; filename=app.apk; size=42'),
-      'app.apk',
-    );
+    assert.strictEqual(filenameFromContentDisposition('attachment; filename=app.apk; size=42'), 'app.apk');
   });
 
   it('should keep a quoted filename containing a semicolon', function () {


### PR DESCRIPTION
`configureApp` only matched `filename="..."` with quotes. A lot of CDNs send `attachment; filename=app.apk` or `filename*=UTF-8''app.apk`, so those fell through to the URL basename and you could get the wrong name or a defaulted `.apk` / `.ipa`.

This prefers RFC 5987 `filename*`, then a quoted `filename`, then an unquoted token. Empty `filename=""` is treated as missing so we keep the URL fallback instead of capturing the quote characters.

A name taken from the header still skips the URL-path extension defaulting. That was already true for quoted filenames; it now also applies when the name was unquoted. So `filename=app.bin` with a driver that wants `.apk` fails `verifyAppExtension` instead of being renamed.
