### PR TITLE
fix: Address several TODOs

### DIFF
--- a/packages/appium/lib/appium.ts
+++ b/packages/appium/lib/appium.ts
@@ -62,6 +62,14 @@ const desiredCapabilityConstraints = {
 export type AppiumDriverConstraints = typeof desiredCapabilityConstraints;
 export type W3CAppiumDriverCaps = W3CDriverCaps<AppiumDriverConstraints>;
 
+/**
+ * {@link DriverCaps} with `webSocketUrl` widened to `string`: the client sends it as a boolean,
+ * but the inner driver's response carries the resolved BiDi URL as a string.
+ */
+type DriverCapsWithBidiUrl = Omit<DriverCaps<AppiumDriverConstraints>, 'webSocketUrl'> & {
+  webSocketUrl?: string | boolean;
+};
+
 /** Result shape for umbrella {@link AppiumDriver.createSession} / {@link AppiumDriver.deleteSession}. */
 interface SessionHandlerResult<V = unknown> {
   value?: V;
@@ -69,15 +77,13 @@ interface SessionHandlerResult<V = unknown> {
   protocol?: string;
 }
 
-type SessionHandlerCreateResult = SessionHandlerResult<
-  [string, DriverCaps<AppiumDriverConstraints>, string | undefined]
->;
+type SessionHandlerCreateResult = SessionHandlerResult<[string, DriverCapsWithBidiUrl, string | undefined]>;
 
 type SessionHandlerDeleteResult = SessionHandlerResult<void>;
 
 /** @internal Not part of {@link ExternalDriver}; used only when wiring session IPC. */
 type IpcAssignable = {
-  assignIpc?: (ipc: IAppiumIpc) => Promise<void>;
+  assignIpc: (ipc: IAppiumIpc) => Promise<void>;
 };
 
 /**
@@ -285,7 +291,7 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
 
     const protocol = PROTOCOLS.W3C;
     let innerSessionId: string;
-    let dCaps: DriverCaps<AppiumDriverConstraints> & {webSocketUrl?: string | boolean};
+    let dCaps: DriverCapsWithBidiUrl;
     try {
       // Parse the caps into a format that the InnerDriver will accept
       const parsedCaps = parseCapsForInnerDriver<AppiumDriverConstraints>(
@@ -339,7 +345,7 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
 
       [innerSessionId, dCaps] = (await driverInstance.createSession(processedW3CCapabilities as never)) as [
         string,
-        DriverCaps<AppiumDriverConstraints> & {webSocketUrl?: string | boolean},
+        DriverCapsWithBidiUrl,
       ];
       this.sessions[innerSessionId] = driverInstance;
       // create an IPC channel for the driver and all plugins on this session
@@ -349,10 +355,7 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
         log: driverInstance.log,
       });
       const extDriver = driverInstance as unknown as IpcAssignable;
-      if (typeof extDriver.assignIpc === 'function') {
-        // TODO remove this existence guard as a breaking change in Appium 3
-        await extDriver.assignIpc(this.sessionIpcs[innerSessionId]);
-      }
+      await extDriver.assignIpc(this.sessionIpcs[innerSessionId]);
 
       this.attachUnexpectedShutdownHandler(driverInstance, innerSessionId);
 
@@ -384,9 +387,6 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
           `Upstream driver responded with webSocketUrl ${dCaps.webSocketUrl}, will rewrite to ` +
             `${bidiUrl} for response to client`,
         );
-        // @ts-ignore webSocketUrl gets sent by the client as a boolean, but then it is supposed
-        // to come back from the server as a string. TODO figure out how to express this in our
-        // capability constraint system
         dCaps.webSocketUrl = bidiUrl;
       }
     } catch (error: unknown) {
@@ -705,10 +705,7 @@ export class AppiumDriver extends DriverCore<AppiumDriverConstraints> {
         }
         // we also want to assign the IPC channel for this session to the plugins
         const extPlugin = p as unknown as IpcAssignable;
-        if (typeof extPlugin.assignIpc === 'function') {
-          // TODO remove this existence guard as a breaking change in Appium 4
-          await extPlugin.assignIpc(this.sessionIpcs[newSessionId]);
-        }
+        await extPlugin.assignIpc(this.sessionIpcs[newSessionId]);
       }
       this.sessionlessPlugins = [];
     }

--- a/packages/appium/test/e2e/driver.e2e.spec.ts
+++ b/packages/appium/test/e2e/driver.e2e.spec.ts
@@ -785,8 +785,7 @@ describe('Bidi over SSL', function () {
   });
 });
 
-// TODO this test only works if the log has not previously been initialized in the same process.
-describe.skip('Logsink', function () {
+describe('Logsink', function () {
   let server: Awaited<ReturnType<typeof appiumServer>> | null = null;
   const logs: [string, string][] = [];
   const logHandler = function (level: string, message: string) {

--- a/packages/appium/test/unit/parser.spec.ts
+++ b/packages/appium/test/unit/parser.spec.ts
@@ -89,10 +89,7 @@ describe('parser', function () {
         });
 
         it('should throw an error for an invalid value (using "enum")', function () {
-          throwsUncolored(
-            () => p.parseArgs(['--log-level', '-42']),
-            /must be equal to one of the allowed values/i,
-          );
+          throwsUncolored(() => p.parseArgs(['--log-level', '-42']), /must be equal to one of the allowed values/i);
         });
 
         it('should throw an error for incorrectly formatted arg (matching "dest")', function () {

--- a/packages/appium/test/unit/parser.spec.ts
+++ b/packages/appium/test/unit/parser.spec.ts
@@ -10,6 +10,7 @@ import {readConfigFile} from '../../lib/bootstrap/config-file.js';
 import {ArgParser, getParser} from '../../lib/cli/parser.js';
 import {DRIVER_TYPE, PLUGIN_TYPE, SETUP_SUBCOMMAND} from '../../lib/constants.js';
 import {INSTALL_TYPES} from '../../lib/extension/manifest/index.js';
+import {stripColorCodes} from '../../lib/logsink.js';
 import * as schema from '../../lib/schema/schema.js';
 import {resolveFixture} from '../helpers.js';
 
@@ -59,8 +60,18 @@ describe('parser', function () {
         }
       });
 
-      // TODO: figure out how best to suppress color in error message
       describe('invalid arguments', function () {
+        /** Schema validation errors are colorized when stdout is a TTY; strip that before matching. */
+        function throwsUncolored(fn: () => unknown, regex: RegExp) {
+          assert.throws(() => {
+            try {
+              fn();
+            } catch (e) {
+              throw new Error(stripColorCodes((e as Error).message), {cause: e});
+            }
+          }, regex);
+        }
+
         it('should throw an error with unknown argument', function () {
           assert.throws(() => {
             p.parseArgs(['--apple']);
@@ -70,21 +81,18 @@ describe('parser', function () {
         // FIXME: this test will not work until we restore the formatting restriction to the address validation
         // see #18716
         it.skip('should throw an error for an invalid value ("hostname")', function () {
-          assert.throws(() => {
-            p.parseArgs(['--address', '-42']);
-          }, /must match format "hostname"/i);
+          throwsUncolored(() => p.parseArgs(['--address', '-42']), /must match format "hostname"/i);
         });
 
         it('should throw an error for an invalid value ("uri")', function () {
-          assert.throws(() => {
-            p.parseArgs(['--webhook', 'blub']);
-          }, /must match format "uri"/i);
+          throwsUncolored(() => p.parseArgs(['--webhook', 'blub']), /must match format "uri"/i);
         });
 
         it('should throw an error for an invalid value (using "enum")', function () {
-          assert.throws(() => {
-            p.parseArgs(['--log-level', '-42']);
-          }, /must be equal to one of the allowed values/i);
+          throwsUncolored(
+            () => p.parseArgs(['--log-level', '-42']),
+            /must be equal to one of the allowed values/i,
+          );
         });
 
         it('should throw an error for incorrectly formatted arg (matching "dest")', function () {

--- a/packages/base-driver/test/unit/basedriver/capability.spec.ts
+++ b/packages/base-driver/test/unit/basedriver/capability.spec.ts
@@ -8,8 +8,6 @@ import {createSandbox} from 'sinon';
 import {validator} from '../../../lib/basedriver/validation.js';
 import {BaseDriver, errors} from '../../../lib/index.js';
 
-// TODO: we need module-level mocks for the logger
-
 /** W3C caps for createSession (tests use partial/invalid caps) */
 type TestW3CCaps = W3CCapabilities<Constraints>;
 

--- a/packages/base-driver/test/unit/protocol/routes.spec.ts
+++ b/packages/base-driver/test/unit/protocol/routes.spec.ts
@@ -1,47 +1,23 @@
 import assert from 'node:assert/strict';
-import crypto from 'node:crypto';
-import {describe, it} from 'node:test';
+import {describe, it, snapshot} from 'node:test';
+import type {TestContext} from 'node:test';
 
 import type {HTTPMethod} from '@appium/types';
 
 import {METHOD_MAP, routeToCommandName} from '../../../lib/protocol/index.js';
 
+// Tests run against the compiled build/test/**/*.js; keep the checked-in snapshot next to the
+// TS source instead, so it's reviewable alongside the route change that produced it.
+snapshot.setResolveSnapshotPath(
+  (testFilePath) => `${testFilePath?.replace('/build/test/', '/test/').replace(/\.js$/, '.ts')}.snapshot`,
+);
+
 describe('Routes', function () {
   describe('ensure protocol consistency', function () {
-    // TODO test against an explicit protocol rather than a hash of a previous
-    // protocol
-    it('should not change protocol between patch versions', function () {
-      const shasum = crypto.createHash('sha1');
-      for (const [url, urlMapping] of Object.entries(METHOD_MAP)) {
-        shasum.update(url);
-        for (const [method, methodMapping] of Object.entries(
-          urlMapping as Record<
-            string,
-            {command?: string; payloadParams?: {required?: any[]; optional?: any[]; wrap?: string}}
-          >,
-        )) {
-          shasum.update(method);
-          if (methodMapping.command) {
-            shasum.update(methodMapping.command);
-          }
-          if (methodMapping.payloadParams) {
-            let allParams = (methodMapping.payloadParams.required ?? []).flat();
-            if (methodMapping.payloadParams.optional) {
-              allParams = allParams.concat((methodMapping.payloadParams.optional ?? []).flat());
-            }
-            for (const param of allParams) {
-              shasum.update(String(param));
-            }
-            if (methodMapping.payloadParams.wrap) {
-              shasum.update('skip');
-              shasum.update(methodMapping.payloadParams.wrap);
-            }
-          }
-        }
-      }
-      const hash = shasum.digest('hex').substring(0, 8);
-      // Update this value again only when an intentional route/command/param change is made.
-      assert.strictEqual(hash, '21fb0683');
+    it('should not change protocol between patch versions', function (t: TestContext) {
+      // Update the snapshot (`--test-update-snapshots`) only when an intentional
+      // route/command/param change is made; review the diff before committing it.
+      t.assert.snapshot(METHOD_MAP);
     });
   });
 

--- a/packages/base-driver/test/unit/protocol/routes.spec.ts.snapshot
+++ b/packages/base-driver/test/unit/protocol/routes.spec.ts.snapshot
@@ -1,0 +1,955 @@
+exports[`Routes > ensure protocol consistency > should not change protocol between patch versions 1`] = `
+{
+  "/session": {
+    "POST": {
+      "command": "createSession",
+      "payloadParams": {
+        "optional": [
+          "capabilities"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId": {
+    "DELETE": {
+      "command": "deleteSession"
+    }
+  },
+  "/status": {
+    "GET": {
+      "command": "getStatus"
+    }
+  },
+  "/session/:sessionId/timeouts": {
+    "GET": {
+      "command": "getTimeouts"
+    },
+    "POST": {
+      "command": "timeouts",
+      "payloadParams": {
+        "optional": [
+          "type",
+          "ms",
+          "script",
+          "pageLoad",
+          "implicit"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/url": {
+    "GET": {
+      "command": "getUrl"
+    },
+    "POST": {
+      "command": "setUrl",
+      "payloadParams": {
+        "required": [
+          "url"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/forward": {
+    "POST": {
+      "command": "forward"
+    }
+  },
+  "/session/:sessionId/back": {
+    "POST": {
+      "command": "back"
+    }
+  },
+  "/session/:sessionId/refresh": {
+    "POST": {
+      "command": "refresh"
+    }
+  },
+  "/session/:sessionId/title": {
+    "GET": {
+      "command": "title"
+    }
+  },
+  "/session/:sessionId/window": {
+    "GET": {
+      "command": "getWindowHandle"
+    },
+    "POST": {
+      "command": "setWindow",
+      "payloadParams": {
+        "required": [
+          "handle"
+        ]
+      }
+    },
+    "DELETE": {
+      "command": "closeWindow"
+    }
+  },
+  "/session/:sessionId/window/handles": {
+    "GET": {
+      "command": "getWindowHandles"
+    }
+  },
+  "/session/:sessionId/window/new": {
+    "POST": {
+      "command": "createNewWindow",
+      "payloadParams": {
+        "optional": [
+          "type"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/frame": {
+    "POST": {
+      "command": "setFrame",
+      "payloadParams": {
+        "required": [
+          "id"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/frame/parent": {
+    "POST": {
+      "command": "switchToParentFrame"
+    }
+  },
+  "/session/:sessionId/window/rect": {
+    "GET": {
+      "command": "getWindowRect"
+    },
+    "POST": {
+      "command": "setWindowRect",
+      "payloadParams": {
+        "optional": [
+          "x",
+          "y",
+          "width",
+          "height"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/window/maximize": {
+    "POST": {
+      "command": "maximizeWindow"
+    }
+  },
+  "/session/:sessionId/window/minimize": {
+    "POST": {
+      "command": "minimizeWindow"
+    }
+  },
+  "/session/:sessionId/window/fullscreen": {
+    "POST": {
+      "command": "fullScreenWindow"
+    }
+  },
+  "/session/:sessionId/element/active": {
+    "GET": {
+      "command": "active"
+    }
+  },
+  "/session/:sessionId/element/:elementId/shadow": {
+    "GET": {
+      "command": "elementShadowRoot"
+    }
+  },
+  "/session/:sessionId/element": {
+    "POST": {
+      "command": "findElement",
+      "payloadParams": {
+        "required": [
+          "using",
+          "value"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/elements": {
+    "POST": {
+      "command": "findElements",
+      "payloadParams": {
+        "required": [
+          "using",
+          "value"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/element/:elementId/element": {
+    "POST": {
+      "command": "findElementFromElement",
+      "payloadParams": {
+        "required": [
+          "using",
+          "value"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/element/:elementId/elements": {
+    "POST": {
+      "command": "findElementsFromElement",
+      "payloadParams": {
+        "required": [
+          "using",
+          "value"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/shadow/:shadowId/element": {
+    "POST": {
+      "command": "findElementFromShadowRoot",
+      "payloadParams": {
+        "required": [
+          "using",
+          "value"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/shadow/:shadowId/elements": {
+    "POST": {
+      "command": "findElementsFromShadowRoot",
+      "payloadParams": {
+        "required": [
+          "using",
+          "value"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/element/:elementId/selected": {
+    "GET": {
+      "command": "elementSelected"
+    }
+  },
+  "/session/:sessionId/element/:elementId/displayed": {
+    "GET": {
+      "command": "elementDisplayed"
+    }
+  },
+  "/session/:sessionId/element/:elementId/attribute/:name": {
+    "GET": {
+      "command": "getAttribute"
+    }
+  },
+  "/session/:sessionId/element/:elementId/property/:name": {
+    "GET": {
+      "command": "getProperty"
+    }
+  },
+  "/session/:sessionId/element/:elementId/css/:propertyName": {
+    "GET": {
+      "command": "getCssProperty"
+    }
+  },
+  "/session/:sessionId/element/:elementId/text": {
+    "GET": {
+      "command": "getText"
+    }
+  },
+  "/session/:sessionId/element/:elementId/name": {
+    "GET": {
+      "command": "getName"
+    }
+  },
+  "/session/:sessionId/element/:elementId/rect": {
+    "GET": {
+      "command": "getElementRect"
+    }
+  },
+  "/session/:sessionId/element/:elementId/enabled": {
+    "GET": {
+      "command": "elementEnabled"
+    }
+  },
+  "/session/:sessionId/element/:elementId/computedrole": {
+    "GET": {
+      "command": "getComputedRole"
+    }
+  },
+  "/session/:sessionId/element/:elementId/computedlabel": {
+    "GET": {
+      "command": "getComputedLabel"
+    }
+  },
+  "/session/:sessionId/element/:elementId/click": {
+    "POST": {
+      "command": "click"
+    }
+  },
+  "/session/:sessionId/element/:elementId/clear": {
+    "POST": {
+      "command": "clear"
+    }
+  },
+  "/session/:sessionId/element/:elementId/value": {
+    "POST": {
+      "command": "setValue",
+      "payloadParams": {
+        "required": [
+          "text"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/source": {
+    "GET": {
+      "command": "getPageSource"
+    }
+  },
+  "/session/:sessionId/execute/sync": {
+    "POST": {
+      "command": "execute",
+      "payloadParams": {
+        "required": [
+          "script",
+          "args"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/execute/async": {
+    "POST": {
+      "command": "executeAsync",
+      "payloadParams": {
+        "required": [
+          "script",
+          "args"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/cookie": {
+    "GET": {
+      "command": "getCookies"
+    },
+    "POST": {
+      "command": "setCookie",
+      "payloadParams": {
+        "required": [
+          "cookie"
+        ]
+      }
+    },
+    "DELETE": {
+      "command": "deleteCookies"
+    }
+  },
+  "/session/:sessionId/cookie/:name": {
+    "GET": {
+      "command": "getCookie"
+    },
+    "DELETE": {
+      "command": "deleteCookie"
+    }
+  },
+  "/session/:sessionId/actions": {
+    "POST": {
+      "command": "performActions",
+      "payloadParams": {
+        "required": [
+          "actions"
+        ]
+      }
+    },
+    "DELETE": {
+      "command": "releaseActions"
+    }
+  },
+  "/session/:sessionId/alert/dismiss": {
+    "POST": {
+      "command": "postDismissAlert"
+    }
+  },
+  "/session/:sessionId/alert/accept": {
+    "POST": {
+      "command": "postAcceptAlert"
+    }
+  },
+  "/session/:sessionId/alert/text": {
+    "GET": {
+      "command": "getAlertText"
+    },
+    "POST": {
+      "command": "setAlertText",
+      "payloadParams": {
+        "required": [
+          "text"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/screenshot": {
+    "GET": {
+      "command": "getScreenshot"
+    }
+  },
+  "/session/:sessionId/element/:elementId/screenshot": {
+    "GET": {
+      "command": "getElementScreenshot"
+    }
+  },
+  "/session/:sessionId/print": {
+    "POST": {
+      "command": "printPage",
+      "payloadParams": {
+        "optional": [
+          "orientation",
+          "scale",
+          "background",
+          "page",
+          "margin",
+          "shrinkToFit",
+          "pageRanges"
+        ]
+      }
+    }
+  },
+  "/appium/sessions": {
+    "GET": {
+      "command": "getAppiumSessions"
+    }
+  },
+  "/session/:sessionId/appium/context": {
+    "GET": {
+      "command": "getCurrentContext"
+    },
+    "POST": {
+      "command": "setContext",
+      "payloadParams": {
+        "required": [
+          "name"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/contexts": {
+    "GET": {
+      "command": "getContexts"
+    }
+  },
+  "/session/:sessionId/appium/capabilities": {
+    "GET": {
+      "command": "getAppiumSessionCapabilities"
+    }
+  },
+  "/session/:sessionId/appium/settings": {
+    "POST": {
+      "command": "updateSettings",
+      "payloadParams": {
+        "required": [
+          "settings"
+        ]
+      }
+    },
+    "GET": {
+      "command": "getSettings"
+    }
+  },
+  "/session/:sessionId/appium/commands": {
+    "GET": {
+      "command": "listCommands"
+    }
+  },
+  "/session/:sessionId/appium/extensions": {
+    "GET": {
+      "command": "listExtensions"
+    }
+  },
+  "/session/:sessionId/appium/events": {
+    "POST": {
+      "command": "getLogEvents",
+      "payloadParams": {
+        "optional": [
+          "type"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/log_event": {
+    "POST": {
+      "command": "logCustomEvent",
+      "payloadParams": {
+        "required": [
+          "vendor",
+          "event"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/rotation": {
+    "GET": {
+      "command": "getRotation"
+    },
+    "POST": {
+      "command": "setRotation",
+      "payloadParams": {
+        "required": [
+          "x",
+          "y",
+          "z"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/orientation": {
+    "GET": {
+      "command": "getOrientation"
+    },
+    "POST": {
+      "command": "setOrientation",
+      "payloadParams": {
+        "required": [
+          "orientation"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/system_time": {
+    "GET": {
+      "command": "getDeviceTime"
+    },
+    "POST": {
+      "command": "getDeviceTime",
+      "payloadParams": {
+        "optional": [
+          "format"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/activate_app": {
+    "POST": {
+      "command": "activateApp",
+      "payloadParams": {
+        "required": [
+          [
+            "appId"
+          ],
+          [
+            "bundleId"
+          ]
+        ],
+        "optional": [
+          "options"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/terminate_app": {
+    "POST": {
+      "command": "terminateApp",
+      "payloadParams": {
+        "required": [
+          [
+            "appId"
+          ],
+          [
+            "bundleId"
+          ]
+        ],
+        "optional": [
+          "options"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/app_state": {
+    "POST": {
+      "command": "queryAppState",
+      "payloadParams": {
+        "required": [
+          [
+            "appId"
+          ],
+          [
+            "bundleId"
+          ]
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/install_app": {
+    "POST": {
+      "command": "installApp",
+      "payloadParams": {
+        "required": [
+          "appPath"
+        ],
+        "optional": [
+          "options"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/remove_app": {
+    "POST": {
+      "command": "removeApp",
+      "payloadParams": {
+        "required": [
+          [
+            "appId"
+          ],
+          [
+            "bundleId"
+          ]
+        ],
+        "optional": [
+          "options"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/app_installed": {
+    "POST": {
+      "command": "isAppInstalled",
+      "payloadParams": {
+        "required": [
+          [
+            "appId"
+          ],
+          [
+            "bundleId"
+          ]
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/hide_keyboard": {
+    "POST": {
+      "command": "hideKeyboard",
+      "payloadParams": {
+        "optional": [
+          "strategy",
+          "key",
+          "keyCode",
+          "keyName"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/is_keyboard_shown": {
+    "GET": {
+      "command": "isKeyboardShown"
+    }
+  },
+  "/session/:sessionId/appium/device/push_file": {
+    "POST": {
+      "command": "pushFile",
+      "payloadParams": {
+        "required": [
+          "path",
+          "data"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/pull_file": {
+    "POST": {
+      "command": "pullFile",
+      "payloadParams": {
+        "required": [
+          "path"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/appium/device/pull_folder": {
+    "POST": {
+      "command": "pullFolder",
+      "payloadParams": {
+        "required": [
+          "path"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/permissions": {
+    "POST": {
+      "command": "setPermissions",
+      "payloadParams": {
+        "required": [
+          "descriptor",
+          "state"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/deviceposture": {
+    "POST": {
+      "command": "setDevicePosture",
+      "payloadParams": {
+        "required": [
+          "posture"
+        ]
+      }
+    },
+    "DELETE": {
+      "command": "clearDevicePosture"
+    }
+  },
+  "/session/:sessionId/sensor": {
+    "POST": {
+      "command": "createVirtualSensor",
+      "payloadParams": {
+        "required": [
+          "type"
+        ],
+        "optional": [
+          "connected",
+          "maxSamplingFrequency",
+          "minSamplingFrequency"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/sensor/:sensorType": {
+    "GET": {
+      "command": "getVirtualSensorInfo"
+    },
+    "POST": {
+      "command": "updateVirtualSensorReading",
+      "payloadParams": {
+        "required": [
+          "reading"
+        ]
+      }
+    },
+    "DELETE": {
+      "command": "deleteVirtualSensor"
+    }
+  },
+  "/session/:sessionId/webauthn/authenticator": {
+    "POST": {
+      "command": "addVirtualAuthenticator",
+      "payloadParams": {
+        "required": [
+          "protocol",
+          "transport"
+        ],
+        "optional": [
+          "hasResidentKey",
+          "hasUserVerification",
+          "isUserConsenting",
+          "isUserVerified"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId": {
+    "DELETE": {
+      "command": "removeVirtualAuthenticator"
+    }
+  },
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId/credential": {
+    "POST": {
+      "command": "addAuthCredential",
+      "payloadParams": {
+        "required": [
+          "credentialId",
+          "isResidentCredential",
+          "rpId",
+          "privateKey"
+        ],
+        "optional": [
+          "userHandle",
+          "signCount"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId/credentials": {
+    "GET": {
+      "command": "getAuthCredential"
+    },
+    "DELETE": {
+      "command": "removeAllAuthCredentials"
+    }
+  },
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId/credentials/:credentialId": {
+    "DELETE": {
+      "command": "removeAuthCredential"
+    }
+  },
+  "/session/:sessionId/webauthn/authenticator/:authenticatorId/uv": {
+    "POST": {
+      "command": "setUserAuthVerified",
+      "payloadParams": {
+        "required": [
+          "isUserVerified"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/secure-payment-confirmation/set-mode": {
+    "POST": {
+      "command": "setSPCTransactionMode",
+      "payloadParams": {
+        "required": [
+          "mode"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/fedcm/canceldialog": {
+    "POST": {
+      "command": "fedCMCancelDialog"
+    }
+  },
+  "/session/:sessionId/fedcm/selectaccount": {
+    "POST": {
+      "command": "fedCMSelectAccount",
+      "payloadParams": {
+        "required": [
+          "accountIndex"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/fedcm/clickdialogbutton": {
+    "POST": {
+      "command": "fedCMClickDialogButton",
+      "payloadParams": {
+        "required": [
+          "dialogButton"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/fedcm/accountlist": {
+    "GET": {
+      "command": "fedCMGetAccounts"
+    }
+  },
+  "/session/:sessionId/fedcm/gettitle": {
+    "GET": {
+      "command": "fedCMGetTitle"
+    }
+  },
+  "/session/:sessionId/fedcm/getdialogtype": {
+    "GET": {
+      "command": "fedCMGetDialogType"
+    }
+  },
+  "/session/:sessionId/fedcm/setdelayenabled": {
+    "POST": {
+      "command": "fedCMSetDelayEnabled",
+      "payloadParams": {
+        "required": [
+          "enabled"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/fedcm/resetcooldown": {
+    "POST": {
+      "command": "fedCMResetCooldown"
+    }
+  },
+  "/session/:sessionId/pressuresource": {
+    "POST": {
+      "command": "createVirtualPressureSource",
+      "payloadParams": {
+        "required": [
+          "type"
+        ],
+        "optional": [
+          "supported"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/pressuresource/:pressureSourceType": {
+    "POST": {
+      "command": "updateVirtualPressureSource",
+      "payloadParams": {
+        "required": [
+          "sample"
+        ]
+      }
+    },
+    "DELETE": {
+      "command": "deleteVirtualPressureSource"
+    }
+  },
+  "/session/:sessionId/privacy": {
+    "GET": {
+      "command": "getGlobalPrivacyControl"
+    },
+    "POST": {
+      "command": "setGlobalPrivacyControl",
+      "payloadParams": {
+        "required": [
+          "gpc"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/reporting/generate_test_report": {
+    "POST": {
+      "command": "generateTestReport",
+      "payloadParams": {
+        "required": [
+          "message"
+        ],
+        "optional": [
+          "group"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/se/log": {
+    "POST": {
+      "command": "getLog",
+      "payloadParams": {
+        "required": [
+          "type"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/se/log/types": {
+    "GET": {
+      "command": "getLogTypes"
+    }
+  },
+  "/session/:sessionId/:vendor/cdp/execute": {
+    "POST": {
+      "command": "executeCdp",
+      "payloadParams": {
+        "required": [
+          "cmd",
+          "params"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/custom-handlers/set-mode": {
+    "POST": {
+      "command": "setRPHRegistrationMode",
+      "payloadParams": {
+        "required": [
+          "mode"
+        ]
+      }
+    }
+  },
+  "/session/:sessionId/storageaccess": {
+    "POST": {
+      "command": "setStorageAccess",
+      "payloadParams": {
+        "required": [
+          "blocked",
+          "origin"
+        ]
+      }
+    }
+  }
+}
+`;

--- a/packages/fake-driver/lib/commands/general.ts
+++ b/packages/fake-driver/lib/commands/general.ts
@@ -72,16 +72,6 @@ export async function performActions(this: FakeDriver, actions: ActionSequence[]
 /** releaseActions. */
 export async function releaseActions(this: FakeDriver): Promise<void> {}
 
-/** Supported log types: 'actions'. TODO: add more log types if needed for tests. */
-export async function getLog(this: FakeDriver, type: string): Promise<ActionSequence[][]> {
-  switch (type) {
-    case 'actions':
-      return this.appModel.actionLog;
-    default:
-      throw new Error(`Don't understand log type '${type}'`);
-  }
-}
-
 /** mobileShake. */
 export async function mobileShake(this: FakeDriver): Promise<void> {
   this.shook = true;

--- a/packages/fake-driver/lib/driver.ts
+++ b/packages/fake-driver/lib/driver.ts
@@ -31,6 +31,14 @@ export class FakeDriver<Thing extends IpcData = null> extends BaseDriver<FakeDri
 
   readonly desiredCapConstraints = desiredCapConstraints;
 
+  /** Registers 'actions' with the base driver's generic getLogTypes/getLog commands. */
+  readonly supportedLogTypes = {
+    actions: {
+      description: 'Log of all actions performed against the driver in this session',
+      getter: () => this.appModel.actionLog,
+    },
+  };
+
   curContext: string;
   readonly appModel: FakeApp;
   _proxyActive: boolean;
@@ -103,7 +111,6 @@ export class FakeDriver<Thing extends IpcData = null> extends BaseDriver<FakeDri
   getWindowRect = generalCommands.getWindowRect;
   performActions = generalCommands.performActions;
   releaseActions = generalCommands.releaseActions;
-  getLog = generalCommands.getLog;
   mobileShake = generalCommands.mobileShake;
   doubleClick = generalCommands.doubleClick;
   execute = generalCommands.execute;
@@ -118,6 +125,7 @@ export class FakeDriver<Thing extends IpcData = null> extends BaseDriver<FakeDri
   private _bidiProxyUrl: string | null;
   private _clockRunning = false;
   private ipcFakeThing?: IIpcSubscription<Thing>;
+  private readonly deprecatedCommandsCalled: string[] = [];
 
   constructor(opts: InitialOpts = {} as InitialOpts, shouldValidateCaps = true) {
     super(opts, shouldValidateCaps);
@@ -234,14 +242,14 @@ export class FakeDriver<Thing extends IpcData = null> extends BaseDriver<FakeDri
     return this.cliArgs;
   }
 
-  /** TODO: track deprecated commands when called and return their names. */
   async getDeprecatedCommandsCalled(): Promise<string[]> {
     await sleep(1);
-    return [];
+    return this.deprecatedCommandsCalled;
   }
 
   async callDeprecatedCommand(): Promise<void> {
     await sleep(1);
+    this.deprecatedCommandsCalled.push(this.callDeprecatedCommand.name);
   }
 
   async doSomeMath(num1: number, num2: number): Promise<number> {

--- a/packages/fake-driver/test/e2e/driver.e2e.spec.ts
+++ b/packages/fake-driver/test/e2e/driver.e2e.spec.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import {Agent} from 'node:http';
-import {describe, it, before, after, type TestContext, beforeEach, afterEach} from 'node:test';
+import {describe, it, before, after, beforeEach, afterEach} from 'node:test';
 
 import {createAppiumURL, getTestPort} from '@appium/driver-test-support';
 import type {AppiumServer, BaseNSCapabilities, Capabilities, Constraints, W3CCapabilities} from '@appium/types';
@@ -82,12 +82,7 @@ describe(`FakeDriver E2E`, function () {
   });
 
   describe('session handling', function () {
-    it('should handle idempotency while creating sessions', async function (ctx: TestContext) {
-      // TODO: Fix this test for Node 24+
-      if (parseInt(process.versions.node.split('.')[0], 10) >= 24) {
-        return ctx.skip();
-      }
-
+    it('should handle idempotency while creating sessions', async function () {
       // workaround for https://github.com/node-fetch/node-fetch/issues/1735
       const httpAgent = new Agent({keepAlive: true});
 
@@ -116,12 +111,7 @@ describe(`FakeDriver E2E`, function () {
       assert.strictEqual(data.value, null);
     });
 
-    it('should handle idempotency while creating parallel sessions', async function (ctx: TestContext) {
-      // TODO: Fix this test for Node 24+
-      if (parseInt(process.versions.node.split('.')[0], 10) >= 24) {
-        return ctx.skip();
-      }
-
+    it('should handle idempotency while creating parallel sessions', async function () {
       // workaround for https://github.com/node-fetch/node-fetch/issues/1735
       const httpAgent = new Agent({keepAlive: true});
 

--- a/packages/fake-driver/test/e2e/general.e2e.spec.ts
+++ b/packages/fake-driver/test/e2e/general.e2e.spec.ts
@@ -17,8 +17,7 @@ export function generalTests(context: {port: number}) {
       return await deleteSession(driver);
     });
 
-    it.skip('should set geolocation', async function () {
-      // TODO unquarantine when WD fixes what it sends the server
+    it('should set geolocation', async function () {
       await driver.setGeoLocation({latitude: -30, longitude: 30});
     });
     it('should get geolocation', async function () {
@@ -30,8 +29,6 @@ export function generalTests(context: {port: number}) {
       const source = await driver.getPageSource();
       assert.ok(source.includes('<MockNavBar id="nav"'));
     });
-    // TODO do we want to test driver.pageIndex? probably not
-
     it('should get the orientation', async function () {
       assert.strictEqual(await driver.getOrientation(), 'PORTRAIT');
     });

--- a/packages/images-plugin/lib/finder.ts
+++ b/packages/images-plugin/lib/finder.ts
@@ -101,21 +101,14 @@ export class ImageElementFinder {
     } = settings;
 
     log.info(`Finding image element with match threshold ${threshold}`);
-    if (!driver.getWindowRect && !Object.hasOwn(driver, 'getWindowSize')) {
+    if (!driver.getWindowRect) {
       throw new Error("This driver does not support the required 'getWindowRect' command");
     }
-    let screenSize: Size;
-    if (driver.getWindowRect) {
-      const screenRect = await driver.getWindowRect();
-      screenSize = {
-        width: screenRect.width,
-        height: screenRect.height,
-      };
-    } else {
-      // TODO: Drop the deprecated endpoint
-      // @ts-expect-error - deprecated getWindowSize method
-      screenSize = await driver.getWindowSize();
-    }
+    const screenRect = await driver.getWindowRect();
+    const screenSize: Size = {
+      width: screenRect.width,
+      height: screenRect.height,
+    };
 
     // someone might have sent in a template that's larger than the screen
     // dimensions. If so let's check and cut it down to size since the algorithm

--- a/packages/storage-plugin/lib/plugin.ts
+++ b/packages/storage-plugin/lib/plugin.ts
@@ -14,12 +14,6 @@ import type {AddRequestResult, ItemOptions, StorageItem} from './types.js';
 
 const log = logger.getLogger('StoragePlugin');
 
-// @appium/types is still CommonJS, so its `ws` Server type resolves through the "require"
-// condition, while this ESM package resolves the same class through "import" — TypeScript
-// treats them as structurally distinct even though they are identical at runtime.
-// TODO: Remove this workaround once @appium/types is migrated to ESM.
-type WSHandlerServer = Parameters<AppiumServer['addWebSocketHandler']>[1];
-
 let SHARED_STORAGE: Storage | null = null;
 const STORAGE_PREFIX = '/appium/storage';
 /**
@@ -213,8 +207,8 @@ async function prepareWebSockets(
     log.info(`The ${streamPathname} web socket server has notified about an error: ${e.message}`);
   });
   await Promise.all([
-    httpServer.addWebSocketHandler(streamPathname, streamServer as unknown as WSHandlerServer),
-    httpServer.addWebSocketHandler(eventsPathname, eventsServer as unknown as WSHandlerServer),
+    httpServer.addWebSocketHandler(streamPathname, streamServer),
+    httpServer.addWebSocketHandler(eventsPathname, eventsServer),
   ]);
 
   return [streamPathname, eventsPathname];


### PR DESCRIPTION
## Summary

Sweep of stale/actionable `TODO` and `FIXME` comments found across the repo. Each fix was
verified individually (root-caused, then confirmed with a real repro or test run) rather than
just deleting the comment — see the commit messages for the reasoning behind each one.

- **appium**
  - Removed the `assignIpc` existence guards in `appium.ts` — `assignIpc` has always been
    present via `ExtensionCore`, so the runtime checks were dead weight left over from the
    Appium 3/4 migration.
  - Fixed the `webSocketUrl` typing so it no longer needs `@ts-ignore`: the old
    `DriverCaps<...> & {webSocketUrl?: string | boolean}` intersected rather than widened the
    field, collapsing back to `boolean | undefined`.
  - Un-skipped the `Logsink` e2e test — `logsink.init()` re-registers its log listener on every
    server start, so the "only works if the log wasn't already initialized" caveat no longer
    holds.
  - Made the CLI arg-validation tests strip ANSI color codes before matching: they were only
    passing by luck of where `@sidvind/better-ajv-errors`' color codes land when stdout is a TTY.

- **base-driver**
  - Removed a stale "we need module-level mocks for the logger" comment — `@appium/support`'s
    `getLogger()` already has that mechanism, and these tests don't need it (they spy on the
    instance logger instead).
  - Replaced the protocol sha1-hash regression test with `node:test`'s built-in snapshot
    assertion, so a route/command/param change now shows an actual diff instead of an opaque
    hash mismatch.

- **fake-driver**
  - `getDeprecatedCommandsCalled()` was a permanent stub returning `[]`; it now tracks real
    calls to `callDeprecatedCommand()` per instance.
  - `getLog('actions')` bypassed `BaseDriver`'s generic `supportedLogTypes` mechanism, so
    `getLogTypes()` reported no types even though `'actions'` worked. Wired it through
    `supportedLogTypes` instead, which also fixes the error message and removes the
    driver-specific switch statement.
  - Un-skipped tests blocked on a stale Node 24+ guard and a stale upstream WebdriverIO
    workaround — both pass cleanly now.

- **images-plugin**
  - Dropped the deprecated `getWindowSize` fallback in `finder.ts`. Checked every driver in the
    ecosystem (android, uiautomator2, espresso, xcuitest, mac2, windows, desktop, novawindows,
    chromium, safari, gecko, flutter): none reach that branch anymore — they either implement
    `getWindowRect` directly, or implement neither and already fail the preceding guard.

- **storage-plugin**
  - Removed the `ws` `Server` type workaround for `@appium/types` — that package became
    ESM-only in a later commit than this workaround was added, so the CJS/ESM type mismatch it
    worked around can no longer happen.
