### PR TITLE
fix(appium): lock the extension manifest while driver/plugin commands run

### DIFF
--- a/packages/appium/lib/cli/extension.ts
+++ b/packages/appium/lib/cli/extension.ts
@@ -1,12 +1,12 @@
 /* eslint-disable no-console */
-import {util} from '@appium/support';
 import type {Class, DriverType, ExtensionType, PluginType} from '@appium/types';
 import type {Args, CliExtensionCommand, CliExtensionSubcommand} from 'appium/types/index.js';
 
 import {DRIVER_TYPE, PLUGIN_TYPE} from '../constants.js';
 import type {ExtensionConfig} from '../extension/extension-config.js';
+import {reloadManifest} from '../extension/index.js';
 import {isExtensionCommandArgs} from '../schema/cli-args-guards.js';
-import {resolveManifestLockfilePath} from '../utils/index.js';
+import {withManifestLock} from '../utils/index.js';
 import DriverCliCommand from './driver-command.js';
 import PluginCliCommand from './plugin-command.js';
 import {errAndQuit, JSON_SPACES} from './utils.js';
@@ -46,13 +46,11 @@ export async function runExtensionCommand<Cmd extends CliExtensionCommand, SubCm
   // Serialize this against any other `driver`/`plugin` CLI command running (in this or another
   // process) against the same `APPIUM_HOME`, so concurrent commands can't race to read, mutate,
   // and write the same extension manifest out from under each other.
-  const lockFile = await resolveManifestLockfilePath(config.appiumHome);
-  const acquireLock = util.getLockFileGuard<Record<string, unknown>>(lockFile);
-
-  return acquireLock(async () => {
+  return withManifestLock<Record<string, unknown>>(config.appiumHome, async () => {
     // Refresh from disk while holding the lock, in case another process wrote to the manifest
-    // between this process's startup read and now.
-    await config.manifest.read();
+    // between this process's startup read and now, and revalidate so derived state (installed
+    // extensions, pending validation summary, duplicate-automationName tracking) is current too.
+    await reloadManifest(config.manifest);
 
     let jsonResult: Record<string, unknown> = {};
     const CommandClass = commandClasses[type] as ExtCommand<Cmd>;

--- a/packages/appium/lib/cli/extension.ts
+++ b/packages/appium/lib/cli/extension.ts
@@ -1,10 +1,12 @@
 /* eslint-disable no-console */
+import {util} from '@appium/support';
 import type {Class, DriverType, ExtensionType, PluginType} from '@appium/types';
 import type {Args, CliExtensionCommand, CliExtensionSubcommand} from 'appium/types/index.js';
 
 import {DRIVER_TYPE, PLUGIN_TYPE} from '../constants.js';
 import type {ExtensionConfig} from '../extension/extension-config.js';
 import {isExtensionCommandArgs} from '../schema/cli-args-guards.js';
+import {resolveManifestLockfilePath} from '../utils/index.js';
 import DriverCliCommand from './driver-command.js';
 import PluginCliCommand from './plugin-command.js';
 import {errAndQuit, JSON_SPACES} from './utils.js';
@@ -30,9 +32,6 @@ export async function runExtensionCommand<Cmd extends CliExtensionCommand, SubCm
   args: Args<Cmd, SubCmd>,
   config: ExtensionConfig<Cmd>,
 ) {
-  // TODO driver config file should be locked while any of these commands are
-  // running to prevent weird situations
-  let jsonResult: Record<string, unknown> = {};
   const {extensionType: type} = config; // NOTE this is the same as `args.subcommand`
   if (!isExtensionCommandArgs(args)) {
     throw new TypeError(`Cannot call ${type} command without a subcommand like 'install'`);
@@ -43,23 +42,37 @@ export async function runExtensionCommand<Cmd extends CliExtensionCommand, SubCm
   if (suppressOutput) {
     json = true;
   }
-  const CommandClass = commandClasses[type] as ExtCommand<Cmd>;
-  const cmd = new CommandClass({config, json} as any);
-  cmd.printPendingValidationSummary();
-  try {
-    jsonResult = (await cmd.execute(args)) as Record<string, unknown>;
-  } catch (err) {
-    // in the suppress output case, we are calling this function internally and should
-    // just throw instead of printing an error and ending the process
-    if (suppressOutput) {
-      throw err;
+
+  // Serialize this against any other `driver`/`plugin` CLI command running (in this or another
+  // process) against the same `APPIUM_HOME`, so concurrent commands can't race to read, mutate,
+  // and write the same extension manifest out from under each other.
+  const lockFile = await resolveManifestLockfilePath(config.appiumHome);
+  const acquireLock = util.getLockFileGuard<Record<string, unknown>>(lockFile);
+
+  return acquireLock(async () => {
+    // Refresh from disk while holding the lock, in case another process wrote to the manifest
+    // between this process's startup read and now.
+    await config.manifest.read();
+
+    let jsonResult: Record<string, unknown> = {};
+    const CommandClass = commandClasses[type] as ExtCommand<Cmd>;
+    const cmd = new CommandClass({config, json} as any);
+    cmd.printPendingValidationSummary();
+    try {
+      jsonResult = (await cmd.execute(args)) as Record<string, unknown>;
+    } catch (err) {
+      // in the suppress output case, we are calling this function internally and should
+      // just throw instead of printing an error and ending the process
+      if (suppressOutput) {
+        throw err;
+      }
+      errAndQuit(json, err);
     }
-    errAndQuit(json, err);
-  }
 
-  if (json && !suppressOutput) {
-    console.log(JSON.stringify(jsonResult, null, JSON_SPACES));
-  }
+    if (json && !suppressOutput) {
+      console.log(JSON.stringify(jsonResult, null, JSON_SPACES));
+    }
 
-  return jsonResult;
+    return jsonResult;
+  });
 }

--- a/packages/appium/lib/extension/extension-config.ts
+++ b/packages/appium/lib/extension/extension-config.ts
@@ -64,7 +64,6 @@ const EMPTY_VALIDATION_SUMMARY: ExtensionValidationSummary = {
 export abstract class ExtensionConfig<ExtType extends ExtensionType> {
   readonly extensionType: ExtType;
   readonly manifest: Manifest;
-  readonly installedExtensions: ExtRecord<ExtType>;
   /** Populated by {@linkcode ExtensionConfig.validate}; see {@linkcode ExtensionValidationSummary}. */
   private validationSummary: ExtensionValidationSummary = EMPTY_VALIDATION_SUMMARY;
   private listDataCache: ExtensionList<ExtType> | undefined;
@@ -72,7 +71,14 @@ export abstract class ExtensionConfig<ExtType extends ExtensionType> {
   protected constructor(extensionType: ExtType, manifest: Manifest) {
     this.extensionType = extensionType;
     this.manifest = manifest;
-    this.installedExtensions = manifest.getExtensionData(extensionType);
+  }
+
+  /**
+   * Live installed-extension map for this extension kind (same object the manifest holds).
+   * Recomputed on every access so it stays in sync across a {@link Manifest.read} reload.
+   */
+  get installedExtensions(): ExtRecord<ExtType> {
+    return this.manifest.getExtensionData(this.extensionType);
   }
 
   /** Path to `extensions.yaml` after the manifest has been read; otherwise undefined. */

--- a/packages/appium/lib/extension/index.ts
+++ b/packages/appium/lib/extension/index.ts
@@ -5,7 +5,7 @@ import {asyncmap} from 'asyncbox';
 
 import {USE_ALL_PLUGINS} from '../constants.js';
 import {log} from '../logger.js';
-import {zip} from '../utils/index.js';
+import {withManifestLock, zip} from '../utils/index.js';
 import {DriverConfig} from './driver-config.js';
 import {Manifest} from './manifest/index.js';
 import {PluginConfig} from './plugin-config.js';
@@ -19,6 +19,22 @@ export type PluginNameMap = Map<PluginClass, string>;
 export type DriverNameMap = Map<DriverClass, string>;
 
 /**
+ * Re-reads `manifest` from disk and revalidates whichever `DriverConfig`/`PluginConfig`
+ * singletons already exist for it, so their derived state (installed extensions, pending
+ * validation summary, {@link DriverConfig}'s duplicate-`automationName` tracking) reflects the
+ * freshly-read data rather than a stale pre-reload snapshot.
+ *
+ * Callers must run this under {@link withManifestLock} -- both because `manifest.read()` may
+ * itself write the manifest (initialization, migration, or sync with installed packages), and
+ * because anything a caller does afterward that depends on the result staying current (e.g.
+ * writing the manifest back out) needs to stay in the same critical section.
+ */
+export async function reloadManifest(manifest: Manifest): Promise<void> {
+  await manifest.read();
+  await Promise.all([DriverConfig.getInstance(manifest)?.validate(), PluginConfig.getInstance(manifest)?.validate()]);
+}
+
+/**
  * Loads extensions and creates `ExtensionConfig` instances.
  *
  * - Reads the manifest file, creating if necessary
@@ -29,11 +45,11 @@ export type DriverNameMap = Map<DriverClass, string>;
  */
 export async function loadExtensions(appiumHome: string): Promise<ExtensionConfigs> {
   const manifest = Manifest.getInstance(appiumHome);
-  await manifest.read();
   const driverConfig = DriverConfig.getInstance(manifest) ?? DriverConfig.create(manifest);
   const pluginConfig = PluginConfig.getInstance(manifest) ?? PluginConfig.create(manifest);
 
-  await Promise.all([driverConfig.validate(), pluginConfig.validate()]);
+  await withManifestLock(appiumHome, () => reloadManifest(manifest));
+
   return {driverConfig, pluginConfig};
 }
 

--- a/packages/appium/lib/schema/schema.ts
+++ b/packages/appium/lib/schema/schema.ts
@@ -169,16 +169,23 @@ class AppiumSchema {
     >) {
       for (const [extName, schema] of extensionSchemas.entries()) {
         const $ref = ArgSpec.toSchemaBaseRef(extType, extName);
-        (schema as any).$id = $ref;
-        (schema as any).additionalProperties = false;
+        // Clone rather than mutate the registered schema in place: extensions whose schema is
+        // freshly re-parsed on every manifest reload (an inline object, as opposed to one
+        // `import()`ed from a file, which Node's module cache returns by the same reference every
+        // time) would otherwise stop deep-equaling their own registered copy on a later
+        // `registerSchema()` call, once this injects `$id`/`additionalProperties` -- causing a
+        // false "conflicts with an existing schema" error and dropping the extension entirely.
+        const finalizedSchema = structuredClone(schema) as StrictSchemaObject;
+        (finalizedSchema as any).$id = $ref;
+        (finalizedSchema as any).additionalProperties = false;
         baseSchema.properties.server.properties[extType].properties[extName] = {
           $ref,
           $comment: extName,
         };
-        await ajv.validateSchema(schema, true);
-        addArgSpecs((schema as any).properties, extType, extName);
-        ajv.addSchema(schema, $ref);
-        finalizedSchemas[$ref] = schema as StrictSchemaObject;
+        await ajv.validateSchema(finalizedSchema, true);
+        addArgSpecs((finalizedSchema as any).properties, extType, extName);
+        ajv.addSchema(finalizedSchema, $ref);
+        finalizedSchemas[$ref] = finalizedSchema;
       }
     }
 

--- a/packages/appium/lib/utils/env.ts
+++ b/packages/appium/lib/utils/env.ts
@@ -1,7 +1,7 @@
 import {homedir} from 'node:os';
 import path from 'node:path';
 
-import {util} from '@appium/support';
+import {fs, util} from '@appium/support';
 import * as semver from 'semver';
 
 import {type NormalizedPackageJson, readPackage} from './read-package.js';
@@ -140,3 +140,17 @@ export const resolveManifestLockfilePath = util.memoize(async function _resolveM
 ): Promise<string> {
   return path.join(appiumHome ?? (await resolveAppiumHome()), MANIFEST_LOCKFILE_RELATIVE_PATH);
 });
+
+/**
+ * Runs `behavior` under the cross-process lock guarding the extension manifest for `appiumHome`,
+ * so callers can't race each other's manifest reads/writes. Covers the *entire* read-modify-write
+ * cycle a caller needs protected -- e.g. a manifest reload plus whatever depends on it staying
+ * current, such as re-validating extension configs or writing the manifest back out.
+ */
+export async function withManifestLock<T>(appiumHome: string, behavior: () => Promise<T> | T): Promise<T> {
+  const lockFile = await resolveManifestLockfilePath(appiumHome);
+  // The manifest itself may not exist yet (e.g. a brand new `APPIUM_HOME`) -- its directory
+  // wouldn't either, and creating the lockfile requires it to already be there.
+  await fs.mkdirp(path.dirname(lockFile));
+  return util.getLockFileGuard<T>(lockFile)(behavior);
+}

--- a/packages/appium/lib/utils/env.ts
+++ b/packages/appium/lib/utils/env.ts
@@ -146,11 +146,29 @@ export const resolveManifestLockfilePath = util.memoize(async function _resolveM
  * so callers can't race each other's manifest reads/writes. Covers the *entire* read-modify-write
  * cycle a caller needs protected -- e.g. a manifest reload plus whatever depends on it staying
  * current, such as re-validating extension configs or writing the manifest back out.
+ *
+ * Falls back to running `behavior` unlocked if the lockfile's location turns out to be
+ * unwritable (e.g. a preinstalled, read-only `APPIUM_HOME`): nothing else could be racing a write
+ * against a location nothing can write to, and any write `behavior` itself attempts (e.g. a
+ * manifest migration) will still fail with the same underlying error.
  */
 export async function withManifestLock<T>(appiumHome: string, behavior: () => Promise<T> | T): Promise<T> {
   const lockFile = await resolveManifestLockfilePath(appiumHome);
-  // The manifest itself may not exist yet (e.g. a brand new `APPIUM_HOME`) -- its directory
-  // wouldn't either, and creating the lockfile requires it to already be there.
-  await fs.mkdirp(path.dirname(lockFile));
-  return util.getLockFileGuard<T>(lockFile)(behavior);
+  try {
+    // The manifest itself may not exist yet (e.g. a brand new `APPIUM_HOME`) -- its directory
+    // wouldn't either, and creating the lockfile requires it to already be there. A no-op when
+    // the directory already exists, so this doesn't by itself require `appiumHome` to be writable.
+    await fs.mkdirp(path.dirname(lockFile));
+  } catch (err) {
+    if (!isUnwritableLocationError(err)) {
+      throw err;
+    }
+    return behavior();
+  }
+  return util.getLockFileGuard<T>(lockFile, {runUnlockedIfUnwritable: true})(behavior);
+}
+
+function isUnwritableLocationError(err: unknown): boolean {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  return code === 'EACCES' || code === 'EROFS' || code === 'EPERM';
 }

--- a/packages/appium/lib/utils/env.ts
+++ b/packages/appium/lib/utils/env.ts
@@ -22,6 +22,11 @@ export const MANIFEST_BASENAME = 'extensions.yaml';
 export const MANIFEST_RELATIVE_PATH = path.join('node_modules', '.cache', 'appium', MANIFEST_BASENAME);
 
 /**
+ * Relative path to the lockfile guarding the extension manifest from `APPIUM_HOME`.
+ */
+export const MANIFEST_LOCKFILE_RELATIVE_PATH = `${MANIFEST_RELATIVE_PATH}.lock`;
+
+/**
  * Resolves `true` if an `appium` dependency can be found somewhere in the given `cwd`.
  */
 export async function hasAppiumDependency(cwd: string): Promise<boolean> {
@@ -123,4 +128,15 @@ export const resolveManifestPath = util.memoize(async function _resolveManifestP
   appiumHome?: string,
 ): Promise<string> {
   return path.join(appiumHome ?? (await resolveAppiumHome()), MANIFEST_RELATIVE_PATH);
+});
+
+/**
+ * Figure out the extension manifest lockfile path based on `appiumHome`.
+ *
+ * See caveat on {@link resolveManifestPath} about pre-resolving `appiumHome`.
+ */
+export const resolveManifestLockfilePath = util.memoize(async function _resolveManifestLockfilePath(
+  appiumHome?: string,
+): Promise<string> {
+  return path.join(appiumHome ?? (await resolveAppiumHome()), MANIFEST_LOCKFILE_RELATIVE_PATH);
 });

--- a/packages/appium/lib/utils/env.ts
+++ b/packages/appium/lib/utils/env.ts
@@ -1,7 +1,8 @@
-import {homedir} from 'node:os';
+import {createHash} from 'node:crypto';
+import {homedir, tmpdir} from 'node:os';
 import path from 'node:path';
 
-import {fs, util} from '@appium/support';
+import {util} from '@appium/support';
 import * as semver from 'semver';
 
 import {type NormalizedPackageJson, readPackage} from './read-package.js';
@@ -20,11 +21,6 @@ export const MANIFEST_BASENAME = 'extensions.yaml';
  * Relative path to extension manifest file from `APPIUM_HOME`.
  */
 export const MANIFEST_RELATIVE_PATH = path.join('node_modules', '.cache', 'appium', MANIFEST_BASENAME);
-
-/**
- * Relative path to the lockfile guarding the extension manifest from `APPIUM_HOME`.
- */
-export const MANIFEST_LOCKFILE_RELATIVE_PATH = `${MANIFEST_RELATIVE_PATH}.lock`;
 
 /**
  * Resolves `true` if an `appium` dependency can be found somewhere in the given `cwd`.
@@ -131,14 +127,23 @@ export const resolveManifestPath = util.memoize(async function _resolveManifestP
 });
 
 /**
- * Figure out the extension manifest lockfile path based on `appiumHome`.
+ * Figure out the extension manifest lockfile path for `appiumHome`.
+ *
+ * Deliberately lives under the OS temp dir, keyed by a hash of `appiumHome`, rather than
+ * alongside the manifest itself: a directory being unwritable doesn't imply the manifest *file*
+ * inside it is (directory permissions gate creating/removing entries, not overwriting an existing
+ * one), so a lock colocated with the manifest couldn't be relied on to actually be creatable
+ * exactly when protection is needed most. The temp dir is writable in the ordinary case
+ * regardless of `appiumHome`'s own permissions, including a preinstalled, read-only one.
  *
  * See caveat on {@link resolveManifestPath} about pre-resolving `appiumHome`.
  */
 export const resolveManifestLockfilePath = util.memoize(async function _resolveManifestLockfilePath(
   appiumHome?: string,
 ): Promise<string> {
-  return path.join(appiumHome ?? (await resolveAppiumHome()), MANIFEST_LOCKFILE_RELATIVE_PATH);
+  const resolvedHome = path.resolve(appiumHome ?? (await resolveAppiumHome()));
+  const homeHash = createHash('sha256').update(resolvedHome).digest('hex').slice(0, 32);
+  return path.join(tmpdir(), `appium-manifest-${homeHash}.lock`);
 });
 
 /**
@@ -146,29 +151,8 @@ export const resolveManifestLockfilePath = util.memoize(async function _resolveM
  * so callers can't race each other's manifest reads/writes. Covers the *entire* read-modify-write
  * cycle a caller needs protected -- e.g. a manifest reload plus whatever depends on it staying
  * current, such as re-validating extension configs or writing the manifest back out.
- *
- * Falls back to running `behavior` unlocked if the lockfile's location turns out to be
- * unwritable (e.g. a preinstalled, read-only `APPIUM_HOME`): nothing else could be racing a write
- * against a location nothing can write to, and any write `behavior` itself attempts (e.g. a
- * manifest migration) will still fail with the same underlying error.
  */
 export async function withManifestLock<T>(appiumHome: string, behavior: () => Promise<T> | T): Promise<T> {
   const lockFile = await resolveManifestLockfilePath(appiumHome);
-  try {
-    // The manifest itself may not exist yet (e.g. a brand new `APPIUM_HOME`) -- its directory
-    // wouldn't either, and creating the lockfile requires it to already be there. A no-op when
-    // the directory already exists, so this doesn't by itself require `appiumHome` to be writable.
-    await fs.mkdirp(path.dirname(lockFile));
-  } catch (err) {
-    if (!isUnwritableLocationError(err)) {
-      throw err;
-    }
-    return behavior();
-  }
-  return util.getLockFileGuard<T>(lockFile, {runUnlockedIfUnwritable: true})(behavior);
-}
-
-function isUnwritableLocationError(err: unknown): boolean {
-  const code = (err as NodeJS.ErrnoException)?.code;
-  return code === 'EACCES' || code === 'EROFS' || code === 'EPERM';
+  return util.getLockFileGuard<T>(lockFile)(behavior);
 }

--- a/packages/appium/lib/utils/index.ts
+++ b/packages/appium/lib/utils/index.ts
@@ -1,7 +1,6 @@
 export {
   DEFAULT_APPIUM_HOME,
   MANIFEST_BASENAME,
-  MANIFEST_LOCKFILE_RELATIVE_PATH,
   MANIFEST_RELATIVE_PATH,
   findAppiumDependencyPackage,
   hasAppiumDependency,

--- a/packages/appium/lib/utils/index.ts
+++ b/packages/appium/lib/utils/index.ts
@@ -8,6 +8,7 @@ export {
   resolveAppiumHome,
   resolveManifestLockfilePath,
   resolveManifestPath,
+  withManifestLock,
 } from './env.js';
 export {adler32} from './hash.js';
 export {isPackageChanged} from './is-package-changed.js';

--- a/packages/appium/lib/utils/index.ts
+++ b/packages/appium/lib/utils/index.ts
@@ -1,10 +1,12 @@
 export {
   DEFAULT_APPIUM_HOME,
   MANIFEST_BASENAME,
+  MANIFEST_LOCKFILE_RELATIVE_PATH,
   MANIFEST_RELATIVE_PATH,
   findAppiumDependencyPackage,
   hasAppiumDependency,
   resolveAppiumHome,
+  resolveManifestLockfilePath,
   resolveManifestPath,
 } from './env.js';
 export {adler32} from './hash.js';

--- a/packages/appium/test/unit/cli/extension.spec.ts
+++ b/packages/appium/test/unit/cli/extension.spec.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import {after, afterEach, before, beforeEach, describe, it, mock} from 'node:test';
 
 import {fs, tempDir} from '@appium/support';
@@ -155,6 +156,26 @@ describe('runExtensionCommand', function () {
     driverConfig.printValidationSummary({warn() {}, error: (msg?: string) => void errorMessages.push(msg ?? '')});
     assert.ok(errorMessages.some((msg) => msg.includes('Multiple drivers claim support for the same automationName')));
   });
+
+  it('still lists installed extensions when the manifest directory is read-only', async function () {
+    // Populate a valid, current-schema manifest first (needs to write), then lock the directory
+    // down the way a preinstalled, read-only `APPIUM_HOME` would be -- e.g. `driver list
+    // --installed` against a container image built with the manifest already baked in.
+    const {driverConfig} = await loadExtensions(appiumHome);
+    const manifestDir = path.dirname(await resolveManifestPath(appiumHome));
+    await fs.chmod(manifestDir, 0o555);
+    try {
+      const result = await runExtensionCommand(
+        {subcommand: DRIVER_TYPE, driverCommand: 'list', suppressOutput: true} as any,
+        driverConfig,
+      );
+      assert.ok(result);
+      // No lock file could have been created in a read-only directory.
+      assert.strictEqual(await fs.exists(await resolveManifestLockfilePath(appiumHome)), false);
+    } finally {
+      await fs.chmod(manifestDir, 0o755);
+    }
+  });
 });
 
 describe('loadExtensions', function () {
@@ -198,5 +219,22 @@ describe('loadExtensions', function () {
     await heldLockPromise;
     await loadPromise;
     assert.strictEqual(loadResolved, true);
+  });
+
+  it('succeeds against a read-only manifest directory when no write is needed', async function () {
+    // Populate a valid, current-schema manifest normally first (needs to write).
+    await loadExtensions(appiumHome);
+    Manifest.getInstance.cache = new Map();
+
+    const manifestDir = path.dirname(await resolveManifestPath(appiumHome));
+    await fs.chmod(manifestDir, 0o555);
+    try {
+      const {driverConfig} = await loadExtensions(appiumHome);
+      assert.deepStrictEqual(driverConfig.installedExtensions, {});
+      // No lock file could have been created in a read-only directory.
+      assert.strictEqual(await fs.exists(await resolveManifestLockfilePath(appiumHome)), false);
+    } finally {
+      await fs.chmod(manifestDir, 0o755);
+    }
   });
 });

--- a/packages/appium/test/unit/cli/extension.spec.ts
+++ b/packages/appium/test/unit/cli/extension.spec.ts
@@ -2,12 +2,13 @@ import assert from 'node:assert/strict';
 import {after, afterEach, before, beforeEach, describe, it, mock} from 'node:test';
 
 import {fs, tempDir} from '@appium/support';
+import {sleep} from 'asyncbox';
 import * as YAML from 'yaml';
 
 import {DRIVER_TYPE} from '../../../lib/constants.js';
 import {loadExtensions} from '../../../lib/extension/index.js';
 import {Manifest} from '../../../lib/extension/manifest/manifest.js';
-import {resolveManifestLockfilePath, resolveManifestPath} from '../../../lib/utils/index.js';
+import {resolveManifestLockfilePath, resolveManifestPath, withManifestLock} from '../../../lib/utils/index.js';
 
 const FAKE_DRIVER_MANIFEST = {
   pkgName: '@appium/fake-driver',
@@ -18,6 +19,10 @@ const FAKE_DRIVER_MANIFEST = {
   installType: 'npm',
   installSpec: '@appium/fake-driver',
   installPath: '',
+  // Satisfies any Appium version, so `validate()` (now run on every manifest reload) doesn't
+  // fall into `getGenericConfigWarnings()`'s peer-dependency check, which needs a real `list()`
+  // on the command class -- unlike `execute()`, not something `FakeExtensionCommand` stands in for.
+  appiumVersion: '*',
 };
 
 let executeCalls: any[];
@@ -123,5 +128,75 @@ describe('runExtensionCommand', function () {
     // `installedExtensions` is a live getter, so the same `config` object the caller already
     // held onto also reflects the reload -- it isn't stuck on the pre-lock snapshot.
     assert.ok('fake' in driverConfig.installedExtensions);
+  });
+
+  it('revalidates the reloaded manifest, dropping conflicting entries and refreshing derived duplicate-name tracking', async function () {
+    const {driverConfig} = await loadExtensions(appiumHome);
+
+    // Simulate another process installing a *second* driver -- claiming the same `automationName`
+    // as the first -- while this process was waiting for the lock. A plain re-read (with no
+    // revalidation) would let both stand; only revalidating against fresh `knownAutomationNames`
+    // catches the conflict.
+    const manifestPath = await resolveManifestPath(appiumHome);
+    const onDisk = YAML.parse(await fs.readFile(manifestPath, 'utf8'));
+    onDisk.drivers.fake = FAKE_DRIVER_MANIFEST;
+    onDisk.drivers['fake-2'] = {...FAKE_DRIVER_MANIFEST, pkgName: '@appium/fake-driver-2'};
+    await fs.writeFile(manifestPath, YAML.stringify(onDisk), 'utf8');
+
+    await runExtensionCommand(
+      {subcommand: DRIVER_TYPE, driverCommand: 'list', suppressOutput: true} as any,
+      driverConfig,
+    );
+
+    // Only one of the two same-`automationName` drivers should survive revalidation.
+    assert.deepStrictEqual(Object.keys(driverConfig.installedExtensions), ['fake']);
+
+    const errorMessages: string[] = [];
+    driverConfig.printValidationSummary({warn() {}, error: (msg?: string) => void errorMessages.push(msg ?? '')});
+    assert.ok(errorMessages.some((msg) => msg.includes('Multiple drivers claim support for the same automationName')));
+  });
+});
+
+describe('loadExtensions', function () {
+  let appiumHome: string;
+
+  beforeEach(async function () {
+    appiumHome = await tempDir.openDir();
+    Manifest.getInstance.cache = new Map();
+  });
+
+  afterEach(async function () {
+    await fs.rimraf(appiumHome);
+  });
+
+  it('waits for another process holding the manifest lock instead of reading/writing around it', async function () {
+    let lockAcquired = false;
+    let releaseHold: () => void;
+    const holdUntilReleased = new Promise<void>((resolve) => {
+      releaseHold = resolve;
+    });
+    const heldLockPromise = withManifestLock(appiumHome, async () => {
+      lockAcquired = true;
+      await holdUntilReleased;
+    });
+    while (!lockAcquired) {
+      await sleep(5);
+    }
+
+    let loadResolved = false;
+    const loadPromise = loadExtensions(appiumHome).then((result) => {
+      loadResolved = true;
+      return result;
+    });
+
+    // `loadExtensions()` has nothing to do before it needs the lock, so if it isn't actually
+    // waiting on the same lock file, it would resolve almost immediately here.
+    await sleep(200);
+    assert.strictEqual(loadResolved, false);
+
+    releaseHold!();
+    await heldLockPromise;
+    await loadPromise;
+    assert.strictEqual(loadResolved, true);
   });
 });

--- a/packages/appium/test/unit/cli/extension.spec.ts
+++ b/packages/appium/test/unit/cli/extension.spec.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import {after, afterEach, before, beforeEach, describe, it, mock} from 'node:test';
+
+import {fs, tempDir} from '@appium/support';
+import * as YAML from 'yaml';
+
+import {DRIVER_TYPE} from '../../../lib/constants.js';
+import {loadExtensions} from '../../../lib/extension/index.js';
+import {Manifest} from '../../../lib/extension/manifest/manifest.js';
+import {resolveManifestLockfilePath, resolveManifestPath} from '../../../lib/utils/index.js';
+
+const FAKE_DRIVER_MANIFEST = {
+  pkgName: '@appium/fake-driver',
+  version: '1.0.0',
+  automationName: 'Fake',
+  platformNames: ['Fake'],
+  mainClass: 'FakeDriver',
+  installType: 'npm',
+  installSpec: '@appium/fake-driver',
+  installPath: '',
+};
+
+let executeCalls: any[];
+
+/** Stands in for `DriverCliCommand`/`PluginCliCommand` so `execute()` never touches npm/network. */
+class FakeExtensionCommand {
+  config: any;
+  json: boolean;
+
+  constructor({config, json}: {config: any; json: boolean}) {
+    this.config = config;
+    this.json = json;
+  }
+
+  printPendingValidationSummary(): void {}
+
+  async execute(args: any): Promise<Record<string, unknown>> {
+    executeCalls.push(args);
+    if (args.throwError) {
+      throw new Error(args.throwError);
+    }
+    return {installedExtensionsSnapshot: {...this.config.installedExtensions}};
+  }
+}
+
+describe('runExtensionCommand', function () {
+  // `driver-command.js`/`plugin-command.js` must be mocked before `extension.js` is first
+  // imported (see the `before()` hook below), so its type can't come from a normal value import.
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  let runExtensionCommand: (typeof import('../../../lib/cli/extension.js'))['runExtensionCommand'];
+  let appiumHome: string;
+
+  // `driver-command.js`/`plugin-command.js` are mocked once here (before the first import of
+  // `extension.js`, which statically imports both) so every test below shares the same fake
+  // command class; per-test behavior is driven entirely through the `args` passed at call time.
+  before(async function () {
+    mock.module('../../../lib/cli/driver-command.js', {defaultExport: FakeExtensionCommand});
+    mock.module('../../../lib/cli/plugin-command.js', {defaultExport: FakeExtensionCommand});
+    ({runExtensionCommand} = await import('../../../lib/cli/extension.js'));
+  });
+
+  after(function () {
+    mock.reset();
+  });
+
+  beforeEach(async function () {
+    executeCalls = [];
+    appiumHome = await tempDir.openDir();
+    Manifest.getInstance.cache = new Map();
+  });
+
+  afterEach(async function () {
+    await fs.rimraf(appiumHome);
+  });
+
+  it('acquires and releases the manifest lock around the command', async function () {
+    const {driverConfig} = await loadExtensions(appiumHome);
+    const lockFile = await resolveManifestLockfilePath(appiumHome);
+
+    assert.strictEqual(await fs.exists(lockFile), false);
+    await runExtensionCommand(
+      {subcommand: DRIVER_TYPE, driverCommand: 'list', suppressOutput: true} as any,
+      driverConfig,
+    );
+    assert.strictEqual(executeCalls.length, 1);
+    assert.strictEqual(await fs.exists(lockFile), false);
+  });
+
+  it('still releases the lock when the command throws', async function () {
+    const {driverConfig} = await loadExtensions(appiumHome);
+    const lockFile = await resolveManifestLockfilePath(appiumHome);
+
+    await assert.rejects(
+      runExtensionCommand(
+        {subcommand: DRIVER_TYPE, driverCommand: 'list', suppressOutput: true, throwError: 'boom'} as any,
+        driverConfig,
+      ),
+      /boom/,
+    );
+    assert.strictEqual(await fs.exists(lockFile), false);
+  });
+
+  it('re-reads the manifest under the lock, picking up changes written after the initial load', async function () {
+    const {driverConfig} = await loadExtensions(appiumHome);
+    assert.deepStrictEqual(driverConfig.installedExtensions, {});
+
+    // Simulate another CLI process installing a driver after this process's own startup read
+    // but before this command actually runs.
+    const manifestPath = await resolveManifestPath(appiumHome);
+    const onDisk = YAML.parse(await fs.readFile(manifestPath, 'utf8'));
+    onDisk.drivers.fake = FAKE_DRIVER_MANIFEST;
+    await fs.writeFile(manifestPath, YAML.stringify(onDisk), 'utf8');
+
+    // The in-memory config still reflects the state from the initial `loadExtensions()` read.
+    assert.deepStrictEqual(driverConfig.installedExtensions, {});
+
+    const result = await runExtensionCommand(
+      {subcommand: DRIVER_TYPE, driverCommand: 'list', suppressOutput: true} as any,
+      driverConfig,
+    );
+
+    assert.ok('fake' in (result as any).installedExtensionsSnapshot);
+    // `installedExtensions` is a live getter, so the same `config` object the caller already
+    // held onto also reflects the reload -- it isn't stuck on the pre-lock snapshot.
+    assert.ok('fake' in driverConfig.installedExtensions);
+  });
+});

--- a/packages/appium/test/unit/cli/extension.spec.ts
+++ b/packages/appium/test/unit/cli/extension.spec.ts
@@ -160,7 +160,9 @@ describe('runExtensionCommand', function () {
   it('still lists installed extensions when the manifest directory is read-only', async function () {
     // Populate a valid, current-schema manifest first (needs to write), then lock the directory
     // down the way a preinstalled, read-only `APPIUM_HOME` would be -- e.g. `driver list
-    // --installed` against a container image built with the manifest already baked in.
+    // --installed` against a container image built with the manifest already baked in. The lock
+    // lives under the OS temp dir (see `resolveManifestLockfilePath`), not alongside the
+    // manifest, so this doesn't depend on `appiumHome` being writable at all.
     const {driverConfig} = await loadExtensions(appiumHome);
     const manifestDir = path.dirname(await resolveManifestPath(appiumHome));
     await fs.chmod(manifestDir, 0o555);
@@ -170,8 +172,52 @@ describe('runExtensionCommand', function () {
         driverConfig,
       );
       assert.ok(result);
-      // No lock file could have been created in a read-only directory.
-      assert.strictEqual(await fs.exists(await resolveManifestLockfilePath(appiumHome)), false);
+    } finally {
+      await fs.chmod(manifestDir, 0o755);
+    }
+  });
+
+  it('still serializes writes when the manifest directory is non-writable but the manifest file itself is writable', async function () {
+    // A non-writable directory blocks creating new entries in it (e.g. a colocated lockfile),
+    // but not overwriting an existing file's contents -- so a lock derived from directory
+    // writability alone would falsely conclude nothing could race a write here, when the
+    // manifest file itself remains fully writable. This is exactly the setup used above and in
+    // `loadExtensions`'s read-only test, so it's what's actually being locked that matters here.
+    const {driverConfig} = await loadExtensions(appiumHome);
+    const manifestDir = path.dirname(await resolveManifestPath(appiumHome));
+    await fs.chmod(manifestDir, 0o555);
+    try {
+      let firstAcquired = false;
+      let releaseFirst: () => void;
+      const holdUntilReleased = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      const firstLockPromise = withManifestLock(appiumHome, async () => {
+        firstAcquired = true;
+        await holdUntilReleased;
+      });
+      while (!firstAcquired) {
+        await sleep(5);
+      }
+
+      let secondResolved = false;
+      const secondPromise = runExtensionCommand(
+        {subcommand: DRIVER_TYPE, driverCommand: 'list', suppressOutput: true} as any,
+        driverConfig,
+      ).then((result) => {
+        secondResolved = true;
+        return result;
+      });
+
+      // If the non-writable directory made `runExtensionCommand` skip locking, it would resolve
+      // almost immediately here instead of waiting for `firstLockPromise` to release the lock.
+      await sleep(200);
+      assert.strictEqual(secondResolved, false);
+
+      releaseFirst!();
+      await firstLockPromise;
+      await secondPromise;
+      assert.strictEqual(secondResolved, true);
     } finally {
       await fs.chmod(manifestDir, 0o755);
     }
@@ -231,7 +277,8 @@ describe('loadExtensions', function () {
     try {
       const {driverConfig} = await loadExtensions(appiumHome);
       assert.deepStrictEqual(driverConfig.installedExtensions, {});
-      // No lock file could have been created in a read-only directory.
+      // The lock lives under the OS temp dir, not `manifestDir`, and is released once acquired --
+      // i.e. it was never blocked by `manifestDir`'s permissions in the first place.
       assert.strictEqual(await fs.exists(await resolveManifestLockfilePath(appiumHome)), false);
     } finally {
       await fs.chmod(manifestDir, 0o755);

--- a/packages/appium/test/unit/extension/extension-config.spec.ts
+++ b/packages/appium/test/unit/extension/extension-config.spec.ts
@@ -4,7 +4,9 @@ import os from 'node:os';
 import path from 'node:path';
 import {describe, it, beforeEach, afterEach, before, after, mock} from 'node:test';
 
-import {DRIVER_TYPE} from '../../../lib/constants.js';
+import * as YAML from 'yaml';
+
+import {CURRENT_SCHEMA_REV, DRIVER_TYPE} from '../../../lib/constants.js';
 import {APPIUM_VER} from '../../../lib/helpers/build.js';
 import {FAKE_DRIVER_DIR, PROJECT_ROOT} from '../../helpers.js';
 import {applyExtensionMocks, initMocks, resetMockDefaults} from './mocks.js';
@@ -472,6 +474,25 @@ describe('ExtensionConfig', function () {
           );
           assert.notStrictEqual(marker1, marker2);
         });
+      });
+    });
+
+    describe('installedExtensions', function () {
+      it('reflects the manifest live, including after a reload replaces the underlying data', async function () {
+        assert.deepStrictEqual(config.installedExtensions, {[extData.pkgName]: extData});
+
+        MockAppiumSupport.fs.readFile.resolves(
+          YAML.stringify({
+            drivers: {fake: {pkgName: '@appium/fake-driver', version: '1.0.0', mainClass: 'FakeDriver'}},
+            plugins: {},
+            schemaRev: CURRENT_SCHEMA_REV,
+          }),
+        );
+        // `read()` replaces the manifest's whole in-memory data object; a plain field captured
+        // at construction time (the old implementation) would keep pointing at the pre-reload one.
+        await config.manifest.read();
+
+        assert.deepStrictEqual(Object.keys(config.installedExtensions), ['fake']);
       });
     });
   });

--- a/packages/appium/test/unit/schema/schema.spec.ts
+++ b/packages/appium/test/unit/schema/schema.spec.ts
@@ -119,6 +119,18 @@ describe('schema', function () {
           });
         });
 
+        describe('when the schema is a different object but deeply equal, and has since been finalized', function () {
+          it('should not throw', async function () {
+            // A manifest reload re-parses an extension's inline schema from disk into a fresh
+            // object each time -- `finalizeSchema()` must not have mutated the *registered* copy
+            // in a way that makes it stop matching a later, independently-parsed-but-equal one.
+            const buildSchema = () => ({title: 'whoopee', type: 'object', properties: {}});
+            await registerSchema(DRIVER_TYPE, 'whoopee', buildSchema());
+            await finalizeSchema();
+            await assert.doesNotReject(registerSchema(DRIVER_TYPE, 'whoopee', buildSchema()));
+          });
+        });
+
         describe('when the schema is different', function () {
           it('should throw', async function () {
             const schemaObject = {title: 'whoopee'};
@@ -208,7 +220,13 @@ describe('schema', function () {
       });
 
       it('should return the extension schema', function () {
-        assert.deepStrictEqual(getSchema('driver-stuff.json'), DRIVER_SCHEMA_FIXTURE);
+        // `finalizeSchema()` clones a registered schema before stamping `$id`/`additionalProperties`
+        // onto it, so it doesn't overwrite the original `$id` on the fixture object itself.
+        assert.deepStrictEqual(getSchema('driver-stuff.json'), {
+          ...DRIVER_SCHEMA_FIXTURE,
+          $id: 'driver-stuff.json',
+          additionalProperties: false,
+        });
       });
     });
   });
@@ -334,7 +352,11 @@ describe('schema', function () {
         };
         assert.deepStrictEqual(await finalizeSchema(), {
           [APPIUM_CONFIG_SCHEMA_ID]: baseSchemaWithRefs,
-          'driver-stuff.json': DRIVER_SCHEMA_FIXTURE,
+          'driver-stuff.json': {
+            ...DRIVER_SCHEMA_FIXTURE,
+            $id: 'driver-stuff.json',
+            additionalProperties: false,
+          },
         });
       });
     });

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -571,10 +571,16 @@ export function getLockFileGuard<T>(lockFile: string, opts: LockFileOptions = {}
       let acquired = false;
       while (!acquired) {
         try {
-          if (_lockfile.checkSync(lockFile)) {
-            await lock(lockFile, {wait: timeout * 1000});
-          } else {
+          try {
             _lockfile.lockSync(lockFile);
+          } catch (e) {
+            const lockErr = e as NodeJS.ErrnoException;
+            if (lockErr.code !== 'EEXIST') {
+              throw lockErr;
+            }
+            // Someone else is holding the lock (possibly grabbed it between us checking and
+            // locking) -- wait for them to release it instead of failing outright.
+            await lock(lockFile, {wait: timeout * 1000});
           }
           acquired = true;
         } catch (e) {

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -429,13 +429,6 @@ export interface LockFileOptions {
   timeout?: number;
   /** If true, attempt to unlock and retry once if the first acquisition times out (e.g. stale lock). */
   tryRecovery?: boolean;
-  /**
-   * If true, and the lock file's location turns out to be unwritable (`EACCES`/`EROFS`/`EPERM` --
-   * e.g. a read-only directory), run the behavior unlocked instead of throwing. Safe when the
-   * behavior itself no-ops or fails the same way on a genuine write attempt: nothing else could be
-   * racing a write against a location nothing can write to in the first place.
-   */
-  runUnlockedIfUnwritable?: boolean;
 }
 
 /** Options for truncateString(). */
@@ -566,7 +559,7 @@ export async function toInMemoryBase64(srcPath: string, opts: EncodingOptions = 
  * @returns Async function that accepts a callback to run under the lock, plus a `.check()` method
  */
 export function getLockFileGuard<T>(lockFile: string, opts: LockFileOptions = {}): LockFileGuard<T> {
-  const {timeout = 120, tryRecovery = false, runUnlockedIfUnwritable = false} = opts;
+  const {timeout = 120, tryRecovery = false} = opts;
 
   const lock = promisify(_lockfile.lock) as (lockfile: string, opts: {wait: number}) => Promise<void>;
   const checkLock = promisify(_lockfile.check) as (lockfile: string) => Promise<boolean>;
@@ -583,11 +576,6 @@ export function getLockFileGuard<T>(lockFile: string, opts: LockFileOptions = {}
           } catch (e) {
             const lockErr = e as NodeJS.ErrnoException;
             if (lockErr.code !== 'EEXIST') {
-              if (runUnlockedIfUnwritable && isUnwritableLocationError(lockErr)) {
-                // We haven't acquired anything yet, so there's nothing to release -- just run the
-                // behavior directly.
-                return await behavior();
-              }
               throw lockErr;
             }
             // Someone else is holding the lock (possibly grabbed it between us checking and
@@ -618,9 +606,4 @@ export function getLockFileGuard<T>(lockFile: string, opts: LockFileOptions = {}
   );
 
   return guard;
-}
-
-/** Whether `err` indicates the lock file's location can't be written to at all (as opposed to merely being held). */
-function isUnwritableLocationError(err: NodeJS.ErrnoException): boolean {
-  return err.code === 'EACCES' || err.code === 'EROFS' || err.code === 'EPERM';
 }

--- a/packages/support/lib/util.ts
+++ b/packages/support/lib/util.ts
@@ -429,6 +429,13 @@ export interface LockFileOptions {
   timeout?: number;
   /** If true, attempt to unlock and retry once if the first acquisition times out (e.g. stale lock). */
   tryRecovery?: boolean;
+  /**
+   * If true, and the lock file's location turns out to be unwritable (`EACCES`/`EROFS`/`EPERM` --
+   * e.g. a read-only directory), run the behavior unlocked instead of throwing. Safe when the
+   * behavior itself no-ops or fails the same way on a genuine write attempt: nothing else could be
+   * racing a write against a location nothing can write to in the first place.
+   */
+  runUnlockedIfUnwritable?: boolean;
 }
 
 /** Options for truncateString(). */
@@ -559,7 +566,7 @@ export async function toInMemoryBase64(srcPath: string, opts: EncodingOptions = 
  * @returns Async function that accepts a callback to run under the lock, plus a `.check()` method
  */
 export function getLockFileGuard<T>(lockFile: string, opts: LockFileOptions = {}): LockFileGuard<T> {
-  const {timeout = 120, tryRecovery = false} = opts;
+  const {timeout = 120, tryRecovery = false, runUnlockedIfUnwritable = false} = opts;
 
   const lock = promisify(_lockfile.lock) as (lockfile: string, opts: {wait: number}) => Promise<void>;
   const checkLock = promisify(_lockfile.check) as (lockfile: string) => Promise<boolean>;
@@ -576,6 +583,11 @@ export function getLockFileGuard<T>(lockFile: string, opts: LockFileOptions = {}
           } catch (e) {
             const lockErr = e as NodeJS.ErrnoException;
             if (lockErr.code !== 'EEXIST') {
+              if (runUnlockedIfUnwritable && isUnwritableLocationError(lockErr)) {
+                // We haven't acquired anything yet, so there's nothing to release -- just run the
+                // behavior directly.
+                return await behavior();
+              }
               throw lockErr;
             }
             // Someone else is holding the lock (possibly grabbed it between us checking and
@@ -606,4 +618,9 @@ export function getLockFileGuard<T>(lockFile: string, opts: LockFileOptions = {}
   );
 
   return guard;
+}
+
+/** Whether `err` indicates the lock file's location can't be written to at all (as opposed to merely being held). */
+function isUnwritableLocationError(err: NodeJS.ErrnoException): boolean {
+  return err.code === 'EACCES' || err.code === 'EROFS' || err.code === 'EPERM';
 }


### PR DESCRIPTION
Serializes `appium driver`/`plugin` CLI commands against a per-`APPIUM_HOME` lock file and re-reads `extensions.yaml` after acquiring it, so concurrent processes can no longer race to read-modify-write the manifest and silently clobber each other's changes. `ExtensionConfig.installedExtensions` becomes a live getter so it stays in sync with the manifest across that re-read.

Also fixes a TOCTOU race in `@appium/support`'s `getLockFileGuard`: it checked `checkSync()` then separately called `lockSync()`, so a lock created by another process in that gap surfaced as an uncaught `EEXIST` failure instead of being waited on.
