### PR TITLE
feat!: Change the default log level to `info`

### DIFF
--- a/packages/appium/docs/en/reference/cli/server.md
+++ b/packages/appium/docs/en/reference/cli/server.md
@@ -43,7 +43,7 @@ appium
 |`--local-timezone`|Use local timezone for log timestamps|boolean|`false`|
 |`--log`, `-g`|Path to a file where the server logs should be output. This does not affect output on the console.|string||
 |`--log-filters`|List of log filtering rules. See the [log filtering guide](../../guides/log-filters.md) for details.|array||
-|`--log-level`|The log level for the server logs. Supported values are `debug`, `info`, `warn`, or `error`. Combining two supported values using a colon (e.g. `warn:debug`) allows to set separate log levels for the console and file outputs, respectively.|string|`debug`|
+|`--log-level`|The log level for the server logs. Supported values are `debug`, `info`, `warn`, or `error`. Combining two supported values using a colon (e.g. `warn:debug`) allows to set separate log levels for the console and file outputs, respectively.|string|`info`|
 |`--log-format`|The log format of the server logs. Supported values are `text`, `json`, or `pretty_json`. Setting the value to `json` disables colors.|string|`text`|
 |`--log-no-colors`|Disable colors in the server log|boolean|`false`|
 |`--log-timestamp`|Show timestamps in the server log|boolean|`false`|

--- a/packages/appium/lib/logsink.ts
+++ b/packages/appium/lib/logsink.ts
@@ -204,7 +204,7 @@ async function createTransports(args: ParsedArgs): Promise<Transport[]> {
 
   // Server args are normalized in main so we only see dest form (`loglevel`).
   // Fall back to schema default so Winston never sees undefined.
-  const rawLogLevel = args.loglevel ?? 'debug';
+  const rawLogLevel = args.loglevel ?? 'info';
 
   if (rawLogLevel && rawLogLevel.includes(':')) {
     // --log-level arg can optionally provide diff logging levels for console and file, separated by a colon

--- a/packages/appium/test/fixtures/default-args.ts
+++ b/packages/appium/test/fixtures/default-args.ts
@@ -11,7 +11,7 @@ export default {
   requestTimeout: 3600,
   localTimezone: false,
   logFormat: 'text',
-  loglevel: 'debug',
+  loglevel: 'info',
   logNoColors: false,
   logTimestamp: false,
   longStacktrace: false,

--- a/packages/appium/test/fixtures/flattened-schema.ts
+++ b/packages/appium/test/fixtures/flattened-schema.ts
@@ -244,7 +244,7 @@ export default [
   {
     argSpec: {
       arg: 'log-level',
-      defaultValue: 'debug',
+      defaultValue: 'info',
       dest: 'loglevel',
       extName: undefined,
       extType: undefined,
@@ -254,7 +254,7 @@ export default [
     },
     schema: {
       appiumCliDest: 'loglevel',
-      default: 'debug',
+      default: 'info',
       description: 'Log level (console[:file])',
       enum: [
         'info',

--- a/packages/schema/lib/appium-config-schema.ts
+++ b/packages/schema/lib/appium-config-schema.ts
@@ -155,7 +155,7 @@ export const AppiumConfigJsonSchema = {
         },
         'log-level': {
           appiumCliDest: 'loglevel',
-          default: 'debug',
+          default: 'info',
           description: 'Log level (console[:file])',
           enum: [
             'info',

--- a/packages/schema/lib/appium-config.schema.json
+++ b/packages/schema/lib/appium-config.schema.json
@@ -153,7 +153,7 @@
         },
         "log-level": {
           "appiumCliDest": "loglevel",
-          "default": "debug",
+          "default": "info",
           "description": "Log level (console[:file])",
           "enum": [
             "info",


### PR DESCRIPTION
### Summary

Changes the default `--log-level` from `debug` to `info`. Debug-level logging is very verbose and mostly useful only for troubleshooting; `info` is a more sensible default for everyday server operation.

### Changes

- `packages/appium/lib/logsink.ts`: fallback log level (used when `args.loglevel` is undefined) changed from `'debug'` to `'info'`.
- `packages/schema/lib/appium-config-schema.ts` / `appium-config.schema.json`: schema default for `log-level` updated to `'info'`.
- `packages/appium/docs/en/reference/cli/server.md`: documented default updated to match.
- Test fixtures (`default-args.ts`, `flattened-schema.ts`) updated to reflect the new default.

BREAKING CHANGE: users relying on the implicit `debug` default for console/file logs will now see `info`-level output unless they explicitly pass `--log-level debug`.
