### PR TITLE
fix(support): do not set file-sized Content-Length on default multipart uploads

### DIFF
--- a/packages/support/lib/net.ts
+++ b/packages/support/lib/net.ts
@@ -9,6 +9,7 @@ import {Timer} from './timing';
 import {isPlainObject, toReadableSizeString} from './util';
 
 const DEFAULT_TIMEOUT_MS = 4 * 60 * 1000;
+const DEFAULT_FILE_FIELD_NAME = 'file';
 
 /** Common options for {@linkcode uploadFile} and {@linkcode downloadFile}. */
 export interface NetOptions {
@@ -108,7 +109,11 @@ export async function uploadFile(
   }
   const timer = new Timer().start();
   if (isHttpUploadOptions(uploadOptions, url)) {
-    if (!uploadOptions.fileFieldName) {
+    // mirror the default applied in uploadFileToHttp: only an absent name becomes the multipart
+    // default, so an explicitly falsy one still means a raw body that needs Content-Length
+    const fileFieldName =
+      uploadOptions.fileFieldName === undefined ? DEFAULT_FILE_FIELD_NAME : uploadOptions.fileFieldName;
+    if (!fileFieldName) {
       uploadOptions.headers = {
         ...(isPlainObject(uploadOptions.headers) ? uploadOptions.headers : {}),
         'Content-Length': size,
@@ -224,7 +229,7 @@ async function uploadFileToHttp(
     timeout = DEFAULT_TIMEOUT_MS,
     headers,
     auth,
-    fileFieldName = 'file',
+    fileFieldName = DEFAULT_FILE_FIELD_NAME,
     formFields,
   } = uploadOptions;
   const {href} = parsedUri;

--- a/packages/support/test/unit/net.spec.ts
+++ b/packages/support/test/unit/net.spec.ts
@@ -1,7 +1,50 @@
 import assert from 'node:assert/strict';
-import {describe, it} from 'node:test';
+import http from 'node:http';
+import type {AddressInfo} from 'node:net';
+import path from 'node:path';
+import {after, before, describe, it} from 'node:test';
 
+import {fs, tempDir} from '../../lib';
 import {uploadFile} from '../../lib/net';
+
+const FILE_BYTES = 100;
+
+async function receiveUpload(run: (url: string) => Promise<void>): Promise<{
+  headerLength: number | undefined;
+  received: number;
+  contentType: string | undefined;
+}> {
+  let headerLength: string | undefined;
+  let received = 0;
+  let contentType: string | undefined;
+  const server = http.createServer((req, res) => {
+    headerLength = req.headers['content-length'];
+    contentType = req.headers['content-type'];
+    req.on('data', (chunk) => {
+      received += chunk.length;
+    });
+    req.on('end', () => {
+      res.writeHead(200);
+      res.end('ok');
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const {port} = server.address() as AddressInfo;
+  try {
+    await run(`http://127.0.0.1:${port}/upload`);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+  return {
+    headerLength: headerLength === undefined ? undefined : Number(headerLength),
+    received,
+    contentType,
+  };
+}
 
 describe('net', function () {
   describe('uploadFile()', function () {
@@ -13,6 +56,61 @@ describe('net', function () {
         });
 
       assert.strictEqual(typeof upload, 'function');
+    });
+
+    describe('HTTP upload', function () {
+      let tmpDir: string;
+      let localPath: string;
+
+      before(async function () {
+        tmpDir = await tempDir.openDir();
+        localPath = path.join(tmpDir, 'payload.bin');
+        await fs.writeFile(localPath, Buffer.alloc(FILE_BYTES, 0x61));
+      });
+
+      after(async function () {
+        await fs.rimraf(tmpDir);
+      });
+
+      it('should send a complete multipart body when fileFieldName is omitted', async function () {
+        const {headerLength, received, contentType} = await receiveUpload((url) =>
+          uploadFile(localPath, url, {isMetered: false}),
+        );
+        assert.match(String(contentType), /multipart\/form-data/i);
+        assert.ok(received > FILE_BYTES);
+        assert.strictEqual(headerLength, received);
+      });
+
+      it('should send a complete multipart body when fileFieldName is set', async function () {
+        const {headerLength, received, contentType} = await receiveUpload((url) =>
+          uploadFile(localPath, url, {isMetered: false, fileFieldName: 'file'}),
+        );
+        assert.match(String(contentType), /multipart\/form-data/i);
+        assert.ok(received > FILE_BYTES);
+        assert.strictEqual(headerLength, received);
+      });
+
+      // any falsy fileFieldName is documented as a raw upload, so it must carry Content-Length
+      it('should send a raw body with Content-Length when fileFieldName is null', async function () {
+        const {headerLength, received, contentType} = await receiveUpload((url) =>
+          uploadFile(localPath, url, {
+            isMetered: false,
+            fileFieldName: null as unknown as string,
+          }),
+        );
+        assert.doesNotMatch(String(contentType ?? ''), /multipart\/form-data/i);
+        assert.strictEqual(received, FILE_BYTES);
+        assert.strictEqual(headerLength, FILE_BYTES);
+      });
+
+      it('should send a raw body when fileFieldName is empty', async function () {
+        const {headerLength, received, contentType} = await receiveUpload((url) =>
+          uploadFile(localPath, url, {isMetered: false, fileFieldName: ''}),
+        );
+        assert.doesNotMatch(String(contentType ?? ''), /multipart\/form-data/i);
+        assert.strictEqual(received, FILE_BYTES);
+        assert.strictEqual(headerLength, FILE_BYTES);
+      });
     });
   });
 });


### PR DESCRIPTION
`uploadFile` documents `fileFieldName` as defaulting to `file`, which is multipart. When the name was omitted it still stamped `Content-Length` with the raw file size, then built a larger multipart body. The server read only the file-sized prefix and the request died with `ECONNRESET`.

The Content-Length branch now uses the same default as `uploadFileToHttp`, so only an explicitly falsy name (`''` or `null`) is treated as a raw body.
