### PR TITLE
chore!: cleanup remaining code for removed JSONWP/MJSONWP methods

### DIFF
--- a/packages/base-driver/lib/protocol/params.ts
+++ b/packages/base-driver/lib/protocol/params.ts
@@ -199,7 +199,7 @@ export function wrapParams<T>(paramSets: PayloadParams, jsonObj: T): T | Record<
 }
 
 /**
- * There are commands like setNetworkConnection which send parameters wrapped inside a key such as
+ * There are commands like setCookie which send parameters wrapped inside a key such as
  * "parameters". This function unwraps them (eg. {"parameters": {"type": 1}} becomes {"type": 1}).
  * @param paramSets - Payload spec, used for its `unwrap` key
  * @param jsonObj - Parsed JSON request body

--- a/packages/base-driver/lib/protocol/validators.ts
+++ b/packages/base-driver/lib/protocol/validators.ts
@@ -10,12 +10,6 @@ export const validators = {
       throw new Error(`'${util.truncateString(String(url), {length: MAX_URL_ERROR_LENGTH})}' must be a valid URL`);
     }
   },
-  /** @deprecated Only used by the deprecated `setNetworkConnection` MJSONWP route. */
-  setNetworkConnection: (type: any) => {
-    if (!Number.isInteger(Number(type)) || ![0, 1, 2, 4, 6].includes(Number(type))) {
-      throw new Error('Network type must be one of 0, 1, 2, 4, 6');
-    }
-  },
 } satisfies Record<string, CommandValidator>;
 
 /**

--- a/packages/base-driver/test/e2e/protocol/fake-driver.ts
+++ b/packages/base-driver/test/e2e/protocol/fake-driver.ts
@@ -83,10 +83,6 @@ class FakeDriver extends BaseDriver<Constraints> {
     return ms;
   }
 
-  async setNetworkConnection(type: number): Promise<number> {
-    return type;
-  }
-
   async moveTo(element: string | null, xOffset: number, yOffset: number): Promise<unknown[]> {
     return [element, xOffset, yOffset];
   }

--- a/packages/fake-driver/lib/command-maps/new-method-map.ts
+++ b/packages/fake-driver/lib/command-maps/new-method-map.ts
@@ -16,8 +16,4 @@ export const NEW_METHOD_MAP = {
   '/session/:sessionId/doubleclick': {
     POST: {command: 'doubleClick'},
   },
-  '/session/:sessionId/location': {
-    GET: {command: 'getGeoLocation'},
-    POST: {command: 'setGeoLocation', payloadParams: {required: ['location']}},
-  },
 } as const satisfies MethodMap<FakeDriver>;

--- a/packages/fake-driver/lib/commands/general.ts
+++ b/packages/fake-driver/lib/commands/general.ts
@@ -1,4 +1,4 @@
-import type {ActionSequence, Location, Orientation, Rect, Size} from '@appium/types';
+import type {ActionSequence, Orientation, Rect, Size} from '@appium/types';
 import {errors} from 'appium/driver.js';
 
 import type {FakeDriver} from '../driver.js';
@@ -17,18 +17,6 @@ export async function keys(this: FakeDriver, value: string | string[]): Promise<
     throw new errors.InvalidElementStateError();
   }
   await this.setValue(value, this.focusedElId);
-}
-
-/** setGeoLocation. */
-export async function setGeoLocation(this: FakeDriver, location: Location): Promise<Location> {
-  this.appModel.lat = location.latitude;
-  this.appModel.long = location.longitude;
-  return location;
-}
-
-/** getGeoLocation. */
-export async function getGeoLocation(this: FakeDriver): Promise<Location> {
-  return this.appModel.currentGeoLocation;
 }
 
 /** getPageSource. */

--- a/packages/fake-driver/lib/driver.ts
+++ b/packages/fake-driver/lib/driver.ts
@@ -101,8 +101,6 @@ export class FakeDriver<Thing extends IpcData = null> extends BaseDriver<FakeDri
   // General commands
   title = generalCommands.title;
   keys = generalCommands.keys;
-  setGeoLocation = generalCommands.setGeoLocation;
-  getGeoLocation = generalCommands.getGeoLocation;
   getPageSource = generalCommands.getPageSource;
   getOrientation = generalCommands.getOrientation;
   setOrientation = generalCommands.setOrientation;

--- a/packages/fake-driver/lib/fake-app.ts
+++ b/packages/fake-driver/lib/fake-app.ts
@@ -1,7 +1,7 @@
 import {readFileSync} from 'node:fs';
 import path from 'node:path';
 
-import type {ActionSequence, Location, Orientation} from '@appium/types';
+import type {ActionSequence, Orientation} from '@appium/types';
 import XMLDom from '@xmldom/xmldom';
 import type {Document as XMLDocument, Node as XMLNode} from '@xmldom/xmldom';
 import {fs} from 'appium/support.js';
@@ -23,8 +23,6 @@ export class FakeApp {
   activeWebview: FakeWebView | null;
   activeFrame: XMLDocument | null;
   activeAlert: FakeElement | null;
-  lat: number;
-  long: number;
   rawXml: string;
   currentOrientation: Orientation;
   actionLog: ActionSequence[][];
@@ -37,8 +35,6 @@ export class FakeApp {
     this.activeWebview = null;
     this.activeFrame = null;
     this.activeAlert = null;
-    this.lat = 0;
-    this.long = 0;
     this._width = null;
     this._height = null;
     this.rawXml = '';
@@ -54,13 +50,6 @@ export class FakeApp {
     const node = nodes[0];
     const firstChild = node.firstChild as unknown as {data: string} | null;
     return firstChild?.data ?? '';
-  }
-
-  get currentGeoLocation(): Location {
-    return {
-      latitude: this.lat,
-      longitude: this.long,
-    };
   }
 
   get orientation(): Orientation {

--- a/packages/fake-driver/test/e2e/general.e2e.spec.ts
+++ b/packages/fake-driver/test/e2e/general.e2e.spec.ts
@@ -17,14 +17,6 @@ export function generalTests(context: {port: number}) {
       return await deleteSession(driver);
     });
 
-    it('should set geolocation', async function () {
-      await driver.setGeoLocation({latitude: -30, longitude: 30});
-    });
-    it('should get geolocation', async function () {
-      const geo = await driver.getGeoLocation();
-      assert.ok(geo.latitude !== undefined && geo.latitude !== null);
-      assert.ok(geo.longitude !== undefined && geo.longitude !== null);
-    });
     it('should get app source', async function () {
       const source = await driver.getPageSource();
       assert.ok(source.includes('<MockNavBar id="nav"'));

--- a/packages/types/lib/commands/jsonwp.ts
+++ b/packages/types/lib/commands/jsonwp.ts
@@ -15,27 +15,6 @@ export interface IJSONWPCommands {
    * @param orientation - the orientation string
    */
   setOrientation?(orientation: string): Promise<void>;
-
-  /**
-   * Get the virtual or real geographical location of a device
-   *
-   * @returns The location
-   */
-  getGeoLocation?(): Promise<Location>;
-
-  /**
-   * Set the virtual geographical location of a device
-   *
-   * @param location - the location including latitude and longitude
-   * @returns The complete location
-   */
-  setGeoLocation?(location: Partial<Location>): Promise<Location>;
 }
 
 export type Orientation = 'LANDSCAPE' | 'PORTRAIT';
-
-export interface Location {
-  latitude: number;
-  longitude: number;
-  altitude?: number;
-}

--- a/packages/types/lib/commands/mjsonwp.ts
+++ b/packages/types/lib/commands/mjsonwp.ts
@@ -27,25 +27,6 @@ export interface IMJSONWPCommands<Ctx = string> {
   getContexts?(): Promise<Ctx[]>;
 
   /**
-   * Get the network connection state of a device
-   * @see {@link https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#device-modes}
-   *
-   * @returns A number which is a bitmask representing categories like Data, Wifi, and Airplane
-   * mode status
-   */
-  getNetworkConnection?(): Promise<number>;
-
-  /**
-   * Set the network connection of the device
-   * @see {@link https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#device-modes}
-   *
-   * @param type - the bitmask representing network state
-   * @returns A number which is a bitmask representing categories like Data, Wifi, and Airplane
-   * mode status
-   */
-  setNetworkConnection?(type: number): Promise<number>;
-
-  /**
    * Get the current rotation state of the device
    * @see {@link https://github.com/SeleniumHQ/mobile-spec/blob/master/spec-draft.md#device-rotation}
    *


### PR DESCRIPTION
Follow-up to #22763, removing remaining code related to the removed network connection and geolocation methods.

BREAKING CHANGE: types for the following commands have been removed: `getGeoLocation`, `setGeoLocation`, `getNetworkConnection`, `setNetworkConnection`. The `Location` type has also been removed.